### PR TITLE
Updated to reflect name of REST API attribute

### DIFF
--- a/client/sdk/com/vmware/vcenter.rb
+++ b/client/sdk/com/vmware/vcenter.rb
@@ -2764,7 +2764,7 @@ module Com::Vmware::Vcenter
                 end
             end
 
-            attr_accessor :guest_os,
+            attr_accessor :guest_OS,
                           :name,
                           :placement,
                           :hardware_version,
@@ -2872,7 +2872,7 @@ module Com::Vmware::Vcenter
                 end
             end
 
-            attr_accessor :guest_os,
+            attr_accessor :guest_OS,
                           :name,
                           :power_state,
                           :hardware,


### PR DESCRIPTION
Modified the attribute for the `Info` and `CreateSpec` classes so that they match the specification of the REST API.

On limited tests this fixes #8, however with the other issues I have not been able to do a complete end to end test to make sure it all works.