### PR TITLE
Reformat code for stylistic changes

### DIFF
--- a/client/samples/lib/sample/vcenter/vm/power.rb
+++ b/client/samples/lib/sample/vcenter/vm/power.rb
@@ -55,7 +55,7 @@ EOL
     log.info "Getting the VM Details #{vm_name}"
     @vm_id = VMHelper.get_vm(service_manager.vapi_config, @vm_name)
     @status = vm_power_svc.get(vm_id)
-    if status.state.to_s == (VM_POWER_CLASS::State.new('POWERED_ON')).to_s
+    if status.state == VM_POWER_CLASS::State::POWERED_ON
       log.info "The VM  #{vm_name} is powered ON and it would be powered OFF"
       vm_power_svc.stop(vm_id)
     end

--- a/client/sdk/com/vmware/appliance.rb
+++ b/client/sdk/com/vmware/appliance.rb
@@ -1,5 +1,6 @@
 #---------------------------------------------------------------------------
-# Copyright 2016 VMware, Inc.  All rights reserved.
+# Copyright 2017 VMware, Inc.  All rights reserved.
+#
 # AUTO GENERATED FILE -- DO NOT MODIFY!
 #
 # vAPI type descriptors for package com.vmware.appliance.
@@ -8,440 +9,410 @@ require 'vapi'
 
 # declare the module hierarchy before we use the shorthand syntax below
 module Com
-    module Vmware
-        module Appliance
-        end
+  module Vmware
+    module Appliance
     end
+  end
 end
 
 module Com::Vmware::Appliance
+  # ``Com::Vmware::Appliance::Monitoring``   class  provides  methods  Get and list monitoring data for requested item.
+  class Monitoring < VAPI::Bindings::VapiService
+    # static metamodel definitions
+    SERVICE_ID = VAPI::Core::ServiceIdentifier.new('com.vmware.appliance.monitoring')
 
-    # ``Com::Vmware::Appliance::Monitoring``   class  provides  methods  Get and list monitoring data for requested item.
-    class Monitoring < VAPI::Bindings::VapiService
+    QUERY_INFO = VAPI::Bindings::OperationInfo.new(
+      VAPI::Core::OperationIdentifier.new('query', SERVICE_ID),
+      VAPI::Bindings::OperationInputType.new(
+        'item' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Appliance::Monitoring::MonitoredItemDataRequest')
+      ),
+      VAPI::Bindings::ListType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Appliance::Monitoring::MonitoredItemData')),
+      {
+        'com.vmware.vapi.std.errors.error' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Error')
+      },
+      [],
+      []
+    )
 
-        protected
+    LIST_INFO = VAPI::Bindings::OperationInfo.new(
+      VAPI::Core::OperationIdentifier.new('list', SERVICE_ID),
+      VAPI::Bindings::OperationInputType.new,
+      VAPI::Bindings::ListType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Appliance::Monitoring::MonitoredItem')),
+      {
+        'com.vmware.vapi.std.errors.error' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Error')
+      },
+      [],
+      []
+    )
 
-        # static metamodel definitions
-        @@service_id = VAPI::Core::ServiceIdentifier.new('com.vmware.appliance.monitoring')
+    GET_INFO = VAPI::Bindings::OperationInfo.new(
+      VAPI::Core::OperationIdentifier.new('get', SERVICE_ID),
+      VAPI::Bindings::OperationInputType.new(
+        'stat_id' => VAPI::Bindings::IdType.new('com.vmware.appliance.monitoring')
+      ),
+      VAPI::Bindings::ReferenceType.new('Com::Vmware::Appliance::Monitoring::MonitoredItem'),
+      {
+        'com.vmware.vapi.std.errors.error' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Error')
+      },
+      [],
+      []
+    )
 
-        @@query_info = VAPI::Bindings::OperationInfo.new(
-            VAPI::Core::OperationIdentifier.new('query', @@service_id),
-            VAPI::Bindings::OperationInputType.new({
-                'item' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Appliance::Monitoring::MonitoredItemDataRequest'),
-            }),
-            VAPI::Bindings::ListType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Appliance::Monitoring::MonitoredItemData')),
-            {
-                'com.vmware.vapi.std.errors.error' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Error'),
+    SERVICE_INFO = VAPI::Bindings::ServiceInfo.new(
+      SERVICE_ID,
+      'query' => QUERY_INFO,
+      'list' => LIST_INFO,
+      'get' => GET_INFO
+    )
 
-            },
-            [],
-            [])
-        @@list_info = VAPI::Bindings::OperationInfo.new(
-            VAPI::Core::OperationIdentifier.new('list', @@service_id),
-            VAPI::Bindings::OperationInputType.new,
-            VAPI::Bindings::ListType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Appliance::Monitoring::MonitoredItem')),
-            {
-                'com.vmware.vapi.std.errors.error' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Error'),
-
-            },
-            [],
-            [])
-        @@get_info = VAPI::Bindings::OperationInfo.new(
-            VAPI::Core::OperationIdentifier.new('get', @@service_id),
-            VAPI::Bindings::OperationInputType.new({
-                'stat_id' => VAPI::Bindings::IdType.new(resource_types='com.vmware.appliance.monitoring'),
-            }),
-            VAPI::Bindings::ReferenceType.new('Com::Vmware::Appliance::Monitoring::MonitoredItem'),
-            {
-                'com.vmware.vapi.std.errors.error' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Error'),
-
-            },
-            [],
-            [])
-
-        @@service_info = VAPI::Bindings::ServiceInfo.new(@@service_id, {
-            'query' => @@query_info,
-            'list' => @@list_info,
-            'get' => @@get_info,
-        })
-
-        public
-
-        # Constructs a new instance.
-        #
-        # @param config [VAPI::Bindings::StubConfig] A hash with the api provider details.
-        def initialize(config)
-            super(config, @@service_info)
-        end
-
-
-        # Get monitoring data.
-        #
-        # @param item [Com::Vmware::Appliance::Monitoring::MonitoredItemDataRequest]
-        #     MonitoredItemDataRequest Structure
-        # @return [Array<Com::Vmware::Appliance::Monitoring::MonitoredItemData>]
-        #     list of MonitoredItemData structure
-        # @raise [Com::Vmware::Vapi::Std::Errors::Error]
-        #     Generic error
-        def query(item)
-            invoke_with_info(@@query_info, {
-                'item' => item,
-            })
-        end
-
-
-        # Get monitored items list
-        #
-        # @return [Array<Com::Vmware::Appliance::Monitoring::MonitoredItem>]
-        #     list of names
-        # @raise [Com::Vmware::Vapi::Std::Errors::Error]
-        #     Generic error
-        def list()
-            invoke_with_info(@@list_info)
-        end
-
-
-        # Get monitored item info
-        #
-        # @param stat_id [String]
-        #     statistic item id
-        # @return [Com::Vmware::Appliance::Monitoring::MonitoredItem]
-        #     MonitoredItem structure
-        # @raise [Com::Vmware::Vapi::Std::Errors::Error]
-        #     Generic error
-        def get(stat_id)
-            invoke_with_info(@@get_info, {
-                'stat_id' => stat_id,
-            })
-        end
-
-
-
-        # ``Com::Vmware::Appliance::Monitoring::MonitoredItemData``   class  Structure representing monitored item data.
-        # @!attribute [rw] name
-        #     @return [String]
-        #     Monitored item IDs Ex: CPU, MEMORY, STORAGE_TOTAL
-        # @!attribute [rw] interval
-        #     @return [Com::Vmware::Appliance::Monitoring::IntervalType]
-        #     interval between values in hours, minutes
-        # @!attribute [rw] function
-        #     @return [Com::Vmware::Appliance::Monitoring::FunctionType]
-        #     aggregation function
-        # @!attribute [rw] start_time
-        #     @return [DateTime]
-        #     Starting time
-        # @!attribute [rw] end_time
-        #     @return [DateTime]
-        #     Ending time
-        # @!attribute [rw] data
-        #     @return [Array<String>]
-        #     list of values
-        class MonitoredItemData < VAPI::Bindings::VapiStruct
-
-            class << self
-                # Holds (gets or creates) the binding type metadata for this structure type.
-                # @scope class
-                # @return [VAPI::Bindings::StructType] the binding type
-                def binding_type
-                    @binding_type ||= VAPI::Bindings::StructType.new(
-                        'com.vmware.appliance.monitoring.monitored_item_data',
-                        {
-                            'name' => VAPI::Bindings::IdType.new(resource_types='com.vmware.appliance.monitoring'),
-                            'interval' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Appliance::Monitoring::IntervalType'),
-                            'function' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Appliance::Monitoring::FunctionType'),
-                            'start_time' => VAPI::Bindings::DateTimeType.instance,
-                            'end_time' => VAPI::Bindings::DateTimeType.instance,
-                            'data' => VAPI::Bindings::ListType.new(VAPI::Bindings::StringType.instance),
-                        },
-                        MonitoredItemData,
-                        false,
-                        nil)
-                end
-            end
-
-            attr_accessor :name,
-                          :interval,
-                          :function,
-                          :start_time,
-                          :end_time,
-                          :data
-
-            # Constructs a new instance.
-            # @param ruby_values [Hash] a map of initial property values (optional)
-            # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
-            def initialize(ruby_values=nil, struct_value=nil)
-                super(self.class.binding_type, ruby_values, struct_value)
-            end
-        end
-
-
-        # ``Com::Vmware::Appliance::Monitoring::MonitoredItemDataRequest``   class  Structure representing requested monitored item data.
-        # @!attribute [rw] names
-        #     @return [Array<String>]
-        #     monitored item IDs Ex: CPU, MEMORY
-        # @!attribute [rw] interval
-        #     @return [Com::Vmware::Appliance::Monitoring::IntervalType]
-        #     interval between values in hours, minutes
-        # @!attribute [rw] function
-        #     @return [Com::Vmware::Appliance::Monitoring::FunctionType]
-        #     aggregation function
-        # @!attribute [rw] start_time
-        #     @return [DateTime]
-        #     Starting time
-        # @!attribute [rw] end_time
-        #     @return [DateTime]
-        #     Ending time
-        class MonitoredItemDataRequest < VAPI::Bindings::VapiStruct
-
-            class << self
-                # Holds (gets or creates) the binding type metadata for this structure type.
-                # @scope class
-                # @return [VAPI::Bindings::StructType] the binding type
-                def binding_type
-                    @binding_type ||= VAPI::Bindings::StructType.new(
-                        'com.vmware.appliance.monitoring.monitored_item_data_request',
-                        {
-                            'names' => VAPI::Bindings::ListType.new(VAPI::Bindings::IdType.new),
-                            'interval' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Appliance::Monitoring::IntervalType'),
-                            'function' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Appliance::Monitoring::FunctionType'),
-                            'start_time' => VAPI::Bindings::DateTimeType.instance,
-                            'end_time' => VAPI::Bindings::DateTimeType.instance,
-                        },
-                        MonitoredItemDataRequest,
-                        false,
-                        nil)
-                end
-            end
-
-            attr_accessor :names,
-                          :interval,
-                          :function,
-                          :start_time,
-                          :end_time
-
-            # Constructs a new instance.
-            # @param ruby_values [Hash] a map of initial property values (optional)
-            # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
-            def initialize(ruby_values=nil, struct_value=nil)
-                super(self.class.binding_type, ruby_values, struct_value)
-            end
-        end
-
-
-        # ``Com::Vmware::Appliance::Monitoring::MonitoredItem``   class  Structure representing requested monitored item data.
-        # @!attribute [rw] id
-        #     @return [String]
-        #     monitored item ID Ex: CPU, MEMORY
-        # @!attribute [rw] name
-        #     @return [String]
-        #     monitored item name Ex: "Network write speed"
-        # @!attribute [rw] units
-        #     @return [String]
-        #     Y-axis label EX: "Mbps", "%"
-        # @!attribute [rw] category
-        #     @return [String]
-        #     category Ex: network, storage etc
-        # @!attribute [rw] instance
-        #     @return [String]
-        #     instance name Ex: eth0
-        # @!attribute [rw] description
-        #     @return [String]
-        #     monitored item description Ex: com.vmware.applmgmt.mon.descr.net.rx.packetRate.eth0
-        class MonitoredItem < VAPI::Bindings::VapiStruct
-
-            class << self
-                # Holds (gets or creates) the binding type metadata for this structure type.
-                # @scope class
-                # @return [VAPI::Bindings::StructType] the binding type
-                def binding_type
-                    @binding_type ||= VAPI::Bindings::StructType.new(
-                        'com.vmware.appliance.monitoring.monitored_item',
-                        {
-                            'id' => VAPI::Bindings::IdType.new(resource_types='com.vmware.appliance.monitoring'),
-                            'name' => VAPI::Bindings::StringType.instance,
-                            'units' => VAPI::Bindings::StringType.instance,
-                            'category' => VAPI::Bindings::StringType.instance,
-                            'instance' => VAPI::Bindings::StringType.instance,
-                            'description' => VAPI::Bindings::StringType.instance,
-                        },
-                        MonitoredItem,
-                        false,
-                        nil)
-                end
-            end
-
-            attr_accessor :id,
-                          :name,
-                          :units,
-                          :category,
-                          :instance,
-                          :description
-
-            # Constructs a new instance.
-            # @param ruby_values [Hash] a map of initial property values (optional)
-            # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
-            def initialize(ruby_values=nil, struct_value=nil)
-                super(self.class.binding_type, ruby_values, struct_value)
-            end
-        end
-
-
-
-        # ``Com::Vmware::Appliance::Monitoring::FunctionType``   enumerated type  Defines aggregation function
-        # @!attribute [rw] count
-        #     @return [Com::Vmware::Appliance::Monitoring::FunctionType]
-        #     Aggregation takes count per period (sum)
-        # @!attribute [rw] max
-        #     @return [Com::Vmware::Appliance::Monitoring::FunctionType]
-        #     Aggregation takes maximums per period
-        # @!attribute [rw] avg
-        #     @return [Com::Vmware::Appliance::Monitoring::FunctionType]
-        #     Aggregation takes average per period
-        # @!attribute [rw] min
-        #     @return [Com::Vmware::Appliance::Monitoring::FunctionType]
-        #     Aggregation takes minimums per period
-        class FunctionType < VAPI::Bindings::VapiEnum
-
-            class << self
-                # Holds (gets or creates) the binding type metadata for this enumeration type.
-                # @scope class
-                # @return [VAPI::Bindings::EnumType] the binding type
-                def binding_type
-                    @binding_type ||= VAPI::Bindings::EnumType.new(
-                        'com.vmware.appliance.monitoring.function_type',
-                        FunctionType)
-                end
-
-                # Converts from a string value (perhaps off the wire) to an instance
-                # of this enum type.
-                # @param value [String] the actual value of the enum instance
-                # @return [FunctionType] the instance found for the value, otherwise
-                #         an unknown instance will be built for the value
-                def from_string(value)
-                    begin
-                        const_get(value)
-                    rescue NameError
-                        FunctionType.new('UNKNOWN', value)
-                    end
-                end
-            end
-
-            private
-
-            # Constructs a new instance.
-            # @param value [String] the actual value of the enum instance
-            # @param unknown [String] the unknown value when value is 'UKNOWN'
-            def initialize(value, unknown=nil)
-                super(self.class.binding_type, value, unknown)
-            end
-
-            public
-
-            # @!attribute [rw] count
-            #     @return [Com::Vmware::Appliance::Monitoring::FunctionType]
-            #     Aggregation takes count per period (sum)
-            COUNT = FunctionType.new('COUNT')
-
-            # @!attribute [rw] max
-            #     @return [Com::Vmware::Appliance::Monitoring::FunctionType]
-            #     Aggregation takes maximums per period
-            MAX = FunctionType.new('MAX')
-
-            # @!attribute [rw] avg
-            #     @return [Com::Vmware::Appliance::Monitoring::FunctionType]
-            #     Aggregation takes average per period
-            AVG = FunctionType.new('AVG')
-
-            # @!attribute [rw] min
-            #     @return [Com::Vmware::Appliance::Monitoring::FunctionType]
-            #     Aggregation takes minimums per period
-            MIN = FunctionType.new('MIN')
-
-        end
-
-
-        # ``Com::Vmware::Appliance::Monitoring::IntervalType``   enumerated type  Defines interval between the values in hours and mins, for which aggregation will apply
-        # @!attribute [rw] minute_s30
-        #     @return [Com::Vmware::Appliance::Monitoring::IntervalType]
-        #     Thirty minutes interval between values. One week is 336 values.
-        # @!attribute [rw] hour_s2
-        #     @return [Com::Vmware::Appliance::Monitoring::IntervalType]
-        #     Two hours interval between values. One month has 360 values.
-        # @!attribute [rw] minute_s5
-        #     @return [Com::Vmware::Appliance::Monitoring::IntervalType]
-        #     Five minutes interval between values (finest). One day would have 288 values, one week is 2016.
-        # @!attribute [rw] da_y1
-        #     @return [Com::Vmware::Appliance::Monitoring::IntervalType]
-        #     24 hours interval between values. One year has 365 values.
-        # @!attribute [rw] hour_s6
-        #     @return [Com::Vmware::Appliance::Monitoring::IntervalType]
-        #     Six hour interval between values. One quarter is 360 values.
-        class IntervalType < VAPI::Bindings::VapiEnum
-
-            class << self
-                # Holds (gets or creates) the binding type metadata for this enumeration type.
-                # @scope class
-                # @return [VAPI::Bindings::EnumType] the binding type
-                def binding_type
-                    @binding_type ||= VAPI::Bindings::EnumType.new(
-                        'com.vmware.appliance.monitoring.interval_type',
-                        IntervalType)
-                end
-
-                # Converts from a string value (perhaps off the wire) to an instance
-                # of this enum type.
-                # @param value [String] the actual value of the enum instance
-                # @return [IntervalType] the instance found for the value, otherwise
-                #         an unknown instance will be built for the value
-                def from_string(value)
-                    begin
-                        const_get(value)
-                    rescue NameError
-                        IntervalType.new('UNKNOWN', value)
-                    end
-                end
-            end
-
-            private
-
-            # Constructs a new instance.
-            # @param value [String] the actual value of the enum instance
-            # @param unknown [String] the unknown value when value is 'UKNOWN'
-            def initialize(value, unknown=nil)
-                super(self.class.binding_type, value, unknown)
-            end
-
-            public
-
-            # @!attribute [rw] minute_s30
-            #     @return [Com::Vmware::Appliance::Monitoring::IntervalType]
-            #     Thirty minutes interval between values. One week is 336 values.
-            MINUTE_S30 = IntervalType.new('MINUTE_S30')
-
-            # @!attribute [rw] hour_s2
-            #     @return [Com::Vmware::Appliance::Monitoring::IntervalType]
-            #     Two hours interval between values. One month has 360 values.
-            HOUR_S2 = IntervalType.new('HOUR_S2')
-
-            # @!attribute [rw] minute_s5
-            #     @return [Com::Vmware::Appliance::Monitoring::IntervalType]
-            #     Five minutes interval between values (finest). One day would have 288 values, one week is 2016.
-            MINUTE_S5 = IntervalType.new('MINUTE_S5')
-
-            # @!attribute [rw] da_y1
-            #     @return [Com::Vmware::Appliance::Monitoring::IntervalType]
-            #     24 hours interval between values. One year has 365 values.
-            DA_Y1 = IntervalType.new('DA_Y1')
-
-            # @!attribute [rw] hour_s6
-            #     @return [Com::Vmware::Appliance::Monitoring::IntervalType]
-            #     Six hour interval between values. One quarter is 360 values.
-            HOUR_S6 = IntervalType.new('HOUR_S6')
-
-        end
-
-
+    # Constructs a new instance.
+    #
+    # @param config [VAPI::Bindings::StubConfig] A hash with the api provider details.
+    def initialize(config)
+      super(config, SERVICE_INFO)
     end
 
+    # Get monitoring data.
+    #
+    # @param item [Com::Vmware::Appliance::Monitoring::MonitoredItemDataRequest]
+    #     MonitoredItemDataRequest Structure
+    # @return [Array<Com::Vmware::Appliance::Monitoring::MonitoredItemData>]
+    #     list of MonitoredItemData structure
+    # @raise [Com::Vmware::Vapi::Std::Errors::Error]
+    #     Generic error
+    def query(item)
+      invoke_with_info(QUERY_INFO,
+                       'item' => item)
+    end
 
+    # Get monitored items list
+    #
+    # @return [Array<Com::Vmware::Appliance::Monitoring::MonitoredItem>]
+    #     list of names
+    # @raise [Com::Vmware::Vapi::Std::Errors::Error]
+    #     Generic error
+    def list
+      invoke_with_info(LIST_INFO)
+    end
+
+    # Get monitored item info
+    #
+    # @param stat_id [String]
+    #     statistic item id
+    # @return [Com::Vmware::Appliance::Monitoring::MonitoredItem]
+    #     MonitoredItem structure
+    # @raise [Com::Vmware::Vapi::Std::Errors::Error]
+    #     Generic error
+    def get(stat_id)
+      invoke_with_info(GET_INFO,
+                       'stat_id' => stat_id)
+    end
+
+    # ``Com::Vmware::Appliance::Monitoring::MonitoredItemData``   class  Structure representing monitored item data.
+    # @!attribute [rw] name
+    #     @return [String]
+    #     Monitored item IDs Ex: CPU, MEMORY, STORAGE_TOTAL
+    # @!attribute [rw] interval
+    #     @return [Com::Vmware::Appliance::Monitoring::IntervalType]
+    #     interval between values in hours, minutes
+    # @!attribute [rw] function
+    #     @return [Com::Vmware::Appliance::Monitoring::FunctionType]
+    #     aggregation function
+    # @!attribute [rw] start_time
+    #     @return [DateTime]
+    #     Starting time
+    # @!attribute [rw] end_time
+    #     @return [DateTime]
+    #     Ending time
+    # @!attribute [rw] data
+    #     @return [Array<String>]
+    #     list of values
+    class MonitoredItemData < VAPI::Bindings::VapiStruct
+      class << self
+        # Holds (gets or creates) the binding type metadata for this structure type.
+        # @scope class
+        # @return [VAPI::Bindings::StructType] the binding type
+        def binding_type
+          @binding_type ||= VAPI::Bindings::StructType.new(
+            'com.vmware.appliance.monitoring.monitored_item_data',
+            {
+              'name' => VAPI::Bindings::IdType.new('com.vmware.appliance.monitoring'),
+              'interval' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Appliance::Monitoring::IntervalType'),
+              'function' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Appliance::Monitoring::FunctionType'),
+              'start_time' => VAPI::Bindings::DateTimeType.instance,
+              'end_time' => VAPI::Bindings::DateTimeType.instance,
+              'data' => VAPI::Bindings::ListType.new(VAPI::Bindings::StringType.instance)
+            },
+            MonitoredItemData,
+            false,
+            nil
+          )
+        end
+      end
+
+      attr_accessor :name,
+                    :interval,
+                    :function,
+                    :start_time,
+                    :end_time,
+                    :data
+
+      # Constructs a new instance.
+      # @param ruby_values [Hash] a map of initial property values (optional)
+      # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
+      def initialize(ruby_values = nil, struct_value = nil)
+        super(self.class.binding_type, ruby_values, struct_value)
+      end
+    end
+
+    # ``Com::Vmware::Appliance::Monitoring::MonitoredItemDataRequest``   class  Structure representing requested monitored item data.
+    # @!attribute [rw] names
+    #     @return [Array<String>]
+    #     monitored item IDs Ex: CPU, MEMORY
+    # @!attribute [rw] interval
+    #     @return [Com::Vmware::Appliance::Monitoring::IntervalType]
+    #     interval between values in hours, minutes
+    # @!attribute [rw] function
+    #     @return [Com::Vmware::Appliance::Monitoring::FunctionType]
+    #     aggregation function
+    # @!attribute [rw] start_time
+    #     @return [DateTime]
+    #     Starting time
+    # @!attribute [rw] end_time
+    #     @return [DateTime]
+    #     Ending time
+    class MonitoredItemDataRequest < VAPI::Bindings::VapiStruct
+      class << self
+        # Holds (gets or creates) the binding type metadata for this structure type.
+        # @scope class
+        # @return [VAPI::Bindings::StructType] the binding type
+        def binding_type
+          @binding_type ||= VAPI::Bindings::StructType.new(
+            'com.vmware.appliance.monitoring.monitored_item_data_request',
+            {
+              'names' => VAPI::Bindings::ListType.new(VAPI::Bindings::IdType.new),
+              'interval' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Appliance::Monitoring::IntervalType'),
+              'function' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Appliance::Monitoring::FunctionType'),
+              'start_time' => VAPI::Bindings::DateTimeType.instance,
+              'end_time' => VAPI::Bindings::DateTimeType.instance
+            },
+            MonitoredItemDataRequest,
+            false,
+            nil
+          )
+        end
+      end
+
+      attr_accessor :names,
+                    :interval,
+                    :function,
+                    :start_time,
+                    :end_time
+
+      # Constructs a new instance.
+      # @param ruby_values [Hash] a map of initial property values (optional)
+      # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
+      def initialize(ruby_values = nil, struct_value = nil)
+        super(self.class.binding_type, ruby_values, struct_value)
+      end
+    end
+
+    # ``Com::Vmware::Appliance::Monitoring::MonitoredItem``   class  Structure representing requested monitored item data.
+    # @!attribute [rw] id
+    #     @return [String]
+    #     monitored item ID Ex: CPU, MEMORY
+    # @!attribute [rw] name
+    #     @return [String]
+    #     monitored item name Ex: "Network write speed"
+    # @!attribute [rw] units
+    #     @return [String]
+    #     Y-axis label EX: "Mbps", "%"
+    # @!attribute [rw] category
+    #     @return [String]
+    #     category Ex: network, storage etc
+    # @!attribute [rw] instance
+    #     @return [String]
+    #     instance name Ex: eth0
+    # @!attribute [rw] description
+    #     @return [String]
+    #     monitored item description Ex: com.vmware.applmgmt.mon.descr.net.rx.packetRate.eth0
+    class MonitoredItem < VAPI::Bindings::VapiStruct
+      class << self
+        # Holds (gets or creates) the binding type metadata for this structure type.
+        # @scope class
+        # @return [VAPI::Bindings::StructType] the binding type
+        def binding_type
+          @binding_type ||= VAPI::Bindings::StructType.new(
+            'com.vmware.appliance.monitoring.monitored_item',
+            {
+              'id' => VAPI::Bindings::IdType.new('com.vmware.appliance.monitoring'),
+              'name' => VAPI::Bindings::StringType.instance,
+              'units' => VAPI::Bindings::StringType.instance,
+              'category' => VAPI::Bindings::StringType.instance,
+              'instance' => VAPI::Bindings::StringType.instance,
+              'description' => VAPI::Bindings::StringType.instance
+            },
+            MonitoredItem,
+            false,
+            nil
+          )
+        end
+      end
+
+      attr_accessor :id,
+                    :name,
+                    :units,
+                    :category,
+                    :instance,
+                    :description
+
+      # Constructs a new instance.
+      # @param ruby_values [Hash] a map of initial property values (optional)
+      # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
+      def initialize(ruby_values = nil, struct_value = nil)
+        super(self.class.binding_type, ruby_values, struct_value)
+      end
+    end
+
+    # ``Com::Vmware::Appliance::Monitoring::FunctionType``   enumerated type  Defines aggregation function
+    # @!attribute [rw] count
+    #     @return [Com::Vmware::Appliance::Monitoring::FunctionType]
+    #     Aggregation takes count per period (sum)
+    # @!attribute [rw] max
+    #     @return [Com::Vmware::Appliance::Monitoring::FunctionType]
+    #     Aggregation takes maximums per period
+    # @!attribute [rw] avg
+    #     @return [Com::Vmware::Appliance::Monitoring::FunctionType]
+    #     Aggregation takes average per period
+    # @!attribute [rw] min
+    #     @return [Com::Vmware::Appliance::Monitoring::FunctionType]
+    #     Aggregation takes minimums per period
+    class FunctionType < VAPI::Bindings::VapiEnum
+      class << self
+        # Holds (gets or creates) the binding type metadata for this enumeration type.
+        # @scope class
+        # @return [VAPI::Bindings::EnumType] the binding type
+        def binding_type
+          @binding_type ||= VAPI::Bindings::EnumType.new(
+            'com.vmware.appliance.monitoring.function_type',
+            FunctionType
+          )
+        end
+
+        # Converts from a string value (perhaps off the wire) to an instance
+        # of this enum type.
+        # @param value [String] the actual value of the enum instance
+        # @return [FunctionType] the instance found for the value, otherwise
+        #         an unknown instance will be built for the value
+        def from_string(value)
+          const_get(value)
+        rescue NameError
+          FunctionType.send(:new, 'UNKNOWN', value)
+        end
+      end
+
+      # Constructs a new instance.
+      # @param value [String] the actual value of the enum instance
+      # @param unknown [String] the unknown value when value is 'UKNOWN'
+      def initialize(value, unknown = nil)
+        super(self.class.binding_type, value, unknown)
+      end
+
+      private_class_method :new
+
+      # @!attribute [rw] count
+      #     @return [Com::Vmware::Appliance::Monitoring::FunctionType]
+      #     Aggregation takes count per period (sum)
+      COUNT = FunctionType.send(:new, 'COUNT')
+
+      # @!attribute [rw] max
+      #     @return [Com::Vmware::Appliance::Monitoring::FunctionType]
+      #     Aggregation takes maximums per period
+      MAX = FunctionType.send(:new, 'MAX')
+
+      # @!attribute [rw] avg
+      #     @return [Com::Vmware::Appliance::Monitoring::FunctionType]
+      #     Aggregation takes average per period
+      AVG = FunctionType.send(:new, 'AVG')
+
+      # @!attribute [rw] min
+      #     @return [Com::Vmware::Appliance::Monitoring::FunctionType]
+      #     Aggregation takes minimums per period
+      MIN = FunctionType.send(:new, 'MIN')
+    end
+    # ``Com::Vmware::Appliance::Monitoring::IntervalType``   enumerated type  Defines interval between the values in hours and mins, for which aggregation will apply
+    # @!attribute [rw] minute_s30
+    #     @return [Com::Vmware::Appliance::Monitoring::IntervalType]
+    #     Thirty minutes interval between values. One week is 336 values.
+    # @!attribute [rw] hour_s2
+    #     @return [Com::Vmware::Appliance::Monitoring::IntervalType]
+    #     Two hours interval between values. One month has 360 values.
+    # @!attribute [rw] minute_s5
+    #     @return [Com::Vmware::Appliance::Monitoring::IntervalType]
+    #     Five minutes interval between values (finest). One day would have 288 values, one week is 2016.
+    # @!attribute [rw] da_y1
+    #     @return [Com::Vmware::Appliance::Monitoring::IntervalType]
+    #     24 hours interval between values. One year has 365 values.
+    # @!attribute [rw] hour_s6
+    #     @return [Com::Vmware::Appliance::Monitoring::IntervalType]
+    #     Six hour interval between values. One quarter is 360 values.
+    class IntervalType < VAPI::Bindings::VapiEnum
+      class << self
+        # Holds (gets or creates) the binding type metadata for this enumeration type.
+        # @scope class
+        # @return [VAPI::Bindings::EnumType] the binding type
+        def binding_type
+          @binding_type ||= VAPI::Bindings::EnumType.new(
+            'com.vmware.appliance.monitoring.interval_type',
+            IntervalType
+          )
+        end
+
+        # Converts from a string value (perhaps off the wire) to an instance
+        # of this enum type.
+        # @param value [String] the actual value of the enum instance
+        # @return [IntervalType] the instance found for the value, otherwise
+        #         an unknown instance will be built for the value
+        def from_string(value)
+          const_get(value)
+        rescue NameError
+          IntervalType.send(:new, 'UNKNOWN', value)
+        end
+      end
+
+      # Constructs a new instance.
+      # @param value [String] the actual value of the enum instance
+      # @param unknown [String] the unknown value when value is 'UKNOWN'
+      def initialize(value, unknown = nil)
+        super(self.class.binding_type, value, unknown)
+      end
+
+      private_class_method :new
+
+      # @!attribute [rw] minute_s30
+      #     @return [Com::Vmware::Appliance::Monitoring::IntervalType]
+      #     Thirty minutes interval between values. One week is 336 values.
+      MINUTE_S30 = IntervalType.send(:new, 'MINUTE_S30')
+
+      # @!attribute [rw] hour_s2
+      #     @return [Com::Vmware::Appliance::Monitoring::IntervalType]
+      #     Two hours interval between values. One month has 360 values.
+      HOUR_S2 = IntervalType.send(:new, 'HOUR_S2')
+
+      # @!attribute [rw] minute_s5
+      #     @return [Com::Vmware::Appliance::Monitoring::IntervalType]
+      #     Five minutes interval between values (finest). One day would have 288 values, one week is 2016.
+      MINUTE_S5 = IntervalType.send(:new, 'MINUTE_S5')
+
+      # @!attribute [rw] da_y1
+      #     @return [Com::Vmware::Appliance::Monitoring::IntervalType]
+      #     24 hours interval between values. One year has 365 values.
+      DA_Y1 = IntervalType.send(:new, 'DA_Y1')
+
+      # @!attribute [rw] hour_s6
+      #     @return [Com::Vmware::Appliance::Monitoring::IntervalType]
+      #     Six hour interval between values. One quarter is 360 values.
+      HOUR_S6 = IntervalType.send(:new, 'HOUR_S6')
+    end
+  end
 end

--- a/client/sdk/com/vmware/appliance/access.rb
+++ b/client/sdk/com/vmware/appliance/access.rb
@@ -1,5 +1,6 @@
 #---------------------------------------------------------------------------
-# Copyright 2016 VMware, Inc.  All rights reserved.
+# Copyright 2017 VMware, Inc.  All rights reserved.
+#
 # AUTO GENERATED FILE -- DO NOT MODIFY!
 #
 # vAPI type descriptors for package com.vmware.appliance.access.
@@ -8,349 +9,310 @@ require 'vapi'
 
 # declare the module hierarchy before we use the shorthand syntax below
 module Com
-    module Vmware
-        module Appliance
-            module Access
-            end
-        end
+  module Vmware
+    module Appliance
+      module Access
+      end
     end
+  end
 end
 
 module Com::Vmware::Appliance::Access
+  # ``Com::Vmware::Appliance::Access::Consolecli``   class  provides  methods  Get/Set enabled state of CLI.
+  class Consolecli < VAPI::Bindings::VapiService
+    # static metamodel definitions
+    SERVICE_ID = VAPI::Core::ServiceIdentifier.new('com.vmware.appliance.access.consolecli')
 
-    # ``Com::Vmware::Appliance::Access::Consolecli``   class  provides  methods  Get/Set enabled state of CLI.
-    class Consolecli < VAPI::Bindings::VapiService
+    SET_INFO = VAPI::Bindings::OperationInfo.new(
+      VAPI::Core::OperationIdentifier.new('set', SERVICE_ID),
+      VAPI::Bindings::OperationInputType.new(
+        'enabled' => VAPI::Bindings::BooleanType.instance
+      ),
+      VAPI::Bindings::VoidType.instance,
+      {
+        'com.vmware.vapi.std.errors.error' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Error')
+      },
+      [],
+      []
+    )
 
-        protected
+    GET_INFO = VAPI::Bindings::OperationInfo.new(
+      VAPI::Core::OperationIdentifier.new('get', SERVICE_ID),
+      VAPI::Bindings::OperationInputType.new,
+      VAPI::Bindings::BooleanType.instance,
+      {
+        'com.vmware.vapi.std.errors.error' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Error')
+      },
+      [],
+      []
+    )
 
-        # static metamodel definitions
-        @@service_id = VAPI::Core::ServiceIdentifier.new('com.vmware.appliance.access.consolecli')
+    SERVICE_INFO = VAPI::Bindings::ServiceInfo.new(
+      SERVICE_ID,
+      'set' => SET_INFO,
+      'get' => GET_INFO
+    )
 
-        @@set_info = VAPI::Bindings::OperationInfo.new(
-            VAPI::Core::OperationIdentifier.new('set', @@service_id),
-            VAPI::Bindings::OperationInputType.new({
-                'enabled' => VAPI::Bindings::BooleanType.instance,
-            }),
-            VAPI::Bindings::VoidType.instance,
-            {
-                'com.vmware.vapi.std.errors.error' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Error'),
-
-            },
-            [],
-            [])
-        @@get_info = VAPI::Bindings::OperationInfo.new(
-            VAPI::Core::OperationIdentifier.new('get', @@service_id),
-            VAPI::Bindings::OperationInputType.new,
-            VAPI::Bindings::BooleanType.instance,
-            {
-                'com.vmware.vapi.std.errors.error' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Error'),
-
-            },
-            [],
-            [])
-
-        @@service_info = VAPI::Bindings::ServiceInfo.new(@@service_id, {
-            'set' => @@set_info,
-            'get' => @@get_info,
-        })
-
-        public
-
-        # Constructs a new instance.
-        #
-        # @param config [VAPI::Bindings::StubConfig] A hash with the api provider details.
-        def initialize(config)
-            super(config, @@service_info)
-        end
-
-
-        # Set enabled state of the console-based controlled CLI (TTY1).
-        #
-        # @param enabled [Boolean]
-        #     Console-based controlled CLI is enabled.
-        # @return [Void]
-        # @raise [Com::Vmware::Vapi::Std::Errors::Error]
-        #     Generic error
-        def set(enabled)
-            invoke_with_info(@@set_info, {
-                'enabled' => enabled,
-            })
-        end
-
-
-        # Get enabled state of the console-based controlled CLI (TTY1).
-        #
-        # @return [Boolean]
-        #     Console-based controlled CLI is enabled.
-        # @raise [Com::Vmware::Vapi::Std::Errors::Error]
-        #     Generic error
-        def get()
-            invoke_with_info(@@get_info)
-        end
-
-
+    # Constructs a new instance.
+    #
+    # @param config [VAPI::Bindings::StubConfig] A hash with the api provider details.
+    def initialize(config)
+      super(config, SERVICE_INFO)
     end
 
-
-    # ``Com::Vmware::Appliance::Access::Dcui``   class  provides  methods  Get/Set enabled state of DCUI.
-    class Dcui < VAPI::Bindings::VapiService
-
-        protected
-
-        # static metamodel definitions
-        @@service_id = VAPI::Core::ServiceIdentifier.new('com.vmware.appliance.access.dcui')
-
-        @@set_info = VAPI::Bindings::OperationInfo.new(
-            VAPI::Core::OperationIdentifier.new('set', @@service_id),
-            VAPI::Bindings::OperationInputType.new({
-                'enabled' => VAPI::Bindings::BooleanType.instance,
-            }),
-            VAPI::Bindings::VoidType.instance,
-            {
-                'com.vmware.vapi.std.errors.error' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Error'),
-
-            },
-            [],
-            [])
-        @@get_info = VAPI::Bindings::OperationInfo.new(
-            VAPI::Core::OperationIdentifier.new('get', @@service_id),
-            VAPI::Bindings::OperationInputType.new,
-            VAPI::Bindings::BooleanType.instance,
-            {
-                'com.vmware.vapi.std.errors.error' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Error'),
-
-            },
-            [],
-            [])
-
-        @@service_info = VAPI::Bindings::ServiceInfo.new(@@service_id, {
-            'set' => @@set_info,
-            'get' => @@get_info,
-        })
-
-        public
-
-        # Constructs a new instance.
-        #
-        # @param config [VAPI::Bindings::StubConfig] A hash with the api provider details.
-        def initialize(config)
-            super(config, @@service_info)
-        end
-
-
-        # Set enabled state of Direct Console User Interface (DCUI TTY2).
-        #
-        # @param enabled [Boolean]
-        #     DCUI is enabled.
-        # @return [Void]
-        # @raise [Com::Vmware::Vapi::Std::Errors::Error]
-        #     Generic error
-        def set(enabled)
-            invoke_with_info(@@set_info, {
-                'enabled' => enabled,
-            })
-        end
-
-
-        # Get enabled state of Direct Console User Interface (DCUI TTY2).
-        #
-        # @return [Boolean]
-        #     DCUI is enabled.
-        # @raise [Com::Vmware::Vapi::Std::Errors::Error]
-        #     Generic error
-        def get()
-            invoke_with_info(@@get_info)
-        end
-
-
+    # Set enabled state of the console-based controlled CLI (TTY1).
+    #
+    # @param enabled [Boolean]
+    #     Console-based controlled CLI is enabled.
+    # @return [Void]
+    # @raise [Com::Vmware::Vapi::Std::Errors::Error]
+    #     Generic error
+    def set(enabled)
+      invoke_with_info(SET_INFO,
+                       'enabled' => enabled)
     end
 
-
-    # ``Com::Vmware::Appliance::Access::Shell``   class  provides  methods  Get/Set enabled state of BASH.
-    class Shell < VAPI::Bindings::VapiService
-
-        protected
-
-        # static metamodel definitions
-        @@service_id = VAPI::Core::ServiceIdentifier.new('com.vmware.appliance.access.shell')
-
-        @@set_info = VAPI::Bindings::OperationInfo.new(
-            VAPI::Core::OperationIdentifier.new('set', @@service_id),
-            VAPI::Bindings::OperationInputType.new({
-                'config' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Appliance::Access::Shell::ShellConfig'),
-            }),
-            VAPI::Bindings::VoidType.instance,
-            {
-                'com.vmware.vapi.std.errors.error' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Error'),
-
-            },
-            [],
-            [])
-        @@get_info = VAPI::Bindings::OperationInfo.new(
-            VAPI::Core::OperationIdentifier.new('get', @@service_id),
-            VAPI::Bindings::OperationInputType.new,
-            VAPI::Bindings::ReferenceType.new('Com::Vmware::Appliance::Access::Shell::ShellConfig'),
-            {
-                'com.vmware.vapi.std.errors.error' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Error'),
-
-            },
-            [],
-            [])
-
-        @@service_info = VAPI::Bindings::ServiceInfo.new(@@service_id, {
-            'set' => @@set_info,
-            'get' => @@get_info,
-        })
-
-        public
-
-        # Constructs a new instance.
-        #
-        # @param config [VAPI::Bindings::StubConfig] A hash with the api provider details.
-        def initialize(config)
-            super(config, @@service_info)
-        end
-
-
-        # Set enabled state of BASH, that is, access to BASH from within the controlled CLI.
-        #
-        # @param config [Com::Vmware::Appliance::Access::Shell::ShellConfig]
-        #     Shell configuration
-        # @return [Void]
-        # @raise [Com::Vmware::Vapi::Std::Errors::Error]
-        #     Generic error
-        def set(config)
-            invoke_with_info(@@set_info, {
-                'config' => config,
-            })
-        end
-
-
-        # Get enabled state of BASH, that is, access to BASH from within the controlled CLI.
-        #
-        # @return [Com::Vmware::Appliance::Access::Shell::ShellConfig]
-        #     Current shell configuration.
-        # @raise [Com::Vmware::Vapi::Std::Errors::Error]
-        #     Generic error
-        def get()
-            invoke_with_info(@@get_info)
-        end
-
-
-
-        # ``Com::Vmware::Appliance::Access::Shell::ShellConfig``   class  Structure that defines shell configuration.
-        # @!attribute [rw] enabled
-        #     @return [Boolean]
-        #     Enabled can be set to true or false
-        # @!attribute [rw] timeout
-        #     @return [Fixnum]
-        #     The timeout (in seconds) specifies how long you enable the Shell access. The maximum timeout is 86400 seconds(1 day).
-        class ShellConfig < VAPI::Bindings::VapiStruct
-
-            class << self
-                # Holds (gets or creates) the binding type metadata for this structure type.
-                # @scope class
-                # @return [VAPI::Bindings::StructType] the binding type
-                def binding_type
-                    @binding_type ||= VAPI::Bindings::StructType.new(
-                        'com.vmware.appliance.access.shell.shell_config',
-                        {
-                            'enabled' => VAPI::Bindings::BooleanType.instance,
-                            'timeout' => VAPI::Bindings::IntegerType.instance,
-                        },
-                        ShellConfig,
-                        false,
-                        nil)
-                end
-            end
-
-            attr_accessor :enabled,
-                          :timeout
-
-            # Constructs a new instance.
-            # @param ruby_values [Hash] a map of initial property values (optional)
-            # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
-            def initialize(ruby_values=nil, struct_value=nil)
-                super(self.class.binding_type, ruby_values, struct_value)
-            end
-        end
-
-
+    # Get enabled state of the console-based controlled CLI (TTY1).
+    #
+    # @return [Boolean]
+    #     Console-based controlled CLI is enabled.
+    # @raise [Com::Vmware::Vapi::Std::Errors::Error]
+    #     Generic error
+    def get
+      invoke_with_info(GET_INFO)
     end
 
+  end
+  # ``Com::Vmware::Appliance::Access::Dcui``   class  provides  methods  Get/Set enabled state of DCUI.
+  class Dcui < VAPI::Bindings::VapiService
+    # static metamodel definitions
+    SERVICE_ID = VAPI::Core::ServiceIdentifier.new('com.vmware.appliance.access.dcui')
 
-    # ``Com::Vmware::Appliance::Access::Ssh``   class  provides  methods  Get/Set enabled state of SSH-based controlled CLI.
-    class Ssh < VAPI::Bindings::VapiService
+    SET_INFO = VAPI::Bindings::OperationInfo.new(
+      VAPI::Core::OperationIdentifier.new('set', SERVICE_ID),
+      VAPI::Bindings::OperationInputType.new(
+        'enabled' => VAPI::Bindings::BooleanType.instance
+      ),
+      VAPI::Bindings::VoidType.instance,
+      {
+        'com.vmware.vapi.std.errors.error' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Error')
+      },
+      [],
+      []
+    )
 
-        protected
+    GET_INFO = VAPI::Bindings::OperationInfo.new(
+      VAPI::Core::OperationIdentifier.new('get', SERVICE_ID),
+      VAPI::Bindings::OperationInputType.new,
+      VAPI::Bindings::BooleanType.instance,
+      {
+        'com.vmware.vapi.std.errors.error' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Error')
+      },
+      [],
+      []
+    )
 
-        # static metamodel definitions
-        @@service_id = VAPI::Core::ServiceIdentifier.new('com.vmware.appliance.access.ssh')
+    SERVICE_INFO = VAPI::Bindings::ServiceInfo.new(
+      SERVICE_ID,
+      'set' => SET_INFO,
+      'get' => GET_INFO
+    )
 
-        @@set_info = VAPI::Bindings::OperationInfo.new(
-            VAPI::Core::OperationIdentifier.new('set', @@service_id),
-            VAPI::Bindings::OperationInputType.new({
-                'enabled' => VAPI::Bindings::BooleanType.instance,
-            }),
-            VAPI::Bindings::VoidType.instance,
-            {
-                'com.vmware.vapi.std.errors.error' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Error'),
-
-            },
-            [],
-            [])
-        @@get_info = VAPI::Bindings::OperationInfo.new(
-            VAPI::Core::OperationIdentifier.new('get', @@service_id),
-            VAPI::Bindings::OperationInputType.new,
-            VAPI::Bindings::BooleanType.instance,
-            {
-                'com.vmware.vapi.std.errors.error' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Error'),
-
-            },
-            [],
-            [])
-
-        @@service_info = VAPI::Bindings::ServiceInfo.new(@@service_id, {
-            'set' => @@set_info,
-            'get' => @@get_info,
-        })
-
-        public
-
-        # Constructs a new instance.
-        #
-        # @param config [VAPI::Bindings::StubConfig] A hash with the api provider details.
-        def initialize(config)
-            super(config, @@service_info)
-        end
-
-
-        # Set enabled state of the SSH-based controlled CLI.
-        #
-        # @param enabled [Boolean]
-        #     SSH-based controlled CLI is enabled.
-        # @return [Void]
-        # @raise [Com::Vmware::Vapi::Std::Errors::Error]
-        #     Generic error
-        def set(enabled)
-            invoke_with_info(@@set_info, {
-                'enabled' => enabled,
-            })
-        end
-
-
-        # Get enabled state of the SSH-based controlled CLI.
-        #
-        # @return [Boolean]
-        #     SSH-based controlled CLI is enabled.
-        # @raise [Com::Vmware::Vapi::Std::Errors::Error]
-        #     Generic error
-        def get()
-            invoke_with_info(@@get_info)
-        end
-
-
+    # Constructs a new instance.
+    #
+    # @param config [VAPI::Bindings::StubConfig] A hash with the api provider details.
+    def initialize(config)
+      super(config, SERVICE_INFO)
     end
 
+    # Set enabled state of Direct Console User Interface (DCUI TTY2).
+    #
+    # @param enabled [Boolean]
+    #     DCUI is enabled.
+    # @return [Void]
+    # @raise [Com::Vmware::Vapi::Std::Errors::Error]
+    #     Generic error
+    def set(enabled)
+      invoke_with_info(SET_INFO,
+                       'enabled' => enabled)
+    end
 
+    # Get enabled state of Direct Console User Interface (DCUI TTY2).
+    #
+    # @return [Boolean]
+    #     DCUI is enabled.
+    # @raise [Com::Vmware::Vapi::Std::Errors::Error]
+    #     Generic error
+    def get
+      invoke_with_info(GET_INFO)
+    end
+
+  end
+  # ``Com::Vmware::Appliance::Access::Shell``   class  provides  methods  Get/Set enabled state of BASH.
+  class Shell < VAPI::Bindings::VapiService
+    # static metamodel definitions
+    SERVICE_ID = VAPI::Core::ServiceIdentifier.new('com.vmware.appliance.access.shell')
+
+    SET_INFO = VAPI::Bindings::OperationInfo.new(
+      VAPI::Core::OperationIdentifier.new('set', SERVICE_ID),
+      VAPI::Bindings::OperationInputType.new(
+        'config' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Appliance::Access::Shell::ShellConfig')
+      ),
+      VAPI::Bindings::VoidType.instance,
+      {
+        'com.vmware.vapi.std.errors.error' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Error')
+      },
+      [],
+      []
+    )
+
+    GET_INFO = VAPI::Bindings::OperationInfo.new(
+      VAPI::Core::OperationIdentifier.new('get', SERVICE_ID),
+      VAPI::Bindings::OperationInputType.new,
+      VAPI::Bindings::ReferenceType.new('Com::Vmware::Appliance::Access::Shell::ShellConfig'),
+      {
+        'com.vmware.vapi.std.errors.error' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Error')
+      },
+      [],
+      []
+    )
+
+    SERVICE_INFO = VAPI::Bindings::ServiceInfo.new(
+      SERVICE_ID,
+      'set' => SET_INFO,
+      'get' => GET_INFO
+    )
+
+    # Constructs a new instance.
+    #
+    # @param config [VAPI::Bindings::StubConfig] A hash with the api provider details.
+    def initialize(config)
+      super(config, SERVICE_INFO)
+    end
+
+    # Set enabled state of BASH, that is, access to BASH from within the controlled CLI.
+    #
+    # @param config [Com::Vmware::Appliance::Access::Shell::ShellConfig]
+    #     Shell configuration
+    # @return [Void]
+    # @raise [Com::Vmware::Vapi::Std::Errors::Error]
+    #     Generic error
+    def set(config)
+      invoke_with_info(SET_INFO,
+                       'config' => config)
+    end
+
+    # Get enabled state of BASH, that is, access to BASH from within the controlled CLI.
+    #
+    # @return [Com::Vmware::Appliance::Access::Shell::ShellConfig]
+    #     Current shell configuration.
+    # @raise [Com::Vmware::Vapi::Std::Errors::Error]
+    #     Generic error
+    def get
+      invoke_with_info(GET_INFO)
+    end
+
+    # ``Com::Vmware::Appliance::Access::Shell::ShellConfig``   class  Structure that defines shell configuration.
+    # @!attribute [rw] enabled
+    #     @return [Boolean]
+    #     Enabled can be set to true or false
+    # @!attribute [rw] timeout
+    #     @return [Fixnum]
+    #     The timeout (in seconds) specifies how long you enable the Shell access. The maximum timeout is 86400 seconds(1 day).
+    class ShellConfig < VAPI::Bindings::VapiStruct
+      class << self
+        # Holds (gets or creates) the binding type metadata for this structure type.
+        # @scope class
+        # @return [VAPI::Bindings::StructType] the binding type
+        def binding_type
+          @binding_type ||= VAPI::Bindings::StructType.new(
+            'com.vmware.appliance.access.shell.shell_config',
+            {
+              'enabled' => VAPI::Bindings::BooleanType.instance,
+              'timeout' => VAPI::Bindings::IntegerType.instance
+            },
+            ShellConfig,
+            false,
+            nil
+          )
+        end
+      end
+
+      attr_accessor :enabled,
+                    :timeout
+
+      # Constructs a new instance.
+      # @param ruby_values [Hash] a map of initial property values (optional)
+      # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
+      def initialize(ruby_values = nil, struct_value = nil)
+        super(self.class.binding_type, ruby_values, struct_value)
+      end
+    end
+
+  end
+  # ``Com::Vmware::Appliance::Access::Ssh``   class  provides  methods  Get/Set enabled state of SSH-based controlled CLI.
+  class Ssh < VAPI::Bindings::VapiService
+    # static metamodel definitions
+    SERVICE_ID = VAPI::Core::ServiceIdentifier.new('com.vmware.appliance.access.ssh')
+
+    SET_INFO = VAPI::Bindings::OperationInfo.new(
+      VAPI::Core::OperationIdentifier.new('set', SERVICE_ID),
+      VAPI::Bindings::OperationInputType.new(
+        'enabled' => VAPI::Bindings::BooleanType.instance
+      ),
+      VAPI::Bindings::VoidType.instance,
+      {
+        'com.vmware.vapi.std.errors.error' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Error')
+      },
+      [],
+      []
+    )
+
+    GET_INFO = VAPI::Bindings::OperationInfo.new(
+      VAPI::Core::OperationIdentifier.new('get', SERVICE_ID),
+      VAPI::Bindings::OperationInputType.new,
+      VAPI::Bindings::BooleanType.instance,
+      {
+        'com.vmware.vapi.std.errors.error' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Error')
+      },
+      [],
+      []
+    )
+
+    SERVICE_INFO = VAPI::Bindings::ServiceInfo.new(
+      SERVICE_ID,
+      'set' => SET_INFO,
+      'get' => GET_INFO
+    )
+
+    # Constructs a new instance.
+    #
+    # @param config [VAPI::Bindings::StubConfig] A hash with the api provider details.
+    def initialize(config)
+      super(config, SERVICE_INFO)
+    end
+
+    # Set enabled state of the SSH-based controlled CLI.
+    #
+    # @param enabled [Boolean]
+    #     SSH-based controlled CLI is enabled.
+    # @return [Void]
+    # @raise [Com::Vmware::Vapi::Std::Errors::Error]
+    #     Generic error
+    def set(enabled)
+      invoke_with_info(SET_INFO,
+                       'enabled' => enabled)
+    end
+
+    # Get enabled state of the SSH-based controlled CLI.
+    #
+    # @return [Boolean]
+    #     SSH-based controlled CLI is enabled.
+    # @raise [Com::Vmware::Vapi::Std::Errors::Error]
+    #     Generic error
+    def get
+      invoke_with_info(GET_INFO)
+    end
+
+  end
 end

--- a/client/sdk/com/vmware/appliance/health.rb
+++ b/client/sdk/com/vmware/appliance/health.rb
@@ -1,5 +1,6 @@
 #---------------------------------------------------------------------------
-# Copyright 2016 VMware, Inc.  All rights reserved.
+# Copyright 2017 VMware, Inc.  All rights reserved.
+#
 # AUTO GENERATED FILE -- DO NOT MODIFY!
 #
 # vAPI type descriptors for package com.vmware.appliance.health.
@@ -8,986 +9,865 @@ require 'vapi'
 
 # declare the module hierarchy before we use the shorthand syntax below
 module Com
-    module Vmware
-        module Appliance
-            module Health
-            end
-        end
+  module Vmware
+    module Appliance
+      module Health
+      end
     end
+  end
 end
 
 module Com::Vmware::Appliance::Health
+  # ``Com::Vmware::Appliance::Health::Applmgmt``   class  provides  methods  Get health status of applmgmt services.
+  class Applmgmt < VAPI::Bindings::VapiService
+    # static metamodel definitions
+    SERVICE_ID = VAPI::Core::ServiceIdentifier.new('com.vmware.appliance.health.applmgmt')
 
-    # ``Com::Vmware::Appliance::Health::Applmgmt``   class  provides  methods  Get health status of applmgmt services.
-    class Applmgmt < VAPI::Bindings::VapiService
+    GET_INFO = VAPI::Bindings::OperationInfo.new(
+      VAPI::Core::OperationIdentifier.new('get', SERVICE_ID),
+      VAPI::Bindings::OperationInputType.new,
+      VAPI::Bindings::StringType.instance,
+      {
+        'com.vmware.vapi.std.errors.error' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Error')
+      },
+      [],
+      []
+    )
 
-        protected
+    SERVICE_INFO = VAPI::Bindings::ServiceInfo.new(
+      SERVICE_ID,
+      'get' => GET_INFO
+    )
 
-        # static metamodel definitions
-        @@service_id = VAPI::Core::ServiceIdentifier.new('com.vmware.appliance.health.applmgmt')
-
-        @@get_info = VAPI::Bindings::OperationInfo.new(
-            VAPI::Core::OperationIdentifier.new('get', @@service_id),
-            VAPI::Bindings::OperationInputType.new,
-            VAPI::Bindings::StringType.instance,
-            {
-                'com.vmware.vapi.std.errors.error' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Error'),
-
-            },
-            [],
-            [])
-
-        @@service_info = VAPI::Bindings::ServiceInfo.new(@@service_id, {
-            'get' => @@get_info,
-        })
-
-        public
-
-        # Constructs a new instance.
-        #
-        # @param config [VAPI::Bindings::StubConfig] A hash with the api provider details.
-        def initialize(config)
-            super(config, @@service_info)
-        end
-
-
-        # Get health status of applmgmt services.
-        #
-        # @return [String]
-        #     health status.
-        # @raise [Com::Vmware::Vapi::Std::Errors::Error]
-        #     Generic error
-        def get()
-            invoke_with_info(@@get_info)
-        end
-
-
+    # Constructs a new instance.
+    #
+    # @param config [VAPI::Bindings::StubConfig] A hash with the api provider details.
+    def initialize(config)
+      super(config, SERVICE_INFO)
     end
 
-
-    # ``Com::Vmware::Appliance::Health::Databasestorage``   class  provides  methods  Get database storage health.
-    class Databasestorage < VAPI::Bindings::VapiService
-
-        protected
-
-        # static metamodel definitions
-        @@service_id = VAPI::Core::ServiceIdentifier.new('com.vmware.appliance.health.databasestorage')
-
-        @@get_info = VAPI::Bindings::OperationInfo.new(
-            VAPI::Core::OperationIdentifier.new('get', @@service_id),
-            VAPI::Bindings::OperationInputType.new,
-            VAPI::Bindings::ReferenceType.new('Com::Vmware::Appliance::Health::Databasestorage::HealthLevel'),
-            {
-                'com.vmware.vapi.std.errors.error' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Error'),
-
-            },
-            [],
-            [])
-
-        @@service_info = VAPI::Bindings::ServiceInfo.new(@@service_id, {
-            'get' => @@get_info,
-        })
-
-        public
-
-        # Constructs a new instance.
-        #
-        # @param config [VAPI::Bindings::StubConfig] A hash with the api provider details.
-        def initialize(config)
-            super(config, @@service_info)
-        end
-
-
-        # Get database storage health.
-        #
-        # @return [Com::Vmware::Appliance::Health::Databasestorage::HealthLevel]
-        #     Database storage health.
-        # @raise [Com::Vmware::Vapi::Std::Errors::Error]
-        #     Generic error
-        def get()
-            invoke_with_info(@@get_info)
-        end
-
-
-
-        # ``Com::Vmware::Appliance::Health::Databasestorage::HealthLevel``   enumerated type  Defines health levels
-        # @!attribute [rw] orange
-        #     @return [Com::Vmware::Appliance::Health::Databasestorage::HealthLevel]
-        #     The service health is degraded. The service might have serious problems
-        # @!attribute [rw] gray
-        #     @return [Com::Vmware::Appliance::Health::Databasestorage::HealthLevel]
-        #     No health data is available for this service.
-        # @!attribute [rw] green
-        #     @return [Com::Vmware::Appliance::Health::Databasestorage::HealthLevel]
-        #     Service is healthy.
-        # @!attribute [rw] red
-        #     @return [Com::Vmware::Appliance::Health::Databasestorage::HealthLevel]
-        #     The service is unavaiable and is not functioning properly or will stop functioning soon.
-        # @!attribute [rw] yellow
-        #     @return [Com::Vmware::Appliance::Health::Databasestorage::HealthLevel]
-        #     The service is healthy state, but experiencing some levels of problems.
-        class HealthLevel < VAPI::Bindings::VapiEnum
-
-            class << self
-                # Holds (gets or creates) the binding type metadata for this enumeration type.
-                # @scope class
-                # @return [VAPI::Bindings::EnumType] the binding type
-                def binding_type
-                    @binding_type ||= VAPI::Bindings::EnumType.new(
-                        'com.vmware.appliance.health.databasestorage.health_level',
-                        HealthLevel)
-                end
-
-                # Converts from a string value (perhaps off the wire) to an instance
-                # of this enum type.
-                # @param value [String] the actual value of the enum instance
-                # @return [HealthLevel] the instance found for the value, otherwise
-                #         an unknown instance will be built for the value
-                def from_string(value)
-                    begin
-                        const_get(value)
-                    rescue NameError
-                        HealthLevel.new('UNKNOWN', value)
-                    end
-                end
-            end
-
-            private
-
-            # Constructs a new instance.
-            # @param value [String] the actual value of the enum instance
-            # @param unknown [String] the unknown value when value is 'UKNOWN'
-            def initialize(value, unknown=nil)
-                super(self.class.binding_type, value, unknown)
-            end
-
-            public
-
-            # @!attribute [rw] orange
-            #     @return [Com::Vmware::Appliance::Health::Databasestorage::HealthLevel]
-            #     The service health is degraded. The service might have serious problems
-            ORANGE = HealthLevel.new('ORANGE')
-
-            # @!attribute [rw] gray
-            #     @return [Com::Vmware::Appliance::Health::Databasestorage::HealthLevel]
-            #     No health data is available for this service.
-            GRAY = HealthLevel.new('GRAY')
-
-            # @!attribute [rw] green
-            #     @return [Com::Vmware::Appliance::Health::Databasestorage::HealthLevel]
-            #     Service is healthy.
-            GREEN = HealthLevel.new('GREEN')
-
-            # @!attribute [rw] red
-            #     @return [Com::Vmware::Appliance::Health::Databasestorage::HealthLevel]
-            #     The service is unavaiable and is not functioning properly or will stop functioning soon.
-            RED = HealthLevel.new('RED')
-
-            # @!attribute [rw] yellow
-            #     @return [Com::Vmware::Appliance::Health::Databasestorage::HealthLevel]
-            #     The service is healthy state, but experiencing some levels of problems.
-            YELLOW = HealthLevel.new('YELLOW')
-
-        end
-
-
+    # Get health status of applmgmt services.
+    #
+    # @return [String]
+    #     health status.
+    # @raise [Com::Vmware::Vapi::Std::Errors::Error]
+    #     Generic error
+    def get
+      invoke_with_info(GET_INFO)
     end
 
+  end
+  # ``Com::Vmware::Appliance::Health::Databasestorage``   class  provides  methods  Get database storage health.
+  class Databasestorage < VAPI::Bindings::VapiService
+    # static metamodel definitions
+    SERVICE_ID = VAPI::Core::ServiceIdentifier.new('com.vmware.appliance.health.databasestorage')
 
-    # ``Com::Vmware::Appliance::Health::Load``   class  provides  methods  Get load health.
-    class Load < VAPI::Bindings::VapiService
+    GET_INFO = VAPI::Bindings::OperationInfo.new(
+      VAPI::Core::OperationIdentifier.new('get', SERVICE_ID),
+      VAPI::Bindings::OperationInputType.new,
+      VAPI::Bindings::ReferenceType.new('Com::Vmware::Appliance::Health::Databasestorage::HealthLevel'),
+      {
+        'com.vmware.vapi.std.errors.error' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Error')
+      },
+      [],
+      []
+    )
 
-        protected
+    SERVICE_INFO = VAPI::Bindings::ServiceInfo.new(
+      SERVICE_ID,
+      'get' => GET_INFO
+    )
 
-        # static metamodel definitions
-        @@service_id = VAPI::Core::ServiceIdentifier.new('com.vmware.appliance.health.load')
-
-        @@get_info = VAPI::Bindings::OperationInfo.new(
-            VAPI::Core::OperationIdentifier.new('get', @@service_id),
-            VAPI::Bindings::OperationInputType.new,
-            VAPI::Bindings::ReferenceType.new('Com::Vmware::Appliance::Health::Load::HealthLevel'),
-            {
-                'com.vmware.vapi.std.errors.error' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Error'),
-
-            },
-            [],
-            [])
-
-        @@service_info = VAPI::Bindings::ServiceInfo.new(@@service_id, {
-            'get' => @@get_info,
-        })
-
-        public
-
-        # Constructs a new instance.
-        #
-        # @param config [VAPI::Bindings::StubConfig] A hash with the api provider details.
-        def initialize(config)
-            super(config, @@service_info)
-        end
-
-
-        # Get load health.
-        #
-        # @return [Com::Vmware::Appliance::Health::Load::HealthLevel]
-        #     Load health.
-        # @raise [Com::Vmware::Vapi::Std::Errors::Error]
-        #     Generic error
-        def get()
-            invoke_with_info(@@get_info)
-        end
-
-
-
-        # ``Com::Vmware::Appliance::Health::Load::HealthLevel``   enumerated type  Defines health levels
-        # @!attribute [rw] orange
-        #     @return [Com::Vmware::Appliance::Health::Load::HealthLevel]
-        #     The service health is degraded. The service might have serious problems
-        # @!attribute [rw] gray
-        #     @return [Com::Vmware::Appliance::Health::Load::HealthLevel]
-        #     No health data is available for this service.
-        # @!attribute [rw] green
-        #     @return [Com::Vmware::Appliance::Health::Load::HealthLevel]
-        #     Service is healthy.
-        # @!attribute [rw] red
-        #     @return [Com::Vmware::Appliance::Health::Load::HealthLevel]
-        #     The service is unavaiable and is not functioning properly or will stop functioning soon.
-        # @!attribute [rw] yellow
-        #     @return [Com::Vmware::Appliance::Health::Load::HealthLevel]
-        #     The service is healthy state, but experiencing some levels of problems.
-        class HealthLevel < VAPI::Bindings::VapiEnum
-
-            class << self
-                # Holds (gets or creates) the binding type metadata for this enumeration type.
-                # @scope class
-                # @return [VAPI::Bindings::EnumType] the binding type
-                def binding_type
-                    @binding_type ||= VAPI::Bindings::EnumType.new(
-                        'com.vmware.appliance.health.load.health_level',
-                        HealthLevel)
-                end
-
-                # Converts from a string value (perhaps off the wire) to an instance
-                # of this enum type.
-                # @param value [String] the actual value of the enum instance
-                # @return [HealthLevel] the instance found for the value, otherwise
-                #         an unknown instance will be built for the value
-                def from_string(value)
-                    begin
-                        const_get(value)
-                    rescue NameError
-                        HealthLevel.new('UNKNOWN', value)
-                    end
-                end
-            end
-
-            private
-
-            # Constructs a new instance.
-            # @param value [String] the actual value of the enum instance
-            # @param unknown [String] the unknown value when value is 'UKNOWN'
-            def initialize(value, unknown=nil)
-                super(self.class.binding_type, value, unknown)
-            end
-
-            public
-
-            # @!attribute [rw] orange
-            #     @return [Com::Vmware::Appliance::Health::Load::HealthLevel]
-            #     The service health is degraded. The service might have serious problems
-            ORANGE = HealthLevel.new('ORANGE')
-
-            # @!attribute [rw] gray
-            #     @return [Com::Vmware::Appliance::Health::Load::HealthLevel]
-            #     No health data is available for this service.
-            GRAY = HealthLevel.new('GRAY')
-
-            # @!attribute [rw] green
-            #     @return [Com::Vmware::Appliance::Health::Load::HealthLevel]
-            #     Service is healthy.
-            GREEN = HealthLevel.new('GREEN')
-
-            # @!attribute [rw] red
-            #     @return [Com::Vmware::Appliance::Health::Load::HealthLevel]
-            #     The service is unavaiable and is not functioning properly or will stop functioning soon.
-            RED = HealthLevel.new('RED')
-
-            # @!attribute [rw] yellow
-            #     @return [Com::Vmware::Appliance::Health::Load::HealthLevel]
-            #     The service is healthy state, but experiencing some levels of problems.
-            YELLOW = HealthLevel.new('YELLOW')
-
-        end
-
-
+    # Constructs a new instance.
+    #
+    # @param config [VAPI::Bindings::StubConfig] A hash with the api provider details.
+    def initialize(config)
+      super(config, SERVICE_INFO)
     end
 
-
-    # ``Com::Vmware::Appliance::Health::Mem``   class  provides  methods  Get memory health.
-    class Mem < VAPI::Bindings::VapiService
-
-        protected
-
-        # static metamodel definitions
-        @@service_id = VAPI::Core::ServiceIdentifier.new('com.vmware.appliance.health.mem')
-
-        @@get_info = VAPI::Bindings::OperationInfo.new(
-            VAPI::Core::OperationIdentifier.new('get', @@service_id),
-            VAPI::Bindings::OperationInputType.new,
-            VAPI::Bindings::ReferenceType.new('Com::Vmware::Appliance::Health::Mem::HealthLevel'),
-            {
-                'com.vmware.vapi.std.errors.error' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Error'),
-
-            },
-            [],
-            [])
-
-        @@service_info = VAPI::Bindings::ServiceInfo.new(@@service_id, {
-            'get' => @@get_info,
-        })
-
-        public
-
-        # Constructs a new instance.
-        #
-        # @param config [VAPI::Bindings::StubConfig] A hash with the api provider details.
-        def initialize(config)
-            super(config, @@service_info)
-        end
-
-
-        # Get memory health.
-        #
-        # @return [Com::Vmware::Appliance::Health::Mem::HealthLevel]
-        #     Memory health.
-        # @raise [Com::Vmware::Vapi::Std::Errors::Error]
-        #     Generic error
-        def get()
-            invoke_with_info(@@get_info)
-        end
-
-
-
-        # ``Com::Vmware::Appliance::Health::Mem::HealthLevel``   enumerated type  Defines health levels
-        # @!attribute [rw] orange
-        #     @return [Com::Vmware::Appliance::Health::Mem::HealthLevel]
-        #     The service health is degraded. The service might have serious problems
-        # @!attribute [rw] gray
-        #     @return [Com::Vmware::Appliance::Health::Mem::HealthLevel]
-        #     No health data is available for this service.
-        # @!attribute [rw] green
-        #     @return [Com::Vmware::Appliance::Health::Mem::HealthLevel]
-        #     Service is healthy.
-        # @!attribute [rw] red
-        #     @return [Com::Vmware::Appliance::Health::Mem::HealthLevel]
-        #     The service is unavaiable and is not functioning properly or will stop functioning soon.
-        # @!attribute [rw] yellow
-        #     @return [Com::Vmware::Appliance::Health::Mem::HealthLevel]
-        #     The service is healthy state, but experiencing some levels of problems.
-        class HealthLevel < VAPI::Bindings::VapiEnum
-
-            class << self
-                # Holds (gets or creates) the binding type metadata for this enumeration type.
-                # @scope class
-                # @return [VAPI::Bindings::EnumType] the binding type
-                def binding_type
-                    @binding_type ||= VAPI::Bindings::EnumType.new(
-                        'com.vmware.appliance.health.mem.health_level',
-                        HealthLevel)
-                end
-
-                # Converts from a string value (perhaps off the wire) to an instance
-                # of this enum type.
-                # @param value [String] the actual value of the enum instance
-                # @return [HealthLevel] the instance found for the value, otherwise
-                #         an unknown instance will be built for the value
-                def from_string(value)
-                    begin
-                        const_get(value)
-                    rescue NameError
-                        HealthLevel.new('UNKNOWN', value)
-                    end
-                end
-            end
-
-            private
-
-            # Constructs a new instance.
-            # @param value [String] the actual value of the enum instance
-            # @param unknown [String] the unknown value when value is 'UKNOWN'
-            def initialize(value, unknown=nil)
-                super(self.class.binding_type, value, unknown)
-            end
-
-            public
-
-            # @!attribute [rw] orange
-            #     @return [Com::Vmware::Appliance::Health::Mem::HealthLevel]
-            #     The service health is degraded. The service might have serious problems
-            ORANGE = HealthLevel.new('ORANGE')
-
-            # @!attribute [rw] gray
-            #     @return [Com::Vmware::Appliance::Health::Mem::HealthLevel]
-            #     No health data is available for this service.
-            GRAY = HealthLevel.new('GRAY')
-
-            # @!attribute [rw] green
-            #     @return [Com::Vmware::Appliance::Health::Mem::HealthLevel]
-            #     Service is healthy.
-            GREEN = HealthLevel.new('GREEN')
-
-            # @!attribute [rw] red
-            #     @return [Com::Vmware::Appliance::Health::Mem::HealthLevel]
-            #     The service is unavaiable and is not functioning properly or will stop functioning soon.
-            RED = HealthLevel.new('RED')
-
-            # @!attribute [rw] yellow
-            #     @return [Com::Vmware::Appliance::Health::Mem::HealthLevel]
-            #     The service is healthy state, but experiencing some levels of problems.
-            YELLOW = HealthLevel.new('YELLOW')
-
-        end
-
-
+    # Get database storage health.
+    #
+    # @return [Com::Vmware::Appliance::Health::Databasestorage::HealthLevel]
+    #     Database storage health.
+    # @raise [Com::Vmware::Vapi::Std::Errors::Error]
+    #     Generic error
+    def get
+      invoke_with_info(GET_INFO)
     end
 
-
-    # ``Com::Vmware::Appliance::Health::Softwarepackages``   class  provides  methods  Get information on available software updates available in remote VUM repository.
-    class Softwarepackages < VAPI::Bindings::VapiService
-
-        protected
-
-        # static metamodel definitions
-        @@service_id = VAPI::Core::ServiceIdentifier.new('com.vmware.appliance.health.softwarepackages')
-
-        @@get_info = VAPI::Bindings::OperationInfo.new(
-            VAPI::Core::OperationIdentifier.new('get', @@service_id),
-            VAPI::Bindings::OperationInputType.new,
-            VAPI::Bindings::ReferenceType.new('Com::Vmware::Appliance::Health::Softwarepackages::HealthLevel'),
-            {
-                'com.vmware.vapi.std.errors.error' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Error'),
-
-            },
-            [],
-            [])
-
-        @@service_info = VAPI::Bindings::ServiceInfo.new(@@service_id, {
-            'get' => @@get_info,
-        })
-
-        public
-
-        # Constructs a new instance.
-        #
-        # @param config [VAPI::Bindings::StubConfig] A hash with the api provider details.
-        def initialize(config)
-            super(config, @@service_info)
+    # ``Com::Vmware::Appliance::Health::Databasestorage::HealthLevel``   enumerated type  Defines health levels
+    # @!attribute [rw] orange
+    #     @return [Com::Vmware::Appliance::Health::Databasestorage::HealthLevel]
+    #     The service health is degraded. The service might have serious problems
+    # @!attribute [rw] gray
+    #     @return [Com::Vmware::Appliance::Health::Databasestorage::HealthLevel]
+    #     No health data is available for this service.
+    # @!attribute [rw] green
+    #     @return [Com::Vmware::Appliance::Health::Databasestorage::HealthLevel]
+    #     Service is healthy.
+    # @!attribute [rw] red
+    #     @return [Com::Vmware::Appliance::Health::Databasestorage::HealthLevel]
+    #     The service is unavaiable and is not functioning properly or will stop functioning soon.
+    # @!attribute [rw] yellow
+    #     @return [Com::Vmware::Appliance::Health::Databasestorage::HealthLevel]
+    #     The service is healthy state, but experiencing some levels of problems.
+    class HealthLevel < VAPI::Bindings::VapiEnum
+      class << self
+        # Holds (gets or creates) the binding type metadata for this enumeration type.
+        # @scope class
+        # @return [VAPI::Bindings::EnumType] the binding type
+        def binding_type
+          @binding_type ||= VAPI::Bindings::EnumType.new(
+            'com.vmware.appliance.health.databasestorage.health_level',
+            HealthLevel
+          )
         end
 
-
-        # Get information on available software updates available in remote VUM repository. red indicates that security updates are available. orange indicates that non security updates are available. green indicates that there are no updates available. gray indicates that there was an error retreiving information on software updates.
-        #
-        # @return [Com::Vmware::Appliance::Health::Softwarepackages::HealthLevel]
-        #     software updates available.
-        # @raise [Com::Vmware::Vapi::Std::Errors::Error]
-        #     Generic error
-        def get()
-            invoke_with_info(@@get_info)
+        # Converts from a string value (perhaps off the wire) to an instance
+        # of this enum type.
+        # @param value [String] the actual value of the enum instance
+        # @return [HealthLevel] the instance found for the value, otherwise
+        #         an unknown instance will be built for the value
+        def from_string(value)
+          const_get(value)
+        rescue NameError
+          HealthLevel.send(:new, 'UNKNOWN', value)
         end
+      end
 
+      # Constructs a new instance.
+      # @param value [String] the actual value of the enum instance
+      # @param unknown [String] the unknown value when value is 'UKNOWN'
+      def initialize(value, unknown = nil)
+        super(self.class.binding_type, value, unknown)
+      end
 
+      private_class_method :new
 
-        # ``Com::Vmware::Appliance::Health::Softwarepackages::HealthLevel``   enumerated type  Defines health levels
-        # @!attribute [rw] orange
-        #     @return [Com::Vmware::Appliance::Health::Softwarepackages::HealthLevel]
-        #     The service health is degraded. The service might have serious problems
-        # @!attribute [rw] gray
-        #     @return [Com::Vmware::Appliance::Health::Softwarepackages::HealthLevel]
-        #     No health data is available for this service.
-        # @!attribute [rw] green
-        #     @return [Com::Vmware::Appliance::Health::Softwarepackages::HealthLevel]
-        #     Service is healthy.
-        # @!attribute [rw] red
-        #     @return [Com::Vmware::Appliance::Health::Softwarepackages::HealthLevel]
-        #     The service is unavaiable and is not functioning properly or will stop functioning soon.
-        # @!attribute [rw] yellow
-        #     @return [Com::Vmware::Appliance::Health::Softwarepackages::HealthLevel]
-        #     The service is healthy state, but experiencing some levels of problems.
-        class HealthLevel < VAPI::Bindings::VapiEnum
+      # @!attribute [rw] orange
+      #     @return [Com::Vmware::Appliance::Health::Databasestorage::HealthLevel]
+      #     The service health is degraded. The service might have serious problems
+      ORANGE = HealthLevel.send(:new, 'ORANGE')
 
-            class << self
-                # Holds (gets or creates) the binding type metadata for this enumeration type.
-                # @scope class
-                # @return [VAPI::Bindings::EnumType] the binding type
-                def binding_type
-                    @binding_type ||= VAPI::Bindings::EnumType.new(
-                        'com.vmware.appliance.health.softwarepackages.health_level',
-                        HealthLevel)
-                end
+      # @!attribute [rw] gray
+      #     @return [Com::Vmware::Appliance::Health::Databasestorage::HealthLevel]
+      #     No health data is available for this service.
+      GRAY = HealthLevel.send(:new, 'GRAY')
 
-                # Converts from a string value (perhaps off the wire) to an instance
-                # of this enum type.
-                # @param value [String] the actual value of the enum instance
-                # @return [HealthLevel] the instance found for the value, otherwise
-                #         an unknown instance will be built for the value
-                def from_string(value)
-                    begin
-                        const_get(value)
-                    rescue NameError
-                        HealthLevel.new('UNKNOWN', value)
-                    end
-                end
-            end
+      # @!attribute [rw] green
+      #     @return [Com::Vmware::Appliance::Health::Databasestorage::HealthLevel]
+      #     Service is healthy.
+      GREEN = HealthLevel.send(:new, 'GREEN')
 
-            private
+      # @!attribute [rw] red
+      #     @return [Com::Vmware::Appliance::Health::Databasestorage::HealthLevel]
+      #     The service is unavaiable and is not functioning properly or will stop functioning soon.
+      RED = HealthLevel.send(:new, 'RED')
 
-            # Constructs a new instance.
-            # @param value [String] the actual value of the enum instance
-            # @param unknown [String] the unknown value when value is 'UKNOWN'
-            def initialize(value, unknown=nil)
-                super(self.class.binding_type, value, unknown)
-            end
+      # @!attribute [rw] yellow
+      #     @return [Com::Vmware::Appliance::Health::Databasestorage::HealthLevel]
+      #     The service is healthy state, but experiencing some levels of problems.
+      YELLOW = HealthLevel.send(:new, 'YELLOW')
+    end
+  end
+  # ``Com::Vmware::Appliance::Health::Load``   class  provides  methods  Get load health.
+  class Load < VAPI::Bindings::VapiService
+    # static metamodel definitions
+    SERVICE_ID = VAPI::Core::ServiceIdentifier.new('com.vmware.appliance.health.load')
 
-            public
+    GET_INFO = VAPI::Bindings::OperationInfo.new(
+      VAPI::Core::OperationIdentifier.new('get', SERVICE_ID),
+      VAPI::Bindings::OperationInputType.new,
+      VAPI::Bindings::ReferenceType.new('Com::Vmware::Appliance::Health::Load::HealthLevel'),
+      {
+        'com.vmware.vapi.std.errors.error' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Error')
+      },
+      [],
+      []
+    )
 
-            # @!attribute [rw] orange
-            #     @return [Com::Vmware::Appliance::Health::Softwarepackages::HealthLevel]
-            #     The service health is degraded. The service might have serious problems
-            ORANGE = HealthLevel.new('ORANGE')
+    SERVICE_INFO = VAPI::Bindings::ServiceInfo.new(
+      SERVICE_ID,
+      'get' => GET_INFO
+    )
 
-            # @!attribute [rw] gray
-            #     @return [Com::Vmware::Appliance::Health::Softwarepackages::HealthLevel]
-            #     No health data is available for this service.
-            GRAY = HealthLevel.new('GRAY')
-
-            # @!attribute [rw] green
-            #     @return [Com::Vmware::Appliance::Health::Softwarepackages::HealthLevel]
-            #     Service is healthy.
-            GREEN = HealthLevel.new('GREEN')
-
-            # @!attribute [rw] red
-            #     @return [Com::Vmware::Appliance::Health::Softwarepackages::HealthLevel]
-            #     The service is unavaiable and is not functioning properly or will stop functioning soon.
-            RED = HealthLevel.new('RED')
-
-            # @!attribute [rw] yellow
-            #     @return [Com::Vmware::Appliance::Health::Softwarepackages::HealthLevel]
-            #     The service is healthy state, but experiencing some levels of problems.
-            YELLOW = HealthLevel.new('YELLOW')
-
-        end
-
-
+    # Constructs a new instance.
+    #
+    # @param config [VAPI::Bindings::StubConfig] A hash with the api provider details.
+    def initialize(config)
+      super(config, SERVICE_INFO)
     end
 
-
-    # ``Com::Vmware::Appliance::Health::Storage``   class  provides  methods  Get storage health.
-    class Storage < VAPI::Bindings::VapiService
-
-        protected
-
-        # static metamodel definitions
-        @@service_id = VAPI::Core::ServiceIdentifier.new('com.vmware.appliance.health.storage')
-
-        @@get_info = VAPI::Bindings::OperationInfo.new(
-            VAPI::Core::OperationIdentifier.new('get', @@service_id),
-            VAPI::Bindings::OperationInputType.new,
-            VAPI::Bindings::ReferenceType.new('Com::Vmware::Appliance::Health::Storage::HealthLevel'),
-            {
-                'com.vmware.vapi.std.errors.error' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Error'),
-
-            },
-            [],
-            [])
-
-        @@service_info = VAPI::Bindings::ServiceInfo.new(@@service_id, {
-            'get' => @@get_info,
-        })
-
-        public
-
-        # Constructs a new instance.
-        #
-        # @param config [VAPI::Bindings::StubConfig] A hash with the api provider details.
-        def initialize(config)
-            super(config, @@service_info)
-        end
-
-
-        # Get storage health.
-        #
-        # @return [Com::Vmware::Appliance::Health::Storage::HealthLevel]
-        #     Storage health.
-        # @raise [Com::Vmware::Vapi::Std::Errors::Error]
-        #     Generic error
-        def get()
-            invoke_with_info(@@get_info)
-        end
-
-
-
-        # ``Com::Vmware::Appliance::Health::Storage::HealthLevel``   enumerated type  Defines health levels
-        # @!attribute [rw] orange
-        #     @return [Com::Vmware::Appliance::Health::Storage::HealthLevel]
-        #     The service health is degraded. The service might have serious problems
-        # @!attribute [rw] gray
-        #     @return [Com::Vmware::Appliance::Health::Storage::HealthLevel]
-        #     No health data is available for this service.
-        # @!attribute [rw] green
-        #     @return [Com::Vmware::Appliance::Health::Storage::HealthLevel]
-        #     Service is healthy.
-        # @!attribute [rw] red
-        #     @return [Com::Vmware::Appliance::Health::Storage::HealthLevel]
-        #     The service is unavaiable and is not functioning properly or will stop functioning soon.
-        # @!attribute [rw] yellow
-        #     @return [Com::Vmware::Appliance::Health::Storage::HealthLevel]
-        #     The service is healthy state, but experiencing some levels of problems.
-        class HealthLevel < VAPI::Bindings::VapiEnum
-
-            class << self
-                # Holds (gets or creates) the binding type metadata for this enumeration type.
-                # @scope class
-                # @return [VAPI::Bindings::EnumType] the binding type
-                def binding_type
-                    @binding_type ||= VAPI::Bindings::EnumType.new(
-                        'com.vmware.appliance.health.storage.health_level',
-                        HealthLevel)
-                end
-
-                # Converts from a string value (perhaps off the wire) to an instance
-                # of this enum type.
-                # @param value [String] the actual value of the enum instance
-                # @return [HealthLevel] the instance found for the value, otherwise
-                #         an unknown instance will be built for the value
-                def from_string(value)
-                    begin
-                        const_get(value)
-                    rescue NameError
-                        HealthLevel.new('UNKNOWN', value)
-                    end
-                end
-            end
-
-            private
-
-            # Constructs a new instance.
-            # @param value [String] the actual value of the enum instance
-            # @param unknown [String] the unknown value when value is 'UKNOWN'
-            def initialize(value, unknown=nil)
-                super(self.class.binding_type, value, unknown)
-            end
-
-            public
-
-            # @!attribute [rw] orange
-            #     @return [Com::Vmware::Appliance::Health::Storage::HealthLevel]
-            #     The service health is degraded. The service might have serious problems
-            ORANGE = HealthLevel.new('ORANGE')
-
-            # @!attribute [rw] gray
-            #     @return [Com::Vmware::Appliance::Health::Storage::HealthLevel]
-            #     No health data is available for this service.
-            GRAY = HealthLevel.new('GRAY')
-
-            # @!attribute [rw] green
-            #     @return [Com::Vmware::Appliance::Health::Storage::HealthLevel]
-            #     Service is healthy.
-            GREEN = HealthLevel.new('GREEN')
-
-            # @!attribute [rw] red
-            #     @return [Com::Vmware::Appliance::Health::Storage::HealthLevel]
-            #     The service is unavaiable and is not functioning properly or will stop functioning soon.
-            RED = HealthLevel.new('RED')
-
-            # @!attribute [rw] yellow
-            #     @return [Com::Vmware::Appliance::Health::Storage::HealthLevel]
-            #     The service is healthy state, but experiencing some levels of problems.
-            YELLOW = HealthLevel.new('YELLOW')
-
-        end
-
-
+    # Get load health.
+    #
+    # @return [Com::Vmware::Appliance::Health::Load::HealthLevel]
+    #     Load health.
+    # @raise [Com::Vmware::Vapi::Std::Errors::Error]
+    #     Generic error
+    def get
+      invoke_with_info(GET_INFO)
     end
 
-
-    # ``Com::Vmware::Appliance::Health::Swap``   class  provides  methods  Get swap health.
-    class Swap < VAPI::Bindings::VapiService
-
-        protected
-
-        # static metamodel definitions
-        @@service_id = VAPI::Core::ServiceIdentifier.new('com.vmware.appliance.health.swap')
-
-        @@get_info = VAPI::Bindings::OperationInfo.new(
-            VAPI::Core::OperationIdentifier.new('get', @@service_id),
-            VAPI::Bindings::OperationInputType.new,
-            VAPI::Bindings::ReferenceType.new('Com::Vmware::Appliance::Health::Swap::HealthLevel'),
-            {
-                'com.vmware.vapi.std.errors.error' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Error'),
-
-            },
-            [],
-            [])
-
-        @@service_info = VAPI::Bindings::ServiceInfo.new(@@service_id, {
-            'get' => @@get_info,
-        })
-
-        public
-
-        # Constructs a new instance.
-        #
-        # @param config [VAPI::Bindings::StubConfig] A hash with the api provider details.
-        def initialize(config)
-            super(config, @@service_info)
+    # ``Com::Vmware::Appliance::Health::Load::HealthLevel``   enumerated type  Defines health levels
+    # @!attribute [rw] orange
+    #     @return [Com::Vmware::Appliance::Health::Load::HealthLevel]
+    #     The service health is degraded. The service might have serious problems
+    # @!attribute [rw] gray
+    #     @return [Com::Vmware::Appliance::Health::Load::HealthLevel]
+    #     No health data is available for this service.
+    # @!attribute [rw] green
+    #     @return [Com::Vmware::Appliance::Health::Load::HealthLevel]
+    #     Service is healthy.
+    # @!attribute [rw] red
+    #     @return [Com::Vmware::Appliance::Health::Load::HealthLevel]
+    #     The service is unavaiable and is not functioning properly or will stop functioning soon.
+    # @!attribute [rw] yellow
+    #     @return [Com::Vmware::Appliance::Health::Load::HealthLevel]
+    #     The service is healthy state, but experiencing some levels of problems.
+    class HealthLevel < VAPI::Bindings::VapiEnum
+      class << self
+        # Holds (gets or creates) the binding type metadata for this enumeration type.
+        # @scope class
+        # @return [VAPI::Bindings::EnumType] the binding type
+        def binding_type
+          @binding_type ||= VAPI::Bindings::EnumType.new(
+            'com.vmware.appliance.health.load.health_level',
+            HealthLevel
+          )
         end
 
-
-        # Get swap health.
-        #
-        # @return [Com::Vmware::Appliance::Health::Swap::HealthLevel]
-        #     Swap health.
-        # @raise [Com::Vmware::Vapi::Std::Errors::Error]
-        #     Generic error
-        def get()
-            invoke_with_info(@@get_info)
+        # Converts from a string value (perhaps off the wire) to an instance
+        # of this enum type.
+        # @param value [String] the actual value of the enum instance
+        # @return [HealthLevel] the instance found for the value, otherwise
+        #         an unknown instance will be built for the value
+        def from_string(value)
+          const_get(value)
+        rescue NameError
+          HealthLevel.send(:new, 'UNKNOWN', value)
         end
+      end
 
+      # Constructs a new instance.
+      # @param value [String] the actual value of the enum instance
+      # @param unknown [String] the unknown value when value is 'UKNOWN'
+      def initialize(value, unknown = nil)
+        super(self.class.binding_type, value, unknown)
+      end
 
+      private_class_method :new
 
-        # ``Com::Vmware::Appliance::Health::Swap::HealthLevel``   enumerated type  Defines health levels
-        # @!attribute [rw] orange
-        #     @return [Com::Vmware::Appliance::Health::Swap::HealthLevel]
-        #     The service health is degraded. The service might have serious problems
-        # @!attribute [rw] gray
-        #     @return [Com::Vmware::Appliance::Health::Swap::HealthLevel]
-        #     No health data is available for this service.
-        # @!attribute [rw] green
-        #     @return [Com::Vmware::Appliance::Health::Swap::HealthLevel]
-        #     Service is healthy.
-        # @!attribute [rw] red
-        #     @return [Com::Vmware::Appliance::Health::Swap::HealthLevel]
-        #     The service is unavaiable and is not functioning properly or will stop functioning soon.
-        # @!attribute [rw] yellow
-        #     @return [Com::Vmware::Appliance::Health::Swap::HealthLevel]
-        #     The service is healthy state, but experiencing some levels of problems.
-        class HealthLevel < VAPI::Bindings::VapiEnum
+      # @!attribute [rw] orange
+      #     @return [Com::Vmware::Appliance::Health::Load::HealthLevel]
+      #     The service health is degraded. The service might have serious problems
+      ORANGE = HealthLevel.send(:new, 'ORANGE')
 
-            class << self
-                # Holds (gets or creates) the binding type metadata for this enumeration type.
-                # @scope class
-                # @return [VAPI::Bindings::EnumType] the binding type
-                def binding_type
-                    @binding_type ||= VAPI::Bindings::EnumType.new(
-                        'com.vmware.appliance.health.swap.health_level',
-                        HealthLevel)
-                end
+      # @!attribute [rw] gray
+      #     @return [Com::Vmware::Appliance::Health::Load::HealthLevel]
+      #     No health data is available for this service.
+      GRAY = HealthLevel.send(:new, 'GRAY')
 
-                # Converts from a string value (perhaps off the wire) to an instance
-                # of this enum type.
-                # @param value [String] the actual value of the enum instance
-                # @return [HealthLevel] the instance found for the value, otherwise
-                #         an unknown instance will be built for the value
-                def from_string(value)
-                    begin
-                        const_get(value)
-                    rescue NameError
-                        HealthLevel.new('UNKNOWN', value)
-                    end
-                end
-            end
+      # @!attribute [rw] green
+      #     @return [Com::Vmware::Appliance::Health::Load::HealthLevel]
+      #     Service is healthy.
+      GREEN = HealthLevel.send(:new, 'GREEN')
 
-            private
+      # @!attribute [rw] red
+      #     @return [Com::Vmware::Appliance::Health::Load::HealthLevel]
+      #     The service is unavaiable and is not functioning properly or will stop functioning soon.
+      RED = HealthLevel.send(:new, 'RED')
 
-            # Constructs a new instance.
-            # @param value [String] the actual value of the enum instance
-            # @param unknown [String] the unknown value when value is 'UKNOWN'
-            def initialize(value, unknown=nil)
-                super(self.class.binding_type, value, unknown)
-            end
+      # @!attribute [rw] yellow
+      #     @return [Com::Vmware::Appliance::Health::Load::HealthLevel]
+      #     The service is healthy state, but experiencing some levels of problems.
+      YELLOW = HealthLevel.send(:new, 'YELLOW')
+    end
+  end
+  # ``Com::Vmware::Appliance::Health::Mem``   class  provides  methods  Get memory health.
+  class Mem < VAPI::Bindings::VapiService
+    # static metamodel definitions
+    SERVICE_ID = VAPI::Core::ServiceIdentifier.new('com.vmware.appliance.health.mem')
 
-            public
+    GET_INFO = VAPI::Bindings::OperationInfo.new(
+      VAPI::Core::OperationIdentifier.new('get', SERVICE_ID),
+      VAPI::Bindings::OperationInputType.new,
+      VAPI::Bindings::ReferenceType.new('Com::Vmware::Appliance::Health::Mem::HealthLevel'),
+      {
+        'com.vmware.vapi.std.errors.error' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Error')
+      },
+      [],
+      []
+    )
 
-            # @!attribute [rw] orange
-            #     @return [Com::Vmware::Appliance::Health::Swap::HealthLevel]
-            #     The service health is degraded. The service might have serious problems
-            ORANGE = HealthLevel.new('ORANGE')
+    SERVICE_INFO = VAPI::Bindings::ServiceInfo.new(
+      SERVICE_ID,
+      'get' => GET_INFO
+    )
 
-            # @!attribute [rw] gray
-            #     @return [Com::Vmware::Appliance::Health::Swap::HealthLevel]
-            #     No health data is available for this service.
-            GRAY = HealthLevel.new('GRAY')
-
-            # @!attribute [rw] green
-            #     @return [Com::Vmware::Appliance::Health::Swap::HealthLevel]
-            #     Service is healthy.
-            GREEN = HealthLevel.new('GREEN')
-
-            # @!attribute [rw] red
-            #     @return [Com::Vmware::Appliance::Health::Swap::HealthLevel]
-            #     The service is unavaiable and is not functioning properly or will stop functioning soon.
-            RED = HealthLevel.new('RED')
-
-            # @!attribute [rw] yellow
-            #     @return [Com::Vmware::Appliance::Health::Swap::HealthLevel]
-            #     The service is healthy state, but experiencing some levels of problems.
-            YELLOW = HealthLevel.new('YELLOW')
-
-        end
-
-
+    # Constructs a new instance.
+    #
+    # @param config [VAPI::Bindings::StubConfig] A hash with the api provider details.
+    def initialize(config)
+      super(config, SERVICE_INFO)
     end
 
-
-    # ``Com::Vmware::Appliance::Health::System``   class  provides  methods  Get overall health of system.
-    class System < VAPI::Bindings::VapiService
-
-        protected
-
-        # static metamodel definitions
-        @@service_id = VAPI::Core::ServiceIdentifier.new('com.vmware.appliance.health.system')
-
-        @@lastcheck_info = VAPI::Bindings::OperationInfo.new(
-            VAPI::Core::OperationIdentifier.new('lastcheck', @@service_id),
-            VAPI::Bindings::OperationInputType.new,
-            VAPI::Bindings::DateTimeType.instance,
-            {
-                'com.vmware.vapi.std.errors.error' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Error'),
-
-            },
-            [],
-            [])
-        @@get_info = VAPI::Bindings::OperationInfo.new(
-            VAPI::Core::OperationIdentifier.new('get', @@service_id),
-            VAPI::Bindings::OperationInputType.new,
-            VAPI::Bindings::ReferenceType.new('Com::Vmware::Appliance::Health::System::HealthLevel'),
-            {
-                'com.vmware.vapi.std.errors.error' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Error'),
-
-            },
-            [],
-            [])
-
-        @@service_info = VAPI::Bindings::ServiceInfo.new(@@service_id, {
-            'lastcheck' => @@lastcheck_info,
-            'get' => @@get_info,
-        })
-
-        public
-
-        # Constructs a new instance.
-        #
-        # @param config [VAPI::Bindings::StubConfig] A hash with the api provider details.
-        def initialize(config)
-            super(config, @@service_info)
-        end
-
-
-        # Get last check timestamp of the health of the system.
-        #
-        # @return [DateTime]
-        #     System health last check timestamp.
-        # @raise [Com::Vmware::Vapi::Std::Errors::Error]
-        #     Generic error
-        def lastcheck()
-            invoke_with_info(@@lastcheck_info)
-        end
-
-
-        # Get overall health of system.
-        #
-        # @return [Com::Vmware::Appliance::Health::System::HealthLevel]
-        #     System health.
-        # @raise [Com::Vmware::Vapi::Std::Errors::Error]
-        #     Generic error
-        def get()
-            invoke_with_info(@@get_info)
-        end
-
-
-
-        # ``Com::Vmware::Appliance::Health::System::HealthLevel``   enumerated type  Defines health levels
-        # @!attribute [rw] orange
-        #     @return [Com::Vmware::Appliance::Health::System::HealthLevel]
-        #     The service health is degraded. The service might have serious problems
-        # @!attribute [rw] gray
-        #     @return [Com::Vmware::Appliance::Health::System::HealthLevel]
-        #     No health data is available for this service.
-        # @!attribute [rw] green
-        #     @return [Com::Vmware::Appliance::Health::System::HealthLevel]
-        #     Service is healthy.
-        # @!attribute [rw] red
-        #     @return [Com::Vmware::Appliance::Health::System::HealthLevel]
-        #     The service is unavaiable and is not functioning properly or will stop functioning soon.
-        # @!attribute [rw] yellow
-        #     @return [Com::Vmware::Appliance::Health::System::HealthLevel]
-        #     The service is healthy state, but experiencing some levels of problems.
-        class HealthLevel < VAPI::Bindings::VapiEnum
-
-            class << self
-                # Holds (gets or creates) the binding type metadata for this enumeration type.
-                # @scope class
-                # @return [VAPI::Bindings::EnumType] the binding type
-                def binding_type
-                    @binding_type ||= VAPI::Bindings::EnumType.new(
-                        'com.vmware.appliance.health.system.health_level',
-                        HealthLevel)
-                end
-
-                # Converts from a string value (perhaps off the wire) to an instance
-                # of this enum type.
-                # @param value [String] the actual value of the enum instance
-                # @return [HealthLevel] the instance found for the value, otherwise
-                #         an unknown instance will be built for the value
-                def from_string(value)
-                    begin
-                        const_get(value)
-                    rescue NameError
-                        HealthLevel.new('UNKNOWN', value)
-                    end
-                end
-            end
-
-            private
-
-            # Constructs a new instance.
-            # @param value [String] the actual value of the enum instance
-            # @param unknown [String] the unknown value when value is 'UKNOWN'
-            def initialize(value, unknown=nil)
-                super(self.class.binding_type, value, unknown)
-            end
-
-            public
-
-            # @!attribute [rw] orange
-            #     @return [Com::Vmware::Appliance::Health::System::HealthLevel]
-            #     The service health is degraded. The service might have serious problems
-            ORANGE = HealthLevel.new('ORANGE')
-
-            # @!attribute [rw] gray
-            #     @return [Com::Vmware::Appliance::Health::System::HealthLevel]
-            #     No health data is available for this service.
-            GRAY = HealthLevel.new('GRAY')
-
-            # @!attribute [rw] green
-            #     @return [Com::Vmware::Appliance::Health::System::HealthLevel]
-            #     Service is healthy.
-            GREEN = HealthLevel.new('GREEN')
-
-            # @!attribute [rw] red
-            #     @return [Com::Vmware::Appliance::Health::System::HealthLevel]
-            #     The service is unavaiable and is not functioning properly or will stop functioning soon.
-            RED = HealthLevel.new('RED')
-
-            # @!attribute [rw] yellow
-            #     @return [Com::Vmware::Appliance::Health::System::HealthLevel]
-            #     The service is healthy state, but experiencing some levels of problems.
-            YELLOW = HealthLevel.new('YELLOW')
-
-        end
-
-
+    # Get memory health.
+    #
+    # @return [Com::Vmware::Appliance::Health::Mem::HealthLevel]
+    #     Memory health.
+    # @raise [Com::Vmware::Vapi::Std::Errors::Error]
+    #     Generic error
+    def get
+      invoke_with_info(GET_INFO)
     end
 
+    # ``Com::Vmware::Appliance::Health::Mem::HealthLevel``   enumerated type  Defines health levels
+    # @!attribute [rw] orange
+    #     @return [Com::Vmware::Appliance::Health::Mem::HealthLevel]
+    #     The service health is degraded. The service might have serious problems
+    # @!attribute [rw] gray
+    #     @return [Com::Vmware::Appliance::Health::Mem::HealthLevel]
+    #     No health data is available for this service.
+    # @!attribute [rw] green
+    #     @return [Com::Vmware::Appliance::Health::Mem::HealthLevel]
+    #     Service is healthy.
+    # @!attribute [rw] red
+    #     @return [Com::Vmware::Appliance::Health::Mem::HealthLevel]
+    #     The service is unavaiable and is not functioning properly or will stop functioning soon.
+    # @!attribute [rw] yellow
+    #     @return [Com::Vmware::Appliance::Health::Mem::HealthLevel]
+    #     The service is healthy state, but experiencing some levels of problems.
+    class HealthLevel < VAPI::Bindings::VapiEnum
+      class << self
+        # Holds (gets or creates) the binding type metadata for this enumeration type.
+        # @scope class
+        # @return [VAPI::Bindings::EnumType] the binding type
+        def binding_type
+          @binding_type ||= VAPI::Bindings::EnumType.new(
+            'com.vmware.appliance.health.mem.health_level',
+            HealthLevel
+          )
+        end
 
+        # Converts from a string value (perhaps off the wire) to an instance
+        # of this enum type.
+        # @param value [String] the actual value of the enum instance
+        # @return [HealthLevel] the instance found for the value, otherwise
+        #         an unknown instance will be built for the value
+        def from_string(value)
+          const_get(value)
+        rescue NameError
+          HealthLevel.send(:new, 'UNKNOWN', value)
+        end
+      end
+
+      # Constructs a new instance.
+      # @param value [String] the actual value of the enum instance
+      # @param unknown [String] the unknown value when value is 'UKNOWN'
+      def initialize(value, unknown = nil)
+        super(self.class.binding_type, value, unknown)
+      end
+
+      private_class_method :new
+
+      # @!attribute [rw] orange
+      #     @return [Com::Vmware::Appliance::Health::Mem::HealthLevel]
+      #     The service health is degraded. The service might have serious problems
+      ORANGE = HealthLevel.send(:new, 'ORANGE')
+
+      # @!attribute [rw] gray
+      #     @return [Com::Vmware::Appliance::Health::Mem::HealthLevel]
+      #     No health data is available for this service.
+      GRAY = HealthLevel.send(:new, 'GRAY')
+
+      # @!attribute [rw] green
+      #     @return [Com::Vmware::Appliance::Health::Mem::HealthLevel]
+      #     Service is healthy.
+      GREEN = HealthLevel.send(:new, 'GREEN')
+
+      # @!attribute [rw] red
+      #     @return [Com::Vmware::Appliance::Health::Mem::HealthLevel]
+      #     The service is unavaiable and is not functioning properly or will stop functioning soon.
+      RED = HealthLevel.send(:new, 'RED')
+
+      # @!attribute [rw] yellow
+      #     @return [Com::Vmware::Appliance::Health::Mem::HealthLevel]
+      #     The service is healthy state, but experiencing some levels of problems.
+      YELLOW = HealthLevel.send(:new, 'YELLOW')
+    end
+  end
+  # ``Com::Vmware::Appliance::Health::Softwarepackages``   class  provides  methods  Get information on available software updates available in remote VUM repository.
+  class Softwarepackages < VAPI::Bindings::VapiService
+    # static metamodel definitions
+    SERVICE_ID = VAPI::Core::ServiceIdentifier.new('com.vmware.appliance.health.softwarepackages')
+
+    GET_INFO = VAPI::Bindings::OperationInfo.new(
+      VAPI::Core::OperationIdentifier.new('get', SERVICE_ID),
+      VAPI::Bindings::OperationInputType.new,
+      VAPI::Bindings::ReferenceType.new('Com::Vmware::Appliance::Health::Softwarepackages::HealthLevel'),
+      {
+        'com.vmware.vapi.std.errors.error' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Error')
+      },
+      [],
+      []
+    )
+
+    SERVICE_INFO = VAPI::Bindings::ServiceInfo.new(
+      SERVICE_ID,
+      'get' => GET_INFO
+    )
+
+    # Constructs a new instance.
+    #
+    # @param config [VAPI::Bindings::StubConfig] A hash with the api provider details.
+    def initialize(config)
+      super(config, SERVICE_INFO)
+    end
+
+    # Get information on available software updates available in remote VUM repository. red indicates that security updates are available. orange indicates that non security updates are available. green indicates that there are no updates available. gray indicates that there was an error retreiving information on software updates.
+    #
+    # @return [Com::Vmware::Appliance::Health::Softwarepackages::HealthLevel]
+    #     software updates available.
+    # @raise [Com::Vmware::Vapi::Std::Errors::Error]
+    #     Generic error
+    def get
+      invoke_with_info(GET_INFO)
+    end
+
+    # ``Com::Vmware::Appliance::Health::Softwarepackages::HealthLevel``   enumerated type  Defines health levels
+    # @!attribute [rw] orange
+    #     @return [Com::Vmware::Appliance::Health::Softwarepackages::HealthLevel]
+    #     The service health is degraded. The service might have serious problems
+    # @!attribute [rw] gray
+    #     @return [Com::Vmware::Appliance::Health::Softwarepackages::HealthLevel]
+    #     No health data is available for this service.
+    # @!attribute [rw] green
+    #     @return [Com::Vmware::Appliance::Health::Softwarepackages::HealthLevel]
+    #     Service is healthy.
+    # @!attribute [rw] red
+    #     @return [Com::Vmware::Appliance::Health::Softwarepackages::HealthLevel]
+    #     The service is unavaiable and is not functioning properly or will stop functioning soon.
+    # @!attribute [rw] yellow
+    #     @return [Com::Vmware::Appliance::Health::Softwarepackages::HealthLevel]
+    #     The service is healthy state, but experiencing some levels of problems.
+    class HealthLevel < VAPI::Bindings::VapiEnum
+      class << self
+        # Holds (gets or creates) the binding type metadata for this enumeration type.
+        # @scope class
+        # @return [VAPI::Bindings::EnumType] the binding type
+        def binding_type
+          @binding_type ||= VAPI::Bindings::EnumType.new(
+            'com.vmware.appliance.health.softwarepackages.health_level',
+            HealthLevel
+          )
+        end
+
+        # Converts from a string value (perhaps off the wire) to an instance
+        # of this enum type.
+        # @param value [String] the actual value of the enum instance
+        # @return [HealthLevel] the instance found for the value, otherwise
+        #         an unknown instance will be built for the value
+        def from_string(value)
+          const_get(value)
+        rescue NameError
+          HealthLevel.send(:new, 'UNKNOWN', value)
+        end
+      end
+
+      # Constructs a new instance.
+      # @param value [String] the actual value of the enum instance
+      # @param unknown [String] the unknown value when value is 'UKNOWN'
+      def initialize(value, unknown = nil)
+        super(self.class.binding_type, value, unknown)
+      end
+
+      private_class_method :new
+
+      # @!attribute [rw] orange
+      #     @return [Com::Vmware::Appliance::Health::Softwarepackages::HealthLevel]
+      #     The service health is degraded. The service might have serious problems
+      ORANGE = HealthLevel.send(:new, 'ORANGE')
+
+      # @!attribute [rw] gray
+      #     @return [Com::Vmware::Appliance::Health::Softwarepackages::HealthLevel]
+      #     No health data is available for this service.
+      GRAY = HealthLevel.send(:new, 'GRAY')
+
+      # @!attribute [rw] green
+      #     @return [Com::Vmware::Appliance::Health::Softwarepackages::HealthLevel]
+      #     Service is healthy.
+      GREEN = HealthLevel.send(:new, 'GREEN')
+
+      # @!attribute [rw] red
+      #     @return [Com::Vmware::Appliance::Health::Softwarepackages::HealthLevel]
+      #     The service is unavaiable and is not functioning properly or will stop functioning soon.
+      RED = HealthLevel.send(:new, 'RED')
+
+      # @!attribute [rw] yellow
+      #     @return [Com::Vmware::Appliance::Health::Softwarepackages::HealthLevel]
+      #     The service is healthy state, but experiencing some levels of problems.
+      YELLOW = HealthLevel.send(:new, 'YELLOW')
+    end
+  end
+  # ``Com::Vmware::Appliance::Health::Storage``   class  provides  methods  Get storage health.
+  class Storage < VAPI::Bindings::VapiService
+    # static metamodel definitions
+    SERVICE_ID = VAPI::Core::ServiceIdentifier.new('com.vmware.appliance.health.storage')
+
+    GET_INFO = VAPI::Bindings::OperationInfo.new(
+      VAPI::Core::OperationIdentifier.new('get', SERVICE_ID),
+      VAPI::Bindings::OperationInputType.new,
+      VAPI::Bindings::ReferenceType.new('Com::Vmware::Appliance::Health::Storage::HealthLevel'),
+      {
+        'com.vmware.vapi.std.errors.error' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Error')
+      },
+      [],
+      []
+    )
+
+    SERVICE_INFO = VAPI::Bindings::ServiceInfo.new(
+      SERVICE_ID,
+      'get' => GET_INFO
+    )
+
+    # Constructs a new instance.
+    #
+    # @param config [VAPI::Bindings::StubConfig] A hash with the api provider details.
+    def initialize(config)
+      super(config, SERVICE_INFO)
+    end
+
+    # Get storage health.
+    #
+    # @return [Com::Vmware::Appliance::Health::Storage::HealthLevel]
+    #     Storage health.
+    # @raise [Com::Vmware::Vapi::Std::Errors::Error]
+    #     Generic error
+    def get
+      invoke_with_info(GET_INFO)
+    end
+
+    # ``Com::Vmware::Appliance::Health::Storage::HealthLevel``   enumerated type  Defines health levels
+    # @!attribute [rw] orange
+    #     @return [Com::Vmware::Appliance::Health::Storage::HealthLevel]
+    #     The service health is degraded. The service might have serious problems
+    # @!attribute [rw] gray
+    #     @return [Com::Vmware::Appliance::Health::Storage::HealthLevel]
+    #     No health data is available for this service.
+    # @!attribute [rw] green
+    #     @return [Com::Vmware::Appliance::Health::Storage::HealthLevel]
+    #     Service is healthy.
+    # @!attribute [rw] red
+    #     @return [Com::Vmware::Appliance::Health::Storage::HealthLevel]
+    #     The service is unavaiable and is not functioning properly or will stop functioning soon.
+    # @!attribute [rw] yellow
+    #     @return [Com::Vmware::Appliance::Health::Storage::HealthLevel]
+    #     The service is healthy state, but experiencing some levels of problems.
+    class HealthLevel < VAPI::Bindings::VapiEnum
+      class << self
+        # Holds (gets or creates) the binding type metadata for this enumeration type.
+        # @scope class
+        # @return [VAPI::Bindings::EnumType] the binding type
+        def binding_type
+          @binding_type ||= VAPI::Bindings::EnumType.new(
+            'com.vmware.appliance.health.storage.health_level',
+            HealthLevel
+          )
+        end
+
+        # Converts from a string value (perhaps off the wire) to an instance
+        # of this enum type.
+        # @param value [String] the actual value of the enum instance
+        # @return [HealthLevel] the instance found for the value, otherwise
+        #         an unknown instance will be built for the value
+        def from_string(value)
+          const_get(value)
+        rescue NameError
+          HealthLevel.send(:new, 'UNKNOWN', value)
+        end
+      end
+
+      # Constructs a new instance.
+      # @param value [String] the actual value of the enum instance
+      # @param unknown [String] the unknown value when value is 'UKNOWN'
+      def initialize(value, unknown = nil)
+        super(self.class.binding_type, value, unknown)
+      end
+
+      private_class_method :new
+
+      # @!attribute [rw] orange
+      #     @return [Com::Vmware::Appliance::Health::Storage::HealthLevel]
+      #     The service health is degraded. The service might have serious problems
+      ORANGE = HealthLevel.send(:new, 'ORANGE')
+
+      # @!attribute [rw] gray
+      #     @return [Com::Vmware::Appliance::Health::Storage::HealthLevel]
+      #     No health data is available for this service.
+      GRAY = HealthLevel.send(:new, 'GRAY')
+
+      # @!attribute [rw] green
+      #     @return [Com::Vmware::Appliance::Health::Storage::HealthLevel]
+      #     Service is healthy.
+      GREEN = HealthLevel.send(:new, 'GREEN')
+
+      # @!attribute [rw] red
+      #     @return [Com::Vmware::Appliance::Health::Storage::HealthLevel]
+      #     The service is unavaiable and is not functioning properly or will stop functioning soon.
+      RED = HealthLevel.send(:new, 'RED')
+
+      # @!attribute [rw] yellow
+      #     @return [Com::Vmware::Appliance::Health::Storage::HealthLevel]
+      #     The service is healthy state, but experiencing some levels of problems.
+      YELLOW = HealthLevel.send(:new, 'YELLOW')
+    end
+  end
+  # ``Com::Vmware::Appliance::Health::Swap``   class  provides  methods  Get swap health.
+  class Swap < VAPI::Bindings::VapiService
+    # static metamodel definitions
+    SERVICE_ID = VAPI::Core::ServiceIdentifier.new('com.vmware.appliance.health.swap')
+
+    GET_INFO = VAPI::Bindings::OperationInfo.new(
+      VAPI::Core::OperationIdentifier.new('get', SERVICE_ID),
+      VAPI::Bindings::OperationInputType.new,
+      VAPI::Bindings::ReferenceType.new('Com::Vmware::Appliance::Health::Swap::HealthLevel'),
+      {
+        'com.vmware.vapi.std.errors.error' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Error')
+      },
+      [],
+      []
+    )
+
+    SERVICE_INFO = VAPI::Bindings::ServiceInfo.new(
+      SERVICE_ID,
+      'get' => GET_INFO
+    )
+
+    # Constructs a new instance.
+    #
+    # @param config [VAPI::Bindings::StubConfig] A hash with the api provider details.
+    def initialize(config)
+      super(config, SERVICE_INFO)
+    end
+
+    # Get swap health.
+    #
+    # @return [Com::Vmware::Appliance::Health::Swap::HealthLevel]
+    #     Swap health.
+    # @raise [Com::Vmware::Vapi::Std::Errors::Error]
+    #     Generic error
+    def get
+      invoke_with_info(GET_INFO)
+    end
+
+    # ``Com::Vmware::Appliance::Health::Swap::HealthLevel``   enumerated type  Defines health levels
+    # @!attribute [rw] orange
+    #     @return [Com::Vmware::Appliance::Health::Swap::HealthLevel]
+    #     The service health is degraded. The service might have serious problems
+    # @!attribute [rw] gray
+    #     @return [Com::Vmware::Appliance::Health::Swap::HealthLevel]
+    #     No health data is available for this service.
+    # @!attribute [rw] green
+    #     @return [Com::Vmware::Appliance::Health::Swap::HealthLevel]
+    #     Service is healthy.
+    # @!attribute [rw] red
+    #     @return [Com::Vmware::Appliance::Health::Swap::HealthLevel]
+    #     The service is unavaiable and is not functioning properly or will stop functioning soon.
+    # @!attribute [rw] yellow
+    #     @return [Com::Vmware::Appliance::Health::Swap::HealthLevel]
+    #     The service is healthy state, but experiencing some levels of problems.
+    class HealthLevel < VAPI::Bindings::VapiEnum
+      class << self
+        # Holds (gets or creates) the binding type metadata for this enumeration type.
+        # @scope class
+        # @return [VAPI::Bindings::EnumType] the binding type
+        def binding_type
+          @binding_type ||= VAPI::Bindings::EnumType.new(
+            'com.vmware.appliance.health.swap.health_level',
+            HealthLevel
+          )
+        end
+
+        # Converts from a string value (perhaps off the wire) to an instance
+        # of this enum type.
+        # @param value [String] the actual value of the enum instance
+        # @return [HealthLevel] the instance found for the value, otherwise
+        #         an unknown instance will be built for the value
+        def from_string(value)
+          const_get(value)
+        rescue NameError
+          HealthLevel.send(:new, 'UNKNOWN', value)
+        end
+      end
+
+      # Constructs a new instance.
+      # @param value [String] the actual value of the enum instance
+      # @param unknown [String] the unknown value when value is 'UKNOWN'
+      def initialize(value, unknown = nil)
+        super(self.class.binding_type, value, unknown)
+      end
+
+      private_class_method :new
+
+      # @!attribute [rw] orange
+      #     @return [Com::Vmware::Appliance::Health::Swap::HealthLevel]
+      #     The service health is degraded. The service might have serious problems
+      ORANGE = HealthLevel.send(:new, 'ORANGE')
+
+      # @!attribute [rw] gray
+      #     @return [Com::Vmware::Appliance::Health::Swap::HealthLevel]
+      #     No health data is available for this service.
+      GRAY = HealthLevel.send(:new, 'GRAY')
+
+      # @!attribute [rw] green
+      #     @return [Com::Vmware::Appliance::Health::Swap::HealthLevel]
+      #     Service is healthy.
+      GREEN = HealthLevel.send(:new, 'GREEN')
+
+      # @!attribute [rw] red
+      #     @return [Com::Vmware::Appliance::Health::Swap::HealthLevel]
+      #     The service is unavaiable and is not functioning properly or will stop functioning soon.
+      RED = HealthLevel.send(:new, 'RED')
+
+      # @!attribute [rw] yellow
+      #     @return [Com::Vmware::Appliance::Health::Swap::HealthLevel]
+      #     The service is healthy state, but experiencing some levels of problems.
+      YELLOW = HealthLevel.send(:new, 'YELLOW')
+    end
+  end
+  # ``Com::Vmware::Appliance::Health::System``   class  provides  methods  Get overall health of system.
+  class System < VAPI::Bindings::VapiService
+    # static metamodel definitions
+    SERVICE_ID = VAPI::Core::ServiceIdentifier.new('com.vmware.appliance.health.system')
+
+    LASTCHECK_INFO = VAPI::Bindings::OperationInfo.new(
+      VAPI::Core::OperationIdentifier.new('lastcheck', SERVICE_ID),
+      VAPI::Bindings::OperationInputType.new,
+      VAPI::Bindings::DateTimeType.instance,
+      {
+        'com.vmware.vapi.std.errors.error' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Error')
+      },
+      [],
+      []
+    )
+
+    GET_INFO = VAPI::Bindings::OperationInfo.new(
+      VAPI::Core::OperationIdentifier.new('get', SERVICE_ID),
+      VAPI::Bindings::OperationInputType.new,
+      VAPI::Bindings::ReferenceType.new('Com::Vmware::Appliance::Health::System::HealthLevel'),
+      {
+        'com.vmware.vapi.std.errors.error' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Error')
+      },
+      [],
+      []
+    )
+
+    SERVICE_INFO = VAPI::Bindings::ServiceInfo.new(
+      SERVICE_ID,
+      'lastcheck' => LASTCHECK_INFO,
+      'get' => GET_INFO
+    )
+
+    # Constructs a new instance.
+    #
+    # @param config [VAPI::Bindings::StubConfig] A hash with the api provider details.
+    def initialize(config)
+      super(config, SERVICE_INFO)
+    end
+
+    # Get last check timestamp of the health of the system.
+    #
+    # @return [DateTime]
+    #     System health last check timestamp.
+    # @raise [Com::Vmware::Vapi::Std::Errors::Error]
+    #     Generic error
+    def lastcheck
+      invoke_with_info(LASTCHECK_INFO)
+    end
+
+    # Get overall health of system.
+    #
+    # @return [Com::Vmware::Appliance::Health::System::HealthLevel]
+    #     System health.
+    # @raise [Com::Vmware::Vapi::Std::Errors::Error]
+    #     Generic error
+    def get
+      invoke_with_info(GET_INFO)
+    end
+
+    # ``Com::Vmware::Appliance::Health::System::HealthLevel``   enumerated type  Defines health levels
+    # @!attribute [rw] orange
+    #     @return [Com::Vmware::Appliance::Health::System::HealthLevel]
+    #     The service health is degraded. The service might have serious problems
+    # @!attribute [rw] gray
+    #     @return [Com::Vmware::Appliance::Health::System::HealthLevel]
+    #     No health data is available for this service.
+    # @!attribute [rw] green
+    #     @return [Com::Vmware::Appliance::Health::System::HealthLevel]
+    #     Service is healthy.
+    # @!attribute [rw] red
+    #     @return [Com::Vmware::Appliance::Health::System::HealthLevel]
+    #     The service is unavaiable and is not functioning properly or will stop functioning soon.
+    # @!attribute [rw] yellow
+    #     @return [Com::Vmware::Appliance::Health::System::HealthLevel]
+    #     The service is healthy state, but experiencing some levels of problems.
+    class HealthLevel < VAPI::Bindings::VapiEnum
+      class << self
+        # Holds (gets or creates) the binding type metadata for this enumeration type.
+        # @scope class
+        # @return [VAPI::Bindings::EnumType] the binding type
+        def binding_type
+          @binding_type ||= VAPI::Bindings::EnumType.new(
+            'com.vmware.appliance.health.system.health_level',
+            HealthLevel
+          )
+        end
+
+        # Converts from a string value (perhaps off the wire) to an instance
+        # of this enum type.
+        # @param value [String] the actual value of the enum instance
+        # @return [HealthLevel] the instance found for the value, otherwise
+        #         an unknown instance will be built for the value
+        def from_string(value)
+          const_get(value)
+        rescue NameError
+          HealthLevel.send(:new, 'UNKNOWN', value)
+        end
+      end
+
+      # Constructs a new instance.
+      # @param value [String] the actual value of the enum instance
+      # @param unknown [String] the unknown value when value is 'UKNOWN'
+      def initialize(value, unknown = nil)
+        super(self.class.binding_type, value, unknown)
+      end
+
+      private_class_method :new
+
+      # @!attribute [rw] orange
+      #     @return [Com::Vmware::Appliance::Health::System::HealthLevel]
+      #     The service health is degraded. The service might have serious problems
+      ORANGE = HealthLevel.send(:new, 'ORANGE')
+
+      # @!attribute [rw] gray
+      #     @return [Com::Vmware::Appliance::Health::System::HealthLevel]
+      #     No health data is available for this service.
+      GRAY = HealthLevel.send(:new, 'GRAY')
+
+      # @!attribute [rw] green
+      #     @return [Com::Vmware::Appliance::Health::System::HealthLevel]
+      #     Service is healthy.
+      GREEN = HealthLevel.send(:new, 'GREEN')
+
+      # @!attribute [rw] red
+      #     @return [Com::Vmware::Appliance::Health::System::HealthLevel]
+      #     The service is unavaiable and is not functioning properly or will stop functioning soon.
+      RED = HealthLevel.send(:new, 'RED')
+
+      # @!attribute [rw] yellow
+      #     @return [Com::Vmware::Appliance::Health::System::HealthLevel]
+      #     The service is healthy state, but experiencing some levels of problems.
+      YELLOW = HealthLevel.send(:new, 'YELLOW')
+    end
+  end
 end

--- a/client/sdk/com/vmware/appliance/networking.rb
+++ b/client/sdk/com/vmware/appliance/networking.rb
@@ -1,5 +1,6 @@
 #---------------------------------------------------------------------------
-# Copyright 2016 VMware, Inc.  All rights reserved.
+# Copyright 2017 VMware, Inc.  All rights reserved.
+#
 # AUTO GENERATED FILE -- DO NOT MODIFY!
 #
 # vAPI type descriptors for package com.vmware.appliance.networking.
@@ -8,191 +9,171 @@ require 'vapi'
 
 # declare the module hierarchy before we use the shorthand syntax below
 module Com
-    module Vmware
-        module Appliance
-            module Networking
-            end
-        end
+  module Vmware
+    module Appliance
+      module Networking
+      end
     end
+  end
 end
 
 module Com::Vmware::Appliance::Networking
+  # ``Com::Vmware::Appliance::Networking::Interfaces``   class  provides  methods  Provides information about network interface.
+  class Interfaces < VAPI::Bindings::VapiService
+    # static metamodel definitions
+    SERVICE_ID = VAPI::Core::ServiceIdentifier.new('com.vmware.appliance.networking.interfaces')
 
-    # ``Com::Vmware::Appliance::Networking::Interfaces``   class  provides  methods  Provides information about network interface.
-    class Interfaces < VAPI::Bindings::VapiService
+    LIST_INFO = VAPI::Bindings::OperationInfo.new(
+      VAPI::Core::OperationIdentifier.new('list', SERVICE_ID),
+      VAPI::Bindings::OperationInputType.new,
+      VAPI::Bindings::ListType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Appliance::Networking::Interfaces::InterfaceInfo')),
+      {
+        'com.vmware.vapi.std.errors.error' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Error')
+      },
+      [],
+      []
+    )
 
-        protected
+    GET_INFO = VAPI::Bindings::OperationInfo.new(
+      VAPI::Core::OperationIdentifier.new('get', SERVICE_ID),
+      VAPI::Bindings::OperationInputType.new(
+        'interface_name' => VAPI::Bindings::IdType.new('com.vmware.appliance.networking.interfaces')
+      ),
+      VAPI::Bindings::ReferenceType.new('Com::Vmware::Appliance::Networking::Interfaces::InterfaceInfo'),
+      {
+        'com.vmware.vapi.std.errors.error' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Error')
+      },
+      [],
+      []
+    )
 
-        # static metamodel definitions
-        @@service_id = VAPI::Core::ServiceIdentifier.new('com.vmware.appliance.networking.interfaces')
+    SERVICE_INFO = VAPI::Bindings::ServiceInfo.new(
+      SERVICE_ID,
+      'list' => LIST_INFO,
+      'get' => GET_INFO
+    )
 
-        @@list_info = VAPI::Bindings::OperationInfo.new(
-            VAPI::Core::OperationIdentifier.new('list', @@service_id),
-            VAPI::Bindings::OperationInputType.new,
-            VAPI::Bindings::ListType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Appliance::Networking::Interfaces::InterfaceInfo')),
-            {
-                'com.vmware.vapi.std.errors.error' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Error'),
-
-            },
-            [],
-            [])
-        @@get_info = VAPI::Bindings::OperationInfo.new(
-            VAPI::Core::OperationIdentifier.new('get', @@service_id),
-            VAPI::Bindings::OperationInputType.new({
-                'interface_name' => VAPI::Bindings::IdType.new(resource_types='com.vmware.appliance.networking.interfaces'),
-            }),
-            VAPI::Bindings::ReferenceType.new('Com::Vmware::Appliance::Networking::Interfaces::InterfaceInfo'),
-            {
-                'com.vmware.vapi.std.errors.error' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Error'),
-
-            },
-            [],
-            [])
-
-        @@service_info = VAPI::Bindings::ServiceInfo.new(@@service_id, {
-            'list' => @@list_info,
-            'get' => @@get_info,
-        })
-
-        public
-
-        # Constructs a new instance.
-        #
-        # @param config [VAPI::Bindings::StubConfig] A hash with the api provider details.
-        def initialize(config)
-            super(config, @@service_info)
-        end
-
-
-        # Get list of available network interfaces, including those that are not yet configured.
-        #
-        # @return [Array<Com::Vmware::Appliance::Networking::Interfaces::InterfaceInfo>]
-        #     List of InterfaceInfo structures.
-        # @raise [Com::Vmware::Vapi::Std::Errors::Error]
-        #     Generic error
-        def list()
-            invoke_with_info(@@list_info)
-        end
-
-
-        # Get information about a particular network interface.
-        #
-        # @param interface_name [String]
-        #     Network interface, for example, "nic0".
-        # @return [Com::Vmware::Appliance::Networking::Interfaces::InterfaceInfo]
-        #     Network interface information.
-        # @raise [Com::Vmware::Vapi::Std::Errors::Error]
-        #     Generic error
-        def get(interface_name)
-            invoke_with_info(@@get_info, {
-                'interface_name' => interface_name,
-            })
-        end
-
-
-
-        # ``Com::Vmware::Appliance::Networking::Interfaces::InterfaceInfo``   class  Structure that defines properties and status of a network interface.
-        # @!attribute [rw] name
-        #     @return [String]
-        #     Interface name, for example, "nic0", "nic1".
-        # @!attribute [rw] status
-        #     @return [Com::Vmware::Appliance::Networking::Interfaces::InterfaceStatus]
-        #     Interface status.
-        # @!attribute [rw] mac
-        #     @return [String]
-        #     MAC address. For example 00:0C:29:94:BB:5A.
-        class InterfaceInfo < VAPI::Bindings::VapiStruct
-
-            class << self
-                # Holds (gets or creates) the binding type metadata for this structure type.
-                # @scope class
-                # @return [VAPI::Bindings::StructType] the binding type
-                def binding_type
-                    @binding_type ||= VAPI::Bindings::StructType.new(
-                        'com.vmware.appliance.networking.interfaces.interface_info',
-                        {
-                            'name' => VAPI::Bindings::StringType.instance,
-                            'status' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Appliance::Networking::Interfaces::InterfaceStatus'),
-                            'mac' => VAPI::Bindings::StringType.instance,
-                        },
-                        InterfaceInfo,
-                        false,
-                        nil)
-                end
-            end
-
-            attr_accessor :name,
-                          :status,
-                          :mac
-
-            # Constructs a new instance.
-            # @param ruby_values [Hash] a map of initial property values (optional)
-            # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
-            def initialize(ruby_values=nil, struct_value=nil)
-                super(self.class.binding_type, ruby_values, struct_value)
-            end
-        end
-
-
-
-        # ``Com::Vmware::Appliance::Networking::Interfaces::InterfaceStatus``   enumerated type  Defines interface status
-        # @!attribute [rw] down
-        #     @return [Com::Vmware::Appliance::Networking::Interfaces::InterfaceStatus]
-        #     The interface is down.
-        # @!attribute [rw] up
-        #     @return [Com::Vmware::Appliance::Networking::Interfaces::InterfaceStatus]
-        #     The interface is up.
-        class InterfaceStatus < VAPI::Bindings::VapiEnum
-
-            class << self
-                # Holds (gets or creates) the binding type metadata for this enumeration type.
-                # @scope class
-                # @return [VAPI::Bindings::EnumType] the binding type
-                def binding_type
-                    @binding_type ||= VAPI::Bindings::EnumType.new(
-                        'com.vmware.appliance.networking.interfaces.interface_status',
-                        InterfaceStatus)
-                end
-
-                # Converts from a string value (perhaps off the wire) to an instance
-                # of this enum type.
-                # @param value [String] the actual value of the enum instance
-                # @return [InterfaceStatus] the instance found for the value, otherwise
-                #         an unknown instance will be built for the value
-                def from_string(value)
-                    begin
-                        const_get(value)
-                    rescue NameError
-                        InterfaceStatus.new('UNKNOWN', value)
-                    end
-                end
-            end
-
-            private
-
-            # Constructs a new instance.
-            # @param value [String] the actual value of the enum instance
-            # @param unknown [String] the unknown value when value is 'UKNOWN'
-            def initialize(value, unknown=nil)
-                super(self.class.binding_type, value, unknown)
-            end
-
-            public
-
-            # @!attribute [rw] down
-            #     @return [Com::Vmware::Appliance::Networking::Interfaces::InterfaceStatus]
-            #     The interface is down.
-            DOWN = InterfaceStatus.new('DOWN')
-
-            # @!attribute [rw] up
-            #     @return [Com::Vmware::Appliance::Networking::Interfaces::InterfaceStatus]
-            #     The interface is up.
-            UP = InterfaceStatus.new('UP')
-
-        end
-
-
+    # Constructs a new instance.
+    #
+    # @param config [VAPI::Bindings::StubConfig] A hash with the api provider details.
+    def initialize(config)
+      super(config, SERVICE_INFO)
     end
 
+    # Get list of available network interfaces, including those that are not yet configured.
+    #
+    # @return [Array<Com::Vmware::Appliance::Networking::Interfaces::InterfaceInfo>]
+    #     List of InterfaceInfo structures.
+    # @raise [Com::Vmware::Vapi::Std::Errors::Error]
+    #     Generic error
+    def list
+      invoke_with_info(LIST_INFO)
+    end
 
+    # Get information about a particular network interface.
+    #
+    # @param interface_name [String]
+    #     Network interface, for example, "nic0".
+    # @return [Com::Vmware::Appliance::Networking::Interfaces::InterfaceInfo]
+    #     Network interface information.
+    # @raise [Com::Vmware::Vapi::Std::Errors::Error]
+    #     Generic error
+    def get(interface_name)
+      invoke_with_info(GET_INFO,
+                       'interface_name' => interface_name)
+    end
+
+    # ``Com::Vmware::Appliance::Networking::Interfaces::InterfaceInfo``   class  Structure that defines properties and status of a network interface.
+    # @!attribute [rw] name
+    #     @return [String]
+    #     Interface name, for example, "nic0", "nic1".
+    # @!attribute [rw] status
+    #     @return [Com::Vmware::Appliance::Networking::Interfaces::InterfaceStatus]
+    #     Interface status.
+    # @!attribute [rw] mac
+    #     @return [String]
+    #     MAC address. For example 00:0C:29:94:BB:5A.
+    class InterfaceInfo < VAPI::Bindings::VapiStruct
+      class << self
+        # Holds (gets or creates) the binding type metadata for this structure type.
+        # @scope class
+        # @return [VAPI::Bindings::StructType] the binding type
+        def binding_type
+          @binding_type ||= VAPI::Bindings::StructType.new(
+            'com.vmware.appliance.networking.interfaces.interface_info',
+            {
+              'name' => VAPI::Bindings::StringType.instance,
+              'status' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Appliance::Networking::Interfaces::InterfaceStatus'),
+              'mac' => VAPI::Bindings::StringType.instance
+            },
+            InterfaceInfo,
+            false,
+            nil
+          )
+        end
+      end
+
+      attr_accessor :name,
+                    :status,
+                    :mac
+
+      # Constructs a new instance.
+      # @param ruby_values [Hash] a map of initial property values (optional)
+      # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
+      def initialize(ruby_values = nil, struct_value = nil)
+        super(self.class.binding_type, ruby_values, struct_value)
+      end
+    end
+
+    # ``Com::Vmware::Appliance::Networking::Interfaces::InterfaceStatus``   enumerated type  Defines interface status
+    # @!attribute [rw] down
+    #     @return [Com::Vmware::Appliance::Networking::Interfaces::InterfaceStatus]
+    #     The interface is down.
+    # @!attribute [rw] up
+    #     @return [Com::Vmware::Appliance::Networking::Interfaces::InterfaceStatus]
+    #     The interface is up.
+    class InterfaceStatus < VAPI::Bindings::VapiEnum
+      class << self
+        # Holds (gets or creates) the binding type metadata for this enumeration type.
+        # @scope class
+        # @return [VAPI::Bindings::EnumType] the binding type
+        def binding_type
+          @binding_type ||= VAPI::Bindings::EnumType.new(
+            'com.vmware.appliance.networking.interfaces.interface_status',
+            InterfaceStatus
+          )
+        end
+
+        # Converts from a string value (perhaps off the wire) to an instance
+        # of this enum type.
+        # @param value [String] the actual value of the enum instance
+        # @return [InterfaceStatus] the instance found for the value, otherwise
+        #         an unknown instance will be built for the value
+        def from_string(value)
+          const_get(value)
+        rescue NameError
+          InterfaceStatus.send(:new, 'UNKNOWN', value)
+        end
+      end
+
+      # Constructs a new instance.
+      # @param value [String] the actual value of the enum instance
+      # @param unknown [String] the unknown value when value is 'UKNOWN'
+      def initialize(value, unknown = nil)
+        super(self.class.binding_type, value, unknown)
+      end
+
+      private_class_method :new
+
+      # @!attribute [rw] down
+      #     @return [Com::Vmware::Appliance::Networking::Interfaces::InterfaceStatus]
+      #     The interface is down.
+      DOWN = InterfaceStatus.send(:new, 'DOWN')
+
+      # @!attribute [rw] up
+      #     @return [Com::Vmware::Appliance::Networking::Interfaces::InterfaceStatus]
+      #     The interface is up.
+      UP = InterfaceStatus.send(:new, 'UP')
+    end
+  end
 end

--- a/client/sdk/com/vmware/appliance/networking/dns.rb
+++ b/client/sdk/com/vmware/appliance/networking/dns.rb
@@ -1,5 +1,6 @@
 #---------------------------------------------------------------------------
-# Copyright 2016 VMware, Inc.  All rights reserved.
+# Copyright 2017 VMware, Inc.  All rights reserved.
+#
 # AUTO GENERATED FILE -- DO NOT MODIFY!
 #
 # vAPI type descriptors for package com.vmware.appliance.networking.dns.
@@ -8,843 +9,767 @@ require 'vapi'
 
 # declare the module hierarchy before we use the shorthand syntax below
 module Com
-    module Vmware
-        module Appliance
-            module Networking
-                module Dns
-                end
-            end
+  module Vmware
+    module Appliance
+      module Networking
+        module Dns
         end
+      end
     end
+  end
 end
 
 module Com::Vmware::Appliance::Networking::Dns
+  # ``Com::Vmware::Appliance::Networking::Dns::Domains``   class  provides  methods  DNS search domains.
+  class Domains < VAPI::Bindings::VapiService
+    # static metamodel definitions
+    SERVICE_ID = VAPI::Core::ServiceIdentifier.new('com.vmware.appliance.networking.dns.domains')
 
-    # ``Com::Vmware::Appliance::Networking::Dns::Domains``   class  provides  methods  DNS search domains.
-    class Domains < VAPI::Bindings::VapiService
+    ADD_INFO = VAPI::Bindings::OperationInfo.new(
+      VAPI::Core::OperationIdentifier.new('add', SERVICE_ID),
+      VAPI::Bindings::OperationInputType.new(
+        'domain' => VAPI::Bindings::StringType.instance
+      ),
+      VAPI::Bindings::VoidType.instance,
+      {
+        'com.vmware.vapi.std.errors.error' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Error')
+      },
+      [],
+      []
+    )
 
-        protected
+    SET_INFO = VAPI::Bindings::OperationInfo.new(
+      VAPI::Core::OperationIdentifier.new('set', SERVICE_ID),
+      VAPI::Bindings::OperationInputType.new(
+        'domains' => VAPI::Bindings::ListType.new(VAPI::Bindings::StringType.instance)
+      ),
+      VAPI::Bindings::VoidType.instance,
+      {
+        'com.vmware.vapi.std.errors.error' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Error')
+      },
+      [],
+      []
+    )
 
-        # static metamodel definitions
-        @@service_id = VAPI::Core::ServiceIdentifier.new('com.vmware.appliance.networking.dns.domains')
+    LIST_INFO = VAPI::Bindings::OperationInfo.new(
+      VAPI::Core::OperationIdentifier.new('list', SERVICE_ID),
+      VAPI::Bindings::OperationInputType.new,
+      VAPI::Bindings::ListType.new(VAPI::Bindings::StringType.instance),
+      {
+        'com.vmware.vapi.std.errors.error' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Error')
+      },
+      [],
+      []
+    )
 
-        @@add_info = VAPI::Bindings::OperationInfo.new(
-            VAPI::Core::OperationIdentifier.new('add', @@service_id),
-            VAPI::Bindings::OperationInputType.new({
-                'domain' => VAPI::Bindings::StringType.instance,
-            }),
-            VAPI::Bindings::VoidType.instance,
-            {
-                'com.vmware.vapi.std.errors.error' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Error'),
+    SERVICE_INFO = VAPI::Bindings::ServiceInfo.new(
+      SERVICE_ID,
+      'add' => ADD_INFO,
+      'set' => SET_INFO,
+      'list' => LIST_INFO
+    )
 
-            },
-            [],
-            [])
-        @@set_info = VAPI::Bindings::OperationInfo.new(
-            VAPI::Core::OperationIdentifier.new('set', @@service_id),
-            VAPI::Bindings::OperationInputType.new({
-                'domains' => VAPI::Bindings::ListType.new(VAPI::Bindings::StringType.instance),
-            }),
-            VAPI::Bindings::VoidType.instance,
-            {
-                'com.vmware.vapi.std.errors.error' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Error'),
-
-            },
-            [],
-            [])
-        @@list_info = VAPI::Bindings::OperationInfo.new(
-            VAPI::Core::OperationIdentifier.new('list', @@service_id),
-            VAPI::Bindings::OperationInputType.new,
-            VAPI::Bindings::ListType.new(VAPI::Bindings::StringType.instance),
-            {
-                'com.vmware.vapi.std.errors.error' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Error'),
-
-            },
-            [],
-            [])
-
-        @@service_info = VAPI::Bindings::ServiceInfo.new(@@service_id, {
-            'add' => @@add_info,
-            'set' => @@set_info,
-            'list' => @@list_info,
-        })
-
-        public
-
-        # Constructs a new instance.
-        #
-        # @param config [VAPI::Bindings::StubConfig] A hash with the api provider details.
-        def initialize(config)
-            super(config, @@service_info)
-        end
-
-
-        # Add domain to DNS search domains.
-        #
-        # @param domain [String]
-        #     Domain to add.
-        # @return [Void]
-        # @raise [Com::Vmware::Vapi::Std::Errors::Error]
-        #     Generic error
-        def add(domain)
-            invoke_with_info(@@add_info, {
-                'domain' => domain,
-            })
-        end
-
-
-        # Set DNS search domains.
-        #
-        # @param domains [Array<String>]
-        #     List of domains.
-        # @return [Void]
-        # @raise [Com::Vmware::Vapi::Std::Errors::Error]
-        #     Generic error
-        def set(domains)
-            invoke_with_info(@@set_info, {
-                'domains' => domains,
-            })
-        end
-
-
-        # Get list of DNS search domains.
-        #
-        # @return [Array<String>]
-        #     List of domains.
-        # @raise [Com::Vmware::Vapi::Std::Errors::Error]
-        #     Generic error
-        def list()
-            invoke_with_info(@@list_info)
-        end
-
-
+    # Constructs a new instance.
+    #
+    # @param config [VAPI::Bindings::StubConfig] A hash with the api provider details.
+    def initialize(config)
+      super(config, SERVICE_INFO)
     end
 
-
-    # ``Com::Vmware::Appliance::Networking::Dns::Hostname``   class  provides  methods  Performs operations on Fully Qualified Doman Name.
-    class Hostname < VAPI::Bindings::VapiService
-
-        protected
-
-        # static metamodel definitions
-        @@service_id = VAPI::Core::ServiceIdentifier.new('com.vmware.appliance.networking.dns.hostname')
-
-        @@test_info = VAPI::Bindings::OperationInfo.new(
-            VAPI::Core::OperationIdentifier.new('test', @@service_id),
-            VAPI::Bindings::OperationInputType.new({
-                'name' => VAPI::Bindings::StringType.instance,
-            }),
-            VAPI::Bindings::ReferenceType.new('Com::Vmware::Appliance::Networking::Dns::Hostname::TestStatusInfo'),
-            {
-                'com.vmware.vapi.std.errors.error' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Error'),
-
-            },
-            [],
-            [])
-        @@set_info = VAPI::Bindings::OperationInfo.new(
-            VAPI::Core::OperationIdentifier.new('set', @@service_id),
-            VAPI::Bindings::OperationInputType.new({
-                'name' => VAPI::Bindings::StringType.instance,
-            }),
-            VAPI::Bindings::VoidType.instance,
-            {
-                'com.vmware.vapi.std.errors.error' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Error'),
-
-            },
-            [],
-            [])
-        @@get_info = VAPI::Bindings::OperationInfo.new(
-            VAPI::Core::OperationIdentifier.new('get', @@service_id),
-            VAPI::Bindings::OperationInputType.new,
-            VAPI::Bindings::StringType.instance,
-            {
-                'com.vmware.vapi.std.errors.error' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Error'),
-
-            },
-            [],
-            [])
-
-        @@service_info = VAPI::Bindings::ServiceInfo.new(@@service_id, {
-            'test' => @@test_info,
-            'set' => @@set_info,
-            'get' => @@get_info,
-        })
-
-        public
-
-        # Constructs a new instance.
-        #
-        # @param config [VAPI::Bindings::StubConfig] A hash with the api provider details.
-        def initialize(config)
-            super(config, @@service_info)
-        end
-
-
-        # Test the Fully Qualified Domain Name.
-        #
-        # @param name [String]
-        #     FQDN.
-        # @return [Com::Vmware::Appliance::Networking::Dns::Hostname::TestStatusInfo]
-        #     FQDN status
-        # @raise [Com::Vmware::Vapi::Std::Errors::Error]
-        #     Generic error
-        def test(name)
-            invoke_with_info(@@test_info, {
-                'name' => name,
-            })
-        end
-
-
-        # Set the Fully Qualified Domain Name.
-        #
-        # @param name [String]
-        #     FQDN.
-        # @return [Void]
-        # @raise [Com::Vmware::Vapi::Std::Errors::Error]
-        #     Generic error
-        def set(name)
-            invoke_with_info(@@set_info, {
-                'name' => name,
-            })
-        end
-
-
-        # Get the Fully Qualified Doman Name.
-        #
-        # @return [String]
-        #     FQDN.
-        # @raise [Com::Vmware::Vapi::Std::Errors::Error]
-        #     Generic error
-        def get()
-            invoke_with_info(@@get_info)
-        end
-
-
-
-        # ``Com::Vmware::Appliance::Networking::Dns::Hostname::Message``   class  Test result and message
-        # @!attribute [rw] message
-        #     @return [String]
-        #     message
-        # @!attribute [rw] result
-        #     @return [Com::Vmware::Appliance::Networking::Dns::Hostname::MessageStatus]
-        #     result of the test
-        class Message < VAPI::Bindings::VapiStruct
-
-            class << self
-                # Holds (gets or creates) the binding type metadata for this structure type.
-                # @scope class
-                # @return [VAPI::Bindings::StructType] the binding type
-                def binding_type
-                    @binding_type ||= VAPI::Bindings::StructType.new(
-                        'com.vmware.appliance.networking.dns.hostname.message',
-                        {
-                            'message' => VAPI::Bindings::StringType.instance,
-                            'result' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Appliance::Networking::Dns::Hostname::MessageStatus'),
-                        },
-                        Message,
-                        false,
-                        nil)
-                end
-            end
-
-            attr_accessor :message,
-                          :result
-
-            # Constructs a new instance.
-            # @param ruby_values [Hash] a map of initial property values (optional)
-            # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
-            def initialize(ruby_values=nil, struct_value=nil)
-                super(self.class.binding_type, ruby_values, struct_value)
-            end
-        end
-
-
-        # ``Com::Vmware::Appliance::Networking::Dns::Hostname::TestStatusInfo``   class  Overall test result
-        # @!attribute [rw] status
-        #     @return [Com::Vmware::Appliance::Networking::Dns::Hostname::TestStatus]
-        #     Overall status of tests run.
-        # @!attribute [rw] messages
-        #     @return [Array<Com::Vmware::Appliance::Networking::Dns::Hostname::Message>]
-        #     messages
-        class TestStatusInfo < VAPI::Bindings::VapiStruct
-
-            class << self
-                # Holds (gets or creates) the binding type metadata for this structure type.
-                # @scope class
-                # @return [VAPI::Bindings::StructType] the binding type
-                def binding_type
-                    @binding_type ||= VAPI::Bindings::StructType.new(
-                        'com.vmware.appliance.networking.dns.hostname.test_status_info',
-                        {
-                            'status' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Appliance::Networking::Dns::Hostname::TestStatus'),
-                            'messages' => VAPI::Bindings::ListType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Appliance::Networking::Dns::Hostname::Message')),
-                        },
-                        TestStatusInfo,
-                        false,
-                        nil)
-                end
-            end
-
-            attr_accessor :status,
-                          :messages
-
-            # Constructs a new instance.
-            # @param ruby_values [Hash] a map of initial property values (optional)
-            # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
-            def initialize(ruby_values=nil, struct_value=nil)
-                super(self.class.binding_type, ruby_values, struct_value)
-            end
-        end
-
-
-
-        # ``Com::Vmware::Appliance::Networking::Dns::Hostname::TestStatus``   enumerated type  Health indicator
-        # @!attribute [rw] orange
-        #     @return [Com::Vmware::Appliance::Networking::Dns::Hostname::TestStatus]
-        #     In case data has more than one test, this indicates not all tests were successful
-        # @!attribute [rw] green
-        #     @return [Com::Vmware::Appliance::Networking::Dns::Hostname::TestStatus]
-        #     All tests were successful for given data
-        # @!attribute [rw] red
-        #     @return [Com::Vmware::Appliance::Networking::Dns::Hostname::TestStatus]
-        #     All tests failed for given data
-        class TestStatus < VAPI::Bindings::VapiEnum
-
-            class << self
-                # Holds (gets or creates) the binding type metadata for this enumeration type.
-                # @scope class
-                # @return [VAPI::Bindings::EnumType] the binding type
-                def binding_type
-                    @binding_type ||= VAPI::Bindings::EnumType.new(
-                        'com.vmware.appliance.networking.dns.hostname.test_status',
-                        TestStatus)
-                end
-
-                # Converts from a string value (perhaps off the wire) to an instance
-                # of this enum type.
-                # @param value [String] the actual value of the enum instance
-                # @return [TestStatus] the instance found for the value, otherwise
-                #         an unknown instance will be built for the value
-                def from_string(value)
-                    begin
-                        const_get(value)
-                    rescue NameError
-                        TestStatus.new('UNKNOWN', value)
-                    end
-                end
-            end
-
-            private
-
-            # Constructs a new instance.
-            # @param value [String] the actual value of the enum instance
-            # @param unknown [String] the unknown value when value is 'UKNOWN'
-            def initialize(value, unknown=nil)
-                super(self.class.binding_type, value, unknown)
-            end
-
-            public
-
-            # @!attribute [rw] orange
-            #     @return [Com::Vmware::Appliance::Networking::Dns::Hostname::TestStatus]
-            #     In case data has more than one test, this indicates not all tests were successful
-            ORANGE = TestStatus.new('ORANGE')
-
-            # @!attribute [rw] green
-            #     @return [Com::Vmware::Appliance::Networking::Dns::Hostname::TestStatus]
-            #     All tests were successful for given data
-            GREEN = TestStatus.new('GREEN')
-
-            # @!attribute [rw] red
-            #     @return [Com::Vmware::Appliance::Networking::Dns::Hostname::TestStatus]
-            #     All tests failed for given data
-            RED = TestStatus.new('RED')
-
-        end
-
-
-        # ``Com::Vmware::Appliance::Networking::Dns::Hostname::MessageStatus``   enumerated type  Individual test result
-        # @!attribute [rw] failure
-        #     @return [Com::Vmware::Appliance::Networking::Dns::Hostname::MessageStatus]
-        #     message indicates the test failed.
-        # @!attribute [rw] success
-        #     @return [Com::Vmware::Appliance::Networking::Dns::Hostname::MessageStatus]
-        #     message indicates that the test was successful.
-        class MessageStatus < VAPI::Bindings::VapiEnum
-
-            class << self
-                # Holds (gets or creates) the binding type metadata for this enumeration type.
-                # @scope class
-                # @return [VAPI::Bindings::EnumType] the binding type
-                def binding_type
-                    @binding_type ||= VAPI::Bindings::EnumType.new(
-                        'com.vmware.appliance.networking.dns.hostname.message_status',
-                        MessageStatus)
-                end
-
-                # Converts from a string value (perhaps off the wire) to an instance
-                # of this enum type.
-                # @param value [String] the actual value of the enum instance
-                # @return [MessageStatus] the instance found for the value, otherwise
-                #         an unknown instance will be built for the value
-                def from_string(value)
-                    begin
-                        const_get(value)
-                    rescue NameError
-                        MessageStatus.new('UNKNOWN', value)
-                    end
-                end
-            end
-
-            private
-
-            # Constructs a new instance.
-            # @param value [String] the actual value of the enum instance
-            # @param unknown [String] the unknown value when value is 'UKNOWN'
-            def initialize(value, unknown=nil)
-                super(self.class.binding_type, value, unknown)
-            end
-
-            public
-
-            # @!attribute [rw] failure
-            #     @return [Com::Vmware::Appliance::Networking::Dns::Hostname::MessageStatus]
-            #     message indicates the test failed.
-            FAILURE = MessageStatus.new('FAILURE')
-
-            # @!attribute [rw] success
-            #     @return [Com::Vmware::Appliance::Networking::Dns::Hostname::MessageStatus]
-            #     message indicates that the test was successful.
-            SUCCESS = MessageStatus.new('SUCCESS')
-
-        end
-
-
+    # Add domain to DNS search domains.
+    #
+    # @param domain [String]
+    #     Domain to add.
+    # @return [Void]
+    # @raise [Com::Vmware::Vapi::Std::Errors::Error]
+    #     Generic error
+    def add(domain)
+      invoke_with_info(ADD_INFO,
+                       'domain' => domain)
     end
 
-
-    # ``Com::Vmware::Appliance::Networking::Dns::Servers``   class  provides  methods  DNS server configuration.
-    class Servers < VAPI::Bindings::VapiService
-
-        protected
-
-        # static metamodel definitions
-        @@service_id = VAPI::Core::ServiceIdentifier.new('com.vmware.appliance.networking.dns.servers')
-
-        @@test_info = VAPI::Bindings::OperationInfo.new(
-            VAPI::Core::OperationIdentifier.new('test', @@service_id),
-            VAPI::Bindings::OperationInputType.new({
-                'servers' => VAPI::Bindings::ListType.new(VAPI::Bindings::StringType.instance),
-            }),
-            VAPI::Bindings::ReferenceType.new('Com::Vmware::Appliance::Networking::Dns::Servers::TestStatusInfo'),
-            {
-                'com.vmware.vapi.std.errors.error' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Error'),
-
-            },
-            [],
-            [])
-        @@add_info = VAPI::Bindings::OperationInfo.new(
-            VAPI::Core::OperationIdentifier.new('add', @@service_id),
-            VAPI::Bindings::OperationInputType.new({
-                'server' => VAPI::Bindings::StringType.instance,
-            }),
-            VAPI::Bindings::VoidType.instance,
-            {
-                'com.vmware.vapi.std.errors.error' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Error'),
-
-            },
-            [],
-            [])
-        @@set_info = VAPI::Bindings::OperationInfo.new(
-            VAPI::Core::OperationIdentifier.new('set', @@service_id),
-            VAPI::Bindings::OperationInputType.new({
-                'config' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Appliance::Networking::Dns::Servers::DNSServerConfig'),
-            }),
-            VAPI::Bindings::VoidType.instance,
-            {
-                'com.vmware.vapi.std.errors.error' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Error'),
-
-            },
-            [],
-            [])
-        @@get_info = VAPI::Bindings::OperationInfo.new(
-            VAPI::Core::OperationIdentifier.new('get', @@service_id),
-            VAPI::Bindings::OperationInputType.new,
-            VAPI::Bindings::ReferenceType.new('Com::Vmware::Appliance::Networking::Dns::Servers::DNSServerConfig'),
-            {
-                'com.vmware.vapi.std.errors.error' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Error'),
-
-            },
-            [],
-            [])
-
-        @@service_info = VAPI::Bindings::ServiceInfo.new(@@service_id, {
-            'test' => @@test_info,
-            'add' => @@add_info,
-            'set' => @@set_info,
-            'get' => @@get_info,
-        })
-
-        public
-
-        # Constructs a new instance.
-        #
-        # @param config [VAPI::Bindings::StubConfig] A hash with the api provider details.
-        def initialize(config)
-            super(config, @@service_info)
-        end
-
-
-        # Test if dns servers are reachable.
-        #
-        # @param servers [Array<String>]
-        #     DNS servers.
-        # @return [Com::Vmware::Appliance::Networking::Dns::Servers::TestStatusInfo]
-        #     DNS reacable status
-        # @raise [Com::Vmware::Vapi::Std::Errors::Error]
-        #     Generic error
-        def test(servers)
-            invoke_with_info(@@test_info, {
-                'servers' => servers,
-            })
-        end
-
-
-        # Add a DNS server. This method fails if mode argument is "dhcp"
-        #
-        # @param server [String]
-        #     DNS server.
-        # @return [Void]
-        # @raise [Com::Vmware::Vapi::Std::Errors::Error]
-        #     Generic error
-        def add(server)
-            invoke_with_info(@@add_info, {
-                'server' => server,
-            })
-        end
-
-
-        # Set the DNS server configuration. If you set the mode argument to "DHCP", a DHCP refresh is forced.
-        #
-        # @param config [Com::Vmware::Appliance::Networking::Dns::Servers::DNSServerConfig]
-        #     DNS server configuration.
-        # @return [Void]
-        # @raise [Com::Vmware::Vapi::Std::Errors::Error]
-        #     Generic error
-        def set(config)
-            invoke_with_info(@@set_info, {
-                'config' => config,
-            })
-        end
-
-
-        # Get DNS server configuration.
-        #
-        # @return [Com::Vmware::Appliance::Networking::Dns::Servers::DNSServerConfig]
-        #     DNS server configuration.
-        # @raise [Com::Vmware::Vapi::Std::Errors::Error]
-        #     Generic error
-        def get()
-            invoke_with_info(@@get_info)
-        end
-
-
-
-        # ``Com::Vmware::Appliance::Networking::Dns::Servers::DNSServerConfig``   class  This structure represents the configuration state used to determine DNS servers.
-        # @!attribute [rw] mode
-        #     @return [Com::Vmware::Appliance::Networking::Dns::Servers::DNSServerMode]
-        #     Define how to determine the DNS servers. Leave the servers argument empty if the mode argument is "DHCP". Set the servers argument to a comma-separated list of DNS servers if the mode argument is "static". The DNS server are assigned from the specified list.
-        # @!attribute [rw] servers
-        #     @return [Array<String>]
-        #     List of the currently used DNS servers.
-        class DNSServerConfig < VAPI::Bindings::VapiStruct
-
-            class << self
-                # Holds (gets or creates) the binding type metadata for this structure type.
-                # @scope class
-                # @return [VAPI::Bindings::StructType] the binding type
-                def binding_type
-                    @binding_type ||= VAPI::Bindings::StructType.new(
-                        'com.vmware.appliance.networking.dns.servers.DNS_server_config',
-                        {
-                            'mode' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Appliance::Networking::Dns::Servers::DNSServerMode'),
-                            'servers' => VAPI::Bindings::ListType.new(VAPI::Bindings::StringType.instance),
-                        },
-                        DNSServerConfig,
-                        false,
-                        nil)
-                end
-            end
-
-            attr_accessor :mode,
-                          :servers
-
-            # Constructs a new instance.
-            # @param ruby_values [Hash] a map of initial property values (optional)
-            # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
-            def initialize(ruby_values=nil, struct_value=nil)
-                super(self.class.binding_type, ruby_values, struct_value)
-            end
-        end
-
-
-        # ``Com::Vmware::Appliance::Networking::Dns::Servers::Message``   class  Test result and message
-        # @!attribute [rw] message
-        #     @return [String]
-        #     message
-        # @!attribute [rw] result
-        #     @return [Com::Vmware::Appliance::Networking::Dns::Servers::MessageStatus]
-        #     result of the test
-        class Message < VAPI::Bindings::VapiStruct
-
-            class << self
-                # Holds (gets or creates) the binding type metadata for this structure type.
-                # @scope class
-                # @return [VAPI::Bindings::StructType] the binding type
-                def binding_type
-                    @binding_type ||= VAPI::Bindings::StructType.new(
-                        'com.vmware.appliance.networking.dns.servers.message',
-                        {
-                            'message' => VAPI::Bindings::StringType.instance,
-                            'result' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Appliance::Networking::Dns::Servers::MessageStatus'),
-                        },
-                        Message,
-                        false,
-                        nil)
-                end
-            end
-
-            attr_accessor :message,
-                          :result
-
-            # Constructs a new instance.
-            # @param ruby_values [Hash] a map of initial property values (optional)
-            # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
-            def initialize(ruby_values=nil, struct_value=nil)
-                super(self.class.binding_type, ruby_values, struct_value)
-            end
-        end
-
-
-        # ``Com::Vmware::Appliance::Networking::Dns::Servers::TestStatusInfo``   class  Overall test result
-        # @!attribute [rw] status
-        #     @return [Com::Vmware::Appliance::Networking::Dns::Servers::TestStatus]
-        #     Overall status of tests run.
-        # @!attribute [rw] messages
-        #     @return [Array<Com::Vmware::Appliance::Networking::Dns::Servers::Message>]
-        #     messages
-        class TestStatusInfo < VAPI::Bindings::VapiStruct
-
-            class << self
-                # Holds (gets or creates) the binding type metadata for this structure type.
-                # @scope class
-                # @return [VAPI::Bindings::StructType] the binding type
-                def binding_type
-                    @binding_type ||= VAPI::Bindings::StructType.new(
-                        'com.vmware.appliance.networking.dns.servers.test_status_info',
-                        {
-                            'status' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Appliance::Networking::Dns::Servers::TestStatus'),
-                            'messages' => VAPI::Bindings::ListType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Appliance::Networking::Dns::Servers::Message')),
-                        },
-                        TestStatusInfo,
-                        false,
-                        nil)
-                end
-            end
-
-            attr_accessor :status,
-                          :messages
-
-            # Constructs a new instance.
-            # @param ruby_values [Hash] a map of initial property values (optional)
-            # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
-            def initialize(ruby_values=nil, struct_value=nil)
-                super(self.class.binding_type, ruby_values, struct_value)
-            end
-        end
-
-
-
-        # ``Com::Vmware::Appliance::Networking::Dns::Servers::DNSServerMode``   enumerated type  Describes DNS Server source (DHCP,static)
-        # @!attribute [rw] dhcp
-        #     @return [Com::Vmware::Appliance::Networking::Dns::Servers::DNSServerMode]
-        #     DNS address is automatically assigned by a DHCP server.
-        # @!attribute [rw] is_static
-        #     @return [Com::Vmware::Appliance::Networking::Dns::Servers::DNSServerMode]
-        #     DNS address is static.
-        class DNSServerMode < VAPI::Bindings::VapiEnum
-
-            class << self
-                # Holds (gets or creates) the binding type metadata for this enumeration type.
-                # @scope class
-                # @return [VAPI::Bindings::EnumType] the binding type
-                def binding_type
-                    @binding_type ||= VAPI::Bindings::EnumType.new(
-                        'com.vmware.appliance.networking.dns.servers.DNS_server_mode',
-                        DNSServerMode)
-                end
-
-                # Converts from a string value (perhaps off the wire) to an instance
-                # of this enum type.
-                # @param value [String] the actual value of the enum instance
-                # @return [DNSServerMode] the instance found for the value, otherwise
-                #         an unknown instance will be built for the value
-                def from_string(value)
-                    begin
-                        const_get(value)
-                    rescue NameError
-                        DNSServerMode.new('UNKNOWN', value)
-                    end
-                end
-            end
-
-            private
-
-            # Constructs a new instance.
-            # @param value [String] the actual value of the enum instance
-            # @param unknown [String] the unknown value when value is 'UKNOWN'
-            def initialize(value, unknown=nil)
-                super(self.class.binding_type, value, unknown)
-            end
-
-            public
-
-            # @!attribute [rw] dhcp
-            #     @return [Com::Vmware::Appliance::Networking::Dns::Servers::DNSServerMode]
-            #     DNS address is automatically assigned by a DHCP server.
-            DHCP = DNSServerMode.new('DHCP')
-
-            # @!attribute [rw] is_static
-            #     @return [Com::Vmware::Appliance::Networking::Dns::Servers::DNSServerMode]
-            #     DNS address is static.
-            IS_STATIC = DNSServerMode.new('IS_STATIC')
-
-        end
-
-
-        # ``Com::Vmware::Appliance::Networking::Dns::Servers::TestStatus``   enumerated type  Health indicator
-        # @!attribute [rw] orange
-        #     @return [Com::Vmware::Appliance::Networking::Dns::Servers::TestStatus]
-        #     In case data has more than one test, this indicates not all tests were successful
-        # @!attribute [rw] green
-        #     @return [Com::Vmware::Appliance::Networking::Dns::Servers::TestStatus]
-        #     All tests were successful for given data
-        # @!attribute [rw] red
-        #     @return [Com::Vmware::Appliance::Networking::Dns::Servers::TestStatus]
-        #     All tests failed for given data
-        class TestStatus < VAPI::Bindings::VapiEnum
-
-            class << self
-                # Holds (gets or creates) the binding type metadata for this enumeration type.
-                # @scope class
-                # @return [VAPI::Bindings::EnumType] the binding type
-                def binding_type
-                    @binding_type ||= VAPI::Bindings::EnumType.new(
-                        'com.vmware.appliance.networking.dns.servers.test_status',
-                        TestStatus)
-                end
-
-                # Converts from a string value (perhaps off the wire) to an instance
-                # of this enum type.
-                # @param value [String] the actual value of the enum instance
-                # @return [TestStatus] the instance found for the value, otherwise
-                #         an unknown instance will be built for the value
-                def from_string(value)
-                    begin
-                        const_get(value)
-                    rescue NameError
-                        TestStatus.new('UNKNOWN', value)
-                    end
-                end
-            end
-
-            private
-
-            # Constructs a new instance.
-            # @param value [String] the actual value of the enum instance
-            # @param unknown [String] the unknown value when value is 'UKNOWN'
-            def initialize(value, unknown=nil)
-                super(self.class.binding_type, value, unknown)
-            end
-
-            public
-
-            # @!attribute [rw] orange
-            #     @return [Com::Vmware::Appliance::Networking::Dns::Servers::TestStatus]
-            #     In case data has more than one test, this indicates not all tests were successful
-            ORANGE = TestStatus.new('ORANGE')
-
-            # @!attribute [rw] green
-            #     @return [Com::Vmware::Appliance::Networking::Dns::Servers::TestStatus]
-            #     All tests were successful for given data
-            GREEN = TestStatus.new('GREEN')
-
-            # @!attribute [rw] red
-            #     @return [Com::Vmware::Appliance::Networking::Dns::Servers::TestStatus]
-            #     All tests failed for given data
-            RED = TestStatus.new('RED')
-
-        end
-
-
-        # ``Com::Vmware::Appliance::Networking::Dns::Servers::MessageStatus``   enumerated type  Individual test result
-        # @!attribute [rw] failure
-        #     @return [Com::Vmware::Appliance::Networking::Dns::Servers::MessageStatus]
-        #     message indicates the test failed.
-        # @!attribute [rw] success
-        #     @return [Com::Vmware::Appliance::Networking::Dns::Servers::MessageStatus]
-        #     message indicates that the test was successful.
-        class MessageStatus < VAPI::Bindings::VapiEnum
-
-            class << self
-                # Holds (gets or creates) the binding type metadata for this enumeration type.
-                # @scope class
-                # @return [VAPI::Bindings::EnumType] the binding type
-                def binding_type
-                    @binding_type ||= VAPI::Bindings::EnumType.new(
-                        'com.vmware.appliance.networking.dns.servers.message_status',
-                        MessageStatus)
-                end
-
-                # Converts from a string value (perhaps off the wire) to an instance
-                # of this enum type.
-                # @param value [String] the actual value of the enum instance
-                # @return [MessageStatus] the instance found for the value, otherwise
-                #         an unknown instance will be built for the value
-                def from_string(value)
-                    begin
-                        const_get(value)
-                    rescue NameError
-                        MessageStatus.new('UNKNOWN', value)
-                    end
-                end
-            end
-
-            private
-
-            # Constructs a new instance.
-            # @param value [String] the actual value of the enum instance
-            # @param unknown [String] the unknown value when value is 'UKNOWN'
-            def initialize(value, unknown=nil)
-                super(self.class.binding_type, value, unknown)
-            end
-
-            public
-
-            # @!attribute [rw] failure
-            #     @return [Com::Vmware::Appliance::Networking::Dns::Servers::MessageStatus]
-            #     message indicates the test failed.
-            FAILURE = MessageStatus.new('FAILURE')
-
-            # @!attribute [rw] success
-            #     @return [Com::Vmware::Appliance::Networking::Dns::Servers::MessageStatus]
-            #     message indicates that the test was successful.
-            SUCCESS = MessageStatus.new('SUCCESS')
-
-        end
-
-
+    # Set DNS search domains.
+    #
+    # @param domains [Array<String>]
+    #     List of domains.
+    # @return [Void]
+    # @raise [Com::Vmware::Vapi::Std::Errors::Error]
+    #     Generic error
+    def set(domains)
+      invoke_with_info(SET_INFO,
+                       'domains' => domains)
     end
 
+    # Get list of DNS search domains.
+    #
+    # @return [Array<String>]
+    #     List of domains.
+    # @raise [Com::Vmware::Vapi::Std::Errors::Error]
+    #     Generic error
+    def list
+      invoke_with_info(LIST_INFO)
+    end
 
+  end
+  # ``Com::Vmware::Appliance::Networking::Dns::Hostname``   class  provides  methods  Performs operations on Fully Qualified Doman Name.
+  class Hostname < VAPI::Bindings::VapiService
+    # static metamodel definitions
+    SERVICE_ID = VAPI::Core::ServiceIdentifier.new('com.vmware.appliance.networking.dns.hostname')
+
+    TEST_INFO = VAPI::Bindings::OperationInfo.new(
+      VAPI::Core::OperationIdentifier.new('test', SERVICE_ID),
+      VAPI::Bindings::OperationInputType.new(
+        'name' => VAPI::Bindings::StringType.instance
+      ),
+      VAPI::Bindings::ReferenceType.new('Com::Vmware::Appliance::Networking::Dns::Hostname::TestStatusInfo'),
+      {
+        'com.vmware.vapi.std.errors.error' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Error')
+      },
+      [],
+      []
+    )
+
+    SET_INFO = VAPI::Bindings::OperationInfo.new(
+      VAPI::Core::OperationIdentifier.new('set', SERVICE_ID),
+      VAPI::Bindings::OperationInputType.new(
+        'name' => VAPI::Bindings::StringType.instance
+      ),
+      VAPI::Bindings::VoidType.instance,
+      {
+        'com.vmware.vapi.std.errors.error' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Error')
+      },
+      [],
+      []
+    )
+
+    GET_INFO = VAPI::Bindings::OperationInfo.new(
+      VAPI::Core::OperationIdentifier.new('get', SERVICE_ID),
+      VAPI::Bindings::OperationInputType.new,
+      VAPI::Bindings::StringType.instance,
+      {
+        'com.vmware.vapi.std.errors.error' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Error')
+      },
+      [],
+      []
+    )
+
+    SERVICE_INFO = VAPI::Bindings::ServiceInfo.new(
+      SERVICE_ID,
+      'test' => TEST_INFO,
+      'set' => SET_INFO,
+      'get' => GET_INFO
+    )
+
+    # Constructs a new instance.
+    #
+    # @param config [VAPI::Bindings::StubConfig] A hash with the api provider details.
+    def initialize(config)
+      super(config, SERVICE_INFO)
+    end
+
+    # Test the Fully Qualified Domain Name.
+    #
+    # @param name [String]
+    #     FQDN.
+    # @return [Com::Vmware::Appliance::Networking::Dns::Hostname::TestStatusInfo]
+    #     FQDN status
+    # @raise [Com::Vmware::Vapi::Std::Errors::Error]
+    #     Generic error
+    def test(name)
+      invoke_with_info(TEST_INFO,
+                       'name' => name)
+    end
+
+    # Set the Fully Qualified Domain Name.
+    #
+    # @param name [String]
+    #     FQDN.
+    # @return [Void]
+    # @raise [Com::Vmware::Vapi::Std::Errors::Error]
+    #     Generic error
+    def set(name)
+      invoke_with_info(SET_INFO,
+                       'name' => name)
+    end
+
+    # Get the Fully Qualified Doman Name.
+    #
+    # @return [String]
+    #     FQDN.
+    # @raise [Com::Vmware::Vapi::Std::Errors::Error]
+    #     Generic error
+    def get
+      invoke_with_info(GET_INFO)
+    end
+
+    # ``Com::Vmware::Appliance::Networking::Dns::Hostname::Message``   class  Test result and message
+    # @!attribute [rw] message
+    #     @return [String]
+    #     message
+    # @!attribute [rw] result
+    #     @return [Com::Vmware::Appliance::Networking::Dns::Hostname::MessageStatus]
+    #     result of the test
+    class Message < VAPI::Bindings::VapiStruct
+      class << self
+        # Holds (gets or creates) the binding type metadata for this structure type.
+        # @scope class
+        # @return [VAPI::Bindings::StructType] the binding type
+        def binding_type
+          @binding_type ||= VAPI::Bindings::StructType.new(
+            'com.vmware.appliance.networking.dns.hostname.message',
+            {
+              'message' => VAPI::Bindings::StringType.instance,
+              'result' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Appliance::Networking::Dns::Hostname::MessageStatus')
+            },
+            Message,
+            false,
+            nil
+          )
+        end
+      end
+
+      attr_accessor :message,
+                    :result
+
+      # Constructs a new instance.
+      # @param ruby_values [Hash] a map of initial property values (optional)
+      # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
+      def initialize(ruby_values = nil, struct_value = nil)
+        super(self.class.binding_type, ruby_values, struct_value)
+      end
+    end
+
+    # ``Com::Vmware::Appliance::Networking::Dns::Hostname::TestStatusInfo``   class  Overall test result
+    # @!attribute [rw] status
+    #     @return [Com::Vmware::Appliance::Networking::Dns::Hostname::TestStatus]
+    #     Overall status of tests run.
+    # @!attribute [rw] messages
+    #     @return [Array<Com::Vmware::Appliance::Networking::Dns::Hostname::Message>]
+    #     messages
+    class TestStatusInfo < VAPI::Bindings::VapiStruct
+      class << self
+        # Holds (gets or creates) the binding type metadata for this structure type.
+        # @scope class
+        # @return [VAPI::Bindings::StructType] the binding type
+        def binding_type
+          @binding_type ||= VAPI::Bindings::StructType.new(
+            'com.vmware.appliance.networking.dns.hostname.test_status_info',
+            {
+              'status' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Appliance::Networking::Dns::Hostname::TestStatus'),
+              'messages' => VAPI::Bindings::ListType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Appliance::Networking::Dns::Hostname::Message'))
+            },
+            TestStatusInfo,
+            false,
+            nil
+          )
+        end
+      end
+
+      attr_accessor :status,
+                    :messages
+
+      # Constructs a new instance.
+      # @param ruby_values [Hash] a map of initial property values (optional)
+      # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
+      def initialize(ruby_values = nil, struct_value = nil)
+        super(self.class.binding_type, ruby_values, struct_value)
+      end
+    end
+
+    # ``Com::Vmware::Appliance::Networking::Dns::Hostname::TestStatus``   enumerated type  Health indicator
+    # @!attribute [rw] orange
+    #     @return [Com::Vmware::Appliance::Networking::Dns::Hostname::TestStatus]
+    #     In case data has more than one test, this indicates not all tests were successful
+    # @!attribute [rw] green
+    #     @return [Com::Vmware::Appliance::Networking::Dns::Hostname::TestStatus]
+    #     All tests were successful for given data
+    # @!attribute [rw] red
+    #     @return [Com::Vmware::Appliance::Networking::Dns::Hostname::TestStatus]
+    #     All tests failed for given data
+    class TestStatus < VAPI::Bindings::VapiEnum
+      class << self
+        # Holds (gets or creates) the binding type metadata for this enumeration type.
+        # @scope class
+        # @return [VAPI::Bindings::EnumType] the binding type
+        def binding_type
+          @binding_type ||= VAPI::Bindings::EnumType.new(
+            'com.vmware.appliance.networking.dns.hostname.test_status',
+            TestStatus
+          )
+        end
+
+        # Converts from a string value (perhaps off the wire) to an instance
+        # of this enum type.
+        # @param value [String] the actual value of the enum instance
+        # @return [TestStatus] the instance found for the value, otherwise
+        #         an unknown instance will be built for the value
+        def from_string(value)
+          const_get(value)
+        rescue NameError
+          TestStatus.send(:new, 'UNKNOWN', value)
+        end
+      end
+
+      # Constructs a new instance.
+      # @param value [String] the actual value of the enum instance
+      # @param unknown [String] the unknown value when value is 'UKNOWN'
+      def initialize(value, unknown = nil)
+        super(self.class.binding_type, value, unknown)
+      end
+
+      private_class_method :new
+
+      # @!attribute [rw] orange
+      #     @return [Com::Vmware::Appliance::Networking::Dns::Hostname::TestStatus]
+      #     In case data has more than one test, this indicates not all tests were successful
+      ORANGE = TestStatus.send(:new, 'ORANGE')
+
+      # @!attribute [rw] green
+      #     @return [Com::Vmware::Appliance::Networking::Dns::Hostname::TestStatus]
+      #     All tests were successful for given data
+      GREEN = TestStatus.send(:new, 'GREEN')
+
+      # @!attribute [rw] red
+      #     @return [Com::Vmware::Appliance::Networking::Dns::Hostname::TestStatus]
+      #     All tests failed for given data
+      RED = TestStatus.send(:new, 'RED')
+    end
+    # ``Com::Vmware::Appliance::Networking::Dns::Hostname::MessageStatus``   enumerated type  Individual test result
+    # @!attribute [rw] failure
+    #     @return [Com::Vmware::Appliance::Networking::Dns::Hostname::MessageStatus]
+    #     message indicates the test failed.
+    # @!attribute [rw] success
+    #     @return [Com::Vmware::Appliance::Networking::Dns::Hostname::MessageStatus]
+    #     message indicates that the test was successful.
+    class MessageStatus < VAPI::Bindings::VapiEnum
+      class << self
+        # Holds (gets or creates) the binding type metadata for this enumeration type.
+        # @scope class
+        # @return [VAPI::Bindings::EnumType] the binding type
+        def binding_type
+          @binding_type ||= VAPI::Bindings::EnumType.new(
+            'com.vmware.appliance.networking.dns.hostname.message_status',
+            MessageStatus
+          )
+        end
+
+        # Converts from a string value (perhaps off the wire) to an instance
+        # of this enum type.
+        # @param value [String] the actual value of the enum instance
+        # @return [MessageStatus] the instance found for the value, otherwise
+        #         an unknown instance will be built for the value
+        def from_string(value)
+          const_get(value)
+        rescue NameError
+          MessageStatus.send(:new, 'UNKNOWN', value)
+        end
+      end
+
+      # Constructs a new instance.
+      # @param value [String] the actual value of the enum instance
+      # @param unknown [String] the unknown value when value is 'UKNOWN'
+      def initialize(value, unknown = nil)
+        super(self.class.binding_type, value, unknown)
+      end
+
+      private_class_method :new
+
+      # @!attribute [rw] failure
+      #     @return [Com::Vmware::Appliance::Networking::Dns::Hostname::MessageStatus]
+      #     message indicates the test failed.
+      FAILURE = MessageStatus.send(:new, 'FAILURE')
+
+      # @!attribute [rw] success
+      #     @return [Com::Vmware::Appliance::Networking::Dns::Hostname::MessageStatus]
+      #     message indicates that the test was successful.
+      SUCCESS = MessageStatus.send(:new, 'SUCCESS')
+    end
+  end
+  # ``Com::Vmware::Appliance::Networking::Dns::Servers``   class  provides  methods  DNS server configuration.
+  class Servers < VAPI::Bindings::VapiService
+    # static metamodel definitions
+    SERVICE_ID = VAPI::Core::ServiceIdentifier.new('com.vmware.appliance.networking.dns.servers')
+
+    TEST_INFO = VAPI::Bindings::OperationInfo.new(
+      VAPI::Core::OperationIdentifier.new('test', SERVICE_ID),
+      VAPI::Bindings::OperationInputType.new(
+        'servers' => VAPI::Bindings::ListType.new(VAPI::Bindings::StringType.instance)
+      ),
+      VAPI::Bindings::ReferenceType.new('Com::Vmware::Appliance::Networking::Dns::Servers::TestStatusInfo'),
+      {
+        'com.vmware.vapi.std.errors.error' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Error')
+      },
+      [],
+      []
+    )
+
+    ADD_INFO = VAPI::Bindings::OperationInfo.new(
+      VAPI::Core::OperationIdentifier.new('add', SERVICE_ID),
+      VAPI::Bindings::OperationInputType.new(
+        'server' => VAPI::Bindings::StringType.instance
+      ),
+      VAPI::Bindings::VoidType.instance,
+      {
+        'com.vmware.vapi.std.errors.error' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Error')
+      },
+      [],
+      []
+    )
+
+    SET_INFO = VAPI::Bindings::OperationInfo.new(
+      VAPI::Core::OperationIdentifier.new('set', SERVICE_ID),
+      VAPI::Bindings::OperationInputType.new(
+        'config' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Appliance::Networking::Dns::Servers::DNSServerConfig')
+      ),
+      VAPI::Bindings::VoidType.instance,
+      {
+        'com.vmware.vapi.std.errors.error' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Error')
+      },
+      [],
+      []
+    )
+
+    GET_INFO = VAPI::Bindings::OperationInfo.new(
+      VAPI::Core::OperationIdentifier.new('get', SERVICE_ID),
+      VAPI::Bindings::OperationInputType.new,
+      VAPI::Bindings::ReferenceType.new('Com::Vmware::Appliance::Networking::Dns::Servers::DNSServerConfig'),
+      {
+        'com.vmware.vapi.std.errors.error' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Error')
+      },
+      [],
+      []
+    )
+
+    SERVICE_INFO = VAPI::Bindings::ServiceInfo.new(
+      SERVICE_ID,
+      'test' => TEST_INFO,
+      'add' => ADD_INFO,
+      'set' => SET_INFO,
+      'get' => GET_INFO
+    )
+
+    # Constructs a new instance.
+    #
+    # @param config [VAPI::Bindings::StubConfig] A hash with the api provider details.
+    def initialize(config)
+      super(config, SERVICE_INFO)
+    end
+
+    # Test if dns servers are reachable.
+    #
+    # @param servers [Array<String>]
+    #     DNS servers.
+    # @return [Com::Vmware::Appliance::Networking::Dns::Servers::TestStatusInfo]
+    #     DNS reacable status
+    # @raise [Com::Vmware::Vapi::Std::Errors::Error]
+    #     Generic error
+    def test(servers)
+      invoke_with_info(TEST_INFO,
+                       'servers' => servers)
+    end
+
+    # Add a DNS server. This method fails if mode argument is "dhcp"
+    #
+    # @param server [String]
+    #     DNS server.
+    # @return [Void]
+    # @raise [Com::Vmware::Vapi::Std::Errors::Error]
+    #     Generic error
+    def add(server)
+      invoke_with_info(ADD_INFO,
+                       'server' => server)
+    end
+
+    # Set the DNS server configuration. If you set the mode argument to "DHCP", a DHCP refresh is forced.
+    #
+    # @param config [Com::Vmware::Appliance::Networking::Dns::Servers::DNSServerConfig]
+    #     DNS server configuration.
+    # @return [Void]
+    # @raise [Com::Vmware::Vapi::Std::Errors::Error]
+    #     Generic error
+    def set(config)
+      invoke_with_info(SET_INFO,
+                       'config' => config)
+    end
+
+    # Get DNS server configuration.
+    #
+    # @return [Com::Vmware::Appliance::Networking::Dns::Servers::DNSServerConfig]
+    #     DNS server configuration.
+    # @raise [Com::Vmware::Vapi::Std::Errors::Error]
+    #     Generic error
+    def get
+      invoke_with_info(GET_INFO)
+    end
+
+    # ``Com::Vmware::Appliance::Networking::Dns::Servers::DNSServerConfig``   class  This structure represents the configuration state used to determine DNS servers.
+    # @!attribute [rw] mode
+    #     @return [Com::Vmware::Appliance::Networking::Dns::Servers::DNSServerMode]
+    #     Define how to determine the DNS servers. Leave the servers argument empty if the mode argument is "DHCP". Set the servers argument to a comma-separated list of DNS servers if the mode argument is "static". The DNS server are assigned from the specified list.
+    # @!attribute [rw] servers
+    #     @return [Array<String>]
+    #     List of the currently used DNS servers.
+    class DNSServerConfig < VAPI::Bindings::VapiStruct
+      class << self
+        # Holds (gets or creates) the binding type metadata for this structure type.
+        # @scope class
+        # @return [VAPI::Bindings::StructType] the binding type
+        def binding_type
+          @binding_type ||= VAPI::Bindings::StructType.new(
+            'com.vmware.appliance.networking.dns.servers.DNS_server_config',
+            {
+              'mode' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Appliance::Networking::Dns::Servers::DNSServerMode'),
+              'servers' => VAPI::Bindings::ListType.new(VAPI::Bindings::StringType.instance)
+            },
+            DNSServerConfig,
+            false,
+            nil
+          )
+        end
+      end
+
+      attr_accessor :mode,
+                    :servers
+
+      # Constructs a new instance.
+      # @param ruby_values [Hash] a map of initial property values (optional)
+      # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
+      def initialize(ruby_values = nil, struct_value = nil)
+        super(self.class.binding_type, ruby_values, struct_value)
+      end
+    end
+
+    # ``Com::Vmware::Appliance::Networking::Dns::Servers::Message``   class  Test result and message
+    # @!attribute [rw] message
+    #     @return [String]
+    #     message
+    # @!attribute [rw] result
+    #     @return [Com::Vmware::Appliance::Networking::Dns::Servers::MessageStatus]
+    #     result of the test
+    class Message < VAPI::Bindings::VapiStruct
+      class << self
+        # Holds (gets or creates) the binding type metadata for this structure type.
+        # @scope class
+        # @return [VAPI::Bindings::StructType] the binding type
+        def binding_type
+          @binding_type ||= VAPI::Bindings::StructType.new(
+            'com.vmware.appliance.networking.dns.servers.message',
+            {
+              'message' => VAPI::Bindings::StringType.instance,
+              'result' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Appliance::Networking::Dns::Servers::MessageStatus')
+            },
+            Message,
+            false,
+            nil
+          )
+        end
+      end
+
+      attr_accessor :message,
+                    :result
+
+      # Constructs a new instance.
+      # @param ruby_values [Hash] a map of initial property values (optional)
+      # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
+      def initialize(ruby_values = nil, struct_value = nil)
+        super(self.class.binding_type, ruby_values, struct_value)
+      end
+    end
+
+    # ``Com::Vmware::Appliance::Networking::Dns::Servers::TestStatusInfo``   class  Overall test result
+    # @!attribute [rw] status
+    #     @return [Com::Vmware::Appliance::Networking::Dns::Servers::TestStatus]
+    #     Overall status of tests run.
+    # @!attribute [rw] messages
+    #     @return [Array<Com::Vmware::Appliance::Networking::Dns::Servers::Message>]
+    #     messages
+    class TestStatusInfo < VAPI::Bindings::VapiStruct
+      class << self
+        # Holds (gets or creates) the binding type metadata for this structure type.
+        # @scope class
+        # @return [VAPI::Bindings::StructType] the binding type
+        def binding_type
+          @binding_type ||= VAPI::Bindings::StructType.new(
+            'com.vmware.appliance.networking.dns.servers.test_status_info',
+            {
+              'status' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Appliance::Networking::Dns::Servers::TestStatus'),
+              'messages' => VAPI::Bindings::ListType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Appliance::Networking::Dns::Servers::Message'))
+            },
+            TestStatusInfo,
+            false,
+            nil
+          )
+        end
+      end
+
+      attr_accessor :status,
+                    :messages
+
+      # Constructs a new instance.
+      # @param ruby_values [Hash] a map of initial property values (optional)
+      # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
+      def initialize(ruby_values = nil, struct_value = nil)
+        super(self.class.binding_type, ruby_values, struct_value)
+      end
+    end
+
+    # ``Com::Vmware::Appliance::Networking::Dns::Servers::DNSServerMode``   enumerated type  Describes DNS Server source (DHCP,static)
+    # @!attribute [rw] dhcp
+    #     @return [Com::Vmware::Appliance::Networking::Dns::Servers::DNSServerMode]
+    #     DNS address is automatically assigned by a DHCP server.
+    # @!attribute [rw] is_static
+    #     @return [Com::Vmware::Appliance::Networking::Dns::Servers::DNSServerMode]
+    #     DNS address is static.
+    class DNSServerMode < VAPI::Bindings::VapiEnum
+      class << self
+        # Holds (gets or creates) the binding type metadata for this enumeration type.
+        # @scope class
+        # @return [VAPI::Bindings::EnumType] the binding type
+        def binding_type
+          @binding_type ||= VAPI::Bindings::EnumType.new(
+            'com.vmware.appliance.networking.dns.servers.DNS_server_mode',
+            DNSServerMode
+          )
+        end
+
+        # Converts from a string value (perhaps off the wire) to an instance
+        # of this enum type.
+        # @param value [String] the actual value of the enum instance
+        # @return [DNSServerMode] the instance found for the value, otherwise
+        #         an unknown instance will be built for the value
+        def from_string(value)
+          const_get(value)
+        rescue NameError
+          DNSServerMode.send(:new, 'UNKNOWN', value)
+        end
+      end
+
+      # Constructs a new instance.
+      # @param value [String] the actual value of the enum instance
+      # @param unknown [String] the unknown value when value is 'UKNOWN'
+      def initialize(value, unknown = nil)
+        super(self.class.binding_type, value, unknown)
+      end
+
+      private_class_method :new
+
+      # @!attribute [rw] dhcp
+      #     @return [Com::Vmware::Appliance::Networking::Dns::Servers::DNSServerMode]
+      #     DNS address is automatically assigned by a DHCP server.
+      DHCP = DNSServerMode.send(:new, 'DHCP')
+
+      # @!attribute [rw] is_static
+      #     @return [Com::Vmware::Appliance::Networking::Dns::Servers::DNSServerMode]
+      #     DNS address is static.
+      IS_STATIC = DNSServerMode.send(:new, 'IS_STATIC')
+    end
+    # ``Com::Vmware::Appliance::Networking::Dns::Servers::TestStatus``   enumerated type  Health indicator
+    # @!attribute [rw] orange
+    #     @return [Com::Vmware::Appliance::Networking::Dns::Servers::TestStatus]
+    #     In case data has more than one test, this indicates not all tests were successful
+    # @!attribute [rw] green
+    #     @return [Com::Vmware::Appliance::Networking::Dns::Servers::TestStatus]
+    #     All tests were successful for given data
+    # @!attribute [rw] red
+    #     @return [Com::Vmware::Appliance::Networking::Dns::Servers::TestStatus]
+    #     All tests failed for given data
+    class TestStatus < VAPI::Bindings::VapiEnum
+      class << self
+        # Holds (gets or creates) the binding type metadata for this enumeration type.
+        # @scope class
+        # @return [VAPI::Bindings::EnumType] the binding type
+        def binding_type
+          @binding_type ||= VAPI::Bindings::EnumType.new(
+            'com.vmware.appliance.networking.dns.servers.test_status',
+            TestStatus
+          )
+        end
+
+        # Converts from a string value (perhaps off the wire) to an instance
+        # of this enum type.
+        # @param value [String] the actual value of the enum instance
+        # @return [TestStatus] the instance found for the value, otherwise
+        #         an unknown instance will be built for the value
+        def from_string(value)
+          const_get(value)
+        rescue NameError
+          TestStatus.send(:new, 'UNKNOWN', value)
+        end
+      end
+
+      # Constructs a new instance.
+      # @param value [String] the actual value of the enum instance
+      # @param unknown [String] the unknown value when value is 'UKNOWN'
+      def initialize(value, unknown = nil)
+        super(self.class.binding_type, value, unknown)
+      end
+
+      private_class_method :new
+
+      # @!attribute [rw] orange
+      #     @return [Com::Vmware::Appliance::Networking::Dns::Servers::TestStatus]
+      #     In case data has more than one test, this indicates not all tests were successful
+      ORANGE = TestStatus.send(:new, 'ORANGE')
+
+      # @!attribute [rw] green
+      #     @return [Com::Vmware::Appliance::Networking::Dns::Servers::TestStatus]
+      #     All tests were successful for given data
+      GREEN = TestStatus.send(:new, 'GREEN')
+
+      # @!attribute [rw] red
+      #     @return [Com::Vmware::Appliance::Networking::Dns::Servers::TestStatus]
+      #     All tests failed for given data
+      RED = TestStatus.send(:new, 'RED')
+    end
+    # ``Com::Vmware::Appliance::Networking::Dns::Servers::MessageStatus``   enumerated type  Individual test result
+    # @!attribute [rw] failure
+    #     @return [Com::Vmware::Appliance::Networking::Dns::Servers::MessageStatus]
+    #     message indicates the test failed.
+    # @!attribute [rw] success
+    #     @return [Com::Vmware::Appliance::Networking::Dns::Servers::MessageStatus]
+    #     message indicates that the test was successful.
+    class MessageStatus < VAPI::Bindings::VapiEnum
+      class << self
+        # Holds (gets or creates) the binding type metadata for this enumeration type.
+        # @scope class
+        # @return [VAPI::Bindings::EnumType] the binding type
+        def binding_type
+          @binding_type ||= VAPI::Bindings::EnumType.new(
+            'com.vmware.appliance.networking.dns.servers.message_status',
+            MessageStatus
+          )
+        end
+
+        # Converts from a string value (perhaps off the wire) to an instance
+        # of this enum type.
+        # @param value [String] the actual value of the enum instance
+        # @return [MessageStatus] the instance found for the value, otherwise
+        #         an unknown instance will be built for the value
+        def from_string(value)
+          const_get(value)
+        rescue NameError
+          MessageStatus.send(:new, 'UNKNOWN', value)
+        end
+      end
+
+      # Constructs a new instance.
+      # @param value [String] the actual value of the enum instance
+      # @param unknown [String] the unknown value when value is 'UKNOWN'
+      def initialize(value, unknown = nil)
+        super(self.class.binding_type, value, unknown)
+      end
+
+      private_class_method :new
+
+      # @!attribute [rw] failure
+      #     @return [Com::Vmware::Appliance::Networking::Dns::Servers::MessageStatus]
+      #     message indicates the test failed.
+      FAILURE = MessageStatus.send(:new, 'FAILURE')
+
+      # @!attribute [rw] success
+      #     @return [Com::Vmware::Appliance::Networking::Dns::Servers::MessageStatus]
+      #     message indicates that the test was successful.
+      SUCCESS = MessageStatus.send(:new, 'SUCCESS')
+    end
+  end
 end

--- a/client/sdk/com/vmware/appliance/recovery.rb
+++ b/client/sdk/com/vmware/appliance/recovery.rb
@@ -1,5 +1,6 @@
 #---------------------------------------------------------------------------
-# Copyright 2016 VMware, Inc.  All rights reserved.
+# Copyright 2017 VMware, Inc.  All rights reserved.
+#
 # AUTO GENERATED FILE -- DO NOT MODIFY!
 #
 # vAPI type descriptors for package com.vmware.appliance.recovery.
@@ -8,664 +9,614 @@ require 'vapi'
 
 # declare the module hierarchy before we use the shorthand syntax below
 module Com
-    module Vmware
-        module Appliance
-            module Recovery
-            end
-        end
+  module Vmware
+    module Appliance
+      module Recovery
+      end
     end
+  end
 end
 
 module Com::Vmware::Appliance::Recovery
+  # ``Com::Vmware::Appliance::Recovery::Backup``   class  provides  methods  Performs backup restore operations
+  class BackupService < VAPI::Bindings::VapiService
+    # static metamodel definitions
+    SERVICE_ID = VAPI::Core::ServiceIdentifier.new('com.vmware.appliance.recovery.backup')
 
-    # ``Com::Vmware::Appliance::Recovery::Backup``   class  provides  methods  Performs backup restore operations
-    class BackupService < VAPI::Bindings::VapiService
+    VALIDATE_INFO = VAPI::Bindings::OperationInfo.new(
+      VAPI::Core::OperationIdentifier.new('validate', SERVICE_ID),
+      VAPI::Bindings::OperationInputType.new(
+        'piece' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Appliance::Recovery::Backup::BackupRequest')
+      ),
+      VAPI::Bindings::ReferenceType.new('Com::Vmware::Appliance::Recovery::Backup::ReturnResult'),
+      {
+        'com.vmware.vapi.std.errors.feature_in_use' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::FeatureInUse'),
+        'com.vmware.vapi.std.errors.error' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Error')
+      },
+      [],
+      []
+    )
 
-        protected
+    SERVICE_INFO = VAPI::Bindings::ServiceInfo.new(
+      SERVICE_ID,
+      'validate' => VALIDATE_INFO
+    )
 
-        # static metamodel definitions
-        @@service_id = VAPI::Core::ServiceIdentifier.new('com.vmware.appliance.recovery.backup')
-
-        @@validate_info = VAPI::Bindings::OperationInfo.new(
-            VAPI::Core::OperationIdentifier.new('validate', @@service_id),
-            VAPI::Bindings::OperationInputType.new({
-                'piece' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Appliance::Recovery::Backup::BackupRequest'),
-            }),
-            VAPI::Bindings::ReferenceType.new('Com::Vmware::Appliance::Recovery::Backup::ReturnResult'),
-            {
-                'com.vmware.vapi.std.errors.feature_in_use' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::FeatureInUse'),
-                'com.vmware.vapi.std.errors.error' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Error'),
-
-            },
-            [],
-            [])
-
-        @@service_info = VAPI::Bindings::ServiceInfo.new(@@service_id, {
-            'validate' => @@validate_info,
-        })
-
-        public
-
-        # Constructs a new instance.
-        #
-        # @param config [VAPI::Bindings::StubConfig] A hash with the api provider details.
-        def initialize(config)
-            super(config, @@service_info)
-        end
-
-
-        # Check for backup errors without starting backup.
-        #
-        # @param piece [Com::Vmware::Appliance::Recovery::Backup::BackupRequest]
-        #     BackupRequest Structure
-        # @return [Com::Vmware::Appliance::Recovery::Backup::ReturnResult]
-        #     ReturnResult Structure
-        # @raise [Com::Vmware::Vapi::Std::Errors::FeatureInUse]
-        #     A backup or restore is already in progress
-        # @raise [Com::Vmware::Vapi::Std::Errors::Error]
-        #     Generic error
-        def validate(piece)
-            invoke_with_info(@@validate_info, {
-                'piece' => piece,
-            })
-        end
-
-
-
-        # ``Com::Vmware::Appliance::Recovery::Backup::LocalizableMessage``   class  Structure representing message
-        # @!attribute [rw] id
-        #     @return [String]
-        #     id in message bundle
-        # @!attribute [rw] default_message
-        #     @return [String]
-        #     text in english
-        # @!attribute [rw] args
-        #     @return [Array<String>]
-        #     nested data
-        class LocalizableMessage < VAPI::Bindings::VapiStruct
-
-            class << self
-                # Holds (gets or creates) the binding type metadata for this structure type.
-                # @scope class
-                # @return [VAPI::Bindings::StructType] the binding type
-                def binding_type
-                    @binding_type ||= VAPI::Bindings::StructType.new(
-                        'com.vmware.appliance.recovery.backup.localizable_message',
-                        {
-                            'id' => VAPI::Bindings::StringType.instance,
-                            'default_message' => VAPI::Bindings::StringType.instance,
-                            'args' => VAPI::Bindings::ListType.new(VAPI::Bindings::StringType.instance),
-                        },
-                        LocalizableMessage,
-                        false,
-                        nil)
-                end
-            end
-
-            attr_accessor :id,
-                          :default_message,
-                          :args
-
-            # Constructs a new instance.
-            # @param ruby_values [Hash] a map of initial property values (optional)
-            # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
-            def initialize(ruby_values=nil, struct_value=nil)
-                super(self.class.binding_type, ruby_values, struct_value)
-            end
-        end
-
-
-        # ``Com::Vmware::Appliance::Recovery::Backup::ReturnResult``   class  Structure representing precheck result
-        # @!attribute [rw] status
-        #     @return [Com::Vmware::Appliance::Recovery::Backup::ReturnStatus]
-        #     Check status
-        # @!attribute [rw] messages
-        #     @return [Array<Com::Vmware::Appliance::Recovery::Backup::LocalizableMessage>]
-        #     List of messages
-        class ReturnResult < VAPI::Bindings::VapiStruct
-
-            class << self
-                # Holds (gets or creates) the binding type metadata for this structure type.
-                # @scope class
-                # @return [VAPI::Bindings::StructType] the binding type
-                def binding_type
-                    @binding_type ||= VAPI::Bindings::StructType.new(
-                        'com.vmware.appliance.recovery.backup.return_result',
-                        {
-                            'status' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Appliance::Recovery::Backup::ReturnStatus'),
-                            'messages' => VAPI::Bindings::ListType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Appliance::Recovery::Backup::LocalizableMessage')),
-                        },
-                        ReturnResult,
-                        false,
-                        nil)
-                end
-            end
-
-            attr_accessor :status,
-                          :messages
-
-            # Constructs a new instance.
-            # @param ruby_values [Hash] a map of initial property values (optional)
-            # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
-            def initialize(ruby_values=nil, struct_value=nil)
-                super(self.class.binding_type, ruby_values, struct_value)
-            end
-        end
-
-
-        # ``Com::Vmware::Appliance::Recovery::Backup::BackupRequest``   class  Structure representing requested backup piece
-        # @!attribute [rw] parts
-        #     @return [Array<String>]
-        #     a list of optional parts. Run backup parts APIs to get list of optional parts and description
-        # @!attribute [rw] backup_password
-        #     @return [String, nil]
-        #     a password for a backup piece The backupPassword must adhere to the following password requirements: At least 8 characters, cannot be more than 20 characters in length. At least 1 uppercase letter. At least 1 lowercase letter. At least 1 numeric digit. At least 1 special character (i.e. any character not in [0-9,a-z,A-Z]). Only visible ASCII characters (for example, no space).
-        #     backupPassword If no password then the piece will not be encrypted
-        # @!attribute [rw] location_type
-        #     @return [Com::Vmware::Appliance::Recovery::Backup::LocationType]
-        #     a type of location
-        # @!attribute [rw] location
-        #     @return [String]
-        #     path or url
-        # @!attribute [rw] location_user
-        #     @return [String, nil]
-        #     username for location
-        #     locationUser User name for this location if login is required.
-        # @!attribute [rw] location_password
-        #     @return [String, nil]
-        #     password for location
-        #     locationPassword Password for the specified user if login is required at this location.
-        # @!attribute [rw] comment
-        #     @return [String, nil]
-        #     Custom comment
-        #     comment an optional comment
-        class BackupRequest < VAPI::Bindings::VapiStruct
-
-            class << self
-                # Holds (gets or creates) the binding type metadata for this structure type.
-                # @scope class
-                # @return [VAPI::Bindings::StructType] the binding type
-                def binding_type
-                    @binding_type ||= VAPI::Bindings::StructType.new(
-                        'com.vmware.appliance.recovery.backup.backup_request',
-                        {
-                            'parts' => VAPI::Bindings::ListType.new(VAPI::Bindings::StringType.instance),
-                            'backup_password' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::SecretType.instance),
-                            'location_type' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Appliance::Recovery::Backup::LocationType'),
-                            'location' => VAPI::Bindings::StringType.instance,
-                            'location_user' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::StringType.instance),
-                            'location_password' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::SecretType.instance),
-                            'comment' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::StringType.instance),
-                        },
-                        BackupRequest,
-                        false,
-                        nil)
-                end
-            end
-
-            attr_accessor :parts,
-                          :backup_password,
-                          :location_type,
-                          :location,
-                          :location_user,
-                          :location_password,
-                          :comment
-
-            # Constructs a new instance.
-            # @param ruby_values [Hash] a map of initial property values (optional)
-            # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
-            def initialize(ruby_values=nil, struct_value=nil)
-                super(self.class.binding_type, ruby_values, struct_value)
-            end
-        end
-
-
-
-        # ``Com::Vmware::Appliance::Recovery::Backup::ReturnStatus``   enumerated type  Defines the state of precheck
-        # @!attribute [rw] fail
-        #     @return [Com::Vmware::Appliance::Recovery::Backup::ReturnStatus]
-        #     Check failed
-        # @!attribute [rw] warning
-        #     @return [Com::Vmware::Appliance::Recovery::Backup::ReturnStatus]
-        #     Passed with warnings
-        # @!attribute [rw] ok
-        #     @return [Com::Vmware::Appliance::Recovery::Backup::ReturnStatus]
-        #     Check passed
-        class ReturnStatus < VAPI::Bindings::VapiEnum
-
-            class << self
-                # Holds (gets or creates) the binding type metadata for this enumeration type.
-                # @scope class
-                # @return [VAPI::Bindings::EnumType] the binding type
-                def binding_type
-                    @binding_type ||= VAPI::Bindings::EnumType.new(
-                        'com.vmware.appliance.recovery.backup.return_status',
-                        ReturnStatus)
-                end
-
-                # Converts from a string value (perhaps off the wire) to an instance
-                # of this enum type.
-                # @param value [String] the actual value of the enum instance
-                # @return [ReturnStatus] the instance found for the value, otherwise
-                #         an unknown instance will be built for the value
-                def from_string(value)
-                    begin
-                        const_get(value)
-                    rescue NameError
-                        ReturnStatus.new('UNKNOWN', value)
-                    end
-                end
-            end
-
-            private
-
-            # Constructs a new instance.
-            # @param value [String] the actual value of the enum instance
-            # @param unknown [String] the unknown value when value is 'UKNOWN'
-            def initialize(value, unknown=nil)
-                super(self.class.binding_type, value, unknown)
-            end
-
-            public
-
-            # @!attribute [rw] fail
-            #     @return [Com::Vmware::Appliance::Recovery::Backup::ReturnStatus]
-            #     Check failed
-            FAIL = ReturnStatus.new('FAIL')
-
-            # @!attribute [rw] warning
-            #     @return [Com::Vmware::Appliance::Recovery::Backup::ReturnStatus]
-            #     Passed with warnings
-            WARNING = ReturnStatus.new('WARNING')
-
-            # @!attribute [rw] ok
-            #     @return [Com::Vmware::Appliance::Recovery::Backup::ReturnStatus]
-            #     Check passed
-            OK = ReturnStatus.new('OK')
-
-        end
-
-
-        # ``Com::Vmware::Appliance::Recovery::Backup::LocationType``   enumerated type  Defines type of all locations for backup/restore
-        # @!attribute [rw] ftps
-        #     @return [Com::Vmware::Appliance::Recovery::Backup::LocationType]
-        #     Destination is FTPS server
-        # @!attribute [rw] http
-        #     @return [Com::Vmware::Appliance::Recovery::Backup::LocationType]
-        #     Destination is HTTP server
-        # @!attribute [rw] scp
-        #     @return [Com::Vmware::Appliance::Recovery::Backup::LocationType]
-        #     Destination is SSH server
-        # @!attribute [rw] https
-        #     @return [Com::Vmware::Appliance::Recovery::Backup::LocationType]
-        #     Destination is HTTPS server
-        # @!attribute [rw] ftp
-        #     @return [Com::Vmware::Appliance::Recovery::Backup::LocationType]
-        #     Destination is FTP server
-        class LocationType < VAPI::Bindings::VapiEnum
-
-            class << self
-                # Holds (gets or creates) the binding type metadata for this enumeration type.
-                # @scope class
-                # @return [VAPI::Bindings::EnumType] the binding type
-                def binding_type
-                    @binding_type ||= VAPI::Bindings::EnumType.new(
-                        'com.vmware.appliance.recovery.backup.location_type',
-                        LocationType)
-                end
-
-                # Converts from a string value (perhaps off the wire) to an instance
-                # of this enum type.
-                # @param value [String] the actual value of the enum instance
-                # @return [LocationType] the instance found for the value, otherwise
-                #         an unknown instance will be built for the value
-                def from_string(value)
-                    begin
-                        const_get(value)
-                    rescue NameError
-                        LocationType.new('UNKNOWN', value)
-                    end
-                end
-            end
-
-            private
-
-            # Constructs a new instance.
-            # @param value [String] the actual value of the enum instance
-            # @param unknown [String] the unknown value when value is 'UKNOWN'
-            def initialize(value, unknown=nil)
-                super(self.class.binding_type, value, unknown)
-            end
-
-            public
-
-            # @!attribute [rw] ftps
-            #     @return [Com::Vmware::Appliance::Recovery::Backup::LocationType]
-            #     Destination is FTPS server
-            FTPS = LocationType.new('FTPS')
-
-            # @!attribute [rw] http
-            #     @return [Com::Vmware::Appliance::Recovery::Backup::LocationType]
-            #     Destination is HTTP server
-            HTTP = LocationType.new('HTTP')
-
-            # @!attribute [rw] scp
-            #     @return [Com::Vmware::Appliance::Recovery::Backup::LocationType]
-            #     Destination is SSH server
-            SCP = LocationType.new('SCP')
-
-            # @!attribute [rw] https
-            #     @return [Com::Vmware::Appliance::Recovery::Backup::LocationType]
-            #     Destination is HTTPS server
-            HTTPS = LocationType.new('HTTPS')
-
-            # @!attribute [rw] ftp
-            #     @return [Com::Vmware::Appliance::Recovery::Backup::LocationType]
-            #     Destination is FTP server
-            FTP = LocationType.new('FTP')
-
-        end
-
-
+    # Constructs a new instance.
+    #
+    # @param config [VAPI::Bindings::StubConfig] A hash with the api provider details.
+    def initialize(config)
+      super(config, SERVICE_INFO)
     end
 
-
-    # ``Com::Vmware::Appliance::Recovery::Restore``   class  provides  methods  Performs restore operations
-    class RestoreService < VAPI::Bindings::VapiService
-
-        protected
-
-        # static metamodel definitions
-        @@service_id = VAPI::Core::ServiceIdentifier.new('com.vmware.appliance.recovery.restore')
-
-        @@validate_info = VAPI::Bindings::OperationInfo.new(
-            VAPI::Core::OperationIdentifier.new('validate', @@service_id),
-            VAPI::Bindings::OperationInputType.new({
-                'piece' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Appliance::Recovery::Restore::RestoreRequest'),
-            }),
-            VAPI::Bindings::ReferenceType.new('Com::Vmware::Appliance::Recovery::Restore::Metadata'),
-            {
-                'com.vmware.vapi.std.errors.error' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Error'),
-
-            },
-            [],
-            [])
-
-        @@service_info = VAPI::Bindings::ServiceInfo.new(@@service_id, {
-            'validate' => @@validate_info,
-        })
-
-        public
-
-        # Constructs a new instance.
-        #
-        # @param config [VAPI::Bindings::StubConfig] A hash with the api provider details.
-        def initialize(config)
-            super(config, @@service_info)
-        end
-
-
-        # Get metadata before restore
-        #
-        # @param piece [Com::Vmware::Appliance::Recovery::Restore::RestoreRequest]
-        #     RestoreRequest Structure
-        # @return [Com::Vmware::Appliance::Recovery::Restore::Metadata]
-        #     Metadata Structure
-        # @raise [Com::Vmware::Vapi::Std::Errors::Error]
-        #     Generic error
-        def validate(piece)
-            invoke_with_info(@@validate_info, {
-                'piece' => piece,
-            })
-        end
-
-
-
-        # ``Com::Vmware::Appliance::Recovery::Restore::RestoreRequest``   class  Structure representing requested restore piece
-        # @!attribute [rw] backup_password
-        #     @return [String, nil]
-        #     a password for a backup piece
-        #     backupPassword If no password then the piece will not be decrypted
-        # @!attribute [rw] location_type
-        #     @return [Com::Vmware::Appliance::Recovery::Restore::LocationType]
-        #     a type of location
-        # @!attribute [rw] location
-        #     @return [String]
-        #     path or url
-        # @!attribute [rw] location_user
-        #     @return [String, nil]
-        #     username for location
-        #     locationUser User name for this location if login is required.
-        # @!attribute [rw] location_password
-        #     @return [String, nil]
-        #     password for location
-        #     locationPassword Password for the specified user if login is required at this location.
-        class RestoreRequest < VAPI::Bindings::VapiStruct
-
-            class << self
-                # Holds (gets or creates) the binding type metadata for this structure type.
-                # @scope class
-                # @return [VAPI::Bindings::StructType] the binding type
-                def binding_type
-                    @binding_type ||= VAPI::Bindings::StructType.new(
-                        'com.vmware.appliance.recovery.restore.restore_request',
-                        {
-                            'backup_password' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::SecretType.instance),
-                            'location_type' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Appliance::Recovery::Restore::LocationType'),
-                            'location' => VAPI::Bindings::StringType.instance,
-                            'location_user' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::StringType.instance),
-                            'location_password' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::SecretType.instance),
-                        },
-                        RestoreRequest,
-                        false,
-                        nil)
-                end
-            end
-
-            attr_accessor :backup_password,
-                          :location_type,
-                          :location,
-                          :location_user,
-                          :location_password
-
-            # Constructs a new instance.
-            # @param ruby_values [Hash] a map of initial property values (optional)
-            # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
-            def initialize(ruby_values=nil, struct_value=nil)
-                super(self.class.binding_type, ruby_values, struct_value)
-            end
-        end
-
-
-        # ``Com::Vmware::Appliance::Recovery::Restore::LocalizableMessage``   class  Structure representing message
-        # @!attribute [rw] id
-        #     @return [String]
-        #     id in message bundle
-        # @!attribute [rw] default_message
-        #     @return [String]
-        #     text in english
-        # @!attribute [rw] args
-        #     @return [Array<String>]
-        #     nested data
-        class LocalizableMessage < VAPI::Bindings::VapiStruct
-
-            class << self
-                # Holds (gets or creates) the binding type metadata for this structure type.
-                # @scope class
-                # @return [VAPI::Bindings::StructType] the binding type
-                def binding_type
-                    @binding_type ||= VAPI::Bindings::StructType.new(
-                        'com.vmware.appliance.recovery.restore.localizable_message',
-                        {
-                            'id' => VAPI::Bindings::StringType.instance,
-                            'default_message' => VAPI::Bindings::StringType.instance,
-                            'args' => VAPI::Bindings::ListType.new(VAPI::Bindings::StringType.instance),
-                        },
-                        LocalizableMessage,
-                        false,
-                        nil)
-                end
-            end
-
-            attr_accessor :id,
-                          :default_message,
-                          :args
-
-            # Constructs a new instance.
-            # @param ruby_values [Hash] a map of initial property values (optional)
-            # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
-            def initialize(ruby_values=nil, struct_value=nil)
-                super(self.class.binding_type, ruby_values, struct_value)
-            end
-        end
-
-
-        # ``Com::Vmware::Appliance::Recovery::Restore::Metadata``   class  Structure representing metadata
-        # @!attribute [rw] timestamp
-        #     @return [DateTime]
-        #     Time when this backup was completed.
-        # @!attribute [rw] parts
-        #     @return [Array<String>]
-        #     List of parts included in the backup.
-        # @!attribute [rw] version
-        #     @return [String]
-        #     VCSA version
-        # @!attribute [rw] boxname
-        #     @return [String]
-        #     Box name is PNID/ FQDN etc
-        # @!attribute [rw] comment
-        #     @return [String]
-        #     Custom comment
-        # @!attribute [rw] applicable
-        #     @return [Boolean]
-        #     Does the VCSA match the deployment type, network properties and version of backed up VC
-        # @!attribute [rw] messages
-        #     @return [Array<Com::Vmware::Appliance::Recovery::Restore::LocalizableMessage>]
-        #     Any messages if the backup is not aplicable
-        class Metadata < VAPI::Bindings::VapiStruct
-
-            class << self
-                # Holds (gets or creates) the binding type metadata for this structure type.
-                # @scope class
-                # @return [VAPI::Bindings::StructType] the binding type
-                def binding_type
-                    @binding_type ||= VAPI::Bindings::StructType.new(
-                        'com.vmware.appliance.recovery.restore.metadata',
-                        {
-                            'timestamp' => VAPI::Bindings::DateTimeType.instance,
-                            'parts' => VAPI::Bindings::ListType.new(VAPI::Bindings::StringType.instance),
-                            'version' => VAPI::Bindings::StringType.instance,
-                            'boxname' => VAPI::Bindings::StringType.instance,
-                            'comment' => VAPI::Bindings::StringType.instance,
-                            'applicable' => VAPI::Bindings::BooleanType.instance,
-                            'messages' => VAPI::Bindings::ListType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Appliance::Recovery::Restore::LocalizableMessage')),
-                        },
-                        Metadata,
-                        false,
-                        nil)
-                end
-            end
-
-            attr_accessor :timestamp,
-                          :parts,
-                          :version,
-                          :boxname,
-                          :comment,
-                          :applicable,
-                          :messages
-
-            # Constructs a new instance.
-            # @param ruby_values [Hash] a map of initial property values (optional)
-            # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
-            def initialize(ruby_values=nil, struct_value=nil)
-                super(self.class.binding_type, ruby_values, struct_value)
-            end
-        end
-
-
-
-        # ``Com::Vmware::Appliance::Recovery::Restore::LocationType``   enumerated type  Defines type of all locations for backup/restore
-        # @!attribute [rw] ftps
-        #     @return [Com::Vmware::Appliance::Recovery::Restore::LocationType]
-        #     Destination is FTPS server
-        # @!attribute [rw] http
-        #     @return [Com::Vmware::Appliance::Recovery::Restore::LocationType]
-        #     Destination is HTTP server
-        # @!attribute [rw] scp
-        #     @return [Com::Vmware::Appliance::Recovery::Restore::LocationType]
-        #     Destination is SSH server
-        # @!attribute [rw] https
-        #     @return [Com::Vmware::Appliance::Recovery::Restore::LocationType]
-        #     Destination is HTTPS server
-        # @!attribute [rw] ftp
-        #     @return [Com::Vmware::Appliance::Recovery::Restore::LocationType]
-        #     Destination is FTP server
-        class LocationType < VAPI::Bindings::VapiEnum
-
-            class << self
-                # Holds (gets or creates) the binding type metadata for this enumeration type.
-                # @scope class
-                # @return [VAPI::Bindings::EnumType] the binding type
-                def binding_type
-                    @binding_type ||= VAPI::Bindings::EnumType.new(
-                        'com.vmware.appliance.recovery.restore.location_type',
-                        LocationType)
-                end
-
-                # Converts from a string value (perhaps off the wire) to an instance
-                # of this enum type.
-                # @param value [String] the actual value of the enum instance
-                # @return [LocationType] the instance found for the value, otherwise
-                #         an unknown instance will be built for the value
-                def from_string(value)
-                    begin
-                        const_get(value)
-                    rescue NameError
-                        LocationType.new('UNKNOWN', value)
-                    end
-                end
-            end
-
-            private
-
-            # Constructs a new instance.
-            # @param value [String] the actual value of the enum instance
-            # @param unknown [String] the unknown value when value is 'UKNOWN'
-            def initialize(value, unknown=nil)
-                super(self.class.binding_type, value, unknown)
-            end
-
-            public
-
-            # @!attribute [rw] ftps
-            #     @return [Com::Vmware::Appliance::Recovery::Restore::LocationType]
-            #     Destination is FTPS server
-            FTPS = LocationType.new('FTPS')
-
-            # @!attribute [rw] http
-            #     @return [Com::Vmware::Appliance::Recovery::Restore::LocationType]
-            #     Destination is HTTP server
-            HTTP = LocationType.new('HTTP')
-
-            # @!attribute [rw] scp
-            #     @return [Com::Vmware::Appliance::Recovery::Restore::LocationType]
-            #     Destination is SSH server
-            SCP = LocationType.new('SCP')
-
-            # @!attribute [rw] https
-            #     @return [Com::Vmware::Appliance::Recovery::Restore::LocationType]
-            #     Destination is HTTPS server
-            HTTPS = LocationType.new('HTTPS')
-
-            # @!attribute [rw] ftp
-            #     @return [Com::Vmware::Appliance::Recovery::Restore::LocationType]
-            #     Destination is FTP server
-            FTP = LocationType.new('FTP')
-
-        end
-
-
+    # Check for backup errors without starting backup.
+    #
+    # @param piece [Com::Vmware::Appliance::Recovery::Backup::BackupRequest]
+    #     BackupRequest Structure
+    # @return [Com::Vmware::Appliance::Recovery::Backup::ReturnResult]
+    #     ReturnResult Structure
+    # @raise [Com::Vmware::Vapi::Std::Errors::FeatureInUse]
+    #     A backup or restore is already in progress
+    # @raise [Com::Vmware::Vapi::Std::Errors::Error]
+    #     Generic error
+    def validate(piece)
+      invoke_with_info(VALIDATE_INFO,
+                       'piece' => piece)
     end
 
+    # ``Com::Vmware::Appliance::Recovery::Backup::LocalizableMessage``   class  Structure representing message
+    # @!attribute [rw] id
+    #     @return [String]
+    #     id in message bundle
+    # @!attribute [rw] default_message
+    #     @return [String]
+    #     text in english
+    # @!attribute [rw] args
+    #     @return [Array<String>]
+    #     nested data
+    class LocalizableMessage < VAPI::Bindings::VapiStruct
+      class << self
+        # Holds (gets or creates) the binding type metadata for this structure type.
+        # @scope class
+        # @return [VAPI::Bindings::StructType] the binding type
+        def binding_type
+          @binding_type ||= VAPI::Bindings::StructType.new(
+            'com.vmware.appliance.recovery.backup.localizable_message',
+            {
+              'id' => VAPI::Bindings::StringType.instance,
+              'default_message' => VAPI::Bindings::StringType.instance,
+              'args' => VAPI::Bindings::ListType.new(VAPI::Bindings::StringType.instance)
+            },
+            LocalizableMessage,
+            false,
+            nil
+          )
+        end
+      end
 
+      attr_accessor :id,
+                    :default_message,
+                    :args
+
+      # Constructs a new instance.
+      # @param ruby_values [Hash] a map of initial property values (optional)
+      # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
+      def initialize(ruby_values = nil, struct_value = nil)
+        super(self.class.binding_type, ruby_values, struct_value)
+      end
+    end
+
+    # ``Com::Vmware::Appliance::Recovery::Backup::ReturnResult``   class  Structure representing precheck result
+    # @!attribute [rw] status
+    #     @return [Com::Vmware::Appliance::Recovery::Backup::ReturnStatus]
+    #     Check status
+    # @!attribute [rw] messages
+    #     @return [Array<Com::Vmware::Appliance::Recovery::Backup::LocalizableMessage>]
+    #     List of messages
+    class ReturnResult < VAPI::Bindings::VapiStruct
+      class << self
+        # Holds (gets or creates) the binding type metadata for this structure type.
+        # @scope class
+        # @return [VAPI::Bindings::StructType] the binding type
+        def binding_type
+          @binding_type ||= VAPI::Bindings::StructType.new(
+            'com.vmware.appliance.recovery.backup.return_result',
+            {
+              'status' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Appliance::Recovery::Backup::ReturnStatus'),
+              'messages' => VAPI::Bindings::ListType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Appliance::Recovery::Backup::LocalizableMessage'))
+            },
+            ReturnResult,
+            false,
+            nil
+          )
+        end
+      end
+
+      attr_accessor :status,
+                    :messages
+
+      # Constructs a new instance.
+      # @param ruby_values [Hash] a map of initial property values (optional)
+      # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
+      def initialize(ruby_values = nil, struct_value = nil)
+        super(self.class.binding_type, ruby_values, struct_value)
+      end
+    end
+
+    # ``Com::Vmware::Appliance::Recovery::Backup::BackupRequest``   class  Structure representing requested backup piece
+    # @!attribute [rw] parts
+    #     @return [Array<String>]
+    #     a list of optional parts. Run backup parts APIs to get list of optional parts and description
+    # @!attribute [rw] backup_password
+    #     @return [String, nil]
+    #     a password for a backup piece The backupPassword must adhere to the following password requirements: At least 8 characters, cannot be more than 20 characters in length. At least 1 uppercase letter. At least 1 lowercase letter. At least 1 numeric digit. At least 1 special character (i.e. any character not in [0-9,a-z,A-Z]). Only visible ASCII characters (for example, no space).
+    #     backupPassword If no password then the piece will not be encrypted
+    # @!attribute [rw] location_type
+    #     @return [Com::Vmware::Appliance::Recovery::Backup::LocationType]
+    #     a type of location
+    # @!attribute [rw] location
+    #     @return [String]
+    #     path or url
+    # @!attribute [rw] location_user
+    #     @return [String, nil]
+    #     username for location
+    #     locationUser User name for this location if login is required.
+    # @!attribute [rw] location_password
+    #     @return [String, nil]
+    #     password for location
+    #     locationPassword Password for the specified user if login is required at this location.
+    # @!attribute [rw] comment
+    #     @return [String, nil]
+    #     Custom comment
+    #     comment an optional comment
+    class BackupRequest < VAPI::Bindings::VapiStruct
+      class << self
+        # Holds (gets or creates) the binding type metadata for this structure type.
+        # @scope class
+        # @return [VAPI::Bindings::StructType] the binding type
+        def binding_type
+          @binding_type ||= VAPI::Bindings::StructType.new(
+            'com.vmware.appliance.recovery.backup.backup_request',
+            {
+              'parts' => VAPI::Bindings::ListType.new(VAPI::Bindings::StringType.instance),
+              'backup_password' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::SecretType.instance),
+              'location_type' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Appliance::Recovery::Backup::LocationType'),
+              'location' => VAPI::Bindings::StringType.instance,
+              'location_user' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::StringType.instance),
+              'location_password' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::SecretType.instance),
+              'comment' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::StringType.instance)
+            },
+            BackupRequest,
+            false,
+            nil
+          )
+        end
+      end
+
+      attr_accessor :parts,
+                    :backup_password,
+                    :location_type,
+                    :location,
+                    :location_user,
+                    :location_password,
+                    :comment
+
+      # Constructs a new instance.
+      # @param ruby_values [Hash] a map of initial property values (optional)
+      # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
+      def initialize(ruby_values = nil, struct_value = nil)
+        super(self.class.binding_type, ruby_values, struct_value)
+      end
+    end
+
+    # ``Com::Vmware::Appliance::Recovery::Backup::ReturnStatus``   enumerated type  Defines the state of precheck
+    # @!attribute [rw] fail
+    #     @return [Com::Vmware::Appliance::Recovery::Backup::ReturnStatus]
+    #     Check failed
+    # @!attribute [rw] warning
+    #     @return [Com::Vmware::Appliance::Recovery::Backup::ReturnStatus]
+    #     Passed with warnings
+    # @!attribute [rw] ok
+    #     @return [Com::Vmware::Appliance::Recovery::Backup::ReturnStatus]
+    #     Check passed
+    class ReturnStatus < VAPI::Bindings::VapiEnum
+      class << self
+        # Holds (gets or creates) the binding type metadata for this enumeration type.
+        # @scope class
+        # @return [VAPI::Bindings::EnumType] the binding type
+        def binding_type
+          @binding_type ||= VAPI::Bindings::EnumType.new(
+            'com.vmware.appliance.recovery.backup.return_status',
+            ReturnStatus
+          )
+        end
+
+        # Converts from a string value (perhaps off the wire) to an instance
+        # of this enum type.
+        # @param value [String] the actual value of the enum instance
+        # @return [ReturnStatus] the instance found for the value, otherwise
+        #         an unknown instance will be built for the value
+        def from_string(value)
+          const_get(value)
+        rescue NameError
+          ReturnStatus.send(:new, 'UNKNOWN', value)
+        end
+      end
+
+      # Constructs a new instance.
+      # @param value [String] the actual value of the enum instance
+      # @param unknown [String] the unknown value when value is 'UKNOWN'
+      def initialize(value, unknown = nil)
+        super(self.class.binding_type, value, unknown)
+      end
+
+      private_class_method :new
+
+      # @!attribute [rw] fail
+      #     @return [Com::Vmware::Appliance::Recovery::Backup::ReturnStatus]
+      #     Check failed
+      FAIL = ReturnStatus.send(:new, 'FAIL')
+
+      # @!attribute [rw] warning
+      #     @return [Com::Vmware::Appliance::Recovery::Backup::ReturnStatus]
+      #     Passed with warnings
+      WARNING = ReturnStatus.send(:new, 'WARNING')
+
+      # @!attribute [rw] ok
+      #     @return [Com::Vmware::Appliance::Recovery::Backup::ReturnStatus]
+      #     Check passed
+      OK = ReturnStatus.send(:new, 'OK')
+    end
+    # ``Com::Vmware::Appliance::Recovery::Backup::LocationType``   enumerated type  Defines type of all locations for backup/restore
+    # @!attribute [rw] ftps
+    #     @return [Com::Vmware::Appliance::Recovery::Backup::LocationType]
+    #     Destination is FTPS server
+    # @!attribute [rw] http
+    #     @return [Com::Vmware::Appliance::Recovery::Backup::LocationType]
+    #     Destination is HTTP server
+    # @!attribute [rw] scp
+    #     @return [Com::Vmware::Appliance::Recovery::Backup::LocationType]
+    #     Destination is SSH server
+    # @!attribute [rw] https
+    #     @return [Com::Vmware::Appliance::Recovery::Backup::LocationType]
+    #     Destination is HTTPS server
+    # @!attribute [rw] ftp
+    #     @return [Com::Vmware::Appliance::Recovery::Backup::LocationType]
+    #     Destination is FTP server
+    class LocationType < VAPI::Bindings::VapiEnum
+      class << self
+        # Holds (gets or creates) the binding type metadata for this enumeration type.
+        # @scope class
+        # @return [VAPI::Bindings::EnumType] the binding type
+        def binding_type
+          @binding_type ||= VAPI::Bindings::EnumType.new(
+            'com.vmware.appliance.recovery.backup.location_type',
+            LocationType
+          )
+        end
+
+        # Converts from a string value (perhaps off the wire) to an instance
+        # of this enum type.
+        # @param value [String] the actual value of the enum instance
+        # @return [LocationType] the instance found for the value, otherwise
+        #         an unknown instance will be built for the value
+        def from_string(value)
+          const_get(value)
+        rescue NameError
+          LocationType.send(:new, 'UNKNOWN', value)
+        end
+      end
+
+      # Constructs a new instance.
+      # @param value [String] the actual value of the enum instance
+      # @param unknown [String] the unknown value when value is 'UKNOWN'
+      def initialize(value, unknown = nil)
+        super(self.class.binding_type, value, unknown)
+      end
+
+      private_class_method :new
+
+      # @!attribute [rw] ftps
+      #     @return [Com::Vmware::Appliance::Recovery::Backup::LocationType]
+      #     Destination is FTPS server
+      FTPS = LocationType.send(:new, 'FTPS')
+
+      # @!attribute [rw] http
+      #     @return [Com::Vmware::Appliance::Recovery::Backup::LocationType]
+      #     Destination is HTTP server
+      HTTP = LocationType.send(:new, 'HTTP')
+
+      # @!attribute [rw] scp
+      #     @return [Com::Vmware::Appliance::Recovery::Backup::LocationType]
+      #     Destination is SSH server
+      SCP = LocationType.send(:new, 'SCP')
+
+      # @!attribute [rw] https
+      #     @return [Com::Vmware::Appliance::Recovery::Backup::LocationType]
+      #     Destination is HTTPS server
+      HTTPS = LocationType.send(:new, 'HTTPS')
+
+      # @!attribute [rw] ftp
+      #     @return [Com::Vmware::Appliance::Recovery::Backup::LocationType]
+      #     Destination is FTP server
+      FTP = LocationType.send(:new, 'FTP')
+    end
+  end
+  # ``Com::Vmware::Appliance::Recovery::Restore``   class  provides  methods  Performs restore operations
+  class RestoreService < VAPI::Bindings::VapiService
+    # static metamodel definitions
+    SERVICE_ID = VAPI::Core::ServiceIdentifier.new('com.vmware.appliance.recovery.restore')
+
+    VALIDATE_INFO = VAPI::Bindings::OperationInfo.new(
+      VAPI::Core::OperationIdentifier.new('validate', SERVICE_ID),
+      VAPI::Bindings::OperationInputType.new(
+        'piece' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Appliance::Recovery::Restore::RestoreRequest')
+      ),
+      VAPI::Bindings::ReferenceType.new('Com::Vmware::Appliance::Recovery::Restore::Metadata'),
+      {
+        'com.vmware.vapi.std.errors.error' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Error')
+      },
+      [],
+      []
+    )
+
+    SERVICE_INFO = VAPI::Bindings::ServiceInfo.new(
+      SERVICE_ID,
+      'validate' => VALIDATE_INFO
+    )
+
+    # Constructs a new instance.
+    #
+    # @param config [VAPI::Bindings::StubConfig] A hash with the api provider details.
+    def initialize(config)
+      super(config, SERVICE_INFO)
+    end
+
+    # Get metadata before restore
+    #
+    # @param piece [Com::Vmware::Appliance::Recovery::Restore::RestoreRequest]
+    #     RestoreRequest Structure
+    # @return [Com::Vmware::Appliance::Recovery::Restore::Metadata]
+    #     Metadata Structure
+    # @raise [Com::Vmware::Vapi::Std::Errors::Error]
+    #     Generic error
+    def validate(piece)
+      invoke_with_info(VALIDATE_INFO,
+                       'piece' => piece)
+    end
+
+    # ``Com::Vmware::Appliance::Recovery::Restore::RestoreRequest``   class  Structure representing requested restore piece
+    # @!attribute [rw] backup_password
+    #     @return [String, nil]
+    #     a password for a backup piece
+    #     backupPassword If no password then the piece will not be decrypted
+    # @!attribute [rw] location_type
+    #     @return [Com::Vmware::Appliance::Recovery::Restore::LocationType]
+    #     a type of location
+    # @!attribute [rw] location
+    #     @return [String]
+    #     path or url
+    # @!attribute [rw] location_user
+    #     @return [String, nil]
+    #     username for location
+    #     locationUser User name for this location if login is required.
+    # @!attribute [rw] location_password
+    #     @return [String, nil]
+    #     password for location
+    #     locationPassword Password for the specified user if login is required at this location.
+    class RestoreRequest < VAPI::Bindings::VapiStruct
+      class << self
+        # Holds (gets or creates) the binding type metadata for this structure type.
+        # @scope class
+        # @return [VAPI::Bindings::StructType] the binding type
+        def binding_type
+          @binding_type ||= VAPI::Bindings::StructType.new(
+            'com.vmware.appliance.recovery.restore.restore_request',
+            {
+              'backup_password' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::SecretType.instance),
+              'location_type' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Appliance::Recovery::Restore::LocationType'),
+              'location' => VAPI::Bindings::StringType.instance,
+              'location_user' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::StringType.instance),
+              'location_password' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::SecretType.instance)
+            },
+            RestoreRequest,
+            false,
+            nil
+          )
+        end
+      end
+
+      attr_accessor :backup_password,
+                    :location_type,
+                    :location,
+                    :location_user,
+                    :location_password
+
+      # Constructs a new instance.
+      # @param ruby_values [Hash] a map of initial property values (optional)
+      # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
+      def initialize(ruby_values = nil, struct_value = nil)
+        super(self.class.binding_type, ruby_values, struct_value)
+      end
+    end
+
+    # ``Com::Vmware::Appliance::Recovery::Restore::LocalizableMessage``   class  Structure representing message
+    # @!attribute [rw] id
+    #     @return [String]
+    #     id in message bundle
+    # @!attribute [rw] default_message
+    #     @return [String]
+    #     text in english
+    # @!attribute [rw] args
+    #     @return [Array<String>]
+    #     nested data
+    class LocalizableMessage < VAPI::Bindings::VapiStruct
+      class << self
+        # Holds (gets or creates) the binding type metadata for this structure type.
+        # @scope class
+        # @return [VAPI::Bindings::StructType] the binding type
+        def binding_type
+          @binding_type ||= VAPI::Bindings::StructType.new(
+            'com.vmware.appliance.recovery.restore.localizable_message',
+            {
+              'id' => VAPI::Bindings::StringType.instance,
+              'default_message' => VAPI::Bindings::StringType.instance,
+              'args' => VAPI::Bindings::ListType.new(VAPI::Bindings::StringType.instance)
+            },
+            LocalizableMessage,
+            false,
+            nil
+          )
+        end
+      end
+
+      attr_accessor :id,
+                    :default_message,
+                    :args
+
+      # Constructs a new instance.
+      # @param ruby_values [Hash] a map of initial property values (optional)
+      # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
+      def initialize(ruby_values = nil, struct_value = nil)
+        super(self.class.binding_type, ruby_values, struct_value)
+      end
+    end
+
+    # ``Com::Vmware::Appliance::Recovery::Restore::Metadata``   class  Structure representing metadata
+    # @!attribute [rw] timestamp
+    #     @return [DateTime]
+    #     Time when this backup was completed.
+    # @!attribute [rw] parts
+    #     @return [Array<String>]
+    #     List of parts included in the backup.
+    # @!attribute [rw] version
+    #     @return [String]
+    #     VCSA version
+    # @!attribute [rw] boxname
+    #     @return [String]
+    #     Box name is PNID/ FQDN etc
+    # @!attribute [rw] comment
+    #     @return [String]
+    #     Custom comment
+    # @!attribute [rw] applicable
+    #     @return [Boolean]
+    #     Does the VCSA match the deployment type, network properties and version of backed up VC
+    # @!attribute [rw] messages
+    #     @return [Array<Com::Vmware::Appliance::Recovery::Restore::LocalizableMessage>]
+    #     Any messages if the backup is not aplicable
+    class Metadata < VAPI::Bindings::VapiStruct
+      class << self
+        # Holds (gets or creates) the binding type metadata for this structure type.
+        # @scope class
+        # @return [VAPI::Bindings::StructType] the binding type
+        def binding_type
+          @binding_type ||= VAPI::Bindings::StructType.new(
+            'com.vmware.appliance.recovery.restore.metadata',
+            {
+              'timestamp' => VAPI::Bindings::DateTimeType.instance,
+              'parts' => VAPI::Bindings::ListType.new(VAPI::Bindings::StringType.instance),
+              'version' => VAPI::Bindings::StringType.instance,
+              'boxname' => VAPI::Bindings::StringType.instance,
+              'comment' => VAPI::Bindings::StringType.instance,
+              'applicable' => VAPI::Bindings::BooleanType.instance,
+              'messages' => VAPI::Bindings::ListType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Appliance::Recovery::Restore::LocalizableMessage'))
+            },
+            Metadata,
+            false,
+            nil
+          )
+        end
+      end
+
+      attr_accessor :timestamp,
+                    :parts,
+                    :version,
+                    :boxname,
+                    :comment,
+                    :applicable,
+                    :messages
+
+      # Constructs a new instance.
+      # @param ruby_values [Hash] a map of initial property values (optional)
+      # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
+      def initialize(ruby_values = nil, struct_value = nil)
+        super(self.class.binding_type, ruby_values, struct_value)
+      end
+    end
+
+    # ``Com::Vmware::Appliance::Recovery::Restore::LocationType``   enumerated type  Defines type of all locations for backup/restore
+    # @!attribute [rw] ftps
+    #     @return [Com::Vmware::Appliance::Recovery::Restore::LocationType]
+    #     Destination is FTPS server
+    # @!attribute [rw] http
+    #     @return [Com::Vmware::Appliance::Recovery::Restore::LocationType]
+    #     Destination is HTTP server
+    # @!attribute [rw] scp
+    #     @return [Com::Vmware::Appliance::Recovery::Restore::LocationType]
+    #     Destination is SSH server
+    # @!attribute [rw] https
+    #     @return [Com::Vmware::Appliance::Recovery::Restore::LocationType]
+    #     Destination is HTTPS server
+    # @!attribute [rw] ftp
+    #     @return [Com::Vmware::Appliance::Recovery::Restore::LocationType]
+    #     Destination is FTP server
+    class LocationType < VAPI::Bindings::VapiEnum
+      class << self
+        # Holds (gets or creates) the binding type metadata for this enumeration type.
+        # @scope class
+        # @return [VAPI::Bindings::EnumType] the binding type
+        def binding_type
+          @binding_type ||= VAPI::Bindings::EnumType.new(
+            'com.vmware.appliance.recovery.restore.location_type',
+            LocationType
+          )
+        end
+
+        # Converts from a string value (perhaps off the wire) to an instance
+        # of this enum type.
+        # @param value [String] the actual value of the enum instance
+        # @return [LocationType] the instance found for the value, otherwise
+        #         an unknown instance will be built for the value
+        def from_string(value)
+          const_get(value)
+        rescue NameError
+          LocationType.send(:new, 'UNKNOWN', value)
+        end
+      end
+
+      # Constructs a new instance.
+      # @param value [String] the actual value of the enum instance
+      # @param unknown [String] the unknown value when value is 'UKNOWN'
+      def initialize(value, unknown = nil)
+        super(self.class.binding_type, value, unknown)
+      end
+
+      private_class_method :new
+
+      # @!attribute [rw] ftps
+      #     @return [Com::Vmware::Appliance::Recovery::Restore::LocationType]
+      #     Destination is FTPS server
+      FTPS = LocationType.send(:new, 'FTPS')
+
+      # @!attribute [rw] http
+      #     @return [Com::Vmware::Appliance::Recovery::Restore::LocationType]
+      #     Destination is HTTP server
+      HTTP = LocationType.send(:new, 'HTTP')
+
+      # @!attribute [rw] scp
+      #     @return [Com::Vmware::Appliance::Recovery::Restore::LocationType]
+      #     Destination is SSH server
+      SCP = LocationType.send(:new, 'SCP')
+
+      # @!attribute [rw] https
+      #     @return [Com::Vmware::Appliance::Recovery::Restore::LocationType]
+      #     Destination is HTTPS server
+      HTTPS = LocationType.send(:new, 'HTTPS')
+
+      # @!attribute [rw] ftp
+      #     @return [Com::Vmware::Appliance::Recovery::Restore::LocationType]
+      #     Destination is FTP server
+      FTP = LocationType.send(:new, 'FTP')
+    end
+  end
 end

--- a/client/sdk/com/vmware/appliance/recovery/backup.rb
+++ b/client/sdk/com/vmware/appliance/recovery/backup.rb
@@ -1,5 +1,6 @@
 #---------------------------------------------------------------------------
-# Copyright 2016 VMware, Inc.  All rights reserved.
+# Copyright 2017 VMware, Inc.  All rights reserved.
+#
 # AUTO GENERATED FILE -- DO NOT MODIFY!
 #
 # vAPI type descriptors for package com.vmware.appliance.recovery.backup.
@@ -8,756 +9,705 @@ require 'vapi'
 
 # declare the module hierarchy before we use the shorthand syntax below
 module Com
-    module Vmware
-        module Appliance
-            module Recovery
-                module Backup
-                end
-            end
+  module Vmware
+    module Appliance
+      module Recovery
+        module Backup
         end
+      end
     end
+  end
 end
 
 module Com::Vmware::Appliance::Recovery::Backup
-
-    # ``Com::Vmware::Appliance::Recovery::Backup::Job``   class  provides  methods  Performs backup restore operations
-    class Job < VAPI::Bindings::VapiService
-
-        protected
-
-        # static metamodel definitions
-        @@service_id = VAPI::Core::ServiceIdentifier.new('com.vmware.appliance.recovery.backup.job')
-
-        @@cancel_info = VAPI::Bindings::OperationInfo.new(
-            VAPI::Core::OperationIdentifier.new('cancel', @@service_id),
-            VAPI::Bindings::OperationInputType.new({
-                'id' => VAPI::Bindings::IdType.new(resource_types='com.vmware.appliance.recovery.backup.job'),
-            }),
-            VAPI::Bindings::ReferenceType.new('Com::Vmware::Appliance::Recovery::Backup::Job::ReturnResult'),
-            {
-                'com.vmware.vapi.std.errors.not_found' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::NotFound'),
-                'com.vmware.vapi.std.errors.error' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Error'),
-
-            },
-            [],
-            [])
-        @@create_info = VAPI::Bindings::OperationInfo.new(
-            VAPI::Core::OperationIdentifier.new('create', @@service_id),
-            VAPI::Bindings::OperationInputType.new({
-                'piece' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Appliance::Recovery::Backup::Job::BackupRequest'),
-            }),
-            VAPI::Bindings::ReferenceType.new('Com::Vmware::Appliance::Recovery::Backup::Job::BackupJobStatus'),
-            {
-                'com.vmware.vapi.std.errors.feature_in_use' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::FeatureInUse'),
-                'com.vmware.vapi.std.errors.error' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Error'),
-
-            },
-            [],
-            [])
-        @@list_info = VAPI::Bindings::OperationInfo.new(
-            VAPI::Core::OperationIdentifier.new('list', @@service_id),
-            VAPI::Bindings::OperationInputType.new,
-            VAPI::Bindings::ListType.new(VAPI::Bindings::IdType.new),
-            {
-                'com.vmware.vapi.std.errors.error' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Error'),
-
-            },
-            [],
-            [])
-        @@get_info = VAPI::Bindings::OperationInfo.new(
-            VAPI::Core::OperationIdentifier.new('get', @@service_id),
-            VAPI::Bindings::OperationInputType.new({
-                'id' => VAPI::Bindings::IdType.new(resource_types='com.vmware.appliance.recovery.backup.job'),
-            }),
-            VAPI::Bindings::ReferenceType.new('Com::Vmware::Appliance::Recovery::Backup::Job::BackupJobStatus'),
-            {
-                'com.vmware.vapi.std.errors.not_found' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::NotFound'),
-                'com.vmware.vapi.std.errors.error' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Error'),
-
-            },
-            [],
-            [])
-
-        @@service_info = VAPI::Bindings::ServiceInfo.new(@@service_id, {
-            'cancel' => @@cancel_info,
-            'create' => @@create_info,
-            'list' => @@list_info,
-            'get' => @@get_info,
-        })
-
-        public
-
-        # Constructs a new instance.
-        #
-        # @param config [VAPI::Bindings::StubConfig] A hash with the api provider details.
-        def initialize(config)
-            super(config, @@service_info)
-        end
-
-
-        # Cancel the backup job
-        #
-        # @param id [String]
-        #     ID (ID of job)
-        # @return [Com::Vmware::Appliance::Recovery::Backup::Job::ReturnResult]
-        #     BackupJobStatus Structure
-        # @raise [Com::Vmware::Vapi::Std::Errors::NotFound]
-        #     ID is not found
-        # @raise [Com::Vmware::Vapi::Std::Errors::Error]
-        #     Generic error
-        def cancel(id)
-            invoke_with_info(@@cancel_info, {
-                'id' => id,
-            })
-        end
-
-
-        # Initiate backup.
-        #
-        # @param piece [Com::Vmware::Appliance::Recovery::Backup::Job::BackupRequest]
-        #     BackupRequest Structure
-        # @return [Com::Vmware::Appliance::Recovery::Backup::Job::BackupJobStatus]
-        #     BackupJobStatus Structure
-        # @raise [Com::Vmware::Vapi::Std::Errors::FeatureInUse]
-        #     A backup or restore is already in progress
-        # @raise [Com::Vmware::Vapi::Std::Errors::Error]
-        #     Generic error
-        def create(piece)
-            invoke_with_info(@@create_info, {
-                'piece' => piece,
-            })
-        end
-
-
-        # Get list of backup jobs
-        #
-        # @return [Array<String>]
-        #     list of BackupJob IDs
-        # @raise [Com::Vmware::Vapi::Std::Errors::Error]
-        #     Generic error
-        def list()
-            invoke_with_info(@@list_info)
-        end
-
-
-        # See backup job progress/result.
-        #
-        # @param id [String]
-        #     ID (ID of job)
-        # @return [Com::Vmware::Appliance::Recovery::Backup::Job::BackupJobStatus]
-        #     BackupJobStatus Structure
-        # @raise [Com::Vmware::Vapi::Std::Errors::NotFound]
-        #     ID is not found
-        # @raise [Com::Vmware::Vapi::Std::Errors::Error]
-        #     Generic error
-        def get(id)
-            invoke_with_info(@@get_info, {
-                'id' => id,
-            })
-        end
-
-
-
-        # ``Com::Vmware::Appliance::Recovery::Backup::Job::LocalizableMessage``   class  Structure representing message
-        # @!attribute [rw] id
-        #     @return [String]
-        #     id in message bundle
-        # @!attribute [rw] default_message
-        #     @return [String]
-        #     text in english
-        # @!attribute [rw] args
-        #     @return [Array<String>]
-        #     nested data
-        class LocalizableMessage < VAPI::Bindings::VapiStruct
-
-            class << self
-                # Holds (gets or creates) the binding type metadata for this structure type.
-                # @scope class
-                # @return [VAPI::Bindings::StructType] the binding type
-                def binding_type
-                    @binding_type ||= VAPI::Bindings::StructType.new(
-                        'com.vmware.appliance.recovery.backup.job.localizable_message',
-                        {
-                            'id' => VAPI::Bindings::StringType.instance,
-                            'default_message' => VAPI::Bindings::StringType.instance,
-                            'args' => VAPI::Bindings::ListType.new(VAPI::Bindings::StringType.instance),
-                        },
-                        LocalizableMessage,
-                        false,
-                        nil)
-                end
-            end
-
-            attr_accessor :id,
-                          :default_message,
-                          :args
-
-            # Constructs a new instance.
-            # @param ruby_values [Hash] a map of initial property values (optional)
-            # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
-            def initialize(ruby_values=nil, struct_value=nil)
-                super(self.class.binding_type, ruby_values, struct_value)
-            end
-        end
-
-
-        # ``Com::Vmware::Appliance::Recovery::Backup::Job::ReturnResult``   class  Structure representing precheck result
-        # @!attribute [rw] status
-        #     @return [Com::Vmware::Appliance::Recovery::Backup::Job::ReturnStatus]
-        #     Check status
-        # @!attribute [rw] messages
-        #     @return [Array<Com::Vmware::Appliance::Recovery::Backup::Job::LocalizableMessage>]
-        #     List of messages
-        class ReturnResult < VAPI::Bindings::VapiStruct
-
-            class << self
-                # Holds (gets or creates) the binding type metadata for this structure type.
-                # @scope class
-                # @return [VAPI::Bindings::StructType] the binding type
-                def binding_type
-                    @binding_type ||= VAPI::Bindings::StructType.new(
-                        'com.vmware.appliance.recovery.backup.job.return_result',
-                        {
-                            'status' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Appliance::Recovery::Backup::Job::ReturnStatus'),
-                            'messages' => VAPI::Bindings::ListType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Appliance::Recovery::Backup::Job::LocalizableMessage')),
-                        },
-                        ReturnResult,
-                        false,
-                        nil)
-                end
-            end
-
-            attr_accessor :status,
-                          :messages
-
-            # Constructs a new instance.
-            # @param ruby_values [Hash] a map of initial property values (optional)
-            # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
-            def initialize(ruby_values=nil, struct_value=nil)
-                super(self.class.binding_type, ruby_values, struct_value)
-            end
-        end
-
-
-        # ``Com::Vmware::Appliance::Recovery::Backup::Job::BackupRequest``   class  Structure representing requested backup piece
-        # @!attribute [rw] parts
-        #     @return [Array<String>]
-        #     a list of optional parts. Run backup parts APIs to get list of optional parts and description
-        # @!attribute [rw] backup_password
-        #     @return [String, nil]
-        #     a password for a backup piece The backupPassword must adhere to the following password requirements: At least 8 characters, cannot be more than 20 characters in length. At least 1 uppercase letter. At least 1 lowercase letter. At least 1 numeric digit. At least 1 special character (i.e. any character not in [0-9,a-z,A-Z]). Only visible ASCII characters (for example, no space).
-        #     backupPassword If no password then the piece will not be encrypted
-        # @!attribute [rw] location_type
-        #     @return [Com::Vmware::Appliance::Recovery::Backup::Job::LocationType]
-        #     a type of location
-        # @!attribute [rw] location
-        #     @return [String]
-        #     path or url
-        # @!attribute [rw] location_user
-        #     @return [String, nil]
-        #     username for location
-        #     locationUser User name for this location if login is required.
-        # @!attribute [rw] location_password
-        #     @return [String, nil]
-        #     password for location
-        #     locationPassword Password for the specified user if login is required at this location.
-        # @!attribute [rw] comment
-        #     @return [String, nil]
-        #     Custom comment
-        #     comment an optional comment
-        class BackupRequest < VAPI::Bindings::VapiStruct
-
-            class << self
-                # Holds (gets or creates) the binding type metadata for this structure type.
-                # @scope class
-                # @return [VAPI::Bindings::StructType] the binding type
-                def binding_type
-                    @binding_type ||= VAPI::Bindings::StructType.new(
-                        'com.vmware.appliance.recovery.backup.job.backup_request',
-                        {
-                            'parts' => VAPI::Bindings::ListType.new(VAPI::Bindings::StringType.instance),
-                            'backup_password' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::SecretType.instance),
-                            'location_type' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Appliance::Recovery::Backup::Job::LocationType'),
-                            'location' => VAPI::Bindings::StringType.instance,
-                            'location_user' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::StringType.instance),
-                            'location_password' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::SecretType.instance),
-                            'comment' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::StringType.instance),
-                        },
-                        BackupRequest,
-                        false,
-                        nil)
-                end
-            end
-
-            attr_accessor :parts,
-                          :backup_password,
-                          :location_type,
-                          :location,
-                          :location_user,
-                          :location_password,
-                          :comment
-
-            # Constructs a new instance.
-            # @param ruby_values [Hash] a map of initial property values (optional)
-            # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
-            def initialize(ruby_values=nil, struct_value=nil)
-                super(self.class.binding_type, ruby_values, struct_value)
-            end
-        end
-
-
-        # ``Com::Vmware::Appliance::Recovery::Backup::Job::BackupJobStatus``   class  Structure representing backup restore status
-        # @!attribute [rw] id
-        #     @return [String]
-        #     TimeStamp based ID
-        # @!attribute [rw] state
-        #     @return [Com::Vmware::Appliance::Recovery::Backup::Job::BackupRestoreProcessState]
-        #     process state
-        # @!attribute [rw] messages
-        #     @return [Array<Com::Vmware::Appliance::Recovery::Backup::Job::LocalizableMessage>]
-        #     list of messages
-        # @!attribute [rw] progress
-        #     @return [Fixnum]
-        #     percentage complete
-        # @!attribute [rw] start_time
-        #     @return [DateTime]
-        #     Time when this backup was started.
-        # @!attribute [rw] end_time
-        #     @return [DateTime, nil]
-        #     Time when this backup was finished.
-        #     endTime End time is None till backup is finished.
-        class BackupJobStatus < VAPI::Bindings::VapiStruct
-
-            class << self
-                # Holds (gets or creates) the binding type metadata for this structure type.
-                # @scope class
-                # @return [VAPI::Bindings::StructType] the binding type
-                def binding_type
-                    @binding_type ||= VAPI::Bindings::StructType.new(
-                        'com.vmware.appliance.recovery.backup.job.backup_job_status',
-                        {
-                            'id' => VAPI::Bindings::StringType.instance,
-                            'state' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Appliance::Recovery::Backup::Job::BackupRestoreProcessState'),
-                            'messages' => VAPI::Bindings::ListType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Appliance::Recovery::Backup::Job::LocalizableMessage')),
-                            'progress' => VAPI::Bindings::IntegerType.instance,
-                            'start_time' => VAPI::Bindings::DateTimeType.instance,
-                            'end_time' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::DateTimeType.instance),
-                        },
-                        BackupJobStatus,
-                        false,
-                        nil)
-                end
-            end
-
-            attr_accessor :id,
-                          :state,
-                          :messages,
-                          :progress,
-                          :start_time,
-                          :end_time
-
-            # Constructs a new instance.
-            # @param ruby_values [Hash] a map of initial property values (optional)
-            # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
-            def initialize(ruby_values=nil, struct_value=nil)
-                super(self.class.binding_type, ruby_values, struct_value)
-            end
-        end
-
-
-
-        # ``Com::Vmware::Appliance::Recovery::Backup::Job::ReturnStatus``   enumerated type  Defines the state of precheck
-        # @!attribute [rw] fail
-        #     @return [Com::Vmware::Appliance::Recovery::Backup::Job::ReturnStatus]
-        #     Check failed
-        # @!attribute [rw] warning
-        #     @return [Com::Vmware::Appliance::Recovery::Backup::Job::ReturnStatus]
-        #     Passed with warnings
-        # @!attribute [rw] ok
-        #     @return [Com::Vmware::Appliance::Recovery::Backup::Job::ReturnStatus]
-        #     Check passed
-        class ReturnStatus < VAPI::Bindings::VapiEnum
-
-            class << self
-                # Holds (gets or creates) the binding type metadata for this enumeration type.
-                # @scope class
-                # @return [VAPI::Bindings::EnumType] the binding type
-                def binding_type
-                    @binding_type ||= VAPI::Bindings::EnumType.new(
-                        'com.vmware.appliance.recovery.backup.job.return_status',
-                        ReturnStatus)
-                end
-
-                # Converts from a string value (perhaps off the wire) to an instance
-                # of this enum type.
-                # @param value [String] the actual value of the enum instance
-                # @return [ReturnStatus] the instance found for the value, otherwise
-                #         an unknown instance will be built for the value
-                def from_string(value)
-                    begin
-                        const_get(value)
-                    rescue NameError
-                        ReturnStatus.new('UNKNOWN', value)
-                    end
-                end
-            end
-
-            private
-
-            # Constructs a new instance.
-            # @param value [String] the actual value of the enum instance
-            # @param unknown [String] the unknown value when value is 'UKNOWN'
-            def initialize(value, unknown=nil)
-                super(self.class.binding_type, value, unknown)
-            end
-
-            public
-
-            # @!attribute [rw] fail
-            #     @return [Com::Vmware::Appliance::Recovery::Backup::Job::ReturnStatus]
-            #     Check failed
-            FAIL = ReturnStatus.new('FAIL')
-
-            # @!attribute [rw] warning
-            #     @return [Com::Vmware::Appliance::Recovery::Backup::Job::ReturnStatus]
-            #     Passed with warnings
-            WARNING = ReturnStatus.new('WARNING')
-
-            # @!attribute [rw] ok
-            #     @return [Com::Vmware::Appliance::Recovery::Backup::Job::ReturnStatus]
-            #     Check passed
-            OK = ReturnStatus.new('OK')
-
-        end
-
-
-        # ``Com::Vmware::Appliance::Recovery::Backup::Job::LocationType``   enumerated type  Defines type of all locations for backup/restore
-        # @!attribute [rw] ftps
-        #     @return [Com::Vmware::Appliance::Recovery::Backup::Job::LocationType]
-        #     Destination is FTPS server
-        # @!attribute [rw] http
-        #     @return [Com::Vmware::Appliance::Recovery::Backup::Job::LocationType]
-        #     Destination is HTTP server
-        # @!attribute [rw] scp
-        #     @return [Com::Vmware::Appliance::Recovery::Backup::Job::LocationType]
-        #     Destination is SSH server
-        # @!attribute [rw] https
-        #     @return [Com::Vmware::Appliance::Recovery::Backup::Job::LocationType]
-        #     Destination is HTTPS server
-        # @!attribute [rw] ftp
-        #     @return [Com::Vmware::Appliance::Recovery::Backup::Job::LocationType]
-        #     Destination is FTP server
-        class LocationType < VAPI::Bindings::VapiEnum
-
-            class << self
-                # Holds (gets or creates) the binding type metadata for this enumeration type.
-                # @scope class
-                # @return [VAPI::Bindings::EnumType] the binding type
-                def binding_type
-                    @binding_type ||= VAPI::Bindings::EnumType.new(
-                        'com.vmware.appliance.recovery.backup.job.location_type',
-                        LocationType)
-                end
-
-                # Converts from a string value (perhaps off the wire) to an instance
-                # of this enum type.
-                # @param value [String] the actual value of the enum instance
-                # @return [LocationType] the instance found for the value, otherwise
-                #         an unknown instance will be built for the value
-                def from_string(value)
-                    begin
-                        const_get(value)
-                    rescue NameError
-                        LocationType.new('UNKNOWN', value)
-                    end
-                end
-            end
-
-            private
-
-            # Constructs a new instance.
-            # @param value [String] the actual value of the enum instance
-            # @param unknown [String] the unknown value when value is 'UKNOWN'
-            def initialize(value, unknown=nil)
-                super(self.class.binding_type, value, unknown)
-            end
-
-            public
-
-            # @!attribute [rw] ftps
-            #     @return [Com::Vmware::Appliance::Recovery::Backup::Job::LocationType]
-            #     Destination is FTPS server
-            FTPS = LocationType.new('FTPS')
-
-            # @!attribute [rw] http
-            #     @return [Com::Vmware::Appliance::Recovery::Backup::Job::LocationType]
-            #     Destination is HTTP server
-            HTTP = LocationType.new('HTTP')
-
-            # @!attribute [rw] scp
-            #     @return [Com::Vmware::Appliance::Recovery::Backup::Job::LocationType]
-            #     Destination is SSH server
-            SCP = LocationType.new('SCP')
-
-            # @!attribute [rw] https
-            #     @return [Com::Vmware::Appliance::Recovery::Backup::Job::LocationType]
-            #     Destination is HTTPS server
-            HTTPS = LocationType.new('HTTPS')
-
-            # @!attribute [rw] ftp
-            #     @return [Com::Vmware::Appliance::Recovery::Backup::Job::LocationType]
-            #     Destination is FTP server
-            FTP = LocationType.new('FTP')
-
-        end
-
-
-        # ``Com::Vmware::Appliance::Recovery::Backup::Job::BackupRestoreProcessState``   enumerated type  Defines state of backup/restore process
-        # @!attribute [rw] failed
-        #     @return [Com::Vmware::Appliance::Recovery::Backup::Job::BackupRestoreProcessState]
-        #     Failed
-        # @!attribute [rw] inprogress
-        #     @return [Com::Vmware::Appliance::Recovery::Backup::Job::BackupRestoreProcessState]
-        #     In progress
-        # @!attribute [rw] none
-        #     @return [Com::Vmware::Appliance::Recovery::Backup::Job::BackupRestoreProcessState]
-        #     Not started
-        # @!attribute [rw] succeeded
-        #     @return [Com::Vmware::Appliance::Recovery::Backup::Job::BackupRestoreProcessState]
-        #     Completed successfully
-        class BackupRestoreProcessState < VAPI::Bindings::VapiEnum
-
-            class << self
-                # Holds (gets or creates) the binding type metadata for this enumeration type.
-                # @scope class
-                # @return [VAPI::Bindings::EnumType] the binding type
-                def binding_type
-                    @binding_type ||= VAPI::Bindings::EnumType.new(
-                        'com.vmware.appliance.recovery.backup.job.backup_restore_process_state',
-                        BackupRestoreProcessState)
-                end
-
-                # Converts from a string value (perhaps off the wire) to an instance
-                # of this enum type.
-                # @param value [String] the actual value of the enum instance
-                # @return [BackupRestoreProcessState] the instance found for the value, otherwise
-                #         an unknown instance will be built for the value
-                def from_string(value)
-                    begin
-                        const_get(value)
-                    rescue NameError
-                        BackupRestoreProcessState.new('UNKNOWN', value)
-                    end
-                end
-            end
-
-            private
-
-            # Constructs a new instance.
-            # @param value [String] the actual value of the enum instance
-            # @param unknown [String] the unknown value when value is 'UKNOWN'
-            def initialize(value, unknown=nil)
-                super(self.class.binding_type, value, unknown)
-            end
-
-            public
-
-            # @!attribute [rw] failed
-            #     @return [Com::Vmware::Appliance::Recovery::Backup::Job::BackupRestoreProcessState]
-            #     Failed
-            FAILED = BackupRestoreProcessState.new('FAILED')
-
-            # @!attribute [rw] inprogress
-            #     @return [Com::Vmware::Appliance::Recovery::Backup::Job::BackupRestoreProcessState]
-            #     In progress
-            INPROGRESS = BackupRestoreProcessState.new('INPROGRESS')
-
-            # @!attribute [rw] none
-            #     @return [Com::Vmware::Appliance::Recovery::Backup::Job::BackupRestoreProcessState]
-            #     Not started
-            NONE = BackupRestoreProcessState.new('NONE')
-
-            # @!attribute [rw] succeeded
-            #     @return [Com::Vmware::Appliance::Recovery::Backup::Job::BackupRestoreProcessState]
-            #     Completed successfully
-            SUCCEEDED = BackupRestoreProcessState.new('SUCCEEDED')
-
-        end
-
-
+  # ``Com::Vmware::Appliance::Recovery::Backup::Job``   class  provides  methods  Performs backup restore operations
+  class Job < VAPI::Bindings::VapiService
+    # static metamodel definitions
+    SERVICE_ID = VAPI::Core::ServiceIdentifier.new('com.vmware.appliance.recovery.backup.job')
+
+    CANCEL_INFO = VAPI::Bindings::OperationInfo.new(
+      VAPI::Core::OperationIdentifier.new('cancel', SERVICE_ID),
+      VAPI::Bindings::OperationInputType.new(
+        'id' => VAPI::Bindings::IdType.new('com.vmware.appliance.recovery.backup.job')
+      ),
+      VAPI::Bindings::ReferenceType.new('Com::Vmware::Appliance::Recovery::Backup::Job::ReturnResult'),
+      {
+        'com.vmware.vapi.std.errors.not_found' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::NotFound'),
+        'com.vmware.vapi.std.errors.error' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Error')
+      },
+      [],
+      []
+    )
+
+    CREATE_INFO = VAPI::Bindings::OperationInfo.new(
+      VAPI::Core::OperationIdentifier.new('create', SERVICE_ID),
+      VAPI::Bindings::OperationInputType.new(
+        'piece' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Appliance::Recovery::Backup::Job::BackupRequest')
+      ),
+      VAPI::Bindings::ReferenceType.new('Com::Vmware::Appliance::Recovery::Backup::Job::BackupJobStatus'),
+      {
+        'com.vmware.vapi.std.errors.feature_in_use' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::FeatureInUse'),
+        'com.vmware.vapi.std.errors.error' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Error')
+      },
+      [],
+      []
+    )
+
+    LIST_INFO = VAPI::Bindings::OperationInfo.new(
+      VAPI::Core::OperationIdentifier.new('list', SERVICE_ID),
+      VAPI::Bindings::OperationInputType.new,
+      VAPI::Bindings::ListType.new(VAPI::Bindings::IdType.new),
+      {
+        'com.vmware.vapi.std.errors.error' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Error')
+      },
+      [],
+      []
+    )
+
+    GET_INFO = VAPI::Bindings::OperationInfo.new(
+      VAPI::Core::OperationIdentifier.new('get', SERVICE_ID),
+      VAPI::Bindings::OperationInputType.new(
+        'id' => VAPI::Bindings::IdType.new('com.vmware.appliance.recovery.backup.job')
+      ),
+      VAPI::Bindings::ReferenceType.new('Com::Vmware::Appliance::Recovery::Backup::Job::BackupJobStatus'),
+      {
+        'com.vmware.vapi.std.errors.not_found' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::NotFound'),
+        'com.vmware.vapi.std.errors.error' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Error')
+      },
+      [],
+      []
+    )
+
+    SERVICE_INFO = VAPI::Bindings::ServiceInfo.new(
+      SERVICE_ID,
+      'cancel' => CANCEL_INFO,
+      'create' => CREATE_INFO,
+      'list' => LIST_INFO,
+      'get' => GET_INFO
+    )
+
+    # Constructs a new instance.
+    #
+    # @param config [VAPI::Bindings::StubConfig] A hash with the api provider details.
+    def initialize(config)
+      super(config, SERVICE_INFO)
     end
 
-
-    # ``Com::Vmware::Appliance::Recovery::Backup::Parts``   class  provides  methods  Provides list of parts optional for the backup
-    class Parts < VAPI::Bindings::VapiService
-
-        protected
-
-        # static metamodel definitions
-        @@service_id = VAPI::Core::ServiceIdentifier.new('com.vmware.appliance.recovery.backup.parts')
-
-        @@list_info = VAPI::Bindings::OperationInfo.new(
-            VAPI::Core::OperationIdentifier.new('list', @@service_id),
-            VAPI::Bindings::OperationInputType.new,
-            VAPI::Bindings::ListType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Appliance::Recovery::Backup::Parts::Part')),
-            {
-                'com.vmware.vapi.std.errors.error' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Error'),
-
-            },
-            [],
-            [])
-        @@get_info = VAPI::Bindings::OperationInfo.new(
-            VAPI::Core::OperationIdentifier.new('get', @@service_id),
-            VAPI::Bindings::OperationInputType.new({
-                'id' => VAPI::Bindings::IdType.new(resource_types='com.vmware.appliance.recovery.backup.parts'),
-            }),
-            VAPI::Bindings::IntegerType.instance,
-            {
-                'com.vmware.vapi.std.errors.error' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Error'),
-
-            },
-            [],
-            [])
-
-        @@service_info = VAPI::Bindings::ServiceInfo.new(@@service_id, {
-            'list' => @@list_info,
-            'get' => @@get_info,
-        })
-
-        public
-
-        # Constructs a new instance.
-        #
-        # @param config [VAPI::Bindings::StubConfig] A hash with the api provider details.
-        def initialize(config)
-            super(config, @@service_info)
-        end
-
-
-        # Get a list of the backup parts
-        #
-        # @return [Array<Com::Vmware::Appliance::Recovery::Backup::Parts::Part>]
-        #     list of parts
-        # @raise [Com::Vmware::Vapi::Std::Errors::Error]
-        #     Generic error
-        def list()
-            invoke_with_info(@@list_info)
-        end
-
-
-        # Get size of the optional part
-        #
-        # @param id [String]
-        #     part id
-        # @return [Fixnum]
-        #     int size
-        # @raise [Com::Vmware::Vapi::Std::Errors::Error]
-        #     Generic error
-        def get(id)
-            invoke_with_info(@@get_info, {
-                'id' => id,
-            })
-        end
-
-
-
-        # ``Com::Vmware::Appliance::Recovery::Backup::Parts::LocalizableMessage``   class  Structure representing message
-        # @!attribute [rw] id
-        #     @return [String]
-        #     id in message bundle
-        # @!attribute [rw] default_message
-        #     @return [String]
-        #     text in english
-        # @!attribute [rw] args
-        #     @return [Array<String>]
-        #     nested data
-        class LocalizableMessage < VAPI::Bindings::VapiStruct
-
-            class << self
-                # Holds (gets or creates) the binding type metadata for this structure type.
-                # @scope class
-                # @return [VAPI::Bindings::StructType] the binding type
-                def binding_type
-                    @binding_type ||= VAPI::Bindings::StructType.new(
-                        'com.vmware.appliance.recovery.backup.parts.localizable_message',
-                        {
-                            'id' => VAPI::Bindings::StringType.instance,
-                            'default_message' => VAPI::Bindings::StringType.instance,
-                            'args' => VAPI::Bindings::ListType.new(VAPI::Bindings::StringType.instance),
-                        },
-                        LocalizableMessage,
-                        false,
-                        nil)
-                end
-            end
-
-            attr_accessor :id,
-                          :default_message,
-                          :args
-
-            # Constructs a new instance.
-            # @param ruby_values [Hash] a map of initial property values (optional)
-            # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
-            def initialize(ruby_values=nil, struct_value=nil)
-                super(self.class.binding_type, ruby_values, struct_value)
-            end
-        end
-
-
-        # ``Com::Vmware::Appliance::Recovery::Backup::Parts::Part``   class  Structure representing backup restore part
-        # @!attribute [rw] id
-        #     @return [String]
-        #     part ID
-        # @!attribute [rw] name
-        #     @return [Com::Vmware::Appliance::Recovery::Backup::Parts::LocalizableMessage]
-        #     part name id in message bundle
-        # @!attribute [rw] description
-        #     @return [Com::Vmware::Appliance::Recovery::Backup::Parts::LocalizableMessage]
-        #     part description id in message bundle
-        # @!attribute [rw] selected_by_default
-        #     @return [Boolean]
-        #     Is part selected by default in UI
-        # @!attribute [rw] optional
-        #     @return [Boolean]
-        #     Estimated size of this piece
-        class Part < VAPI::Bindings::VapiStruct
-
-            class << self
-                # Holds (gets or creates) the binding type metadata for this structure type.
-                # @scope class
-                # @return [VAPI::Bindings::StructType] the binding type
-                def binding_type
-                    @binding_type ||= VAPI::Bindings::StructType.new(
-                        'com.vmware.appliance.recovery.backup.parts.part',
-                        {
-                            'id' => VAPI::Bindings::IdType.new(resource_types='com.vmware.appliance.recovery.backup.parts'),
-                            'name' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Appliance::Recovery::Backup::Parts::LocalizableMessage'),
-                            'description' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Appliance::Recovery::Backup::Parts::LocalizableMessage'),
-                            'selected_by_default' => VAPI::Bindings::BooleanType.instance,
-                            'optional' => VAPI::Bindings::BooleanType.instance,
-                        },
-                        Part,
-                        false,
-                        nil)
-                end
-            end
-
-            attr_accessor :id,
-                          :name,
-                          :description,
-                          :selected_by_default,
-                          :optional
-
-            # Constructs a new instance.
-            # @param ruby_values [Hash] a map of initial property values (optional)
-            # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
-            def initialize(ruby_values=nil, struct_value=nil)
-                super(self.class.binding_type, ruby_values, struct_value)
-            end
-        end
-
-
+    # Cancel the backup job
+    #
+    # @param id [String]
+    #     ID (ID of job)
+    # @return [Com::Vmware::Appliance::Recovery::Backup::Job::ReturnResult]
+    #     BackupJobStatus Structure
+    # @raise [Com::Vmware::Vapi::Std::Errors::NotFound]
+    #     ID is not found
+    # @raise [Com::Vmware::Vapi::Std::Errors::Error]
+    #     Generic error
+    def cancel(id)
+      invoke_with_info(CANCEL_INFO,
+                       'id' => id)
     end
 
+    # Initiate backup.
+    #
+    # @param piece [Com::Vmware::Appliance::Recovery::Backup::Job::BackupRequest]
+    #     BackupRequest Structure
+    # @return [Com::Vmware::Appliance::Recovery::Backup::Job::BackupJobStatus]
+    #     BackupJobStatus Structure
+    # @raise [Com::Vmware::Vapi::Std::Errors::FeatureInUse]
+    #     A backup or restore is already in progress
+    # @raise [Com::Vmware::Vapi::Std::Errors::Error]
+    #     Generic error
+    def create(piece)
+      invoke_with_info(CREATE_INFO,
+                       'piece' => piece)
+    end
 
+    # Get list of backup jobs
+    #
+    # @return [Array<String>]
+    #     list of BackupJob IDs
+    # @raise [Com::Vmware::Vapi::Std::Errors::Error]
+    #     Generic error
+    def list
+      invoke_with_info(LIST_INFO)
+    end
+
+    # See backup job progress/result.
+    #
+    # @param id [String]
+    #     ID (ID of job)
+    # @return [Com::Vmware::Appliance::Recovery::Backup::Job::BackupJobStatus]
+    #     BackupJobStatus Structure
+    # @raise [Com::Vmware::Vapi::Std::Errors::NotFound]
+    #     ID is not found
+    # @raise [Com::Vmware::Vapi::Std::Errors::Error]
+    #     Generic error
+    def get(id)
+      invoke_with_info(GET_INFO,
+                       'id' => id)
+    end
+
+    # ``Com::Vmware::Appliance::Recovery::Backup::Job::LocalizableMessage``   class  Structure representing message
+    # @!attribute [rw] id
+    #     @return [String]
+    #     id in message bundle
+    # @!attribute [rw] default_message
+    #     @return [String]
+    #     text in english
+    # @!attribute [rw] args
+    #     @return [Array<String>]
+    #     nested data
+    class LocalizableMessage < VAPI::Bindings::VapiStruct
+      class << self
+        # Holds (gets or creates) the binding type metadata for this structure type.
+        # @scope class
+        # @return [VAPI::Bindings::StructType] the binding type
+        def binding_type
+          @binding_type ||= VAPI::Bindings::StructType.new(
+            'com.vmware.appliance.recovery.backup.job.localizable_message',
+            {
+              'id' => VAPI::Bindings::StringType.instance,
+              'default_message' => VAPI::Bindings::StringType.instance,
+              'args' => VAPI::Bindings::ListType.new(VAPI::Bindings::StringType.instance)
+            },
+            LocalizableMessage,
+            false,
+            nil
+          )
+        end
+      end
+
+      attr_accessor :id,
+                    :default_message,
+                    :args
+
+      # Constructs a new instance.
+      # @param ruby_values [Hash] a map of initial property values (optional)
+      # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
+      def initialize(ruby_values = nil, struct_value = nil)
+        super(self.class.binding_type, ruby_values, struct_value)
+      end
+    end
+
+    # ``Com::Vmware::Appliance::Recovery::Backup::Job::ReturnResult``   class  Structure representing precheck result
+    # @!attribute [rw] status
+    #     @return [Com::Vmware::Appliance::Recovery::Backup::Job::ReturnStatus]
+    #     Check status
+    # @!attribute [rw] messages
+    #     @return [Array<Com::Vmware::Appliance::Recovery::Backup::Job::LocalizableMessage>]
+    #     List of messages
+    class ReturnResult < VAPI::Bindings::VapiStruct
+      class << self
+        # Holds (gets or creates) the binding type metadata for this structure type.
+        # @scope class
+        # @return [VAPI::Bindings::StructType] the binding type
+        def binding_type
+          @binding_type ||= VAPI::Bindings::StructType.new(
+            'com.vmware.appliance.recovery.backup.job.return_result',
+            {
+              'status' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Appliance::Recovery::Backup::Job::ReturnStatus'),
+              'messages' => VAPI::Bindings::ListType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Appliance::Recovery::Backup::Job::LocalizableMessage'))
+            },
+            ReturnResult,
+            false,
+            nil
+          )
+        end
+      end
+
+      attr_accessor :status,
+                    :messages
+
+      # Constructs a new instance.
+      # @param ruby_values [Hash] a map of initial property values (optional)
+      # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
+      def initialize(ruby_values = nil, struct_value = nil)
+        super(self.class.binding_type, ruby_values, struct_value)
+      end
+    end
+
+    # ``Com::Vmware::Appliance::Recovery::Backup::Job::BackupRequest``   class  Structure representing requested backup piece
+    # @!attribute [rw] parts
+    #     @return [Array<String>]
+    #     a list of optional parts. Run backup parts APIs to get list of optional parts and description
+    # @!attribute [rw] backup_password
+    #     @return [String, nil]
+    #     a password for a backup piece The backupPassword must adhere to the following password requirements: At least 8 characters, cannot be more than 20 characters in length. At least 1 uppercase letter. At least 1 lowercase letter. At least 1 numeric digit. At least 1 special character (i.e. any character not in [0-9,a-z,A-Z]). Only visible ASCII characters (for example, no space).
+    #     backupPassword If no password then the piece will not be encrypted
+    # @!attribute [rw] location_type
+    #     @return [Com::Vmware::Appliance::Recovery::Backup::Job::LocationType]
+    #     a type of location
+    # @!attribute [rw] location
+    #     @return [String]
+    #     path or url
+    # @!attribute [rw] location_user
+    #     @return [String, nil]
+    #     username for location
+    #     locationUser User name for this location if login is required.
+    # @!attribute [rw] location_password
+    #     @return [String, nil]
+    #     password for location
+    #     locationPassword Password for the specified user if login is required at this location.
+    # @!attribute [rw] comment
+    #     @return [String, nil]
+    #     Custom comment
+    #     comment an optional comment
+    class BackupRequest < VAPI::Bindings::VapiStruct
+      class << self
+        # Holds (gets or creates) the binding type metadata for this structure type.
+        # @scope class
+        # @return [VAPI::Bindings::StructType] the binding type
+        def binding_type
+          @binding_type ||= VAPI::Bindings::StructType.new(
+            'com.vmware.appliance.recovery.backup.job.backup_request',
+            {
+              'parts' => VAPI::Bindings::ListType.new(VAPI::Bindings::StringType.instance),
+              'backup_password' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::SecretType.instance),
+              'location_type' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Appliance::Recovery::Backup::Job::LocationType'),
+              'location' => VAPI::Bindings::StringType.instance,
+              'location_user' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::StringType.instance),
+              'location_password' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::SecretType.instance),
+              'comment' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::StringType.instance)
+            },
+            BackupRequest,
+            false,
+            nil
+          )
+        end
+      end
+
+      attr_accessor :parts,
+                    :backup_password,
+                    :location_type,
+                    :location,
+                    :location_user,
+                    :location_password,
+                    :comment
+
+      # Constructs a new instance.
+      # @param ruby_values [Hash] a map of initial property values (optional)
+      # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
+      def initialize(ruby_values = nil, struct_value = nil)
+        super(self.class.binding_type, ruby_values, struct_value)
+      end
+    end
+
+    # ``Com::Vmware::Appliance::Recovery::Backup::Job::BackupJobStatus``   class  Structure representing backup restore status
+    # @!attribute [rw] id
+    #     @return [String]
+    #     TimeStamp based ID
+    # @!attribute [rw] state
+    #     @return [Com::Vmware::Appliance::Recovery::Backup::Job::BackupRestoreProcessState]
+    #     process state
+    # @!attribute [rw] messages
+    #     @return [Array<Com::Vmware::Appliance::Recovery::Backup::Job::LocalizableMessage>]
+    #     list of messages
+    # @!attribute [rw] progress
+    #     @return [Fixnum]
+    #     percentage complete
+    # @!attribute [rw] start_time
+    #     @return [DateTime]
+    #     Time when this backup was started.
+    # @!attribute [rw] end_time
+    #     @return [DateTime, nil]
+    #     Time when this backup was finished.
+    #     endTime End time is None till backup is finished.
+    class BackupJobStatus < VAPI::Bindings::VapiStruct
+      class << self
+        # Holds (gets or creates) the binding type metadata for this structure type.
+        # @scope class
+        # @return [VAPI::Bindings::StructType] the binding type
+        def binding_type
+          @binding_type ||= VAPI::Bindings::StructType.new(
+            'com.vmware.appliance.recovery.backup.job.backup_job_status',
+            {
+              'id' => VAPI::Bindings::StringType.instance,
+              'state' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Appliance::Recovery::Backup::Job::BackupRestoreProcessState'),
+              'messages' => VAPI::Bindings::ListType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Appliance::Recovery::Backup::Job::LocalizableMessage')),
+              'progress' => VAPI::Bindings::IntegerType.instance,
+              'start_time' => VAPI::Bindings::DateTimeType.instance,
+              'end_time' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::DateTimeType.instance)
+            },
+            BackupJobStatus,
+            false,
+            nil
+          )
+        end
+      end
+
+      attr_accessor :id,
+                    :state,
+                    :messages,
+                    :progress,
+                    :start_time,
+                    :end_time
+
+      # Constructs a new instance.
+      # @param ruby_values [Hash] a map of initial property values (optional)
+      # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
+      def initialize(ruby_values = nil, struct_value = nil)
+        super(self.class.binding_type, ruby_values, struct_value)
+      end
+    end
+
+    # ``Com::Vmware::Appliance::Recovery::Backup::Job::ReturnStatus``   enumerated type  Defines the state of precheck
+    # @!attribute [rw] fail
+    #     @return [Com::Vmware::Appliance::Recovery::Backup::Job::ReturnStatus]
+    #     Check failed
+    # @!attribute [rw] warning
+    #     @return [Com::Vmware::Appliance::Recovery::Backup::Job::ReturnStatus]
+    #     Passed with warnings
+    # @!attribute [rw] ok
+    #     @return [Com::Vmware::Appliance::Recovery::Backup::Job::ReturnStatus]
+    #     Check passed
+    class ReturnStatus < VAPI::Bindings::VapiEnum
+      class << self
+        # Holds (gets or creates) the binding type metadata for this enumeration type.
+        # @scope class
+        # @return [VAPI::Bindings::EnumType] the binding type
+        def binding_type
+          @binding_type ||= VAPI::Bindings::EnumType.new(
+            'com.vmware.appliance.recovery.backup.job.return_status',
+            ReturnStatus
+          )
+        end
+
+        # Converts from a string value (perhaps off the wire) to an instance
+        # of this enum type.
+        # @param value [String] the actual value of the enum instance
+        # @return [ReturnStatus] the instance found for the value, otherwise
+        #         an unknown instance will be built for the value
+        def from_string(value)
+          const_get(value)
+        rescue NameError
+          ReturnStatus.send(:new, 'UNKNOWN', value)
+        end
+      end
+
+      # Constructs a new instance.
+      # @param value [String] the actual value of the enum instance
+      # @param unknown [String] the unknown value when value is 'UKNOWN'
+      def initialize(value, unknown = nil)
+        super(self.class.binding_type, value, unknown)
+      end
+
+      private_class_method :new
+
+      # @!attribute [rw] fail
+      #     @return [Com::Vmware::Appliance::Recovery::Backup::Job::ReturnStatus]
+      #     Check failed
+      FAIL = ReturnStatus.send(:new, 'FAIL')
+
+      # @!attribute [rw] warning
+      #     @return [Com::Vmware::Appliance::Recovery::Backup::Job::ReturnStatus]
+      #     Passed with warnings
+      WARNING = ReturnStatus.send(:new, 'WARNING')
+
+      # @!attribute [rw] ok
+      #     @return [Com::Vmware::Appliance::Recovery::Backup::Job::ReturnStatus]
+      #     Check passed
+      OK = ReturnStatus.send(:new, 'OK')
+    end
+    # ``Com::Vmware::Appliance::Recovery::Backup::Job::LocationType``   enumerated type  Defines type of all locations for backup/restore
+    # @!attribute [rw] ftps
+    #     @return [Com::Vmware::Appliance::Recovery::Backup::Job::LocationType]
+    #     Destination is FTPS server
+    # @!attribute [rw] http
+    #     @return [Com::Vmware::Appliance::Recovery::Backup::Job::LocationType]
+    #     Destination is HTTP server
+    # @!attribute [rw] scp
+    #     @return [Com::Vmware::Appliance::Recovery::Backup::Job::LocationType]
+    #     Destination is SSH server
+    # @!attribute [rw] https
+    #     @return [Com::Vmware::Appliance::Recovery::Backup::Job::LocationType]
+    #     Destination is HTTPS server
+    # @!attribute [rw] ftp
+    #     @return [Com::Vmware::Appliance::Recovery::Backup::Job::LocationType]
+    #     Destination is FTP server
+    class LocationType < VAPI::Bindings::VapiEnum
+      class << self
+        # Holds (gets or creates) the binding type metadata for this enumeration type.
+        # @scope class
+        # @return [VAPI::Bindings::EnumType] the binding type
+        def binding_type
+          @binding_type ||= VAPI::Bindings::EnumType.new(
+            'com.vmware.appliance.recovery.backup.job.location_type',
+            LocationType
+          )
+        end
+
+        # Converts from a string value (perhaps off the wire) to an instance
+        # of this enum type.
+        # @param value [String] the actual value of the enum instance
+        # @return [LocationType] the instance found for the value, otherwise
+        #         an unknown instance will be built for the value
+        def from_string(value)
+          const_get(value)
+        rescue NameError
+          LocationType.send(:new, 'UNKNOWN', value)
+        end
+      end
+
+      # Constructs a new instance.
+      # @param value [String] the actual value of the enum instance
+      # @param unknown [String] the unknown value when value is 'UKNOWN'
+      def initialize(value, unknown = nil)
+        super(self.class.binding_type, value, unknown)
+      end
+
+      private_class_method :new
+
+      # @!attribute [rw] ftps
+      #     @return [Com::Vmware::Appliance::Recovery::Backup::Job::LocationType]
+      #     Destination is FTPS server
+      FTPS = LocationType.send(:new, 'FTPS')
+
+      # @!attribute [rw] http
+      #     @return [Com::Vmware::Appliance::Recovery::Backup::Job::LocationType]
+      #     Destination is HTTP server
+      HTTP = LocationType.send(:new, 'HTTP')
+
+      # @!attribute [rw] scp
+      #     @return [Com::Vmware::Appliance::Recovery::Backup::Job::LocationType]
+      #     Destination is SSH server
+      SCP = LocationType.send(:new, 'SCP')
+
+      # @!attribute [rw] https
+      #     @return [Com::Vmware::Appliance::Recovery::Backup::Job::LocationType]
+      #     Destination is HTTPS server
+      HTTPS = LocationType.send(:new, 'HTTPS')
+
+      # @!attribute [rw] ftp
+      #     @return [Com::Vmware::Appliance::Recovery::Backup::Job::LocationType]
+      #     Destination is FTP server
+      FTP = LocationType.send(:new, 'FTP')
+    end
+    # ``Com::Vmware::Appliance::Recovery::Backup::Job::BackupRestoreProcessState``   enumerated type  Defines state of backup/restore process
+    # @!attribute [rw] failed
+    #     @return [Com::Vmware::Appliance::Recovery::Backup::Job::BackupRestoreProcessState]
+    #     Failed
+    # @!attribute [rw] inprogress
+    #     @return [Com::Vmware::Appliance::Recovery::Backup::Job::BackupRestoreProcessState]
+    #     In progress
+    # @!attribute [rw] none
+    #     @return [Com::Vmware::Appliance::Recovery::Backup::Job::BackupRestoreProcessState]
+    #     Not started
+    # @!attribute [rw] succeeded
+    #     @return [Com::Vmware::Appliance::Recovery::Backup::Job::BackupRestoreProcessState]
+    #     Completed successfully
+    class BackupRestoreProcessState < VAPI::Bindings::VapiEnum
+      class << self
+        # Holds (gets or creates) the binding type metadata for this enumeration type.
+        # @scope class
+        # @return [VAPI::Bindings::EnumType] the binding type
+        def binding_type
+          @binding_type ||= VAPI::Bindings::EnumType.new(
+            'com.vmware.appliance.recovery.backup.job.backup_restore_process_state',
+            BackupRestoreProcessState
+          )
+        end
+
+        # Converts from a string value (perhaps off the wire) to an instance
+        # of this enum type.
+        # @param value [String] the actual value of the enum instance
+        # @return [BackupRestoreProcessState] the instance found for the value, otherwise
+        #         an unknown instance will be built for the value
+        def from_string(value)
+          const_get(value)
+        rescue NameError
+          BackupRestoreProcessState.send(:new, 'UNKNOWN', value)
+        end
+      end
+
+      # Constructs a new instance.
+      # @param value [String] the actual value of the enum instance
+      # @param unknown [String] the unknown value when value is 'UKNOWN'
+      def initialize(value, unknown = nil)
+        super(self.class.binding_type, value, unknown)
+      end
+
+      private_class_method :new
+
+      # @!attribute [rw] failed
+      #     @return [Com::Vmware::Appliance::Recovery::Backup::Job::BackupRestoreProcessState]
+      #     Failed
+      FAILED = BackupRestoreProcessState.send(:new, 'FAILED')
+
+      # @!attribute [rw] inprogress
+      #     @return [Com::Vmware::Appliance::Recovery::Backup::Job::BackupRestoreProcessState]
+      #     In progress
+      INPROGRESS = BackupRestoreProcessState.send(:new, 'INPROGRESS')
+
+      # @!attribute [rw] none
+      #     @return [Com::Vmware::Appliance::Recovery::Backup::Job::BackupRestoreProcessState]
+      #     Not started
+      NONE = BackupRestoreProcessState.send(:new, 'NONE')
+
+      # @!attribute [rw] succeeded
+      #     @return [Com::Vmware::Appliance::Recovery::Backup::Job::BackupRestoreProcessState]
+      #     Completed successfully
+      SUCCEEDED = BackupRestoreProcessState.send(:new, 'SUCCEEDED')
+    end
+  end
+  # ``Com::Vmware::Appliance::Recovery::Backup::Parts``   class  provides  methods  Provides list of parts optional for the backup
+  class Parts < VAPI::Bindings::VapiService
+    # static metamodel definitions
+    SERVICE_ID = VAPI::Core::ServiceIdentifier.new('com.vmware.appliance.recovery.backup.parts')
+
+    LIST_INFO = VAPI::Bindings::OperationInfo.new(
+      VAPI::Core::OperationIdentifier.new('list', SERVICE_ID),
+      VAPI::Bindings::OperationInputType.new,
+      VAPI::Bindings::ListType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Appliance::Recovery::Backup::Parts::Part')),
+      {
+        'com.vmware.vapi.std.errors.error' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Error')
+      },
+      [],
+      []
+    )
+
+    GET_INFO = VAPI::Bindings::OperationInfo.new(
+      VAPI::Core::OperationIdentifier.new('get', SERVICE_ID),
+      VAPI::Bindings::OperationInputType.new(
+        'id' => VAPI::Bindings::IdType.new('com.vmware.appliance.recovery.backup.parts')
+      ),
+      VAPI::Bindings::IntegerType.instance,
+      {
+        'com.vmware.vapi.std.errors.error' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Error')
+      },
+      [],
+      []
+    )
+
+    SERVICE_INFO = VAPI::Bindings::ServiceInfo.new(
+      SERVICE_ID,
+      'list' => LIST_INFO,
+      'get' => GET_INFO
+    )
+
+    # Constructs a new instance.
+    #
+    # @param config [VAPI::Bindings::StubConfig] A hash with the api provider details.
+    def initialize(config)
+      super(config, SERVICE_INFO)
+    end
+
+    # Get a list of the backup parts
+    #
+    # @return [Array<Com::Vmware::Appliance::Recovery::Backup::Parts::Part>]
+    #     list of parts
+    # @raise [Com::Vmware::Vapi::Std::Errors::Error]
+    #     Generic error
+    def list
+      invoke_with_info(LIST_INFO)
+    end
+
+    # Get size of the optional part
+    #
+    # @param id [String]
+    #     part id
+    # @return [Fixnum]
+    #     int size
+    # @raise [Com::Vmware::Vapi::Std::Errors::Error]
+    #     Generic error
+    def get(id)
+      invoke_with_info(GET_INFO,
+                       'id' => id)
+    end
+
+    # ``Com::Vmware::Appliance::Recovery::Backup::Parts::LocalizableMessage``   class  Structure representing message
+    # @!attribute [rw] id
+    #     @return [String]
+    #     id in message bundle
+    # @!attribute [rw] default_message
+    #     @return [String]
+    #     text in english
+    # @!attribute [rw] args
+    #     @return [Array<String>]
+    #     nested data
+    class LocalizableMessage < VAPI::Bindings::VapiStruct
+      class << self
+        # Holds (gets or creates) the binding type metadata for this structure type.
+        # @scope class
+        # @return [VAPI::Bindings::StructType] the binding type
+        def binding_type
+          @binding_type ||= VAPI::Bindings::StructType.new(
+            'com.vmware.appliance.recovery.backup.parts.localizable_message',
+            {
+              'id' => VAPI::Bindings::StringType.instance,
+              'default_message' => VAPI::Bindings::StringType.instance,
+              'args' => VAPI::Bindings::ListType.new(VAPI::Bindings::StringType.instance)
+            },
+            LocalizableMessage,
+            false,
+            nil
+          )
+        end
+      end
+
+      attr_accessor :id,
+                    :default_message,
+                    :args
+
+      # Constructs a new instance.
+      # @param ruby_values [Hash] a map of initial property values (optional)
+      # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
+      def initialize(ruby_values = nil, struct_value = nil)
+        super(self.class.binding_type, ruby_values, struct_value)
+      end
+    end
+
+    # ``Com::Vmware::Appliance::Recovery::Backup::Parts::Part``   class  Structure representing backup restore part
+    # @!attribute [rw] id
+    #     @return [String]
+    #     part ID
+    # @!attribute [rw] name
+    #     @return [Com::Vmware::Appliance::Recovery::Backup::Parts::LocalizableMessage]
+    #     part name id in message bundle
+    # @!attribute [rw] description
+    #     @return [Com::Vmware::Appliance::Recovery::Backup::Parts::LocalizableMessage]
+    #     part description id in message bundle
+    # @!attribute [rw] selected_by_default
+    #     @return [Boolean]
+    #     Is part selected by default in UI
+    # @!attribute [rw] optional
+    #     @return [Boolean]
+    #     Estimated size of this piece
+    class Part < VAPI::Bindings::VapiStruct
+      class << self
+        # Holds (gets or creates) the binding type metadata for this structure type.
+        # @scope class
+        # @return [VAPI::Bindings::StructType] the binding type
+        def binding_type
+          @binding_type ||= VAPI::Bindings::StructType.new(
+            'com.vmware.appliance.recovery.backup.parts.part',
+            {
+              'id' => VAPI::Bindings::IdType.new('com.vmware.appliance.recovery.backup.parts'),
+              'name' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Appliance::Recovery::Backup::Parts::LocalizableMessage'),
+              'description' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Appliance::Recovery::Backup::Parts::LocalizableMessage'),
+              'selected_by_default' => VAPI::Bindings::BooleanType.instance,
+              'optional' => VAPI::Bindings::BooleanType.instance
+            },
+            Part,
+            false,
+            nil
+          )
+        end
+      end
+
+      attr_accessor :id,
+                    :name,
+                    :description,
+                    :selected_by_default,
+                    :optional
+
+      # Constructs a new instance.
+      # @param ruby_values [Hash] a map of initial property values (optional)
+      # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
+      def initialize(ruby_values = nil, struct_value = nil)
+        super(self.class.binding_type, ruby_values, struct_value)
+      end
+    end
+
+  end
 end

--- a/client/sdk/com/vmware/appliance/recovery/restore.rb
+++ b/client/sdk/com/vmware/appliance/recovery/restore.rb
@@ -1,5 +1,6 @@
 #---------------------------------------------------------------------------
-# Copyright 2016 VMware, Inc.  All rights reserved.
+# Copyright 2017 VMware, Inc.  All rights reserved.
+#
 # AUTO GENERATED FILE -- DO NOT MODIFY!
 #
 # vAPI type descriptors for package com.vmware.appliance.recovery.restore.
@@ -8,520 +9,483 @@ require 'vapi'
 
 # declare the module hierarchy before we use the shorthand syntax below
 module Com
-    module Vmware
-        module Appliance
-            module Recovery
-                module Restore
-                end
-            end
+  module Vmware
+    module Appliance
+      module Recovery
+        module Restore
         end
+      end
     end
+  end
 end
 
 module Com::Vmware::Appliance::Recovery::Restore
-
-    # ``Com::Vmware::Appliance::Recovery::Restore::Job``   class  provides  methods  Performs restore operations
-    class Job < VAPI::Bindings::VapiService
-
-        protected
-
-        # static metamodel definitions
-        @@service_id = VAPI::Core::ServiceIdentifier.new('com.vmware.appliance.recovery.restore.job')
-
-        @@cancel_info = VAPI::Bindings::OperationInfo.new(
-            VAPI::Core::OperationIdentifier.new('cancel', @@service_id),
-            VAPI::Bindings::OperationInputType.new,
-            VAPI::Bindings::ReferenceType.new('Com::Vmware::Appliance::Recovery::Restore::Job::ReturnResult'),
-            {
-                'com.vmware.vapi.std.errors.error' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Error'),
-
-            },
-            [],
-            [])
-        @@create_info = VAPI::Bindings::OperationInfo.new(
-            VAPI::Core::OperationIdentifier.new('create', @@service_id),
-            VAPI::Bindings::OperationInputType.new({
-                'piece' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Appliance::Recovery::Restore::Job::RestoreRequest'),
-            }),
-            VAPI::Bindings::ReferenceType.new('Com::Vmware::Appliance::Recovery::Restore::Job::RestoreJobStatus'),
-            {
-                'com.vmware.vapi.std.errors.feature_in_use' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::FeatureInUse'),
-                'com.vmware.vapi.std.errors.not_allowed_in_current_state' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::NotAllowedInCurrentState'),
-                'com.vmware.vapi.std.errors.error' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Error'),
-
-            },
-            [],
-            [])
-        @@get_info = VAPI::Bindings::OperationInfo.new(
-            VAPI::Core::OperationIdentifier.new('get', @@service_id),
-            VAPI::Bindings::OperationInputType.new,
-            VAPI::Bindings::ReferenceType.new('Com::Vmware::Appliance::Recovery::Restore::Job::RestoreJobStatus'),
-            {
-                'com.vmware.vapi.std.errors.error' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Error'),
-
-            },
-            [],
-            [])
-
-        @@service_info = VAPI::Bindings::ServiceInfo.new(@@service_id, {
-            'cancel' => @@cancel_info,
-            'create' => @@create_info,
-            'get' => @@get_info,
-        })
-
-        public
-
-        # Constructs a new instance.
-        #
-        # @param config [VAPI::Bindings::StubConfig] A hash with the api provider details.
-        def initialize(config)
-            super(config, @@service_info)
-        end
-
-
-        # Cancel the backup job
-        #
-        # @return [Com::Vmware::Appliance::Recovery::Restore::Job::ReturnResult]
-        #     RestoreJobStatus Structure
-        # @raise [Com::Vmware::Vapi::Std::Errors::Error]
-        #     Generic error
-        def cancel()
-            invoke_with_info(@@cancel_info)
-        end
-
-
-        # Initiate restore.
-        #
-        # @param piece [Com::Vmware::Appliance::Recovery::Restore::Job::RestoreRequest]
-        #     RestoreRequest Structure
-        # @return [Com::Vmware::Appliance::Recovery::Restore::Job::RestoreJobStatus]
-        #     RestoreJobStatus Structure
-        # @raise [Com::Vmware::Vapi::Std::Errors::FeatureInUse]
-        #     A backup or restore is already in progress
-        # @raise [Com::Vmware::Vapi::Std::Errors::NotAllowedInCurrentState]
-        #     Restore is allowed only after deployment and before firstboot
-        # @raise [Com::Vmware::Vapi::Std::Errors::Error]
-        #     Generic error
-        def create(piece)
-            invoke_with_info(@@create_info, {
-                'piece' => piece,
-            })
-        end
-
-
-        # See restore job progress/result.
-        #
-        # @return [Com::Vmware::Appliance::Recovery::Restore::Job::RestoreJobStatus]
-        #     RestoreJobStatus Structure
-        # @raise [Com::Vmware::Vapi::Std::Errors::Error]
-        #     Generic error
-        def get()
-            invoke_with_info(@@get_info)
-        end
-
-
-
-        # ``Com::Vmware::Appliance::Recovery::Restore::Job::LocalizableMessage``   class  Structure representing message
-        # @!attribute [rw] id
-        #     @return [String]
-        #     id in message bundle
-        # @!attribute [rw] default_message
-        #     @return [String]
-        #     text in english
-        # @!attribute [rw] args
-        #     @return [Array<String>]
-        #     nested data
-        class LocalizableMessage < VAPI::Bindings::VapiStruct
-
-            class << self
-                # Holds (gets or creates) the binding type metadata for this structure type.
-                # @scope class
-                # @return [VAPI::Bindings::StructType] the binding type
-                def binding_type
-                    @binding_type ||= VAPI::Bindings::StructType.new(
-                        'com.vmware.appliance.recovery.restore.job.localizable_message',
-                        {
-                            'id' => VAPI::Bindings::StringType.instance,
-                            'default_message' => VAPI::Bindings::StringType.instance,
-                            'args' => VAPI::Bindings::ListType.new(VAPI::Bindings::StringType.instance),
-                        },
-                        LocalizableMessage,
-                        false,
-                        nil)
-                end
-            end
-
-            attr_accessor :id,
-                          :default_message,
-                          :args
-
-            # Constructs a new instance.
-            # @param ruby_values [Hash] a map of initial property values (optional)
-            # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
-            def initialize(ruby_values=nil, struct_value=nil)
-                super(self.class.binding_type, ruby_values, struct_value)
-            end
-        end
-
-
-        # ``Com::Vmware::Appliance::Recovery::Restore::Job::ReturnResult``   class  Structure representing precheck result
-        # @!attribute [rw] status
-        #     @return [Com::Vmware::Appliance::Recovery::Restore::Job::ReturnStatus]
-        #     Check status
-        # @!attribute [rw] messages
-        #     @return [Array<Com::Vmware::Appliance::Recovery::Restore::Job::LocalizableMessage>]
-        #     List of messages
-        class ReturnResult < VAPI::Bindings::VapiStruct
-
-            class << self
-                # Holds (gets or creates) the binding type metadata for this structure type.
-                # @scope class
-                # @return [VAPI::Bindings::StructType] the binding type
-                def binding_type
-                    @binding_type ||= VAPI::Bindings::StructType.new(
-                        'com.vmware.appliance.recovery.restore.job.return_result',
-                        {
-                            'status' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Appliance::Recovery::Restore::Job::ReturnStatus'),
-                            'messages' => VAPI::Bindings::ListType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Appliance::Recovery::Restore::Job::LocalizableMessage')),
-                        },
-                        ReturnResult,
-                        false,
-                        nil)
-                end
-            end
-
-            attr_accessor :status,
-                          :messages
-
-            # Constructs a new instance.
-            # @param ruby_values [Hash] a map of initial property values (optional)
-            # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
-            def initialize(ruby_values=nil, struct_value=nil)
-                super(self.class.binding_type, ruby_values, struct_value)
-            end
-        end
-
-
-        # ``Com::Vmware::Appliance::Recovery::Restore::Job::RestoreRequest``   class  Structure representing requested restore piece
-        # @!attribute [rw] backup_password
-        #     @return [String, nil]
-        #     a password for a backup piece
-        #     backupPassword If no password then the piece will not be decrypted
-        # @!attribute [rw] location_type
-        #     @return [Com::Vmware::Appliance::Recovery::Restore::Job::LocationType]
-        #     a type of location
-        # @!attribute [rw] location
-        #     @return [String]
-        #     path or url
-        # @!attribute [rw] location_user
-        #     @return [String, nil]
-        #     username for location
-        #     locationUser User name for this location if login is required.
-        # @!attribute [rw] location_password
-        #     @return [String, nil]
-        #     password for location
-        #     locationPassword Password for the specified user if login is required at this location.
-        class RestoreRequest < VAPI::Bindings::VapiStruct
-
-            class << self
-                # Holds (gets or creates) the binding type metadata for this structure type.
-                # @scope class
-                # @return [VAPI::Bindings::StructType] the binding type
-                def binding_type
-                    @binding_type ||= VAPI::Bindings::StructType.new(
-                        'com.vmware.appliance.recovery.restore.job.restore_request',
-                        {
-                            'backup_password' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::SecretType.instance),
-                            'location_type' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Appliance::Recovery::Restore::Job::LocationType'),
-                            'location' => VAPI::Bindings::StringType.instance,
-                            'location_user' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::StringType.instance),
-                            'location_password' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::SecretType.instance),
-                        },
-                        RestoreRequest,
-                        false,
-                        nil)
-                end
-            end
-
-            attr_accessor :backup_password,
-                          :location_type,
-                          :location,
-                          :location_user,
-                          :location_password
-
-            # Constructs a new instance.
-            # @param ruby_values [Hash] a map of initial property values (optional)
-            # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
-            def initialize(ruby_values=nil, struct_value=nil)
-                super(self.class.binding_type, ruby_values, struct_value)
-            end
-        end
-
-
-        # ``Com::Vmware::Appliance::Recovery::Restore::Job::RestoreJobStatus``   class  Structure representing backup restore status
-        # @!attribute [rw] state
-        #     @return [Com::Vmware::Appliance::Recovery::Restore::Job::BackupRestoreProcessState]
-        #     process state
-        # @!attribute [rw] messages
-        #     @return [Array<Com::Vmware::Appliance::Recovery::Restore::Job::LocalizableMessage>]
-        #     list of messages
-        # @!attribute [rw] progress
-        #     @return [Fixnum]
-        #     percentage complete
-        class RestoreJobStatus < VAPI::Bindings::VapiStruct
-
-            class << self
-                # Holds (gets or creates) the binding type metadata for this structure type.
-                # @scope class
-                # @return [VAPI::Bindings::StructType] the binding type
-                def binding_type
-                    @binding_type ||= VAPI::Bindings::StructType.new(
-                        'com.vmware.appliance.recovery.restore.job.restore_job_status',
-                        {
-                            'state' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Appliance::Recovery::Restore::Job::BackupRestoreProcessState'),
-                            'messages' => VAPI::Bindings::ListType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Appliance::Recovery::Restore::Job::LocalizableMessage')),
-                            'progress' => VAPI::Bindings::IntegerType.instance,
-                        },
-                        RestoreJobStatus,
-                        false,
-                        nil)
-                end
-            end
-
-            attr_accessor :state,
-                          :messages,
-                          :progress
-
-            # Constructs a new instance.
-            # @param ruby_values [Hash] a map of initial property values (optional)
-            # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
-            def initialize(ruby_values=nil, struct_value=nil)
-                super(self.class.binding_type, ruby_values, struct_value)
-            end
-        end
-
-
-
-        # ``Com::Vmware::Appliance::Recovery::Restore::Job::ReturnStatus``   enumerated type  Defines the state of precheck
-        # @!attribute [rw] fail
-        #     @return [Com::Vmware::Appliance::Recovery::Restore::Job::ReturnStatus]
-        #     Check failed
-        # @!attribute [rw] warning
-        #     @return [Com::Vmware::Appliance::Recovery::Restore::Job::ReturnStatus]
-        #     Passed with warnings
-        # @!attribute [rw] ok
-        #     @return [Com::Vmware::Appliance::Recovery::Restore::Job::ReturnStatus]
-        #     Check passed
-        class ReturnStatus < VAPI::Bindings::VapiEnum
-
-            class << self
-                # Holds (gets or creates) the binding type metadata for this enumeration type.
-                # @scope class
-                # @return [VAPI::Bindings::EnumType] the binding type
-                def binding_type
-                    @binding_type ||= VAPI::Bindings::EnumType.new(
-                        'com.vmware.appliance.recovery.restore.job.return_status',
-                        ReturnStatus)
-                end
-
-                # Converts from a string value (perhaps off the wire) to an instance
-                # of this enum type.
-                # @param value [String] the actual value of the enum instance
-                # @return [ReturnStatus] the instance found for the value, otherwise
-                #         an unknown instance will be built for the value
-                def from_string(value)
-                    begin
-                        const_get(value)
-                    rescue NameError
-                        ReturnStatus.new('UNKNOWN', value)
-                    end
-                end
-            end
-
-            private
-
-            # Constructs a new instance.
-            # @param value [String] the actual value of the enum instance
-            # @param unknown [String] the unknown value when value is 'UKNOWN'
-            def initialize(value, unknown=nil)
-                super(self.class.binding_type, value, unknown)
-            end
-
-            public
-
-            # @!attribute [rw] fail
-            #     @return [Com::Vmware::Appliance::Recovery::Restore::Job::ReturnStatus]
-            #     Check failed
-            FAIL = ReturnStatus.new('FAIL')
-
-            # @!attribute [rw] warning
-            #     @return [Com::Vmware::Appliance::Recovery::Restore::Job::ReturnStatus]
-            #     Passed with warnings
-            WARNING = ReturnStatus.new('WARNING')
-
-            # @!attribute [rw] ok
-            #     @return [Com::Vmware::Appliance::Recovery::Restore::Job::ReturnStatus]
-            #     Check passed
-            OK = ReturnStatus.new('OK')
-
-        end
-
-
-        # ``Com::Vmware::Appliance::Recovery::Restore::Job::LocationType``   enumerated type  Defines type of all locations for backup/restore
-        # @!attribute [rw] ftps
-        #     @return [Com::Vmware::Appliance::Recovery::Restore::Job::LocationType]
-        #     Destination is FTPS server
-        # @!attribute [rw] http
-        #     @return [Com::Vmware::Appliance::Recovery::Restore::Job::LocationType]
-        #     Destination is HTTP server
-        # @!attribute [rw] scp
-        #     @return [Com::Vmware::Appliance::Recovery::Restore::Job::LocationType]
-        #     Destination is SSH server
-        # @!attribute [rw] https
-        #     @return [Com::Vmware::Appliance::Recovery::Restore::Job::LocationType]
-        #     Destination is HTTPS server
-        # @!attribute [rw] ftp
-        #     @return [Com::Vmware::Appliance::Recovery::Restore::Job::LocationType]
-        #     Destination is FTP server
-        class LocationType < VAPI::Bindings::VapiEnum
-
-            class << self
-                # Holds (gets or creates) the binding type metadata for this enumeration type.
-                # @scope class
-                # @return [VAPI::Bindings::EnumType] the binding type
-                def binding_type
-                    @binding_type ||= VAPI::Bindings::EnumType.new(
-                        'com.vmware.appliance.recovery.restore.job.location_type',
-                        LocationType)
-                end
-
-                # Converts from a string value (perhaps off the wire) to an instance
-                # of this enum type.
-                # @param value [String] the actual value of the enum instance
-                # @return [LocationType] the instance found for the value, otherwise
-                #         an unknown instance will be built for the value
-                def from_string(value)
-                    begin
-                        const_get(value)
-                    rescue NameError
-                        LocationType.new('UNKNOWN', value)
-                    end
-                end
-            end
-
-            private
-
-            # Constructs a new instance.
-            # @param value [String] the actual value of the enum instance
-            # @param unknown [String] the unknown value when value is 'UKNOWN'
-            def initialize(value, unknown=nil)
-                super(self.class.binding_type, value, unknown)
-            end
-
-            public
-
-            # @!attribute [rw] ftps
-            #     @return [Com::Vmware::Appliance::Recovery::Restore::Job::LocationType]
-            #     Destination is FTPS server
-            FTPS = LocationType.new('FTPS')
-
-            # @!attribute [rw] http
-            #     @return [Com::Vmware::Appliance::Recovery::Restore::Job::LocationType]
-            #     Destination is HTTP server
-            HTTP = LocationType.new('HTTP')
-
-            # @!attribute [rw] scp
-            #     @return [Com::Vmware::Appliance::Recovery::Restore::Job::LocationType]
-            #     Destination is SSH server
-            SCP = LocationType.new('SCP')
-
-            # @!attribute [rw] https
-            #     @return [Com::Vmware::Appliance::Recovery::Restore::Job::LocationType]
-            #     Destination is HTTPS server
-            HTTPS = LocationType.new('HTTPS')
-
-            # @!attribute [rw] ftp
-            #     @return [Com::Vmware::Appliance::Recovery::Restore::Job::LocationType]
-            #     Destination is FTP server
-            FTP = LocationType.new('FTP')
-
-        end
-
-
-        # ``Com::Vmware::Appliance::Recovery::Restore::Job::BackupRestoreProcessState``   enumerated type  Defines state of backup/restore process
-        # @!attribute [rw] failed
-        #     @return [Com::Vmware::Appliance::Recovery::Restore::Job::BackupRestoreProcessState]
-        #     Failed
-        # @!attribute [rw] inprogress
-        #     @return [Com::Vmware::Appliance::Recovery::Restore::Job::BackupRestoreProcessState]
-        #     In progress
-        # @!attribute [rw] none
-        #     @return [Com::Vmware::Appliance::Recovery::Restore::Job::BackupRestoreProcessState]
-        #     Not started
-        # @!attribute [rw] succeeded
-        #     @return [Com::Vmware::Appliance::Recovery::Restore::Job::BackupRestoreProcessState]
-        #     Completed successfully
-        class BackupRestoreProcessState < VAPI::Bindings::VapiEnum
-
-            class << self
-                # Holds (gets or creates) the binding type metadata for this enumeration type.
-                # @scope class
-                # @return [VAPI::Bindings::EnumType] the binding type
-                def binding_type
-                    @binding_type ||= VAPI::Bindings::EnumType.new(
-                        'com.vmware.appliance.recovery.restore.job.backup_restore_process_state',
-                        BackupRestoreProcessState)
-                end
-
-                # Converts from a string value (perhaps off the wire) to an instance
-                # of this enum type.
-                # @param value [String] the actual value of the enum instance
-                # @return [BackupRestoreProcessState] the instance found for the value, otherwise
-                #         an unknown instance will be built for the value
-                def from_string(value)
-                    begin
-                        const_get(value)
-                    rescue NameError
-                        BackupRestoreProcessState.new('UNKNOWN', value)
-                    end
-                end
-            end
-
-            private
-
-            # Constructs a new instance.
-            # @param value [String] the actual value of the enum instance
-            # @param unknown [String] the unknown value when value is 'UKNOWN'
-            def initialize(value, unknown=nil)
-                super(self.class.binding_type, value, unknown)
-            end
-
-            public
-
-            # @!attribute [rw] failed
-            #     @return [Com::Vmware::Appliance::Recovery::Restore::Job::BackupRestoreProcessState]
-            #     Failed
-            FAILED = BackupRestoreProcessState.new('FAILED')
-
-            # @!attribute [rw] inprogress
-            #     @return [Com::Vmware::Appliance::Recovery::Restore::Job::BackupRestoreProcessState]
-            #     In progress
-            INPROGRESS = BackupRestoreProcessState.new('INPROGRESS')
-
-            # @!attribute [rw] none
-            #     @return [Com::Vmware::Appliance::Recovery::Restore::Job::BackupRestoreProcessState]
-            #     Not started
-            NONE = BackupRestoreProcessState.new('NONE')
-
-            # @!attribute [rw] succeeded
-            #     @return [Com::Vmware::Appliance::Recovery::Restore::Job::BackupRestoreProcessState]
-            #     Completed successfully
-            SUCCEEDED = BackupRestoreProcessState.new('SUCCEEDED')
-
-        end
-
-
+  # ``Com::Vmware::Appliance::Recovery::Restore::Job``   class  provides  methods  Performs restore operations
+  class Job < VAPI::Bindings::VapiService
+    # static metamodel definitions
+    SERVICE_ID = VAPI::Core::ServiceIdentifier.new('com.vmware.appliance.recovery.restore.job')
+
+    CANCEL_INFO = VAPI::Bindings::OperationInfo.new(
+      VAPI::Core::OperationIdentifier.new('cancel', SERVICE_ID),
+      VAPI::Bindings::OperationInputType.new,
+      VAPI::Bindings::ReferenceType.new('Com::Vmware::Appliance::Recovery::Restore::Job::ReturnResult'),
+      {
+        'com.vmware.vapi.std.errors.error' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Error')
+      },
+      [],
+      []
+    )
+
+    CREATE_INFO = VAPI::Bindings::OperationInfo.new(
+      VAPI::Core::OperationIdentifier.new('create', SERVICE_ID),
+      VAPI::Bindings::OperationInputType.new(
+        'piece' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Appliance::Recovery::Restore::Job::RestoreRequest')
+      ),
+      VAPI::Bindings::ReferenceType.new('Com::Vmware::Appliance::Recovery::Restore::Job::RestoreJobStatus'),
+      {
+        'com.vmware.vapi.std.errors.feature_in_use' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::FeatureInUse'),
+        'com.vmware.vapi.std.errors.not_allowed_in_current_state' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::NotAllowedInCurrentState'),
+        'com.vmware.vapi.std.errors.error' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Error')
+      },
+      [],
+      []
+    )
+
+    GET_INFO = VAPI::Bindings::OperationInfo.new(
+      VAPI::Core::OperationIdentifier.new('get', SERVICE_ID),
+      VAPI::Bindings::OperationInputType.new,
+      VAPI::Bindings::ReferenceType.new('Com::Vmware::Appliance::Recovery::Restore::Job::RestoreJobStatus'),
+      {
+        'com.vmware.vapi.std.errors.error' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Error')
+      },
+      [],
+      []
+    )
+
+    SERVICE_INFO = VAPI::Bindings::ServiceInfo.new(
+      SERVICE_ID,
+      'cancel' => CANCEL_INFO,
+      'create' => CREATE_INFO,
+      'get' => GET_INFO
+    )
+
+    # Constructs a new instance.
+    #
+    # @param config [VAPI::Bindings::StubConfig] A hash with the api provider details.
+    def initialize(config)
+      super(config, SERVICE_INFO)
     end
 
+    # Cancel the backup job
+    #
+    # @return [Com::Vmware::Appliance::Recovery::Restore::Job::ReturnResult]
+    #     RestoreJobStatus Structure
+    # @raise [Com::Vmware::Vapi::Std::Errors::Error]
+    #     Generic error
+    def cancel
+      invoke_with_info(CANCEL_INFO)
+    end
 
+    # Initiate restore.
+    #
+    # @param piece [Com::Vmware::Appliance::Recovery::Restore::Job::RestoreRequest]
+    #     RestoreRequest Structure
+    # @return [Com::Vmware::Appliance::Recovery::Restore::Job::RestoreJobStatus]
+    #     RestoreJobStatus Structure
+    # @raise [Com::Vmware::Vapi::Std::Errors::FeatureInUse]
+    #     A backup or restore is already in progress
+    # @raise [Com::Vmware::Vapi::Std::Errors::NotAllowedInCurrentState]
+    #     Restore is allowed only after deployment and before firstboot
+    # @raise [Com::Vmware::Vapi::Std::Errors::Error]
+    #     Generic error
+    def create(piece)
+      invoke_with_info(CREATE_INFO,
+                       'piece' => piece)
+    end
+
+    # See restore job progress/result.
+    #
+    # @return [Com::Vmware::Appliance::Recovery::Restore::Job::RestoreJobStatus]
+    #     RestoreJobStatus Structure
+    # @raise [Com::Vmware::Vapi::Std::Errors::Error]
+    #     Generic error
+    def get
+      invoke_with_info(GET_INFO)
+    end
+
+    # ``Com::Vmware::Appliance::Recovery::Restore::Job::LocalizableMessage``   class  Structure representing message
+    # @!attribute [rw] id
+    #     @return [String]
+    #     id in message bundle
+    # @!attribute [rw] default_message
+    #     @return [String]
+    #     text in english
+    # @!attribute [rw] args
+    #     @return [Array<String>]
+    #     nested data
+    class LocalizableMessage < VAPI::Bindings::VapiStruct
+      class << self
+        # Holds (gets or creates) the binding type metadata for this structure type.
+        # @scope class
+        # @return [VAPI::Bindings::StructType] the binding type
+        def binding_type
+          @binding_type ||= VAPI::Bindings::StructType.new(
+            'com.vmware.appliance.recovery.restore.job.localizable_message',
+            {
+              'id' => VAPI::Bindings::StringType.instance,
+              'default_message' => VAPI::Bindings::StringType.instance,
+              'args' => VAPI::Bindings::ListType.new(VAPI::Bindings::StringType.instance)
+            },
+            LocalizableMessage,
+            false,
+            nil
+          )
+        end
+      end
+
+      attr_accessor :id,
+                    :default_message,
+                    :args
+
+      # Constructs a new instance.
+      # @param ruby_values [Hash] a map of initial property values (optional)
+      # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
+      def initialize(ruby_values = nil, struct_value = nil)
+        super(self.class.binding_type, ruby_values, struct_value)
+      end
+    end
+
+    # ``Com::Vmware::Appliance::Recovery::Restore::Job::ReturnResult``   class  Structure representing precheck result
+    # @!attribute [rw] status
+    #     @return [Com::Vmware::Appliance::Recovery::Restore::Job::ReturnStatus]
+    #     Check status
+    # @!attribute [rw] messages
+    #     @return [Array<Com::Vmware::Appliance::Recovery::Restore::Job::LocalizableMessage>]
+    #     List of messages
+    class ReturnResult < VAPI::Bindings::VapiStruct
+      class << self
+        # Holds (gets or creates) the binding type metadata for this structure type.
+        # @scope class
+        # @return [VAPI::Bindings::StructType] the binding type
+        def binding_type
+          @binding_type ||= VAPI::Bindings::StructType.new(
+            'com.vmware.appliance.recovery.restore.job.return_result',
+            {
+              'status' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Appliance::Recovery::Restore::Job::ReturnStatus'),
+              'messages' => VAPI::Bindings::ListType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Appliance::Recovery::Restore::Job::LocalizableMessage'))
+            },
+            ReturnResult,
+            false,
+            nil
+          )
+        end
+      end
+
+      attr_accessor :status,
+                    :messages
+
+      # Constructs a new instance.
+      # @param ruby_values [Hash] a map of initial property values (optional)
+      # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
+      def initialize(ruby_values = nil, struct_value = nil)
+        super(self.class.binding_type, ruby_values, struct_value)
+      end
+    end
+
+    # ``Com::Vmware::Appliance::Recovery::Restore::Job::RestoreRequest``   class  Structure representing requested restore piece
+    # @!attribute [rw] backup_password
+    #     @return [String, nil]
+    #     a password for a backup piece
+    #     backupPassword If no password then the piece will not be decrypted
+    # @!attribute [rw] location_type
+    #     @return [Com::Vmware::Appliance::Recovery::Restore::Job::LocationType]
+    #     a type of location
+    # @!attribute [rw] location
+    #     @return [String]
+    #     path or url
+    # @!attribute [rw] location_user
+    #     @return [String, nil]
+    #     username for location
+    #     locationUser User name for this location if login is required.
+    # @!attribute [rw] location_password
+    #     @return [String, nil]
+    #     password for location
+    #     locationPassword Password for the specified user if login is required at this location.
+    class RestoreRequest < VAPI::Bindings::VapiStruct
+      class << self
+        # Holds (gets or creates) the binding type metadata for this structure type.
+        # @scope class
+        # @return [VAPI::Bindings::StructType] the binding type
+        def binding_type
+          @binding_type ||= VAPI::Bindings::StructType.new(
+            'com.vmware.appliance.recovery.restore.job.restore_request',
+            {
+              'backup_password' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::SecretType.instance),
+              'location_type' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Appliance::Recovery::Restore::Job::LocationType'),
+              'location' => VAPI::Bindings::StringType.instance,
+              'location_user' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::StringType.instance),
+              'location_password' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::SecretType.instance)
+            },
+            RestoreRequest,
+            false,
+            nil
+          )
+        end
+      end
+
+      attr_accessor :backup_password,
+                    :location_type,
+                    :location,
+                    :location_user,
+                    :location_password
+
+      # Constructs a new instance.
+      # @param ruby_values [Hash] a map of initial property values (optional)
+      # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
+      def initialize(ruby_values = nil, struct_value = nil)
+        super(self.class.binding_type, ruby_values, struct_value)
+      end
+    end
+
+    # ``Com::Vmware::Appliance::Recovery::Restore::Job::RestoreJobStatus``   class  Structure representing backup restore status
+    # @!attribute [rw] state
+    #     @return [Com::Vmware::Appliance::Recovery::Restore::Job::BackupRestoreProcessState]
+    #     process state
+    # @!attribute [rw] messages
+    #     @return [Array<Com::Vmware::Appliance::Recovery::Restore::Job::LocalizableMessage>]
+    #     list of messages
+    # @!attribute [rw] progress
+    #     @return [Fixnum]
+    #     percentage complete
+    class RestoreJobStatus < VAPI::Bindings::VapiStruct
+      class << self
+        # Holds (gets or creates) the binding type metadata for this structure type.
+        # @scope class
+        # @return [VAPI::Bindings::StructType] the binding type
+        def binding_type
+          @binding_type ||= VAPI::Bindings::StructType.new(
+            'com.vmware.appliance.recovery.restore.job.restore_job_status',
+            {
+              'state' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Appliance::Recovery::Restore::Job::BackupRestoreProcessState'),
+              'messages' => VAPI::Bindings::ListType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Appliance::Recovery::Restore::Job::LocalizableMessage')),
+              'progress' => VAPI::Bindings::IntegerType.instance
+            },
+            RestoreJobStatus,
+            false,
+            nil
+          )
+        end
+      end
+
+      attr_accessor :state,
+                    :messages,
+                    :progress
+
+      # Constructs a new instance.
+      # @param ruby_values [Hash] a map of initial property values (optional)
+      # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
+      def initialize(ruby_values = nil, struct_value = nil)
+        super(self.class.binding_type, ruby_values, struct_value)
+      end
+    end
+
+    # ``Com::Vmware::Appliance::Recovery::Restore::Job::ReturnStatus``   enumerated type  Defines the state of precheck
+    # @!attribute [rw] fail
+    #     @return [Com::Vmware::Appliance::Recovery::Restore::Job::ReturnStatus]
+    #     Check failed
+    # @!attribute [rw] warning
+    #     @return [Com::Vmware::Appliance::Recovery::Restore::Job::ReturnStatus]
+    #     Passed with warnings
+    # @!attribute [rw] ok
+    #     @return [Com::Vmware::Appliance::Recovery::Restore::Job::ReturnStatus]
+    #     Check passed
+    class ReturnStatus < VAPI::Bindings::VapiEnum
+      class << self
+        # Holds (gets or creates) the binding type metadata for this enumeration type.
+        # @scope class
+        # @return [VAPI::Bindings::EnumType] the binding type
+        def binding_type
+          @binding_type ||= VAPI::Bindings::EnumType.new(
+            'com.vmware.appliance.recovery.restore.job.return_status',
+            ReturnStatus
+          )
+        end
+
+        # Converts from a string value (perhaps off the wire) to an instance
+        # of this enum type.
+        # @param value [String] the actual value of the enum instance
+        # @return [ReturnStatus] the instance found for the value, otherwise
+        #         an unknown instance will be built for the value
+        def from_string(value)
+          const_get(value)
+        rescue NameError
+          ReturnStatus.send(:new, 'UNKNOWN', value)
+        end
+      end
+
+      # Constructs a new instance.
+      # @param value [String] the actual value of the enum instance
+      # @param unknown [String] the unknown value when value is 'UKNOWN'
+      def initialize(value, unknown = nil)
+        super(self.class.binding_type, value, unknown)
+      end
+
+      private_class_method :new
+
+      # @!attribute [rw] fail
+      #     @return [Com::Vmware::Appliance::Recovery::Restore::Job::ReturnStatus]
+      #     Check failed
+      FAIL = ReturnStatus.send(:new, 'FAIL')
+
+      # @!attribute [rw] warning
+      #     @return [Com::Vmware::Appliance::Recovery::Restore::Job::ReturnStatus]
+      #     Passed with warnings
+      WARNING = ReturnStatus.send(:new, 'WARNING')
+
+      # @!attribute [rw] ok
+      #     @return [Com::Vmware::Appliance::Recovery::Restore::Job::ReturnStatus]
+      #     Check passed
+      OK = ReturnStatus.send(:new, 'OK')
+    end
+    # ``Com::Vmware::Appliance::Recovery::Restore::Job::LocationType``   enumerated type  Defines type of all locations for backup/restore
+    # @!attribute [rw] ftps
+    #     @return [Com::Vmware::Appliance::Recovery::Restore::Job::LocationType]
+    #     Destination is FTPS server
+    # @!attribute [rw] http
+    #     @return [Com::Vmware::Appliance::Recovery::Restore::Job::LocationType]
+    #     Destination is HTTP server
+    # @!attribute [rw] scp
+    #     @return [Com::Vmware::Appliance::Recovery::Restore::Job::LocationType]
+    #     Destination is SSH server
+    # @!attribute [rw] https
+    #     @return [Com::Vmware::Appliance::Recovery::Restore::Job::LocationType]
+    #     Destination is HTTPS server
+    # @!attribute [rw] ftp
+    #     @return [Com::Vmware::Appliance::Recovery::Restore::Job::LocationType]
+    #     Destination is FTP server
+    class LocationType < VAPI::Bindings::VapiEnum
+      class << self
+        # Holds (gets or creates) the binding type metadata for this enumeration type.
+        # @scope class
+        # @return [VAPI::Bindings::EnumType] the binding type
+        def binding_type
+          @binding_type ||= VAPI::Bindings::EnumType.new(
+            'com.vmware.appliance.recovery.restore.job.location_type',
+            LocationType
+          )
+        end
+
+        # Converts from a string value (perhaps off the wire) to an instance
+        # of this enum type.
+        # @param value [String] the actual value of the enum instance
+        # @return [LocationType] the instance found for the value, otherwise
+        #         an unknown instance will be built for the value
+        def from_string(value)
+          const_get(value)
+        rescue NameError
+          LocationType.send(:new, 'UNKNOWN', value)
+        end
+      end
+
+      # Constructs a new instance.
+      # @param value [String] the actual value of the enum instance
+      # @param unknown [String] the unknown value when value is 'UKNOWN'
+      def initialize(value, unknown = nil)
+        super(self.class.binding_type, value, unknown)
+      end
+
+      private_class_method :new
+
+      # @!attribute [rw] ftps
+      #     @return [Com::Vmware::Appliance::Recovery::Restore::Job::LocationType]
+      #     Destination is FTPS server
+      FTPS = LocationType.send(:new, 'FTPS')
+
+      # @!attribute [rw] http
+      #     @return [Com::Vmware::Appliance::Recovery::Restore::Job::LocationType]
+      #     Destination is HTTP server
+      HTTP = LocationType.send(:new, 'HTTP')
+
+      # @!attribute [rw] scp
+      #     @return [Com::Vmware::Appliance::Recovery::Restore::Job::LocationType]
+      #     Destination is SSH server
+      SCP = LocationType.send(:new, 'SCP')
+
+      # @!attribute [rw] https
+      #     @return [Com::Vmware::Appliance::Recovery::Restore::Job::LocationType]
+      #     Destination is HTTPS server
+      HTTPS = LocationType.send(:new, 'HTTPS')
+
+      # @!attribute [rw] ftp
+      #     @return [Com::Vmware::Appliance::Recovery::Restore::Job::LocationType]
+      #     Destination is FTP server
+      FTP = LocationType.send(:new, 'FTP')
+    end
+    # ``Com::Vmware::Appliance::Recovery::Restore::Job::BackupRestoreProcessState``   enumerated type  Defines state of backup/restore process
+    # @!attribute [rw] failed
+    #     @return [Com::Vmware::Appliance::Recovery::Restore::Job::BackupRestoreProcessState]
+    #     Failed
+    # @!attribute [rw] inprogress
+    #     @return [Com::Vmware::Appliance::Recovery::Restore::Job::BackupRestoreProcessState]
+    #     In progress
+    # @!attribute [rw] none
+    #     @return [Com::Vmware::Appliance::Recovery::Restore::Job::BackupRestoreProcessState]
+    #     Not started
+    # @!attribute [rw] succeeded
+    #     @return [Com::Vmware::Appliance::Recovery::Restore::Job::BackupRestoreProcessState]
+    #     Completed successfully
+    class BackupRestoreProcessState < VAPI::Bindings::VapiEnum
+      class << self
+        # Holds (gets or creates) the binding type metadata for this enumeration type.
+        # @scope class
+        # @return [VAPI::Bindings::EnumType] the binding type
+        def binding_type
+          @binding_type ||= VAPI::Bindings::EnumType.new(
+            'com.vmware.appliance.recovery.restore.job.backup_restore_process_state',
+            BackupRestoreProcessState
+          )
+        end
+
+        # Converts from a string value (perhaps off the wire) to an instance
+        # of this enum type.
+        # @param value [String] the actual value of the enum instance
+        # @return [BackupRestoreProcessState] the instance found for the value, otherwise
+        #         an unknown instance will be built for the value
+        def from_string(value)
+          const_get(value)
+        rescue NameError
+          BackupRestoreProcessState.send(:new, 'UNKNOWN', value)
+        end
+      end
+
+      # Constructs a new instance.
+      # @param value [String] the actual value of the enum instance
+      # @param unknown [String] the unknown value when value is 'UKNOWN'
+      def initialize(value, unknown = nil)
+        super(self.class.binding_type, value, unknown)
+      end
+
+      private_class_method :new
+
+      # @!attribute [rw] failed
+      #     @return [Com::Vmware::Appliance::Recovery::Restore::Job::BackupRestoreProcessState]
+      #     Failed
+      FAILED = BackupRestoreProcessState.send(:new, 'FAILED')
+
+      # @!attribute [rw] inprogress
+      #     @return [Com::Vmware::Appliance::Recovery::Restore::Job::BackupRestoreProcessState]
+      #     In progress
+      INPROGRESS = BackupRestoreProcessState.send(:new, 'INPROGRESS')
+
+      # @!attribute [rw] none
+      #     @return [Com::Vmware::Appliance::Recovery::Restore::Job::BackupRestoreProcessState]
+      #     Not started
+      NONE = BackupRestoreProcessState.send(:new, 'NONE')
+
+      # @!attribute [rw] succeeded
+      #     @return [Com::Vmware::Appliance::Recovery::Restore::Job::BackupRestoreProcessState]
+      #     Completed successfully
+      SUCCEEDED = BackupRestoreProcessState.send(:new, 'SUCCEEDED')
+    end
+  end
 end

--- a/client/sdk/com/vmware/appliance/system.rb
+++ b/client/sdk/com/vmware/appliance/system.rb
@@ -1,5 +1,6 @@
 #---------------------------------------------------------------------------
-# Copyright 2016 VMware, Inc.  All rights reserved.
+# Copyright 2017 VMware, Inc.  All rights reserved.
+#
 # AUTO GENERATED FILE -- DO NOT MODIFY!
 #
 # vAPI type descriptors for package com.vmware.appliance.system.
@@ -8,375 +9,336 @@ require 'vapi'
 
 # declare the module hierarchy before we use the shorthand syntax below
 module Com
-    module Vmware
-        module Appliance
-            module System
-            end
-        end
+  module Vmware
+    module Appliance
+      module System
+      end
     end
+  end
 end
 
 module Com::Vmware::Appliance::System
+  # ``Com::Vmware::Appliance::System::Uptime``   class  provides  methods  Get the system uptime.
+  class Uptime < VAPI::Bindings::VapiService
+    # static metamodel definitions
+    SERVICE_ID = VAPI::Core::ServiceIdentifier.new('com.vmware.appliance.system.uptime')
 
-    # ``Com::Vmware::Appliance::System::Uptime``   class  provides  methods  Get the system uptime.
-    class Uptime < VAPI::Bindings::VapiService
+    GET_INFO = VAPI::Bindings::OperationInfo.new(
+      VAPI::Core::OperationIdentifier.new('get', SERVICE_ID),
+      VAPI::Bindings::OperationInputType.new,
+      VAPI::Bindings::DoubleType.instance,
+      {
+        'com.vmware.vapi.std.errors.error' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Error')
+      },
+      [],
+      []
+    )
 
-        protected
+    SERVICE_INFO = VAPI::Bindings::ServiceInfo.new(
+      SERVICE_ID,
+      'get' => GET_INFO
+    )
 
-        # static metamodel definitions
-        @@service_id = VAPI::Core::ServiceIdentifier.new('com.vmware.appliance.system.uptime')
-
-        @@get_info = VAPI::Bindings::OperationInfo.new(
-            VAPI::Core::OperationIdentifier.new('get', @@service_id),
-            VAPI::Bindings::OperationInputType.new,
-            VAPI::Bindings::DoubleType.instance,
-            {
-                'com.vmware.vapi.std.errors.error' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Error'),
-
-            },
-            [],
-            [])
-
-        @@service_info = VAPI::Bindings::ServiceInfo.new(@@service_id, {
-            'get' => @@get_info,
-        })
-
-        public
-
-        # Constructs a new instance.
-        #
-        # @param config [VAPI::Bindings::StubConfig] A hash with the api provider details.
-        def initialize(config)
-            super(config, @@service_info)
-        end
-
-
-        # Get the system uptime.
-        #
-        # @return [Float]
-        #     system uptime
-        # @raise [Com::Vmware::Vapi::Std::Errors::Error]
-        #     Generic error
-        def get()
-            invoke_with_info(@@get_info)
-        end
-
-
+    # Constructs a new instance.
+    #
+    # @param config [VAPI::Bindings::StubConfig] A hash with the api provider details.
+    def initialize(config)
+      super(config, SERVICE_INFO)
     end
 
-
-    # ``Com::Vmware::Appliance::System::Storage``   class  provides  methods  Appliance storage configuration
-    class Storage < VAPI::Bindings::VapiService
-
-        protected
-
-        # static metamodel definitions
-        @@service_id = VAPI::Core::ServiceIdentifier.new('com.vmware.appliance.system.storage')
-
-        @@list_info = VAPI::Bindings::OperationInfo.new(
-            VAPI::Core::OperationIdentifier.new('list', @@service_id),
-            VAPI::Bindings::OperationInputType.new,
-            VAPI::Bindings::ListType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Appliance::System::Storage::StorageMapping')),
-            {
-                'com.vmware.vapi.std.errors.error' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Error'),
-
-            },
-            [],
-            [])
-        @@resize_info = VAPI::Bindings::OperationInfo.new(
-            VAPI::Core::OperationIdentifier.new('resize', @@service_id),
-            VAPI::Bindings::OperationInputType.new,
-            VAPI::Bindings::VoidType.instance,
-            {
-                'com.vmware.vapi.std.errors.error' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Error'),
-
-            },
-            [],
-            [])
-
-        @@service_info = VAPI::Bindings::ServiceInfo.new(@@service_id, {
-            'list' => @@list_info,
-            'resize' => @@resize_info,
-        })
-
-        public
-
-        # Constructs a new instance.
-        #
-        # @param config [VAPI::Bindings::StubConfig] A hash with the api provider details.
-        def initialize(config)
-            super(config, @@service_info)
-        end
-
-
-        # Get disk to partition mapping
-        #
-        # @return [Array<Com::Vmware::Appliance::System::Storage::StorageMapping>]
-        #     list of mapping items
-        # @raise [Com::Vmware::Vapi::Std::Errors::Error]
-        #     Generic error
-        def list()
-            invoke_with_info(@@list_info)
-        end
-
-
-        # Resize all partitions to 100 percent of disk size
-        #
-        # @return [Void]
-        # @raise [Com::Vmware::Vapi::Std::Errors::Error]
-        #     Generic error
-        def resize()
-            invoke_with_info(@@resize_info)
-        end
-
-
-
-        # ``Com::Vmware::Appliance::System::Storage::StorageMapping``   class  FIXME: no docstring
-        # @!attribute [rw] disk
-        #     @return [String]
-        #     NGC disk ID
-        # @!attribute [rw] partition
-        #     @return [String]
-        #     Storage partition name
-        class StorageMapping < VAPI::Bindings::VapiStruct
-
-            class << self
-                # Holds (gets or creates) the binding type metadata for this structure type.
-                # @scope class
-                # @return [VAPI::Bindings::StructType] the binding type
-                def binding_type
-                    @binding_type ||= VAPI::Bindings::StructType.new(
-                        'com.vmware.appliance.system.storage.storage_mapping',
-                        {
-                            'disk' => VAPI::Bindings::IdType.new(resource_types='com.vmware.appliance.system.storage'),
-                            'partition' => VAPI::Bindings::StringType.instance,
-                        },
-                        StorageMapping,
-                        false,
-                        nil)
-                end
-            end
-
-            attr_accessor :disk,
-                          :partition
-
-            # Constructs a new instance.
-            # @param ruby_values [Hash] a map of initial property values (optional)
-            # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
-            def initialize(ruby_values=nil, struct_value=nil)
-                super(self.class.binding_type, ruby_values, struct_value)
-            end
-        end
-
-
+    # Get the system uptime.
+    #
+    # @return [Float]
+    #     system uptime
+    # @raise [Com::Vmware::Vapi::Std::Errors::Error]
+    #     Generic error
+    def get
+      invoke_with_info(GET_INFO)
     end
 
+  end
+  # ``Com::Vmware::Appliance::System::Storage``   class  provides  methods  Appliance storage configuration
+  class Storage < VAPI::Bindings::VapiService
+    # static metamodel definitions
+    SERVICE_ID = VAPI::Core::ServiceIdentifier.new('com.vmware.appliance.system.storage')
 
-    # ``Com::Vmware::Appliance::System::Time``   class  provides  methods  Gets system time.
-    class Time < VAPI::Bindings::VapiService
+    LIST_INFO = VAPI::Bindings::OperationInfo.new(
+      VAPI::Core::OperationIdentifier.new('list', SERVICE_ID),
+      VAPI::Bindings::OperationInputType.new,
+      VAPI::Bindings::ListType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Appliance::System::Storage::StorageMapping')),
+      {
+        'com.vmware.vapi.std.errors.error' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Error')
+      },
+      [],
+      []
+    )
 
-        protected
+    RESIZE_INFO = VAPI::Bindings::OperationInfo.new(
+      VAPI::Core::OperationIdentifier.new('resize', SERVICE_ID),
+      VAPI::Bindings::OperationInputType.new,
+      VAPI::Bindings::VoidType.instance,
+      {
+        'com.vmware.vapi.std.errors.error' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Error')
+      },
+      [],
+      []
+    )
 
-        # static metamodel definitions
-        @@service_id = VAPI::Core::ServiceIdentifier.new('com.vmware.appliance.system.time')
+    SERVICE_INFO = VAPI::Bindings::ServiceInfo.new(
+      SERVICE_ID,
+      'list' => LIST_INFO,
+      'resize' => RESIZE_INFO
+    )
 
-        @@get_info = VAPI::Bindings::OperationInfo.new(
-            VAPI::Core::OperationIdentifier.new('get', @@service_id),
-            VAPI::Bindings::OperationInputType.new,
-            VAPI::Bindings::ReferenceType.new('Com::Vmware::Appliance::System::Time::SystemTimeStruct'),
-            {
-                'com.vmware.vapi.std.errors.error' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Error'),
-
-            },
-            [],
-            [])
-
-        @@service_info = VAPI::Bindings::ServiceInfo.new(@@service_id, {
-            'get' => @@get_info,
-        })
-
-        public
-
-        # Constructs a new instance.
-        #
-        # @param config [VAPI::Bindings::StubConfig] A hash with the api provider details.
-        def initialize(config)
-            super(config, @@service_info)
-        end
-
-
-        # Get system time.
-        #
-        # @return [Com::Vmware::Appliance::System::Time::SystemTimeStruct]
-        #     System time
-        # @raise [Com::Vmware::Vapi::Std::Errors::Error]
-        #     Generic error
-        def get()
-            invoke_with_info(@@get_info)
-        end
-
-
-
-        # ``Com::Vmware::Appliance::System::Time::SystemTimeStruct``   class  Structure representing the system time.
-        # @!attribute [rw] seconds_since_epoch
-        #     @return [Float]
-        #     seconds since the epoch
-        # @!attribute [rw] date
-        #     @return [String]
-        #     date format: Thu 07-31-2014
-        # @!attribute [rw] time
-        #     @return [String]
-        #     time format: 18:18:32
-        # @!attribute [rw] timezone
-        #     @return [String]
-        #     timezone
-        class SystemTimeStruct < VAPI::Bindings::VapiStruct
-
-            class << self
-                # Holds (gets or creates) the binding type metadata for this structure type.
-                # @scope class
-                # @return [VAPI::Bindings::StructType] the binding type
-                def binding_type
-                    @binding_type ||= VAPI::Bindings::StructType.new(
-                        'com.vmware.appliance.system.time.system_time_struct',
-                        {
-                            'seconds_since_epoch' => VAPI::Bindings::DoubleType.instance,
-                            'date' => VAPI::Bindings::StringType.instance,
-                            'time' => VAPI::Bindings::StringType.instance,
-                            'timezone' => VAPI::Bindings::StringType.instance,
-                        },
-                        SystemTimeStruct,
-                        false,
-                        nil)
-                end
-            end
-
-            attr_accessor :seconds_since_epoch,
-                          :date,
-                          :time,
-                          :timezone
-
-            # Constructs a new instance.
-            # @param ruby_values [Hash] a map of initial property values (optional)
-            # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
-            def initialize(ruby_values=nil, struct_value=nil)
-                super(self.class.binding_type, ruby_values, struct_value)
-            end
-        end
-
-
+    # Constructs a new instance.
+    #
+    # @param config [VAPI::Bindings::StubConfig] A hash with the api provider details.
+    def initialize(config)
+      super(config, SERVICE_INFO)
     end
 
-
-    # ``Com::Vmware::Appliance::System::Version``   class  provides  methods  Get the appliance version.
-    class Version < VAPI::Bindings::VapiService
-
-        protected
-
-        # static metamodel definitions
-        @@service_id = VAPI::Core::ServiceIdentifier.new('com.vmware.appliance.system.version')
-
-        @@get_info = VAPI::Bindings::OperationInfo.new(
-            VAPI::Core::OperationIdentifier.new('get', @@service_id),
-            VAPI::Bindings::OperationInputType.new,
-            VAPI::Bindings::ReferenceType.new('Com::Vmware::Appliance::System::Version::VersionStruct'),
-            {
-                'com.vmware.vapi.std.errors.error' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Error'),
-
-            },
-            [],
-            [])
-
-        @@service_info = VAPI::Bindings::ServiceInfo.new(@@service_id, {
-            'get' => @@get_info,
-        })
-
-        public
-
-        # Constructs a new instance.
-        #
-        # @param config [VAPI::Bindings::StubConfig] A hash with the api provider details.
-        def initialize(config)
-            super(config, @@service_info)
-        end
-
-
-        # Get the version.
-        #
-        # @return [Com::Vmware::Appliance::System::Version::VersionStruct]
-        #     version information about the appliance
-        # @raise [Com::Vmware::Vapi::Std::Errors::Error]
-        #     Generic error
-        def get()
-            invoke_with_info(@@get_info)
-        end
-
-
-
-        # ``Com::Vmware::Appliance::System::Version::VersionStruct``   class  Structure representing appliance version information.
-        # @!attribute [rw] version
-        #     @return [String]
-        #     Appliance version.
-        # @!attribute [rw] product
-        #     @return [String]
-        #     Appliance name.
-        # @!attribute [rw] build
-        #     @return [String]
-        #     Appliance build number.
-        # @!attribute [rw] type
-        #     @return [String]
-        #     Type of product. Same product can have different deployment options, which is represented by type.
-        # @!attribute [rw] summary
-        #     @return [String]
-        #     Summary of patch (empty string, if the appliance has not been patched)
-        # @!attribute [rw] releasedate
-        #     @return [String]
-        #     Release date of patch (empty string, if the appliance has not been patched)
-        # @!attribute [rw] install_time
-        #     @return [String]
-        #     Display the date and time when this system was first installed. Value will not change on subsequent updates.
-        class VersionStruct < VAPI::Bindings::VapiStruct
-
-            class << self
-                # Holds (gets or creates) the binding type metadata for this structure type.
-                # @scope class
-                # @return [VAPI::Bindings::StructType] the binding type
-                def binding_type
-                    @binding_type ||= VAPI::Bindings::StructType.new(
-                        'com.vmware.appliance.system.version.version_struct',
-                        {
-                            'version' => VAPI::Bindings::StringType.instance,
-                            'product' => VAPI::Bindings::StringType.instance,
-                            'build' => VAPI::Bindings::StringType.instance,
-                            'type' => VAPI::Bindings::StringType.instance,
-                            'summary' => VAPI::Bindings::StringType.instance,
-                            'releasedate' => VAPI::Bindings::StringType.instance,
-                            'install_time' => VAPI::Bindings::StringType.instance,
-                        },
-                        VersionStruct,
-                        false,
-                        nil)
-                end
-            end
-
-            attr_accessor :version,
-                          :product,
-                          :build,
-                          :type,
-                          :summary,
-                          :releasedate,
-                          :install_time
-
-            # Constructs a new instance.
-            # @param ruby_values [Hash] a map of initial property values (optional)
-            # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
-            def initialize(ruby_values=nil, struct_value=nil)
-                super(self.class.binding_type, ruby_values, struct_value)
-            end
-        end
-
-
+    # Get disk to partition mapping
+    #
+    # @return [Array<Com::Vmware::Appliance::System::Storage::StorageMapping>]
+    #     list of mapping items
+    # @raise [Com::Vmware::Vapi::Std::Errors::Error]
+    #     Generic error
+    def list
+      invoke_with_info(LIST_INFO)
     end
 
+    # Resize all partitions to 100 percent of disk size
+    #
+    # @return [Void]
+    # @raise [Com::Vmware::Vapi::Std::Errors::Error]
+    #     Generic error
+    def resize
+      invoke_with_info(RESIZE_INFO)
+    end
 
+    # ``Com::Vmware::Appliance::System::Storage::StorageMapping``   class  FIXME: no docstring
+    # @!attribute [rw] disk
+    #     @return [String]
+    #     NGC disk ID
+    # @!attribute [rw] partition
+    #     @return [String]
+    #     Storage partition name
+    class StorageMapping < VAPI::Bindings::VapiStruct
+      class << self
+        # Holds (gets or creates) the binding type metadata for this structure type.
+        # @scope class
+        # @return [VAPI::Bindings::StructType] the binding type
+        def binding_type
+          @binding_type ||= VAPI::Bindings::StructType.new(
+            'com.vmware.appliance.system.storage.storage_mapping',
+            {
+              'disk' => VAPI::Bindings::IdType.new('com.vmware.appliance.system.storage'),
+              'partition' => VAPI::Bindings::StringType.instance
+            },
+            StorageMapping,
+            false,
+            nil
+          )
+        end
+      end
+
+      attr_accessor :disk,
+                    :partition
+
+      # Constructs a new instance.
+      # @param ruby_values [Hash] a map of initial property values (optional)
+      # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
+      def initialize(ruby_values = nil, struct_value = nil)
+        super(self.class.binding_type, ruby_values, struct_value)
+      end
+    end
+
+  end
+  # ``Com::Vmware::Appliance::System::Time``   class  provides  methods  Gets system time.
+  class Time < VAPI::Bindings::VapiService
+    # static metamodel definitions
+    SERVICE_ID = VAPI::Core::ServiceIdentifier.new('com.vmware.appliance.system.time')
+
+    GET_INFO = VAPI::Bindings::OperationInfo.new(
+      VAPI::Core::OperationIdentifier.new('get', SERVICE_ID),
+      VAPI::Bindings::OperationInputType.new,
+      VAPI::Bindings::ReferenceType.new('Com::Vmware::Appliance::System::Time::SystemTimeStruct'),
+      {
+        'com.vmware.vapi.std.errors.error' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Error')
+      },
+      [],
+      []
+    )
+
+    SERVICE_INFO = VAPI::Bindings::ServiceInfo.new(
+      SERVICE_ID,
+      'get' => GET_INFO
+    )
+
+    # Constructs a new instance.
+    #
+    # @param config [VAPI::Bindings::StubConfig] A hash with the api provider details.
+    def initialize(config)
+      super(config, SERVICE_INFO)
+    end
+
+    # Get system time.
+    #
+    # @return [Com::Vmware::Appliance::System::Time::SystemTimeStruct]
+    #     System time
+    # @raise [Com::Vmware::Vapi::Std::Errors::Error]
+    #     Generic error
+    def get
+      invoke_with_info(GET_INFO)
+    end
+
+    # ``Com::Vmware::Appliance::System::Time::SystemTimeStruct``   class  Structure representing the system time.
+    # @!attribute [rw] seconds_since_epoch
+    #     @return [Float]
+    #     seconds since the epoch
+    # @!attribute [rw] date
+    #     @return [String]
+    #     date format: Thu 07-31-2014
+    # @!attribute [rw] time
+    #     @return [String]
+    #     time format: 18:18:32
+    # @!attribute [rw] timezone
+    #     @return [String]
+    #     timezone
+    class SystemTimeStruct < VAPI::Bindings::VapiStruct
+      class << self
+        # Holds (gets or creates) the binding type metadata for this structure type.
+        # @scope class
+        # @return [VAPI::Bindings::StructType] the binding type
+        def binding_type
+          @binding_type ||= VAPI::Bindings::StructType.new(
+            'com.vmware.appliance.system.time.system_time_struct',
+            {
+              'seconds_since_epoch' => VAPI::Bindings::DoubleType.instance,
+              'date' => VAPI::Bindings::StringType.instance,
+              'time' => VAPI::Bindings::StringType.instance,
+              'timezone' => VAPI::Bindings::StringType.instance
+            },
+            SystemTimeStruct,
+            false,
+            nil
+          )
+        end
+      end
+
+      attr_accessor :seconds_since_epoch,
+                    :date,
+                    :time,
+                    :timezone
+
+      # Constructs a new instance.
+      # @param ruby_values [Hash] a map of initial property values (optional)
+      # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
+      def initialize(ruby_values = nil, struct_value = nil)
+        super(self.class.binding_type, ruby_values, struct_value)
+      end
+    end
+
+  end
+  # ``Com::Vmware::Appliance::System::Version``   class  provides  methods  Get the appliance version.
+  class Version < VAPI::Bindings::VapiService
+    # static metamodel definitions
+    SERVICE_ID = VAPI::Core::ServiceIdentifier.new('com.vmware.appliance.system.version')
+
+    GET_INFO = VAPI::Bindings::OperationInfo.new(
+      VAPI::Core::OperationIdentifier.new('get', SERVICE_ID),
+      VAPI::Bindings::OperationInputType.new,
+      VAPI::Bindings::ReferenceType.new('Com::Vmware::Appliance::System::Version::VersionStruct'),
+      {
+        'com.vmware.vapi.std.errors.error' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Error')
+      },
+      [],
+      []
+    )
+
+    SERVICE_INFO = VAPI::Bindings::ServiceInfo.new(
+      SERVICE_ID,
+      'get' => GET_INFO
+    )
+
+    # Constructs a new instance.
+    #
+    # @param config [VAPI::Bindings::StubConfig] A hash with the api provider details.
+    def initialize(config)
+      super(config, SERVICE_INFO)
+    end
+
+    # Get the version.
+    #
+    # @return [Com::Vmware::Appliance::System::Version::VersionStruct]
+    #     version information about the appliance
+    # @raise [Com::Vmware::Vapi::Std::Errors::Error]
+    #     Generic error
+    def get
+      invoke_with_info(GET_INFO)
+    end
+
+    # ``Com::Vmware::Appliance::System::Version::VersionStruct``   class  Structure representing appliance version information.
+    # @!attribute [rw] version
+    #     @return [String]
+    #     Appliance version.
+    # @!attribute [rw] product
+    #     @return [String]
+    #     Appliance name.
+    # @!attribute [rw] build
+    #     @return [String]
+    #     Appliance build number.
+    # @!attribute [rw] type
+    #     @return [String]
+    #     Type of product. Same product can have different deployment options, which is represented by type.
+    # @!attribute [rw] summary
+    #     @return [String]
+    #     Summary of patch (empty string, if the appliance has not been patched)
+    # @!attribute [rw] releasedate
+    #     @return [String]
+    #     Release date of patch (empty string, if the appliance has not been patched)
+    # @!attribute [rw] install_time
+    #     @return [String]
+    #     Display the date and time when this system was first installed. Value will not change on subsequent updates.
+    class VersionStruct < VAPI::Bindings::VapiStruct
+      class << self
+        # Holds (gets or creates) the binding type metadata for this structure type.
+        # @scope class
+        # @return [VAPI::Bindings::StructType] the binding type
+        def binding_type
+          @binding_type ||= VAPI::Bindings::StructType.new(
+            'com.vmware.appliance.system.version.version_struct',
+            {
+              'version' => VAPI::Bindings::StringType.instance,
+              'product' => VAPI::Bindings::StringType.instance,
+              'build' => VAPI::Bindings::StringType.instance,
+              'type' => VAPI::Bindings::StringType.instance,
+              'summary' => VAPI::Bindings::StringType.instance,
+              'releasedate' => VAPI::Bindings::StringType.instance,
+              'install_time' => VAPI::Bindings::StringType.instance
+            },
+            VersionStruct,
+            false,
+            nil
+          )
+        end
+      end
+
+      attr_accessor :version,
+                    :product,
+                    :build,
+                    :type,
+                    :summary,
+                    :releasedate,
+                    :install_time
+
+      # Constructs a new instance.
+      # @param ruby_values [Hash] a map of initial property values (optional)
+      # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
+      def initialize(ruby_values = nil, struct_value = nil)
+        super(self.class.binding_type, ruby_values, struct_value)
+      end
+    end
+
+  end
 end

--- a/client/sdk/com/vmware/appliance/techpreview.rb
+++ b/client/sdk/com/vmware/appliance/techpreview.rb
@@ -1,5 +1,6 @@
 #---------------------------------------------------------------------------
-# Copyright 2016 VMware, Inc.  All rights reserved.
+# Copyright 2017 VMware, Inc.  All rights reserved.
+#
 # AUTO GENERATED FILE -- DO NOT MODIFY!
 #
 # vAPI type descriptors for package com.vmware.appliance.techpreview.
@@ -8,1032 +9,943 @@ require 'vapi'
 
 # declare the module hierarchy before we use the shorthand syntax below
 module Com
-    module Vmware
-        module Appliance
-            module Techpreview
-            end
-        end
+  module Vmware
+    module Appliance
+      module Techpreview
+      end
     end
+  end
 end
 
 module Com::Vmware::Appliance::Techpreview
-
-    # ``Com::Vmware::Appliance::Techpreview::Ntp``   class  provides  methods  Gets NTP configuration status and tests connection to ntp servers.
-    class NtpService < VAPI::Bindings::VapiService
-
-        protected
-
-        # static metamodel definitions
-        @@service_id = VAPI::Core::ServiceIdentifier.new('com.vmware.appliance.techpreview.ntp')
-
-        @@test_info = VAPI::Bindings::OperationInfo.new(
-            VAPI::Core::OperationIdentifier.new('test', @@service_id),
-            VAPI::Bindings::OperationInputType.new({
-                'servers' => VAPI::Bindings::ListType.new(VAPI::Bindings::StringType.instance),
-            }),
-            VAPI::Bindings::ReferenceType.new('Com::Vmware::Appliance::Techpreview::Ntp::TestStatusInfo'),
-            {
-                'com.vmware.vapi.std.errors.error' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Error'),
-
-            },
-            [],
-            [])
-        @@get_info = VAPI::Bindings::OperationInfo.new(
-            VAPI::Core::OperationIdentifier.new('get', @@service_id),
-            VAPI::Bindings::OperationInputType.new,
-            VAPI::Bindings::ReferenceType.new('Com::Vmware::Appliance::Techpreview::Ntp::NTPConfig'),
-            {
-                'com.vmware.vapi.std.errors.error' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Error'),
-
-            },
-            [],
-            [])
-
-        @@service_info = VAPI::Bindings::ServiceInfo.new(@@service_id, {
-            'test' => @@test_info,
-            'get' => @@get_info,
-        })
-
-        public
-
-        # Constructs a new instance.
-        #
-        # @param config [VAPI::Bindings::StubConfig] A hash with the api provider details.
-        def initialize(config)
-            super(config, @@service_info)
-        end
-
-
-        # Test the connection to a list of ntp servers.
-        #
-        # @param servers [Array<String>]
-        #     List of host names or IP addresses of NTP servers.
-        # @return [Com::Vmware::Appliance::Techpreview::Ntp::TestStatusInfo]
-        #     NTP connection status
-        # @raise [Com::Vmware::Vapi::Std::Errors::Error]
-        #     Generic error
-        def test(servers)
-            invoke_with_info(@@test_info, {
-                'servers' => servers,
-            })
-        end
-
-
-        # Get the NTP configuration status. If you run the 'timesync.get' command, you can retrieve the current time synchronization method (NTP- or VMware Tools-based). The 'ntp' command always returns the NTP server information, even when the time synchronization mode is not set to NTP. If the time synchronization mode is not NTP-based, the NTP server status is displayed as down.
-        #
-        # @return [Com::Vmware::Appliance::Techpreview::Ntp::NTPConfig]
-        #     NTP config
-        # @raise [Com::Vmware::Vapi::Std::Errors::Error]
-        #     Generic error
-        def get()
-            invoke_with_info(@@get_info)
-        end
-
-
-
-        # ``Com::Vmware::Appliance::Techpreview::Ntp::NTPConfig``   class  Structure defining the NTP configuration.
-        # @!attribute [rw] status
-        #     @return [Com::Vmware::Appliance::Techpreview::Ntp::NTPStatus]
-        #     NTP daemon running status
-        # @!attribute [rw] servers
-        #     @return [Array<String>]
-        #     List of NTP servers.
-        class NTPConfig < VAPI::Bindings::VapiStruct
-
-            class << self
-                # Holds (gets or creates) the binding type metadata for this structure type.
-                # @scope class
-                # @return [VAPI::Bindings::StructType] the binding type
-                def binding_type
-                    @binding_type ||= VAPI::Bindings::StructType.new(
-                        'com.vmware.appliance.techpreview.ntp.NTP_config',
-                        {
-                            'status' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Appliance::Techpreview::Ntp::NTPStatus'),
-                            'servers' => VAPI::Bindings::ListType.new(VAPI::Bindings::StringType.instance),
-                        },
-                        NTPConfig,
-                        false,
-                        nil)
-                end
-            end
-
-            attr_accessor :status,
-                          :servers
-
-            # Constructs a new instance.
-            # @param ruby_values [Hash] a map of initial property values (optional)
-            # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
-            def initialize(ruby_values=nil, struct_value=nil)
-                super(self.class.binding_type, ruby_values, struct_value)
-            end
-        end
-
-
-        # ``Com::Vmware::Appliance::Techpreview::Ntp::Message``   class  Test result and message
-        # @!attribute [rw] message
-        #     @return [String]
-        #     message
-        # @!attribute [rw] result
-        #     @return [Com::Vmware::Appliance::Techpreview::Ntp::MessageStatus]
-        #     result of the test
-        class Message < VAPI::Bindings::VapiStruct
-
-            class << self
-                # Holds (gets or creates) the binding type metadata for this structure type.
-                # @scope class
-                # @return [VAPI::Bindings::StructType] the binding type
-                def binding_type
-                    @binding_type ||= VAPI::Bindings::StructType.new(
-                        'com.vmware.appliance.techpreview.ntp.message',
-                        {
-                            'message' => VAPI::Bindings::StringType.instance,
-                            'result' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Appliance::Techpreview::Ntp::MessageStatus'),
-                        },
-                        Message,
-                        false,
-                        nil)
-                end
-            end
-
-            attr_accessor :message,
-                          :result
-
-            # Constructs a new instance.
-            # @param ruby_values [Hash] a map of initial property values (optional)
-            # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
-            def initialize(ruby_values=nil, struct_value=nil)
-                super(self.class.binding_type, ruby_values, struct_value)
-            end
-        end
-
-
-        # ``Com::Vmware::Appliance::Techpreview::Ntp::TestStatusInfo``   class  Overall test result
-        # @!attribute [rw] status
-        #     @return [Com::Vmware::Appliance::Techpreview::Ntp::TestStatus]
-        #     Overall status of tests run.
-        # @!attribute [rw] messages
-        #     @return [Array<Com::Vmware::Appliance::Techpreview::Ntp::Message>]
-        #     messages
-        class TestStatusInfo < VAPI::Bindings::VapiStruct
-
-            class << self
-                # Holds (gets or creates) the binding type metadata for this structure type.
-                # @scope class
-                # @return [VAPI::Bindings::StructType] the binding type
-                def binding_type
-                    @binding_type ||= VAPI::Bindings::StructType.new(
-                        'com.vmware.appliance.techpreview.ntp.test_status_info',
-                        {
-                            'status' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Appliance::Techpreview::Ntp::TestStatus'),
-                            'messages' => VAPI::Bindings::ListType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Appliance::Techpreview::Ntp::Message')),
-                        },
-                        TestStatusInfo,
-                        false,
-                        nil)
-                end
-            end
-
-            attr_accessor :status,
-                          :messages
-
-            # Constructs a new instance.
-            # @param ruby_values [Hash] a map of initial property values (optional)
-            # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
-            def initialize(ruby_values=nil, struct_value=nil)
-                super(self.class.binding_type, ruby_values, struct_value)
-            end
-        end
-
-
-
-        # ``Com::Vmware::Appliance::Techpreview::Ntp::NTPStatus``   enumerated type  Defines NTP status
-        # @!attribute [rw] down
-        #     @return [Com::Vmware::Appliance::Techpreview::Ntp::NTPStatus]
-        #     NTP daemon is not running.
-        # @!attribute [rw] unknown
-        #     @return [Com::Vmware::Appliance::Techpreview::Ntp::NTPStatus]
-        #     Cannot retrieve NTP daemon status.
-        # @!attribute [rw] up
-        #     @return [Com::Vmware::Appliance::Techpreview::Ntp::NTPStatus]
-        #     NTP daemon is running.
-        class NTPStatus < VAPI::Bindings::VapiEnum
-
-            class << self
-                # Holds (gets or creates) the binding type metadata for this enumeration type.
-                # @scope class
-                # @return [VAPI::Bindings::EnumType] the binding type
-                def binding_type
-                    @binding_type ||= VAPI::Bindings::EnumType.new(
-                        'com.vmware.appliance.techpreview.ntp.NTP_status',
-                        NTPStatus)
-                end
-
-                # Converts from a string value (perhaps off the wire) to an instance
-                # of this enum type.
-                # @param value [String] the actual value of the enum instance
-                # @return [NTPStatus] the instance found for the value, otherwise
-                #         an unknown instance will be built for the value
-                def from_string(value)
-                    begin
-                        const_get(value)
-                    rescue NameError
-                        NTPStatus.new('UNKNOWN', value)
-                    end
-                end
-            end
-
-            private
-
-            # Constructs a new instance.
-            # @param value [String] the actual value of the enum instance
-            # @param unknown [String] the unknown value when value is 'UKNOWN'
-            def initialize(value, unknown=nil)
-                super(self.class.binding_type, value, unknown)
-            end
-
-            public
-
-            # @!attribute [rw] down
-            #     @return [Com::Vmware::Appliance::Techpreview::Ntp::NTPStatus]
-            #     NTP daemon is not running.
-            DOWN = NTPStatus.new('DOWN')
-
-            # @!attribute [rw] unknown
-            #     @return [Com::Vmware::Appliance::Techpreview::Ntp::NTPStatus]
-            #     Cannot retrieve NTP daemon status.
-            UNKNOWN = NTPStatus.new('UNKNOWN')
-
-            # @!attribute [rw] up
-            #     @return [Com::Vmware::Appliance::Techpreview::Ntp::NTPStatus]
-            #     NTP daemon is running.
-            UP = NTPStatus.new('UP')
-
-        end
-
-
-        # ``Com::Vmware::Appliance::Techpreview::Ntp::TestStatus``   enumerated type  Health indicator
-        # @!attribute [rw] orange
-        #     @return [Com::Vmware::Appliance::Techpreview::Ntp::TestStatus]
-        #     In case data has more than one test, this indicates not all tests were successful
-        # @!attribute [rw] green
-        #     @return [Com::Vmware::Appliance::Techpreview::Ntp::TestStatus]
-        #     All tests were successful for given data
-        # @!attribute [rw] red
-        #     @return [Com::Vmware::Appliance::Techpreview::Ntp::TestStatus]
-        #     All tests failed for given data
-        class TestStatus < VAPI::Bindings::VapiEnum
-
-            class << self
-                # Holds (gets or creates) the binding type metadata for this enumeration type.
-                # @scope class
-                # @return [VAPI::Bindings::EnumType] the binding type
-                def binding_type
-                    @binding_type ||= VAPI::Bindings::EnumType.new(
-                        'com.vmware.appliance.techpreview.ntp.test_status',
-                        TestStatus)
-                end
-
-                # Converts from a string value (perhaps off the wire) to an instance
-                # of this enum type.
-                # @param value [String] the actual value of the enum instance
-                # @return [TestStatus] the instance found for the value, otherwise
-                #         an unknown instance will be built for the value
-                def from_string(value)
-                    begin
-                        const_get(value)
-                    rescue NameError
-                        TestStatus.new('UNKNOWN', value)
-                    end
-                end
-            end
-
-            private
-
-            # Constructs a new instance.
-            # @param value [String] the actual value of the enum instance
-            # @param unknown [String] the unknown value when value is 'UKNOWN'
-            def initialize(value, unknown=nil)
-                super(self.class.binding_type, value, unknown)
-            end
-
-            public
-
-            # @!attribute [rw] orange
-            #     @return [Com::Vmware::Appliance::Techpreview::Ntp::TestStatus]
-            #     In case data has more than one test, this indicates not all tests were successful
-            ORANGE = TestStatus.new('ORANGE')
-
-            # @!attribute [rw] green
-            #     @return [Com::Vmware::Appliance::Techpreview::Ntp::TestStatus]
-            #     All tests were successful for given data
-            GREEN = TestStatus.new('GREEN')
-
-            # @!attribute [rw] red
-            #     @return [Com::Vmware::Appliance::Techpreview::Ntp::TestStatus]
-            #     All tests failed for given data
-            RED = TestStatus.new('RED')
-
-        end
-
-
-        # ``Com::Vmware::Appliance::Techpreview::Ntp::MessageStatus``   enumerated type  Individual test result
-        # @!attribute [rw] failure
-        #     @return [Com::Vmware::Appliance::Techpreview::Ntp::MessageStatus]
-        #     message indicates the test failed.
-        # @!attribute [rw] success
-        #     @return [Com::Vmware::Appliance::Techpreview::Ntp::MessageStatus]
-        #     message indicates that the test was successful.
-        class MessageStatus < VAPI::Bindings::VapiEnum
-
-            class << self
-                # Holds (gets or creates) the binding type metadata for this enumeration type.
-                # @scope class
-                # @return [VAPI::Bindings::EnumType] the binding type
-                def binding_type
-                    @binding_type ||= VAPI::Bindings::EnumType.new(
-                        'com.vmware.appliance.techpreview.ntp.message_status',
-                        MessageStatus)
-                end
-
-                # Converts from a string value (perhaps off the wire) to an instance
-                # of this enum type.
-                # @param value [String] the actual value of the enum instance
-                # @return [MessageStatus] the instance found for the value, otherwise
-                #         an unknown instance will be built for the value
-                def from_string(value)
-                    begin
-                        const_get(value)
-                    rescue NameError
-                        MessageStatus.new('UNKNOWN', value)
-                    end
-                end
-            end
-
-            private
-
-            # Constructs a new instance.
-            # @param value [String] the actual value of the enum instance
-            # @param unknown [String] the unknown value when value is 'UKNOWN'
-            def initialize(value, unknown=nil)
-                super(self.class.binding_type, value, unknown)
-            end
-
-            public
-
-            # @!attribute [rw] failure
-            #     @return [Com::Vmware::Appliance::Techpreview::Ntp::MessageStatus]
-            #     message indicates the test failed.
-            FAILURE = MessageStatus.new('FAILURE')
-
-            # @!attribute [rw] success
-            #     @return [Com::Vmware::Appliance::Techpreview::Ntp::MessageStatus]
-            #     message indicates that the test was successful.
-            SUCCESS = MessageStatus.new('SUCCESS')
-
-        end
-
-
+  # ``Com::Vmware::Appliance::Techpreview::Ntp``   class  provides  methods  Gets NTP configuration status and tests connection to ntp servers.
+  class NtpService < VAPI::Bindings::VapiService
+    # static metamodel definitions
+    SERVICE_ID = VAPI::Core::ServiceIdentifier.new('com.vmware.appliance.techpreview.ntp')
+
+    TEST_INFO = VAPI::Bindings::OperationInfo.new(
+      VAPI::Core::OperationIdentifier.new('test', SERVICE_ID),
+      VAPI::Bindings::OperationInputType.new(
+        'servers' => VAPI::Bindings::ListType.new(VAPI::Bindings::StringType.instance)
+      ),
+      VAPI::Bindings::ReferenceType.new('Com::Vmware::Appliance::Techpreview::Ntp::TestStatusInfo'),
+      {
+        'com.vmware.vapi.std.errors.error' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Error')
+      },
+      [],
+      []
+    )
+
+    GET_INFO = VAPI::Bindings::OperationInfo.new(
+      VAPI::Core::OperationIdentifier.new('get', SERVICE_ID),
+      VAPI::Bindings::OperationInputType.new,
+      VAPI::Bindings::ReferenceType.new('Com::Vmware::Appliance::Techpreview::Ntp::NTPConfig'),
+      {
+        'com.vmware.vapi.std.errors.error' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Error')
+      },
+      [],
+      []
+    )
+
+    SERVICE_INFO = VAPI::Bindings::ServiceInfo.new(
+      SERVICE_ID,
+      'test' => TEST_INFO,
+      'get' => GET_INFO
+    )
+
+    # Constructs a new instance.
+    #
+    # @param config [VAPI::Bindings::StubConfig] A hash with the api provider details.
+    def initialize(config)
+      super(config, SERVICE_INFO)
     end
 
-
-    # ``Com::Vmware::Appliance::Techpreview::Services``   class  provides  methods  Manages services.
-    class ServicesService < VAPI::Bindings::VapiService
-
-        protected
-
-        # static metamodel definitions
-        @@service_id = VAPI::Core::ServiceIdentifier.new('com.vmware.appliance.techpreview.services')
-
-        @@control_info = VAPI::Bindings::OperationInfo.new(
-            VAPI::Core::OperationIdentifier.new('control', @@service_id),
-            VAPI::Bindings::OperationInputType.new({
-                'args' => VAPI::Bindings::ListType.new(VAPI::Bindings::StringType.instance),
-                'name' => VAPI::Bindings::StringType.instance,
-                'timeout' => VAPI::Bindings::IntegerType.instance,
-            }),
-            VAPI::Bindings::VoidType.instance,
-            {
-                'com.vmware.vapi.std.errors.error' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Error'),
-
-            },
-            [],
-            [])
-        @@list_info = VAPI::Bindings::OperationInfo.new(
-            VAPI::Core::OperationIdentifier.new('list', @@service_id),
-            VAPI::Bindings::OperationInputType.new,
-            VAPI::Bindings::ListType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Appliance::Techpreview::Services::ServiceInfo')),
-            {
-                'com.vmware.vapi.std.errors.error' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Error'),
-
-            },
-            [],
-            [])
-        @@stop_info = VAPI::Bindings::OperationInfo.new(
-            VAPI::Core::OperationIdentifier.new('stop', @@service_id),
-            VAPI::Bindings::OperationInputType.new({
-                'name' => VAPI::Bindings::StringType.instance,
-                'timeout' => VAPI::Bindings::IntegerType.instance,
-            }),
-            VAPI::Bindings::VoidType.instance,
-            {
-                'com.vmware.vapi.std.errors.error' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Error'),
-
-            },
-            [],
-            [])
-        @@restart_info = VAPI::Bindings::OperationInfo.new(
-            VAPI::Core::OperationIdentifier.new('restart', @@service_id),
-            VAPI::Bindings::OperationInputType.new({
-                'name' => VAPI::Bindings::StringType.instance,
-                'timeout' => VAPI::Bindings::IntegerType.instance,
-            }),
-            VAPI::Bindings::VoidType.instance,
-            {
-                'com.vmware.vapi.std.errors.error' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Error'),
-
-            },
-            [],
-            [])
-
-        @@service_info = VAPI::Bindings::ServiceInfo.new(@@service_id, {
-            'control' => @@control_info,
-            'list' => @@list_info,
-            'stop' => @@stop_info,
-            'restart' => @@restart_info,
-        })
-
-        public
-
-        # Constructs a new instance.
-        #
-        # @param config [VAPI::Bindings::StubConfig] A hash with the api provider details.
-        def initialize(config)
-            super(config, @@service_info)
-        end
-
-
-        # Manage a service with arbitrary command and arguments.
-        #
-        # @param args [Array<String>]
-        #     Array of arguments.
-        # @param name [String]
-        #     Name of the service.
-        # @param timeout [Fixnum]
-        #     Timeout in seconds. Zero (0) means no timeout.
-        # @return [Void]
-        # @raise [Com::Vmware::Vapi::Std::Errors::Error]
-        #     Generic error
-        def control(args, name, timeout)
-            invoke_with_info(@@control_info, {
-                'args' => args,
-                'name' => name,
-                'timeout' => timeout,
-            })
-        end
-
-
-        # Get a list of all known services.
-        #
-        # @return [Array<Com::Vmware::Appliance::Techpreview::Services::ServiceInfo>]
-        #     List of services.
-        # @raise [Com::Vmware::Vapi::Std::Errors::Error]
-        #     Generic error
-        def list()
-            invoke_with_info(@@list_info)
-        end
-
-
-        # Stop a service
-        #
-        # @param name [String]
-        #     Name of service.
-        # @param timeout [Fixnum]
-        #     Timeout in seconds. Zero (0) means no timeout.
-        # @return [Void]
-        # @raise [Com::Vmware::Vapi::Std::Errors::Error]
-        #     Generic error
-        def stop(name, timeout)
-            invoke_with_info(@@stop_info, {
-                'name' => name,
-                'timeout' => timeout,
-            })
-        end
-
-
-        # start or restart a service
-        #
-        # @param name [String]
-        #     Name of the service to start or restart.
-        # @param timeout [Fixnum]
-        #     Timeout in seconds. Zero (0) means no timeout.
-        # @return [Void]
-        # @raise [Com::Vmware::Vapi::Std::Errors::Error]
-        #     Generic error
-        def restart(name, timeout)
-            invoke_with_info(@@restart_info, {
-                'name' => name,
-                'timeout' => timeout,
-            })
-        end
-
-
-
-        # ``Com::Vmware::Appliance::Techpreview::Services::ServiceInfo``   class  Structure that describes a service and the operations you can perform on a service.
-        # @!attribute [rw] name
-        #     @return [String]
-        #     The name of the service, for example, "vmware-vpxd". This name is unique per machine.
-        # @!attribute [rw] description
-        #     @return [String]
-        #     A description of the service. The description can be empty.
-        # @!attribute [rw] operations
-        #     @return [Array<Com::Vmware::Appliance::Techpreview::Services::ServiceOps>]
-        #     The operations encoded in an array, supported by the service.
-        class ServiceInfo < VAPI::Bindings::VapiStruct
-
-            class << self
-                # Holds (gets or creates) the binding type metadata for this structure type.
-                # @scope class
-                # @return [VAPI::Bindings::StructType] the binding type
-                def binding_type
-                    @binding_type ||= VAPI::Bindings::StructType.new(
-                        'com.vmware.appliance.techpreview.services.service_info',
-                        {
-                            'name' => VAPI::Bindings::StringType.instance,
-                            'description' => VAPI::Bindings::StringType.instance,
-                            'operations' => VAPI::Bindings::ListType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Appliance::Techpreview::Services::ServiceOps')),
-                        },
-                        ServiceInfo,
-                        false,
-                        nil)
-                end
-            end
-
-            attr_accessor :name,
-                          :description,
-                          :operations
-
-            # Constructs a new instance.
-            # @param ruby_values [Hash] a map of initial property values (optional)
-            # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
-            def initialize(ruby_values=nil, struct_value=nil)
-                super(self.class.binding_type, ruby_values, struct_value)
-            end
-        end
-
-
-
-        # ``Com::Vmware::Appliance::Techpreview::Services::ServiceOps``   enumerated type  Defines service operations
-        # @!attribute [rw] control
-        #     @return [Com::Vmware::Appliance::Techpreview::Services::ServiceOps]
-        #     The service accepts arbitrary commands and arguments.
-        # @!attribute [rw] status
-        #     @return [Com::Vmware::Appliance::Techpreview::Services::ServiceOps]
-        #     The service status can be generated.
-        # @!attribute [rw] stop
-        #     @return [Com::Vmware::Appliance::Techpreview::Services::ServiceOps]
-        #     The service can be stopped.
-        # @!attribute [rw] restart
-        #     @return [Com::Vmware::Appliance::Techpreview::Services::ServiceOps]
-        #     The service can be started or restarted.
-        class ServiceOps < VAPI::Bindings::VapiEnum
-
-            class << self
-                # Holds (gets or creates) the binding type metadata for this enumeration type.
-                # @scope class
-                # @return [VAPI::Bindings::EnumType] the binding type
-                def binding_type
-                    @binding_type ||= VAPI::Bindings::EnumType.new(
-                        'com.vmware.appliance.techpreview.services.service_ops',
-                        ServiceOps)
-                end
-
-                # Converts from a string value (perhaps off the wire) to an instance
-                # of this enum type.
-                # @param value [String] the actual value of the enum instance
-                # @return [ServiceOps] the instance found for the value, otherwise
-                #         an unknown instance will be built for the value
-                def from_string(value)
-                    begin
-                        const_get(value)
-                    rescue NameError
-                        ServiceOps.new('UNKNOWN', value)
-                    end
-                end
-            end
-
-            private
-
-            # Constructs a new instance.
-            # @param value [String] the actual value of the enum instance
-            # @param unknown [String] the unknown value when value is 'UKNOWN'
-            def initialize(value, unknown=nil)
-                super(self.class.binding_type, value, unknown)
-            end
-
-            public
-
-            # @!attribute [rw] control
-            #     @return [Com::Vmware::Appliance::Techpreview::Services::ServiceOps]
-            #     The service accepts arbitrary commands and arguments.
-            CONTROL = ServiceOps.new('CONTROL')
-
-            # @!attribute [rw] status
-            #     @return [Com::Vmware::Appliance::Techpreview::Services::ServiceOps]
-            #     The service status can be generated.
-            STATUS = ServiceOps.new('STATUS')
-
-            # @!attribute [rw] stop
-            #     @return [Com::Vmware::Appliance::Techpreview::Services::ServiceOps]
-            #     The service can be stopped.
-            STOP = ServiceOps.new('STOP')
-
-            # @!attribute [rw] restart
-            #     @return [Com::Vmware::Appliance::Techpreview::Services::ServiceOps]
-            #     The service can be started or restarted.
-            RESTART = ServiceOps.new('RESTART')
-
-        end
-
-
+    # Test the connection to a list of ntp servers.
+    #
+    # @param servers [Array<String>]
+    #     List of host names or IP addresses of NTP servers.
+    # @return [Com::Vmware::Appliance::Techpreview::Ntp::TestStatusInfo]
+    #     NTP connection status
+    # @raise [Com::Vmware::Vapi::Std::Errors::Error]
+    #     Generic error
+    def test(servers)
+      invoke_with_info(TEST_INFO,
+                       'servers' => servers)
     end
 
-
-    # ``Com::Vmware::Appliance::Techpreview::Shutdown``   class  provides  methods  Performs reboot/shutdow operations on appliance.
-    class Shutdown < VAPI::Bindings::VapiService
-
-        protected
-
-        # static metamodel definitions
-        @@service_id = VAPI::Core::ServiceIdentifier.new('com.vmware.appliance.techpreview.shutdown')
-
-        @@cancel_info = VAPI::Bindings::OperationInfo.new(
-            VAPI::Core::OperationIdentifier.new('cancel', @@service_id),
-            VAPI::Bindings::OperationInputType.new,
-            VAPI::Bindings::VoidType.instance,
-            {
-                'com.vmware.vapi.std.errors.error' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Error'),
-
-            },
-            [],
-            [])
-        @@poweroff_info = VAPI::Bindings::OperationInfo.new(
-            VAPI::Core::OperationIdentifier.new('poweroff', @@service_id),
-            VAPI::Bindings::OperationInputType.new({
-                'config' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Appliance::Techpreview::Shutdown::ShutdownConfig'),
-            }),
-            VAPI::Bindings::VoidType.instance,
-            {
-                'com.vmware.vapi.std.errors.error' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Error'),
-
-            },
-            [],
-            [])
-        @@reboot_info = VAPI::Bindings::OperationInfo.new(
-            VAPI::Core::OperationIdentifier.new('reboot', @@service_id),
-            VAPI::Bindings::OperationInputType.new({
-                'config' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Appliance::Techpreview::Shutdown::ShutdownConfig'),
-            }),
-            VAPI::Bindings::VoidType.instance,
-            {
-                'com.vmware.vapi.std.errors.error' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Error'),
-
-            },
-            [],
-            [])
-        @@get_info = VAPI::Bindings::OperationInfo.new(
-            VAPI::Core::OperationIdentifier.new('get', @@service_id),
-            VAPI::Bindings::OperationInputType.new,
-            VAPI::Bindings::ReferenceType.new('Com::Vmware::Appliance::Techpreview::Shutdown::ShutdownGetConfig'),
-            {
-                'com.vmware.vapi.std.errors.error' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Error'),
-
-            },
-            [],
-            [])
-
-        @@service_info = VAPI::Bindings::ServiceInfo.new(@@service_id, {
-            'cancel' => @@cancel_info,
-            'poweroff' => @@poweroff_info,
-            'reboot' => @@reboot_info,
-            'get' => @@get_info,
-        })
-
-        public
-
-        # Constructs a new instance.
-        #
-        # @param config [VAPI::Bindings::StubConfig] A hash with the api provider details.
-        def initialize(config)
-            super(config, @@service_info)
-        end
-
-
-        # Cancel pending shutdown action.
-        #
-        # @return [Void]
-        # @raise [Com::Vmware::Vapi::Std::Errors::Error]
-        #     Generic error
-        def cancel()
-            invoke_with_info(@@cancel_info)
-        end
-
-
-        # Power off the appliance.
-        #
-        # @param config [Com::Vmware::Appliance::Techpreview::Shutdown::ShutdownConfig]
-        #     Configuration of poweroff action
-        # @return [Void]
-        # @raise [Com::Vmware::Vapi::Std::Errors::Error]
-        #     Generic error
-        def poweroff(config)
-            invoke_with_info(@@poweroff_info, {
-                'config' => config,
-            })
-        end
-
-
-        # Reboot the appliance.
-        #
-        # @param config [Com::Vmware::Appliance::Techpreview::Shutdown::ShutdownConfig]
-        #     Configuration of reboot action
-        # @return [Void]
-        # @raise [Com::Vmware::Vapi::Std::Errors::Error]
-        #     Generic error
-        def reboot(config)
-            invoke_with_info(@@reboot_info, {
-                'config' => config,
-            })
-        end
-
-
-        # Get details about the pending shutdown action.
-        #
-        # @return [Com::Vmware::Appliance::Techpreview::Shutdown::ShutdownGetConfig]
-        #     Configuration of pending shutdown action.
-        # @raise [Com::Vmware::Vapi::Std::Errors::Error]
-        #     Generic error
-        def get()
-            invoke_with_info(@@get_info)
-        end
-
-
-
-        # ``Com::Vmware::Appliance::Techpreview::Shutdown::ShutdownGetConfig``   class  Structure that defines shutdown configuration returned by Shutdown.get operation
-        # @!attribute [rw] shutdown_time
-        #     @return [String]
-        #     (UTC) time of shutdown represented in "YYYY-MM-DD HH:MM:SS" format.
-        # @!attribute [rw] action
-        #     @return [String]
-        #     Contains a string that describes the pending shutdown operation. The string values for pending operations can be 'poweroff', 'reboot' or ''
-        # @!attribute [rw] reason
-        #     @return [String]
-        #     This will contain string explaining the reason behind the shutdown action
-        class ShutdownGetConfig < VAPI::Bindings::VapiStruct
-
-            class << self
-                # Holds (gets or creates) the binding type metadata for this structure type.
-                # @scope class
-                # @return [VAPI::Bindings::StructType] the binding type
-                def binding_type
-                    @binding_type ||= VAPI::Bindings::StructType.new(
-                        'com.vmware.appliance.techpreview.shutdown.shutdown_get_config',
-                        {
-                            'shutdown_time' => VAPI::Bindings::StringType.instance,
-                            'action' => VAPI::Bindings::StringType.instance,
-                            'reason' => VAPI::Bindings::StringType.instance,
-                        },
-                        ShutdownGetConfig,
-                        false,
-                        nil)
-                end
-            end
-
-            attr_accessor :shutdown_time,
-                          :action,
-                          :reason
-
-            # Constructs a new instance.
-            # @param ruby_values [Hash] a map of initial property values (optional)
-            # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
-            def initialize(ruby_values=nil, struct_value=nil)
-                super(self.class.binding_type, ruby_values, struct_value)
-            end
-        end
-
-
-        # ``Com::Vmware::Appliance::Techpreview::Shutdown::ShutdownConfig``   class  Structure that defines shutdown configuration.
-        # @!attribute [rw] delay
-        #     @return [Fixnum]
-        #     Delay interval in minutes (optional). if you do not specify delay, then the shutdown starts immediately.
-        # @!attribute [rw] reason
-        #     @return [String]
-        #     Reason for performing shutdown (required).
-        class ShutdownConfig < VAPI::Bindings::VapiStruct
-
-            class << self
-                # Holds (gets or creates) the binding type metadata for this structure type.
-                # @scope class
-                # @return [VAPI::Bindings::StructType] the binding type
-                def binding_type
-                    @binding_type ||= VAPI::Bindings::StructType.new(
-                        'com.vmware.appliance.techpreview.shutdown.shutdown_config',
-                        {
-                            'delay' => VAPI::Bindings::IntegerType.instance,
-                            'reason' => VAPI::Bindings::StringType.instance,
-                        },
-                        ShutdownConfig,
-                        false,
-                        nil)
-                end
-            end
-
-            attr_accessor :delay,
-                          :reason
-
-            # Constructs a new instance.
-            # @param ruby_values [Hash] a map of initial property values (optional)
-            # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
-            def initialize(ruby_values=nil, struct_value=nil)
-                super(self.class.binding_type, ruby_values, struct_value)
-            end
-        end
-
-
+    # Get the NTP configuration status. If you run the 'timesync.get' command, you can retrieve the current time synchronization method (NTP- or VMware Tools-based). The 'ntp' command always returns the NTP server information, even when the time synchronization mode is not set to NTP. If the time synchronization mode is not NTP-based, the NTP server status is displayed as down.
+    #
+    # @return [Com::Vmware::Appliance::Techpreview::Ntp::NTPConfig]
+    #     NTP config
+    # @raise [Com::Vmware::Vapi::Std::Errors::Error]
+    #     Generic error
+    def get
+      invoke_with_info(GET_INFO)
     end
 
-
-    # ``Com::Vmware::Appliance::Techpreview::Timesync``   class  provides  methods  Performs time synchronization configuration.
-    class Timesync < VAPI::Bindings::VapiService
-
-        protected
-
-        # static metamodel definitions
-        @@service_id = VAPI::Core::ServiceIdentifier.new('com.vmware.appliance.techpreview.timesync')
-
-        @@set_info = VAPI::Bindings::OperationInfo.new(
-            VAPI::Core::OperationIdentifier.new('set', @@service_id),
-            VAPI::Bindings::OperationInputType.new({
-                'config' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Appliance::Techpreview::Timesync::TimeSyncConfig'),
-            }),
-            VAPI::Bindings::VoidType.instance,
+    # ``Com::Vmware::Appliance::Techpreview::Ntp::NTPConfig``   class  Structure defining the NTP configuration.
+    # @!attribute [rw] status
+    #     @return [Com::Vmware::Appliance::Techpreview::Ntp::NTPStatus]
+    #     NTP daemon running status
+    # @!attribute [rw] servers
+    #     @return [Array<String>]
+    #     List of NTP servers.
+    class NTPConfig < VAPI::Bindings::VapiStruct
+      class << self
+        # Holds (gets or creates) the binding type metadata for this structure type.
+        # @scope class
+        # @return [VAPI::Bindings::StructType] the binding type
+        def binding_type
+          @binding_type ||= VAPI::Bindings::StructType.new(
+            'com.vmware.appliance.techpreview.ntp.NTP_config',
             {
-                'com.vmware.vapi.std.errors.error' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Error'),
-
+              'status' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Appliance::Techpreview::Ntp::NTPStatus'),
+              'servers' => VAPI::Bindings::ListType.new(VAPI::Bindings::StringType.instance)
             },
-            [],
-            [])
-        @@get_info = VAPI::Bindings::OperationInfo.new(
-            VAPI::Core::OperationIdentifier.new('get', @@service_id),
-            VAPI::Bindings::OperationInputType.new,
-            VAPI::Bindings::ReferenceType.new('Com::Vmware::Appliance::Techpreview::Timesync::TimeSyncConfig'),
-            {
-                'com.vmware.vapi.std.errors.error' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Error'),
-
-            },
-            [],
-            [])
-
-        @@service_info = VAPI::Bindings::ServiceInfo.new(@@service_id, {
-            'set' => @@set_info,
-            'get' => @@get_info,
-        })
-
-        public
-
-        # Constructs a new instance.
-        #
-        # @param config [VAPI::Bindings::StubConfig] A hash with the api provider details.
-        def initialize(config)
-            super(config, @@service_info)
+            NTPConfig,
+            false,
+            nil
+          )
         end
+      end
 
+      attr_accessor :status,
+                    :servers
 
-        # Set time synchronization configuration.
-        #
-        # @param config [Com::Vmware::Appliance::Techpreview::Timesync::TimeSyncConfig]
-        #     Time synchronization configuration.
-        # @return [Void]
-        # @raise [Com::Vmware::Vapi::Std::Errors::Error]
-        #     Generic error
-        def set(config)
-            invoke_with_info(@@set_info, {
-                'config' => config,
-            })
-        end
-
-
-        # Get time synchronization configuration.
-        #
-        # @return [Com::Vmware::Appliance::Techpreview::Timesync::TimeSyncConfig]
-        #     Time synchronization configuration.
-        # @raise [Com::Vmware::Vapi::Std::Errors::Error]
-        #     Generic error
-        def get()
-            invoke_with_info(@@get_info)
-        end
-
-
-
-        # ``Com::Vmware::Appliance::Techpreview::Timesync::TimeSyncConfig``   class  Structure defining time synchronization configuration.
-        # @!attribute [rw] mode
-        #     @return [Com::Vmware::Appliance::Techpreview::Timesync::TimeSyncMode]
-        #     Time synchronization mode. Mode can have one of the TimeSyncMode enumeration values.
-        class TimeSyncConfig < VAPI::Bindings::VapiStruct
-
-            class << self
-                # Holds (gets or creates) the binding type metadata for this structure type.
-                # @scope class
-                # @return [VAPI::Bindings::StructType] the binding type
-                def binding_type
-                    @binding_type ||= VAPI::Bindings::StructType.new(
-                        'com.vmware.appliance.techpreview.timesync.time_sync_config',
-                        {
-                            'mode' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Appliance::Techpreview::Timesync::TimeSyncMode'),
-                        },
-                        TimeSyncConfig,
-                        false,
-                        nil)
-                end
-            end
-
-            attr_accessor :mode
-
-            # Constructs a new instance.
-            # @param ruby_values [Hash] a map of initial property values (optional)
-            # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
-            def initialize(ruby_values=nil, struct_value=nil)
-                super(self.class.binding_type, ruby_values, struct_value)
-            end
-        end
-
-
-
-        # ``Com::Vmware::Appliance::Techpreview::Timesync::TimeSyncMode``   enumerated type  Defines different timsync modes
-        # @!attribute [rw] disabled
-        #     @return [Com::Vmware::Appliance::Techpreview::Timesync::TimeSyncMode]
-        #     Time synchronization is disabled.
-        # @!attribute [rw] ntp
-        #     @return [Com::Vmware::Appliance::Techpreview::Timesync::TimeSyncMode]
-        #     NTP-based time synchronization.
-        # @!attribute [rw] host
-        #     @return [Com::Vmware::Appliance::Techpreview::Timesync::TimeSyncMode]
-        #     VMware Tool-based time synchronization.
-        class TimeSyncMode < VAPI::Bindings::VapiEnum
-
-            class << self
-                # Holds (gets or creates) the binding type metadata for this enumeration type.
-                # @scope class
-                # @return [VAPI::Bindings::EnumType] the binding type
-                def binding_type
-                    @binding_type ||= VAPI::Bindings::EnumType.new(
-                        'com.vmware.appliance.techpreview.timesync.time_sync_mode',
-                        TimeSyncMode)
-                end
-
-                # Converts from a string value (perhaps off the wire) to an instance
-                # of this enum type.
-                # @param value [String] the actual value of the enum instance
-                # @return [TimeSyncMode] the instance found for the value, otherwise
-                #         an unknown instance will be built for the value
-                def from_string(value)
-                    begin
-                        const_get(value)
-                    rescue NameError
-                        TimeSyncMode.new('UNKNOWN', value)
-                    end
-                end
-            end
-
-            private
-
-            # Constructs a new instance.
-            # @param value [String] the actual value of the enum instance
-            # @param unknown [String] the unknown value when value is 'UKNOWN'
-            def initialize(value, unknown=nil)
-                super(self.class.binding_type, value, unknown)
-            end
-
-            public
-
-            # @!attribute [rw] disabled
-            #     @return [Com::Vmware::Appliance::Techpreview::Timesync::TimeSyncMode]
-            #     Time synchronization is disabled.
-            DISABLED = TimeSyncMode.new('DISABLED')
-
-            # @!attribute [rw] ntp
-            #     @return [Com::Vmware::Appliance::Techpreview::Timesync::TimeSyncMode]
-            #     NTP-based time synchronization.
-            NTP = TimeSyncMode.new('NTP')
-
-            # @!attribute [rw] host
-            #     @return [Com::Vmware::Appliance::Techpreview::Timesync::TimeSyncMode]
-            #     VMware Tool-based time synchronization.
-            HOST = TimeSyncMode.new('HOST')
-
-        end
-
-
+      # Constructs a new instance.
+      # @param ruby_values [Hash] a map of initial property values (optional)
+      # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
+      def initialize(ruby_values = nil, struct_value = nil)
+        super(self.class.binding_type, ruby_values, struct_value)
+      end
     end
 
+    # ``Com::Vmware::Appliance::Techpreview::Ntp::Message``   class  Test result and message
+    # @!attribute [rw] message
+    #     @return [String]
+    #     message
+    # @!attribute [rw] result
+    #     @return [Com::Vmware::Appliance::Techpreview::Ntp::MessageStatus]
+    #     result of the test
+    class Message < VAPI::Bindings::VapiStruct
+      class << self
+        # Holds (gets or creates) the binding type metadata for this structure type.
+        # @scope class
+        # @return [VAPI::Bindings::StructType] the binding type
+        def binding_type
+          @binding_type ||= VAPI::Bindings::StructType.new(
+            'com.vmware.appliance.techpreview.ntp.message',
+            {
+              'message' => VAPI::Bindings::StringType.instance,
+              'result' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Appliance::Techpreview::Ntp::MessageStatus')
+            },
+            Message,
+            false,
+            nil
+          )
+        end
+      end
 
+      attr_accessor :message,
+                    :result
+
+      # Constructs a new instance.
+      # @param ruby_values [Hash] a map of initial property values (optional)
+      # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
+      def initialize(ruby_values = nil, struct_value = nil)
+        super(self.class.binding_type, ruby_values, struct_value)
+      end
+    end
+
+    # ``Com::Vmware::Appliance::Techpreview::Ntp::TestStatusInfo``   class  Overall test result
+    # @!attribute [rw] status
+    #     @return [Com::Vmware::Appliance::Techpreview::Ntp::TestStatus]
+    #     Overall status of tests run.
+    # @!attribute [rw] messages
+    #     @return [Array<Com::Vmware::Appliance::Techpreview::Ntp::Message>]
+    #     messages
+    class TestStatusInfo < VAPI::Bindings::VapiStruct
+      class << self
+        # Holds (gets or creates) the binding type metadata for this structure type.
+        # @scope class
+        # @return [VAPI::Bindings::StructType] the binding type
+        def binding_type
+          @binding_type ||= VAPI::Bindings::StructType.new(
+            'com.vmware.appliance.techpreview.ntp.test_status_info',
+            {
+              'status' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Appliance::Techpreview::Ntp::TestStatus'),
+              'messages' => VAPI::Bindings::ListType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Appliance::Techpreview::Ntp::Message'))
+            },
+            TestStatusInfo,
+            false,
+            nil
+          )
+        end
+      end
+
+      attr_accessor :status,
+                    :messages
+
+      # Constructs a new instance.
+      # @param ruby_values [Hash] a map of initial property values (optional)
+      # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
+      def initialize(ruby_values = nil, struct_value = nil)
+        super(self.class.binding_type, ruby_values, struct_value)
+      end
+    end
+
+    # ``Com::Vmware::Appliance::Techpreview::Ntp::NTPStatus``   enumerated type  Defines NTP status
+    # @!attribute [rw] down
+    #     @return [Com::Vmware::Appliance::Techpreview::Ntp::NTPStatus]
+    #     NTP daemon is not running.
+    # @!attribute [rw] unknown
+    #     @return [Com::Vmware::Appliance::Techpreview::Ntp::NTPStatus]
+    #     Cannot retrieve NTP daemon status.
+    # @!attribute [rw] up
+    #     @return [Com::Vmware::Appliance::Techpreview::Ntp::NTPStatus]
+    #     NTP daemon is running.
+    class NTPStatus < VAPI::Bindings::VapiEnum
+      class << self
+        # Holds (gets or creates) the binding type metadata for this enumeration type.
+        # @scope class
+        # @return [VAPI::Bindings::EnumType] the binding type
+        def binding_type
+          @binding_type ||= VAPI::Bindings::EnumType.new(
+            'com.vmware.appliance.techpreview.ntp.NTP_status',
+            NTPStatus
+          )
+        end
+
+        # Converts from a string value (perhaps off the wire) to an instance
+        # of this enum type.
+        # @param value [String] the actual value of the enum instance
+        # @return [NTPStatus] the instance found for the value, otherwise
+        #         an unknown instance will be built for the value
+        def from_string(value)
+          const_get(value)
+        rescue NameError
+          NTPStatus.send(:new, 'UNKNOWN', value)
+        end
+      end
+
+      # Constructs a new instance.
+      # @param value [String] the actual value of the enum instance
+      # @param unknown [String] the unknown value when value is 'UKNOWN'
+      def initialize(value, unknown = nil)
+        super(self.class.binding_type, value, unknown)
+      end
+
+      private_class_method :new
+
+      # @!attribute [rw] down
+      #     @return [Com::Vmware::Appliance::Techpreview::Ntp::NTPStatus]
+      #     NTP daemon is not running.
+      DOWN = NTPStatus.send(:new, 'DOWN')
+
+      # @!attribute [rw] unknown
+      #     @return [Com::Vmware::Appliance::Techpreview::Ntp::NTPStatus]
+      #     Cannot retrieve NTP daemon status.
+      UNKNOWN = NTPStatus.send(:new, 'UNKNOWN')
+
+      # @!attribute [rw] up
+      #     @return [Com::Vmware::Appliance::Techpreview::Ntp::NTPStatus]
+      #     NTP daemon is running.
+      UP = NTPStatus.send(:new, 'UP')
+    end
+    # ``Com::Vmware::Appliance::Techpreview::Ntp::TestStatus``   enumerated type  Health indicator
+    # @!attribute [rw] orange
+    #     @return [Com::Vmware::Appliance::Techpreview::Ntp::TestStatus]
+    #     In case data has more than one test, this indicates not all tests were successful
+    # @!attribute [rw] green
+    #     @return [Com::Vmware::Appliance::Techpreview::Ntp::TestStatus]
+    #     All tests were successful for given data
+    # @!attribute [rw] red
+    #     @return [Com::Vmware::Appliance::Techpreview::Ntp::TestStatus]
+    #     All tests failed for given data
+    class TestStatus < VAPI::Bindings::VapiEnum
+      class << self
+        # Holds (gets or creates) the binding type metadata for this enumeration type.
+        # @scope class
+        # @return [VAPI::Bindings::EnumType] the binding type
+        def binding_type
+          @binding_type ||= VAPI::Bindings::EnumType.new(
+            'com.vmware.appliance.techpreview.ntp.test_status',
+            TestStatus
+          )
+        end
+
+        # Converts from a string value (perhaps off the wire) to an instance
+        # of this enum type.
+        # @param value [String] the actual value of the enum instance
+        # @return [TestStatus] the instance found for the value, otherwise
+        #         an unknown instance will be built for the value
+        def from_string(value)
+          const_get(value)
+        rescue NameError
+          TestStatus.send(:new, 'UNKNOWN', value)
+        end
+      end
+
+      # Constructs a new instance.
+      # @param value [String] the actual value of the enum instance
+      # @param unknown [String] the unknown value when value is 'UKNOWN'
+      def initialize(value, unknown = nil)
+        super(self.class.binding_type, value, unknown)
+      end
+
+      private_class_method :new
+
+      # @!attribute [rw] orange
+      #     @return [Com::Vmware::Appliance::Techpreview::Ntp::TestStatus]
+      #     In case data has more than one test, this indicates not all tests were successful
+      ORANGE = TestStatus.send(:new, 'ORANGE')
+
+      # @!attribute [rw] green
+      #     @return [Com::Vmware::Appliance::Techpreview::Ntp::TestStatus]
+      #     All tests were successful for given data
+      GREEN = TestStatus.send(:new, 'GREEN')
+
+      # @!attribute [rw] red
+      #     @return [Com::Vmware::Appliance::Techpreview::Ntp::TestStatus]
+      #     All tests failed for given data
+      RED = TestStatus.send(:new, 'RED')
+    end
+    # ``Com::Vmware::Appliance::Techpreview::Ntp::MessageStatus``   enumerated type  Individual test result
+    # @!attribute [rw] failure
+    #     @return [Com::Vmware::Appliance::Techpreview::Ntp::MessageStatus]
+    #     message indicates the test failed.
+    # @!attribute [rw] success
+    #     @return [Com::Vmware::Appliance::Techpreview::Ntp::MessageStatus]
+    #     message indicates that the test was successful.
+    class MessageStatus < VAPI::Bindings::VapiEnum
+      class << self
+        # Holds (gets or creates) the binding type metadata for this enumeration type.
+        # @scope class
+        # @return [VAPI::Bindings::EnumType] the binding type
+        def binding_type
+          @binding_type ||= VAPI::Bindings::EnumType.new(
+            'com.vmware.appliance.techpreview.ntp.message_status',
+            MessageStatus
+          )
+        end
+
+        # Converts from a string value (perhaps off the wire) to an instance
+        # of this enum type.
+        # @param value [String] the actual value of the enum instance
+        # @return [MessageStatus] the instance found for the value, otherwise
+        #         an unknown instance will be built for the value
+        def from_string(value)
+          const_get(value)
+        rescue NameError
+          MessageStatus.send(:new, 'UNKNOWN', value)
+        end
+      end
+
+      # Constructs a new instance.
+      # @param value [String] the actual value of the enum instance
+      # @param unknown [String] the unknown value when value is 'UKNOWN'
+      def initialize(value, unknown = nil)
+        super(self.class.binding_type, value, unknown)
+      end
+
+      private_class_method :new
+
+      # @!attribute [rw] failure
+      #     @return [Com::Vmware::Appliance::Techpreview::Ntp::MessageStatus]
+      #     message indicates the test failed.
+      FAILURE = MessageStatus.send(:new, 'FAILURE')
+
+      # @!attribute [rw] success
+      #     @return [Com::Vmware::Appliance::Techpreview::Ntp::MessageStatus]
+      #     message indicates that the test was successful.
+      SUCCESS = MessageStatus.send(:new, 'SUCCESS')
+    end
+  end
+  # ``Com::Vmware::Appliance::Techpreview::Services``   class  provides  methods  Manages services.
+  class ServicesService < VAPI::Bindings::VapiService
+    # static metamodel definitions
+    SERVICE_ID = VAPI::Core::ServiceIdentifier.new('com.vmware.appliance.techpreview.services')
+
+    CONTROL_INFO = VAPI::Bindings::OperationInfo.new(
+      VAPI::Core::OperationIdentifier.new('control', SERVICE_ID),
+      VAPI::Bindings::OperationInputType.new(
+        'args' => VAPI::Bindings::ListType.new(VAPI::Bindings::StringType.instance),
+        'name' => VAPI::Bindings::StringType.instance,
+        'timeout' => VAPI::Bindings::IntegerType.instance
+      ),
+      VAPI::Bindings::VoidType.instance,
+      {
+        'com.vmware.vapi.std.errors.error' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Error')
+      },
+      [],
+      []
+    )
+
+    LIST_INFO = VAPI::Bindings::OperationInfo.new(
+      VAPI::Core::OperationIdentifier.new('list', SERVICE_ID),
+      VAPI::Bindings::OperationInputType.new,
+      VAPI::Bindings::ListType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Appliance::Techpreview::Services::ServiceInfo')),
+      {
+        'com.vmware.vapi.std.errors.error' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Error')
+      },
+      [],
+      []
+    )
+
+    STOP_INFO = VAPI::Bindings::OperationInfo.new(
+      VAPI::Core::OperationIdentifier.new('stop', SERVICE_ID),
+      VAPI::Bindings::OperationInputType.new(
+        'name' => VAPI::Bindings::StringType.instance,
+        'timeout' => VAPI::Bindings::IntegerType.instance
+      ),
+      VAPI::Bindings::VoidType.instance,
+      {
+        'com.vmware.vapi.std.errors.error' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Error')
+      },
+      [],
+      []
+    )
+
+    RESTART_INFO = VAPI::Bindings::OperationInfo.new(
+      VAPI::Core::OperationIdentifier.new('restart', SERVICE_ID),
+      VAPI::Bindings::OperationInputType.new(
+        'name' => VAPI::Bindings::StringType.instance,
+        'timeout' => VAPI::Bindings::IntegerType.instance
+      ),
+      VAPI::Bindings::VoidType.instance,
+      {
+        'com.vmware.vapi.std.errors.error' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Error')
+      },
+      [],
+      []
+    )
+
+    SERVICE_INFO = VAPI::Bindings::ServiceInfo.new(
+      SERVICE_ID,
+      'control' => CONTROL_INFO,
+      'list' => LIST_INFO,
+      'stop' => STOP_INFO,
+      'restart' => RESTART_INFO
+    )
+
+    # Constructs a new instance.
+    #
+    # @param config [VAPI::Bindings::StubConfig] A hash with the api provider details.
+    def initialize(config)
+      super(config, SERVICE_INFO)
+    end
+
+    # Manage a service with arbitrary command and arguments.
+    #
+    # @param args [Array<String>]
+    #     Array of arguments.
+    # @param name [String]
+    #     Name of the service.
+    # @param timeout [Fixnum]
+    #     Timeout in seconds. Zero (0) means no timeout.
+    # @return [Void]
+    # @raise [Com::Vmware::Vapi::Std::Errors::Error]
+    #     Generic error
+    def control(args, name, timeout)
+      invoke_with_info(CONTROL_INFO,
+                       'args' => args,
+                       'name' => name,
+                       'timeout' => timeout)
+    end
+
+    # Get a list of all known services.
+    #
+    # @return [Array<Com::Vmware::Appliance::Techpreview::Services::ServiceInfo>]
+    #     List of services.
+    # @raise [Com::Vmware::Vapi::Std::Errors::Error]
+    #     Generic error
+    def list
+      invoke_with_info(LIST_INFO)
+    end
+
+    # Stop a service
+    #
+    # @param name [String]
+    #     Name of service.
+    # @param timeout [Fixnum]
+    #     Timeout in seconds. Zero (0) means no timeout.
+    # @return [Void]
+    # @raise [Com::Vmware::Vapi::Std::Errors::Error]
+    #     Generic error
+    def stop(name, timeout)
+      invoke_with_info(STOP_INFO,
+                       'name' => name,
+                       'timeout' => timeout)
+    end
+
+    # start or restart a service
+    #
+    # @param name [String]
+    #     Name of the service to start or restart.
+    # @param timeout [Fixnum]
+    #     Timeout in seconds. Zero (0) means no timeout.
+    # @return [Void]
+    # @raise [Com::Vmware::Vapi::Std::Errors::Error]
+    #     Generic error
+    def restart(name, timeout)
+      invoke_with_info(RESTART_INFO,
+                       'name' => name,
+                       'timeout' => timeout)
+    end
+
+    # ``Com::Vmware::Appliance::Techpreview::Services::ServiceInfo``   class  Structure that describes a service and the operations you can perform on a service.
+    # @!attribute [rw] name
+    #     @return [String]
+    #     The name of the service, for example, "vmware-vpxd". This name is unique per machine.
+    # @!attribute [rw] description
+    #     @return [String]
+    #     A description of the service. The description can be empty.
+    # @!attribute [rw] operations
+    #     @return [Array<Com::Vmware::Appliance::Techpreview::Services::ServiceOps>]
+    #     The operations encoded in an array, supported by the service.
+    class ServiceInfo < VAPI::Bindings::VapiStruct
+      class << self
+        # Holds (gets or creates) the binding type metadata for this structure type.
+        # @scope class
+        # @return [VAPI::Bindings::StructType] the binding type
+        def binding_type
+          @binding_type ||= VAPI::Bindings::StructType.new(
+            'com.vmware.appliance.techpreview.services.service_info',
+            {
+              'name' => VAPI::Bindings::StringType.instance,
+              'description' => VAPI::Bindings::StringType.instance,
+              'operations' => VAPI::Bindings::ListType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Appliance::Techpreview::Services::ServiceOps'))
+            },
+            ServiceInfo,
+            false,
+            nil
+          )
+        end
+      end
+
+      attr_accessor :name,
+                    :description,
+                    :operations
+
+      # Constructs a new instance.
+      # @param ruby_values [Hash] a map of initial property values (optional)
+      # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
+      def initialize(ruby_values = nil, struct_value = nil)
+        super(self.class.binding_type, ruby_values, struct_value)
+      end
+    end
+
+    # ``Com::Vmware::Appliance::Techpreview::Services::ServiceOps``   enumerated type  Defines service operations
+    # @!attribute [rw] control
+    #     @return [Com::Vmware::Appliance::Techpreview::Services::ServiceOps]
+    #     The service accepts arbitrary commands and arguments.
+    # @!attribute [rw] status
+    #     @return [Com::Vmware::Appliance::Techpreview::Services::ServiceOps]
+    #     The service status can be generated.
+    # @!attribute [rw] stop
+    #     @return [Com::Vmware::Appliance::Techpreview::Services::ServiceOps]
+    #     The service can be stopped.
+    # @!attribute [rw] restart
+    #     @return [Com::Vmware::Appliance::Techpreview::Services::ServiceOps]
+    #     The service can be started or restarted.
+    class ServiceOps < VAPI::Bindings::VapiEnum
+      class << self
+        # Holds (gets or creates) the binding type metadata for this enumeration type.
+        # @scope class
+        # @return [VAPI::Bindings::EnumType] the binding type
+        def binding_type
+          @binding_type ||= VAPI::Bindings::EnumType.new(
+            'com.vmware.appliance.techpreview.services.service_ops',
+            ServiceOps
+          )
+        end
+
+        # Converts from a string value (perhaps off the wire) to an instance
+        # of this enum type.
+        # @param value [String] the actual value of the enum instance
+        # @return [ServiceOps] the instance found for the value, otherwise
+        #         an unknown instance will be built for the value
+        def from_string(value)
+          const_get(value)
+        rescue NameError
+          ServiceOps.send(:new, 'UNKNOWN', value)
+        end
+      end
+
+      # Constructs a new instance.
+      # @param value [String] the actual value of the enum instance
+      # @param unknown [String] the unknown value when value is 'UKNOWN'
+      def initialize(value, unknown = nil)
+        super(self.class.binding_type, value, unknown)
+      end
+
+      private_class_method :new
+
+      # @!attribute [rw] control
+      #     @return [Com::Vmware::Appliance::Techpreview::Services::ServiceOps]
+      #     The service accepts arbitrary commands and arguments.
+      CONTROL = ServiceOps.send(:new, 'CONTROL')
+
+      # @!attribute [rw] status
+      #     @return [Com::Vmware::Appliance::Techpreview::Services::ServiceOps]
+      #     The service status can be generated.
+      STATUS = ServiceOps.send(:new, 'STATUS')
+
+      # @!attribute [rw] stop
+      #     @return [Com::Vmware::Appliance::Techpreview::Services::ServiceOps]
+      #     The service can be stopped.
+      STOP = ServiceOps.send(:new, 'STOP')
+
+      # @!attribute [rw] restart
+      #     @return [Com::Vmware::Appliance::Techpreview::Services::ServiceOps]
+      #     The service can be started or restarted.
+      RESTART = ServiceOps.send(:new, 'RESTART')
+    end
+  end
+  # ``Com::Vmware::Appliance::Techpreview::Shutdown``   class  provides  methods  Performs reboot/shutdow operations on appliance.
+  class Shutdown < VAPI::Bindings::VapiService
+    # static metamodel definitions
+    SERVICE_ID = VAPI::Core::ServiceIdentifier.new('com.vmware.appliance.techpreview.shutdown')
+
+    CANCEL_INFO = VAPI::Bindings::OperationInfo.new(
+      VAPI::Core::OperationIdentifier.new('cancel', SERVICE_ID),
+      VAPI::Bindings::OperationInputType.new,
+      VAPI::Bindings::VoidType.instance,
+      {
+        'com.vmware.vapi.std.errors.error' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Error')
+      },
+      [],
+      []
+    )
+
+    POWEROFF_INFO = VAPI::Bindings::OperationInfo.new(
+      VAPI::Core::OperationIdentifier.new('poweroff', SERVICE_ID),
+      VAPI::Bindings::OperationInputType.new(
+        'config' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Appliance::Techpreview::Shutdown::ShutdownConfig')
+      ),
+      VAPI::Bindings::VoidType.instance,
+      {
+        'com.vmware.vapi.std.errors.error' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Error')
+      },
+      [],
+      []
+    )
+
+    REBOOT_INFO = VAPI::Bindings::OperationInfo.new(
+      VAPI::Core::OperationIdentifier.new('reboot', SERVICE_ID),
+      VAPI::Bindings::OperationInputType.new(
+        'config' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Appliance::Techpreview::Shutdown::ShutdownConfig')
+      ),
+      VAPI::Bindings::VoidType.instance,
+      {
+        'com.vmware.vapi.std.errors.error' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Error')
+      },
+      [],
+      []
+    )
+
+    GET_INFO = VAPI::Bindings::OperationInfo.new(
+      VAPI::Core::OperationIdentifier.new('get', SERVICE_ID),
+      VAPI::Bindings::OperationInputType.new,
+      VAPI::Bindings::ReferenceType.new('Com::Vmware::Appliance::Techpreview::Shutdown::ShutdownGetConfig'),
+      {
+        'com.vmware.vapi.std.errors.error' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Error')
+      },
+      [],
+      []
+    )
+
+    SERVICE_INFO = VAPI::Bindings::ServiceInfo.new(
+      SERVICE_ID,
+      'cancel' => CANCEL_INFO,
+      'poweroff' => POWEROFF_INFO,
+      'reboot' => REBOOT_INFO,
+      'get' => GET_INFO
+    )
+
+    # Constructs a new instance.
+    #
+    # @param config [VAPI::Bindings::StubConfig] A hash with the api provider details.
+    def initialize(config)
+      super(config, SERVICE_INFO)
+    end
+
+    # Cancel pending shutdown action.
+    #
+    # @return [Void]
+    # @raise [Com::Vmware::Vapi::Std::Errors::Error]
+    #     Generic error
+    def cancel
+      invoke_with_info(CANCEL_INFO)
+    end
+
+    # Power off the appliance.
+    #
+    # @param config [Com::Vmware::Appliance::Techpreview::Shutdown::ShutdownConfig]
+    #     Configuration of poweroff action
+    # @return [Void]
+    # @raise [Com::Vmware::Vapi::Std::Errors::Error]
+    #     Generic error
+    def poweroff(config)
+      invoke_with_info(POWEROFF_INFO,
+                       'config' => config)
+    end
+
+    # Reboot the appliance.
+    #
+    # @param config [Com::Vmware::Appliance::Techpreview::Shutdown::ShutdownConfig]
+    #     Configuration of reboot action
+    # @return [Void]
+    # @raise [Com::Vmware::Vapi::Std::Errors::Error]
+    #     Generic error
+    def reboot(config)
+      invoke_with_info(REBOOT_INFO,
+                       'config' => config)
+    end
+
+    # Get details about the pending shutdown action.
+    #
+    # @return [Com::Vmware::Appliance::Techpreview::Shutdown::ShutdownGetConfig]
+    #     Configuration of pending shutdown action.
+    # @raise [Com::Vmware::Vapi::Std::Errors::Error]
+    #     Generic error
+    def get
+      invoke_with_info(GET_INFO)
+    end
+
+    # ``Com::Vmware::Appliance::Techpreview::Shutdown::ShutdownGetConfig``   class  Structure that defines shutdown configuration returned by Shutdown.get operation
+    # @!attribute [rw] shutdown_time
+    #     @return [String]
+    #     (UTC) time of shutdown represented in "YYYY-MM-DD HH:MM:SS" format.
+    # @!attribute [rw] action
+    #     @return [String]
+    #     Contains a string that describes the pending shutdown operation. The string values for pending operations can be 'poweroff', 'reboot' or ''
+    # @!attribute [rw] reason
+    #     @return [String]
+    #     This will contain string explaining the reason behind the shutdown action
+    class ShutdownGetConfig < VAPI::Bindings::VapiStruct
+      class << self
+        # Holds (gets or creates) the binding type metadata for this structure type.
+        # @scope class
+        # @return [VAPI::Bindings::StructType] the binding type
+        def binding_type
+          @binding_type ||= VAPI::Bindings::StructType.new(
+            'com.vmware.appliance.techpreview.shutdown.shutdown_get_config',
+            {
+              'shutdown_time' => VAPI::Bindings::StringType.instance,
+              'action' => VAPI::Bindings::StringType.instance,
+              'reason' => VAPI::Bindings::StringType.instance
+            },
+            ShutdownGetConfig,
+            false,
+            nil
+          )
+        end
+      end
+
+      attr_accessor :shutdown_time,
+                    :action,
+                    :reason
+
+      # Constructs a new instance.
+      # @param ruby_values [Hash] a map of initial property values (optional)
+      # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
+      def initialize(ruby_values = nil, struct_value = nil)
+        super(self.class.binding_type, ruby_values, struct_value)
+      end
+    end
+
+    # ``Com::Vmware::Appliance::Techpreview::Shutdown::ShutdownConfig``   class  Structure that defines shutdown configuration.
+    # @!attribute [rw] delay
+    #     @return [Fixnum]
+    #     Delay interval in minutes (optional). if you do not specify delay, then the shutdown starts immediately.
+    # @!attribute [rw] reason
+    #     @return [String]
+    #     Reason for performing shutdown (required).
+    class ShutdownConfig < VAPI::Bindings::VapiStruct
+      class << self
+        # Holds (gets or creates) the binding type metadata for this structure type.
+        # @scope class
+        # @return [VAPI::Bindings::StructType] the binding type
+        def binding_type
+          @binding_type ||= VAPI::Bindings::StructType.new(
+            'com.vmware.appliance.techpreview.shutdown.shutdown_config',
+            {
+              'delay' => VAPI::Bindings::IntegerType.instance,
+              'reason' => VAPI::Bindings::StringType.instance
+            },
+            ShutdownConfig,
+            false,
+            nil
+          )
+        end
+      end
+
+      attr_accessor :delay,
+                    :reason
+
+      # Constructs a new instance.
+      # @param ruby_values [Hash] a map of initial property values (optional)
+      # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
+      def initialize(ruby_values = nil, struct_value = nil)
+        super(self.class.binding_type, ruby_values, struct_value)
+      end
+    end
+
+  end
+  # ``Com::Vmware::Appliance::Techpreview::Timesync``   class  provides  methods  Performs time synchronization configuration.
+  class Timesync < VAPI::Bindings::VapiService
+    # static metamodel definitions
+    SERVICE_ID = VAPI::Core::ServiceIdentifier.new('com.vmware.appliance.techpreview.timesync')
+
+    SET_INFO = VAPI::Bindings::OperationInfo.new(
+      VAPI::Core::OperationIdentifier.new('set', SERVICE_ID),
+      VAPI::Bindings::OperationInputType.new(
+        'config' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Appliance::Techpreview::Timesync::TimeSyncConfig')
+      ),
+      VAPI::Bindings::VoidType.instance,
+      {
+        'com.vmware.vapi.std.errors.error' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Error')
+      },
+      [],
+      []
+    )
+
+    GET_INFO = VAPI::Bindings::OperationInfo.new(
+      VAPI::Core::OperationIdentifier.new('get', SERVICE_ID),
+      VAPI::Bindings::OperationInputType.new,
+      VAPI::Bindings::ReferenceType.new('Com::Vmware::Appliance::Techpreview::Timesync::TimeSyncConfig'),
+      {
+        'com.vmware.vapi.std.errors.error' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Error')
+      },
+      [],
+      []
+    )
+
+    SERVICE_INFO = VAPI::Bindings::ServiceInfo.new(
+      SERVICE_ID,
+      'set' => SET_INFO,
+      'get' => GET_INFO
+    )
+
+    # Constructs a new instance.
+    #
+    # @param config [VAPI::Bindings::StubConfig] A hash with the api provider details.
+    def initialize(config)
+      super(config, SERVICE_INFO)
+    end
+
+    # Set time synchronization configuration.
+    #
+    # @param config [Com::Vmware::Appliance::Techpreview::Timesync::TimeSyncConfig]
+    #     Time synchronization configuration.
+    # @return [Void]
+    # @raise [Com::Vmware::Vapi::Std::Errors::Error]
+    #     Generic error
+    def set(config)
+      invoke_with_info(SET_INFO,
+                       'config' => config)
+    end
+
+    # Get time synchronization configuration.
+    #
+    # @return [Com::Vmware::Appliance::Techpreview::Timesync::TimeSyncConfig]
+    #     Time synchronization configuration.
+    # @raise [Com::Vmware::Vapi::Std::Errors::Error]
+    #     Generic error
+    def get
+      invoke_with_info(GET_INFO)
+    end
+
+    # ``Com::Vmware::Appliance::Techpreview::Timesync::TimeSyncConfig``   class  Structure defining time synchronization configuration.
+    # @!attribute [rw] mode
+    #     @return [Com::Vmware::Appliance::Techpreview::Timesync::TimeSyncMode]
+    #     Time synchronization mode. Mode can have one of the TimeSyncMode enumeration values.
+    class TimeSyncConfig < VAPI::Bindings::VapiStruct
+      class << self
+        # Holds (gets or creates) the binding type metadata for this structure type.
+        # @scope class
+        # @return [VAPI::Bindings::StructType] the binding type
+        def binding_type
+          @binding_type ||= VAPI::Bindings::StructType.new(
+            'com.vmware.appliance.techpreview.timesync.time_sync_config',
+            {
+              'mode' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Appliance::Techpreview::Timesync::TimeSyncMode')
+            },
+            TimeSyncConfig,
+            false,
+            nil
+          )
+        end
+      end
+
+      attr_accessor :mode
+
+      # Constructs a new instance.
+      # @param ruby_values [Hash] a map of initial property values (optional)
+      # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
+      def initialize(ruby_values = nil, struct_value = nil)
+        super(self.class.binding_type, ruby_values, struct_value)
+      end
+    end
+
+    # ``Com::Vmware::Appliance::Techpreview::Timesync::TimeSyncMode``   enumerated type  Defines different timsync modes
+    # @!attribute [rw] disabled
+    #     @return [Com::Vmware::Appliance::Techpreview::Timesync::TimeSyncMode]
+    #     Time synchronization is disabled.
+    # @!attribute [rw] ntp
+    #     @return [Com::Vmware::Appliance::Techpreview::Timesync::TimeSyncMode]
+    #     NTP-based time synchronization.
+    # @!attribute [rw] host
+    #     @return [Com::Vmware::Appliance::Techpreview::Timesync::TimeSyncMode]
+    #     VMware Tool-based time synchronization.
+    class TimeSyncMode < VAPI::Bindings::VapiEnum
+      class << self
+        # Holds (gets or creates) the binding type metadata for this enumeration type.
+        # @scope class
+        # @return [VAPI::Bindings::EnumType] the binding type
+        def binding_type
+          @binding_type ||= VAPI::Bindings::EnumType.new(
+            'com.vmware.appliance.techpreview.timesync.time_sync_mode',
+            TimeSyncMode
+          )
+        end
+
+        # Converts from a string value (perhaps off the wire) to an instance
+        # of this enum type.
+        # @param value [String] the actual value of the enum instance
+        # @return [TimeSyncMode] the instance found for the value, otherwise
+        #         an unknown instance will be built for the value
+        def from_string(value)
+          const_get(value)
+        rescue NameError
+          TimeSyncMode.send(:new, 'UNKNOWN', value)
+        end
+      end
+
+      # Constructs a new instance.
+      # @param value [String] the actual value of the enum instance
+      # @param unknown [String] the unknown value when value is 'UKNOWN'
+      def initialize(value, unknown = nil)
+        super(self.class.binding_type, value, unknown)
+      end
+
+      private_class_method :new
+
+      # @!attribute [rw] disabled
+      #     @return [Com::Vmware::Appliance::Techpreview::Timesync::TimeSyncMode]
+      #     Time synchronization is disabled.
+      DISABLED = TimeSyncMode.send(:new, 'DISABLED')
+
+      # @!attribute [rw] ntp
+      #     @return [Com::Vmware::Appliance::Techpreview::Timesync::TimeSyncMode]
+      #     NTP-based time synchronization.
+      NTP = TimeSyncMode.send(:new, 'NTP')
+
+      # @!attribute [rw] host
+      #     @return [Com::Vmware::Appliance::Techpreview::Timesync::TimeSyncMode]
+      #     VMware Tool-based time synchronization.
+      HOST = TimeSyncMode.send(:new, 'HOST')
+    end
+  end
 end

--- a/client/sdk/com/vmware/appliance/techpreview/localaccounts.rb
+++ b/client/sdk/com/vmware/appliance/techpreview/localaccounts.rb
@@ -1,5 +1,6 @@
 #---------------------------------------------------------------------------
-# Copyright 2016 VMware, Inc.  All rights reserved.
+# Copyright 2017 VMware, Inc.  All rights reserved.
+#
 # AUTO GENERATED FILE -- DO NOT MODIFY!
 #
 # vAPI type descriptors for package com.vmware.appliance.techpreview.localaccounts.
@@ -8,528 +9,489 @@ require 'vapi'
 
 # declare the module hierarchy before we use the shorthand syntax below
 module Com
-    module Vmware
-        module Appliance
-            module Techpreview
-                module Localaccounts
-                end
-            end
+  module Vmware
+    module Appliance
+      module Techpreview
+        module Localaccounts
         end
+      end
     end
+  end
 end
 
 module Com::Vmware::Appliance::Techpreview::Localaccounts
-
-    # ``Com::Vmware::Appliance::Techpreview::Localaccounts::User``   class  provides  methods  Perform operations on local user account.
-    class User < VAPI::Bindings::VapiService
-
-        protected
-
-        # static metamodel definitions
-        @@service_id = VAPI::Core::ServiceIdentifier.new('com.vmware.appliance.techpreview.localaccounts.user')
-
-        @@delete_info = VAPI::Bindings::OperationInfo.new(
-            VAPI::Core::OperationIdentifier.new('delete', @@service_id),
-            VAPI::Bindings::OperationInputType.new({
-                'username' => VAPI::Bindings::StringType.instance,
-            }),
-            VAPI::Bindings::VoidType.instance,
-            {
-                'com.vmware.vapi.std.errors.error' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Error'),
-
-            },
-            [],
-            [])
-        @@add_info = VAPI::Bindings::OperationInfo.new(
-            VAPI::Core::OperationIdentifier.new('add', @@service_id),
-            VAPI::Bindings::OperationInputType.new({
-                'config' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Appliance::Techpreview::Localaccounts::User::NewUserConfig'),
-            }),
-            VAPI::Bindings::VoidType.instance,
-            {
-                'com.vmware.vapi.std.errors.error' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Error'),
-
-            },
-            [],
-            [])
-        @@set_info = VAPI::Bindings::OperationInfo.new(
-            VAPI::Core::OperationIdentifier.new('set', @@service_id),
-            VAPI::Bindings::OperationInputType.new({
-                'config' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Appliance::Techpreview::Localaccounts::User::UserConfig'),
-            }),
-            VAPI::Bindings::VoidType.instance,
-            {
-                'com.vmware.vapi.std.errors.error' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Error'),
-
-            },
-            [],
-            [])
-        @@list_info = VAPI::Bindings::OperationInfo.new(
-            VAPI::Core::OperationIdentifier.new('list', @@service_id),
-            VAPI::Bindings::OperationInputType.new,
-            VAPI::Bindings::ListType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Appliance::Techpreview::Localaccounts::User::UserConfigGet')),
-            {
-                'com.vmware.vapi.std.errors.error' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Error'),
-
-            },
-            [],
-            [])
-        @@get_info = VAPI::Bindings::OperationInfo.new(
-            VAPI::Core::OperationIdentifier.new('get', @@service_id),
-            VAPI::Bindings::OperationInputType.new({
-                'username' => VAPI::Bindings::StringType.instance,
-            }),
-            VAPI::Bindings::ReferenceType.new('Com::Vmware::Appliance::Techpreview::Localaccounts::User::UserConfigGet'),
-            {
-                'com.vmware.vapi.std.errors.error' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Error'),
-
-            },
-            [],
-            [])
-
-        @@service_info = VAPI::Bindings::ServiceInfo.new(@@service_id, {
-            'delete' => @@delete_info,
-            'add' => @@add_info,
-            'set' => @@set_info,
-            'list' => @@list_info,
-            'get' => @@get_info,
-        })
-
-        public
-
-        # Constructs a new instance.
-        #
-        # @param config [VAPI::Bindings::StubConfig] A hash with the api provider details.
-        def initialize(config)
-            super(config, @@service_info)
-        end
-
-
-        # Delete a local user account.
-        #
-        # @param username [String]
-        #     User login name.
-        # @return [Void]
-        # @raise [Com::Vmware::Vapi::Std::Errors::Error]
-        #     Generic error
-        def delete(username)
-            invoke_with_info(@@delete_info, {
-                'username' => username,
-            })
-        end
-
-
-        # Create a new local user account.
-        #
-        # @param config [Com::Vmware::Appliance::Techpreview::Localaccounts::User::NewUserConfig]
-        #     User configuration.
-        # @return [Void]
-        # @raise [Com::Vmware::Vapi::Std::Errors::Error]
-        #     Generic error
-        def add(config)
-            invoke_with_info(@@add_info, {
-                'config' => config,
-            })
-        end
-
-
-        # Update local user account properties role, full name, enabled status and password
-        #
-        # @param config [Com::Vmware::Appliance::Techpreview::Localaccounts::User::UserConfig]
-        #     User configuration.
-        # @return [Void]
-        # @raise [Com::Vmware::Vapi::Std::Errors::Error]
-        #     Generic error
-        def set(config)
-            invoke_with_info(@@set_info, {
-                'config' => config,
-            })
-        end
-
-
-        # List of local accounts
-        #
-        # @return [Array<Com::Vmware::Appliance::Techpreview::Localaccounts::User::UserConfigGet>]
-        #     User configuration.
-        # @raise [Com::Vmware::Vapi::Std::Errors::Error]
-        #     Generic error
-        def list()
-            invoke_with_info(@@list_info)
-        end
-
-
-        # Get the local user account information.
-        #
-        # @param username [String]
-        #     User login name.
-        # @return [Com::Vmware::Appliance::Techpreview::Localaccounts::User::UserConfigGet]
-        #     local user account information
-        # @raise [Com::Vmware::Vapi::Std::Errors::Error]
-        #     Generic error
-        def get(username)
-            invoke_with_info(@@get_info, {
-                'username' => username,
-            })
-        end
-
-
-
-        # ``Com::Vmware::Appliance::Techpreview::Localaccounts::User::UserConfigGet``   class  Structure defines a user configuration for user.get API.
-        # @!attribute [rw] username
-        #     @return [String]
-        #     User login name
-        # @!attribute [rw] role
-        #     @return [Com::Vmware::Appliance::Techpreview::Localaccounts::User::UserRole]
-        #     User roles
-        # @!attribute [rw] fullname
-        #     @return [String]
-        #     User full name
-        # @!attribute [rw] status
-        #     @return [Com::Vmware::Appliance::Techpreview::Localaccounts::User::UserAccountStatus]
-        #     Shows whether the user account is enabled or disabled.
-        # @!attribute [rw] passwordstatus
-        #     @return [Com::Vmware::Appliance::Techpreview::Localaccounts::User::UserPasswordStatus]
-        #     Shows whether the user account is still valid or expired.
-        # @!attribute [rw] email
-        #     @return [String]
-        #     Email address of the local account.
-        class UserConfigGet < VAPI::Bindings::VapiStruct
-
-            class << self
-                # Holds (gets or creates) the binding type metadata for this structure type.
-                # @scope class
-                # @return [VAPI::Bindings::StructType] the binding type
-                def binding_type
-                    @binding_type ||= VAPI::Bindings::StructType.new(
-                        'com.vmware.appliance.techpreview.localaccounts.user.user_config_get',
-                        {
-                            'username' => VAPI::Bindings::StringType.instance,
-                            'role' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Appliance::Techpreview::Localaccounts::User::UserRole'),
-                            'fullname' => VAPI::Bindings::StringType.instance,
-                            'status' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Appliance::Techpreview::Localaccounts::User::UserAccountStatus'),
-                            'passwordstatus' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Appliance::Techpreview::Localaccounts::User::UserPasswordStatus'),
-                            'email' => VAPI::Bindings::StringType.instance,
-                        },
-                        UserConfigGet,
-                        false,
-                        nil)
-                end
-            end
-
-            attr_accessor :username,
-                          :role,
-                          :fullname,
-                          :status,
-                          :passwordstatus,
-                          :email
-
-            # Constructs a new instance.
-            # @param ruby_values [Hash] a map of initial property values (optional)
-            # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
-            def initialize(ruby_values=nil, struct_value=nil)
-                super(self.class.binding_type, ruby_values, struct_value)
-            end
-        end
-
-
-        # ``Com::Vmware::Appliance::Techpreview::Localaccounts::User::UserConfig``   class  Structure that defines a new user configuration for CLI.
-        # @!attribute [rw] username
-        #     @return [String]
-        #     User login name
-        # @!attribute [rw] role
-        #     @return [Com::Vmware::Appliance::Techpreview::Localaccounts::User::UserRole]
-        #     User roles
-        # @!attribute [rw] fullname
-        #     @return [String]
-        #     User full name
-        # @!attribute [rw] status
-        #     @return [Com::Vmware::Appliance::Techpreview::Localaccounts::User::UserAccountStatus]
-        #     Enabled status of the local account
-        # @!attribute [rw] email
-        #     @return [String]
-        #     email of the local account
-        class UserConfig < VAPI::Bindings::VapiStruct
-
-            class << self
-                # Holds (gets or creates) the binding type metadata for this structure type.
-                # @scope class
-                # @return [VAPI::Bindings::StructType] the binding type
-                def binding_type
-                    @binding_type ||= VAPI::Bindings::StructType.new(
-                        'com.vmware.appliance.techpreview.localaccounts.user.user_config',
-                        {
-                            'username' => VAPI::Bindings::StringType.instance,
-                            'role' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Appliance::Techpreview::Localaccounts::User::UserRole'),
-                            'fullname' => VAPI::Bindings::StringType.instance,
-                            'status' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Appliance::Techpreview::Localaccounts::User::UserAccountStatus'),
-                            'email' => VAPI::Bindings::StringType.instance,
-                        },
-                        UserConfig,
-                        false,
-                        nil)
-                end
-            end
-
-            attr_accessor :username,
-                          :role,
-                          :fullname,
-                          :status,
-                          :email
-
-            # Constructs a new instance.
-            # @param ruby_values [Hash] a map of initial property values (optional)
-            # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
-            def initialize(ruby_values=nil, struct_value=nil)
-                super(self.class.binding_type, ruby_values, struct_value)
-            end
-        end
-
-
-        # ``Com::Vmware::Appliance::Techpreview::Localaccounts::User::NewUserConfig``   class  Structure that defines a new user configuration.
-        # @!attribute [rw] username
-        #     @return [String]
-        #     User login name
-        # @!attribute [rw] role
-        #     @return [Com::Vmware::Appliance::Techpreview::Localaccounts::User::UserRole, nil]
-        #     User roles. The default role is operator.
-        #     role Default role is operator
-        # @!attribute [rw] password
-        #     @return [String]
-        #     User login password In Interactive mode, provide --password as part of the command, and enter the value on the prompt. When accessed remotely, provide --password value as part the command.
-        # @!attribute [rw] fullname
-        #     @return [String, nil]
-        #     User full name
-        #     fullname Optional full name for a person
-        # @!attribute [rw] email
-        #     @return [String, nil]
-        #     Email address of the local account.
-        #     email Optional email
-        class NewUserConfig < VAPI::Bindings::VapiStruct
-
-            class << self
-                # Holds (gets or creates) the binding type metadata for this structure type.
-                # @scope class
-                # @return [VAPI::Bindings::StructType] the binding type
-                def binding_type
-                    @binding_type ||= VAPI::Bindings::StructType.new(
-                        'com.vmware.appliance.techpreview.localaccounts.user.new_user_config',
-                        {
-                            'username' => VAPI::Bindings::StringType.instance,
-                            'role' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Appliance::Techpreview::Localaccounts::User::UserRole')),
-                            'password' => VAPI::Bindings::SecretType.instance,
-                            'fullname' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::StringType.instance),
-                            'email' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::StringType.instance),
-                        },
-                        NewUserConfig,
-                        false,
-                        nil)
-                end
-            end
-
-            attr_accessor :username,
-                          :role,
-                          :password,
-                          :fullname,
-                          :email
-
-            # Constructs a new instance.
-            # @param ruby_values [Hash] a map of initial property values (optional)
-            # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
-            def initialize(ruby_values=nil, struct_value=nil)
-                super(self.class.binding_type, ruby_values, struct_value)
-            end
-        end
-
-
-
-        # ``Com::Vmware::Appliance::Techpreview::Localaccounts::User::UserAccountStatus``   enumerated type  Defines status of user accounts
-        # @!attribute [rw] disabled
-        #     @return [Com::Vmware::Appliance::Techpreview::Localaccounts::User::UserAccountStatus]
-        #     The user account is disabled.
-        # @!attribute [rw] enabled
-        #     @return [Com::Vmware::Appliance::Techpreview::Localaccounts::User::UserAccountStatus]
-        #     The user account is enabled.
-        class UserAccountStatus < VAPI::Bindings::VapiEnum
-
-            class << self
-                # Holds (gets or creates) the binding type metadata for this enumeration type.
-                # @scope class
-                # @return [VAPI::Bindings::EnumType] the binding type
-                def binding_type
-                    @binding_type ||= VAPI::Bindings::EnumType.new(
-                        'com.vmware.appliance.techpreview.localaccounts.user.user_account_status',
-                        UserAccountStatus)
-                end
-
-                # Converts from a string value (perhaps off the wire) to an instance
-                # of this enum type.
-                # @param value [String] the actual value of the enum instance
-                # @return [UserAccountStatus] the instance found for the value, otherwise
-                #         an unknown instance will be built for the value
-                def from_string(value)
-                    begin
-                        const_get(value)
-                    rescue NameError
-                        UserAccountStatus.new('UNKNOWN', value)
-                    end
-                end
-            end
-
-            private
-
-            # Constructs a new instance.
-            # @param value [String] the actual value of the enum instance
-            # @param unknown [String] the unknown value when value is 'UKNOWN'
-            def initialize(value, unknown=nil)
-                super(self.class.binding_type, value, unknown)
-            end
-
-            public
-
-            # @!attribute [rw] disabled
-            #     @return [Com::Vmware::Appliance::Techpreview::Localaccounts::User::UserAccountStatus]
-            #     The user account is disabled.
-            DISABLED = UserAccountStatus.new('DISABLED')
-
-            # @!attribute [rw] enabled
-            #     @return [Com::Vmware::Appliance::Techpreview::Localaccounts::User::UserAccountStatus]
-            #     The user account is enabled.
-            ENABLED = UserAccountStatus.new('ENABLED')
-
-        end
-
-
-        # ``Com::Vmware::Appliance::Techpreview::Localaccounts::User::UserPasswordStatus``   enumerated type  Defines state of user password
-        # @!attribute [rw] notset
-        #     @return [Com::Vmware::Appliance::Techpreview::Localaccounts::User::UserPasswordStatus]
-        #     No password has been set
-        # @!attribute [rw] expired
-        #     @return [Com::Vmware::Appliance::Techpreview::Localaccounts::User::UserPasswordStatus]
-        #     The password has expired.
-        # @!attribute [rw] valid
-        #     @return [Com::Vmware::Appliance::Techpreview::Localaccounts::User::UserPasswordStatus]
-        #     The password is still valid.
-        class UserPasswordStatus < VAPI::Bindings::VapiEnum
-
-            class << self
-                # Holds (gets or creates) the binding type metadata for this enumeration type.
-                # @scope class
-                # @return [VAPI::Bindings::EnumType] the binding type
-                def binding_type
-                    @binding_type ||= VAPI::Bindings::EnumType.new(
-                        'com.vmware.appliance.techpreview.localaccounts.user.user_password_status',
-                        UserPasswordStatus)
-                end
-
-                # Converts from a string value (perhaps off the wire) to an instance
-                # of this enum type.
-                # @param value [String] the actual value of the enum instance
-                # @return [UserPasswordStatus] the instance found for the value, otherwise
-                #         an unknown instance will be built for the value
-                def from_string(value)
-                    begin
-                        const_get(value)
-                    rescue NameError
-                        UserPasswordStatus.new('UNKNOWN', value)
-                    end
-                end
-            end
-
-            private
-
-            # Constructs a new instance.
-            # @param value [String] the actual value of the enum instance
-            # @param unknown [String] the unknown value when value is 'UKNOWN'
-            def initialize(value, unknown=nil)
-                super(self.class.binding_type, value, unknown)
-            end
-
-            public
-
-            # @!attribute [rw] notset
-            #     @return [Com::Vmware::Appliance::Techpreview::Localaccounts::User::UserPasswordStatus]
-            #     No password has been set
-            NOTSET = UserPasswordStatus.new('NOTSET')
-
-            # @!attribute [rw] expired
-            #     @return [Com::Vmware::Appliance::Techpreview::Localaccounts::User::UserPasswordStatus]
-            #     The password has expired.
-            EXPIRED = UserPasswordStatus.new('EXPIRED')
-
-            # @!attribute [rw] valid
-            #     @return [Com::Vmware::Appliance::Techpreview::Localaccounts::User::UserPasswordStatus]
-            #     The password is still valid.
-            VALID = UserPasswordStatus.new('VALID')
-
-        end
-
-
-        # ``Com::Vmware::Appliance::Techpreview::Localaccounts::User::UserRole``   enumerated type  Defines user roles for appliance
-        # @!attribute [rw] admin
-        #     @return [Com::Vmware::Appliance::Techpreview::Localaccounts::User::UserRole]
-        #     Able to configure the appliance.
-        # @!attribute [rw] operator
-        #     @return [Com::Vmware::Appliance::Techpreview::Localaccounts::User::UserRole]
-        #     Able to read the appliance configuration.
-        # @!attribute [rw] super_admin
-        #     @return [Com::Vmware::Appliance::Techpreview::Localaccounts::User::UserRole]
-        #     Able to configure the appliance, manage local accounts and use the BASH shell
-        class UserRole < VAPI::Bindings::VapiEnum
-
-            class << self
-                # Holds (gets or creates) the binding type metadata for this enumeration type.
-                # @scope class
-                # @return [VAPI::Bindings::EnumType] the binding type
-                def binding_type
-                    @binding_type ||= VAPI::Bindings::EnumType.new(
-                        'com.vmware.appliance.techpreview.localaccounts.user.user_role',
-                        UserRole)
-                end
-
-                # Converts from a string value (perhaps off the wire) to an instance
-                # of this enum type.
-                # @param value [String] the actual value of the enum instance
-                # @return [UserRole] the instance found for the value, otherwise
-                #         an unknown instance will be built for the value
-                def from_string(value)
-                    begin
-                        const_get(value)
-                    rescue NameError
-                        UserRole.new('UNKNOWN', value)
-                    end
-                end
-            end
-
-            private
-
-            # Constructs a new instance.
-            # @param value [String] the actual value of the enum instance
-            # @param unknown [String] the unknown value when value is 'UKNOWN'
-            def initialize(value, unknown=nil)
-                super(self.class.binding_type, value, unknown)
-            end
-
-            public
-
-            # @!attribute [rw] admin
-            #     @return [Com::Vmware::Appliance::Techpreview::Localaccounts::User::UserRole]
-            #     Able to configure the appliance.
-            ADMIN = UserRole.new('ADMIN')
-
-            # @!attribute [rw] operator
-            #     @return [Com::Vmware::Appliance::Techpreview::Localaccounts::User::UserRole]
-            #     Able to read the appliance configuration.
-            OPERATOR = UserRole.new('OPERATOR')
-
-            # @!attribute [rw] super_admin
-            #     @return [Com::Vmware::Appliance::Techpreview::Localaccounts::User::UserRole]
-            #     Able to configure the appliance, manage local accounts and use the BASH shell
-            SUPER_ADMIN = UserRole.new('SUPER_ADMIN')
-
-        end
-
-
+  # ``Com::Vmware::Appliance::Techpreview::Localaccounts::User``   class  provides  methods  Perform operations on local user account.
+  class User < VAPI::Bindings::VapiService
+    # static metamodel definitions
+    SERVICE_ID = VAPI::Core::ServiceIdentifier.new('com.vmware.appliance.techpreview.localaccounts.user')
+
+    DELETE_INFO = VAPI::Bindings::OperationInfo.new(
+      VAPI::Core::OperationIdentifier.new('delete', SERVICE_ID),
+      VAPI::Bindings::OperationInputType.new(
+        'username' => VAPI::Bindings::StringType.instance
+      ),
+      VAPI::Bindings::VoidType.instance,
+      {
+        'com.vmware.vapi.std.errors.error' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Error')
+      },
+      [],
+      []
+    )
+
+    ADD_INFO = VAPI::Bindings::OperationInfo.new(
+      VAPI::Core::OperationIdentifier.new('add', SERVICE_ID),
+      VAPI::Bindings::OperationInputType.new(
+        'config' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Appliance::Techpreview::Localaccounts::User::NewUserConfig')
+      ),
+      VAPI::Bindings::VoidType.instance,
+      {
+        'com.vmware.vapi.std.errors.error' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Error')
+      },
+      [],
+      []
+    )
+
+    SET_INFO = VAPI::Bindings::OperationInfo.new(
+      VAPI::Core::OperationIdentifier.new('set', SERVICE_ID),
+      VAPI::Bindings::OperationInputType.new(
+        'config' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Appliance::Techpreview::Localaccounts::User::UserConfig')
+      ),
+      VAPI::Bindings::VoidType.instance,
+      {
+        'com.vmware.vapi.std.errors.error' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Error')
+      },
+      [],
+      []
+    )
+
+    LIST_INFO = VAPI::Bindings::OperationInfo.new(
+      VAPI::Core::OperationIdentifier.new('list', SERVICE_ID),
+      VAPI::Bindings::OperationInputType.new,
+      VAPI::Bindings::ListType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Appliance::Techpreview::Localaccounts::User::UserConfigGet')),
+      {
+        'com.vmware.vapi.std.errors.error' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Error')
+      },
+      [],
+      []
+    )
+
+    GET_INFO = VAPI::Bindings::OperationInfo.new(
+      VAPI::Core::OperationIdentifier.new('get', SERVICE_ID),
+      VAPI::Bindings::OperationInputType.new(
+        'username' => VAPI::Bindings::StringType.instance
+      ),
+      VAPI::Bindings::ReferenceType.new('Com::Vmware::Appliance::Techpreview::Localaccounts::User::UserConfigGet'),
+      {
+        'com.vmware.vapi.std.errors.error' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Error')
+      },
+      [],
+      []
+    )
+
+    SERVICE_INFO = VAPI::Bindings::ServiceInfo.new(
+      SERVICE_ID,
+      'delete' => DELETE_INFO,
+      'add' => ADD_INFO,
+      'set' => SET_INFO,
+      'list' => LIST_INFO,
+      'get' => GET_INFO
+    )
+
+    # Constructs a new instance.
+    #
+    # @param config [VAPI::Bindings::StubConfig] A hash with the api provider details.
+    def initialize(config)
+      super(config, SERVICE_INFO)
     end
 
+    # Delete a local user account.
+    #
+    # @param username [String]
+    #     User login name.
+    # @return [Void]
+    # @raise [Com::Vmware::Vapi::Std::Errors::Error]
+    #     Generic error
+    def delete(username)
+      invoke_with_info(DELETE_INFO,
+                       'username' => username)
+    end
 
+    # Create a new local user account.
+    #
+    # @param config [Com::Vmware::Appliance::Techpreview::Localaccounts::User::NewUserConfig]
+    #     User configuration.
+    # @return [Void]
+    # @raise [Com::Vmware::Vapi::Std::Errors::Error]
+    #     Generic error
+    def add(config)
+      invoke_with_info(ADD_INFO,
+                       'config' => config)
+    end
+
+    # Update local user account properties role, full name, enabled status and password
+    #
+    # @param config [Com::Vmware::Appliance::Techpreview::Localaccounts::User::UserConfig]
+    #     User configuration.
+    # @return [Void]
+    # @raise [Com::Vmware::Vapi::Std::Errors::Error]
+    #     Generic error
+    def set(config)
+      invoke_with_info(SET_INFO,
+                       'config' => config)
+    end
+
+    # List of local accounts
+    #
+    # @return [Array<Com::Vmware::Appliance::Techpreview::Localaccounts::User::UserConfigGet>]
+    #     User configuration.
+    # @raise [Com::Vmware::Vapi::Std::Errors::Error]
+    #     Generic error
+    def list
+      invoke_with_info(LIST_INFO)
+    end
+
+    # Get the local user account information.
+    #
+    # @param username [String]
+    #     User login name.
+    # @return [Com::Vmware::Appliance::Techpreview::Localaccounts::User::UserConfigGet]
+    #     local user account information
+    # @raise [Com::Vmware::Vapi::Std::Errors::Error]
+    #     Generic error
+    def get(username)
+      invoke_with_info(GET_INFO,
+                       'username' => username)
+    end
+
+    # ``Com::Vmware::Appliance::Techpreview::Localaccounts::User::UserConfigGet``   class  Structure defines a user configuration for user.get API.
+    # @!attribute [rw] username
+    #     @return [String]
+    #     User login name
+    # @!attribute [rw] role
+    #     @return [Com::Vmware::Appliance::Techpreview::Localaccounts::User::UserRole]
+    #     User roles
+    # @!attribute [rw] fullname
+    #     @return [String]
+    #     User full name
+    # @!attribute [rw] status
+    #     @return [Com::Vmware::Appliance::Techpreview::Localaccounts::User::UserAccountStatus]
+    #     Shows whether the user account is enabled or disabled.
+    # @!attribute [rw] passwordstatus
+    #     @return [Com::Vmware::Appliance::Techpreview::Localaccounts::User::UserPasswordStatus]
+    #     Shows whether the user account is still valid or expired.
+    # @!attribute [rw] email
+    #     @return [String]
+    #     Email address of the local account.
+    class UserConfigGet < VAPI::Bindings::VapiStruct
+      class << self
+        # Holds (gets or creates) the binding type metadata for this structure type.
+        # @scope class
+        # @return [VAPI::Bindings::StructType] the binding type
+        def binding_type
+          @binding_type ||= VAPI::Bindings::StructType.new(
+            'com.vmware.appliance.techpreview.localaccounts.user.user_config_get',
+            {
+              'username' => VAPI::Bindings::StringType.instance,
+              'role' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Appliance::Techpreview::Localaccounts::User::UserRole'),
+              'fullname' => VAPI::Bindings::StringType.instance,
+              'status' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Appliance::Techpreview::Localaccounts::User::UserAccountStatus'),
+              'passwordstatus' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Appliance::Techpreview::Localaccounts::User::UserPasswordStatus'),
+              'email' => VAPI::Bindings::StringType.instance
+            },
+            UserConfigGet,
+            false,
+            nil
+          )
+        end
+      end
+
+      attr_accessor :username,
+                    :role,
+                    :fullname,
+                    :status,
+                    :passwordstatus,
+                    :email
+
+      # Constructs a new instance.
+      # @param ruby_values [Hash] a map of initial property values (optional)
+      # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
+      def initialize(ruby_values = nil, struct_value = nil)
+        super(self.class.binding_type, ruby_values, struct_value)
+      end
+    end
+
+    # ``Com::Vmware::Appliance::Techpreview::Localaccounts::User::UserConfig``   class  Structure that defines a new user configuration for CLI.
+    # @!attribute [rw] username
+    #     @return [String]
+    #     User login name
+    # @!attribute [rw] role
+    #     @return [Com::Vmware::Appliance::Techpreview::Localaccounts::User::UserRole]
+    #     User roles
+    # @!attribute [rw] fullname
+    #     @return [String]
+    #     User full name
+    # @!attribute [rw] status
+    #     @return [Com::Vmware::Appliance::Techpreview::Localaccounts::User::UserAccountStatus]
+    #     Enabled status of the local account
+    # @!attribute [rw] email
+    #     @return [String]
+    #     email of the local account
+    class UserConfig < VAPI::Bindings::VapiStruct
+      class << self
+        # Holds (gets or creates) the binding type metadata for this structure type.
+        # @scope class
+        # @return [VAPI::Bindings::StructType] the binding type
+        def binding_type
+          @binding_type ||= VAPI::Bindings::StructType.new(
+            'com.vmware.appliance.techpreview.localaccounts.user.user_config',
+            {
+              'username' => VAPI::Bindings::StringType.instance,
+              'role' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Appliance::Techpreview::Localaccounts::User::UserRole'),
+              'fullname' => VAPI::Bindings::StringType.instance,
+              'status' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Appliance::Techpreview::Localaccounts::User::UserAccountStatus'),
+              'email' => VAPI::Bindings::StringType.instance
+            },
+            UserConfig,
+            false,
+            nil
+          )
+        end
+      end
+
+      attr_accessor :username,
+                    :role,
+                    :fullname,
+                    :status,
+                    :email
+
+      # Constructs a new instance.
+      # @param ruby_values [Hash] a map of initial property values (optional)
+      # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
+      def initialize(ruby_values = nil, struct_value = nil)
+        super(self.class.binding_type, ruby_values, struct_value)
+      end
+    end
+
+    # ``Com::Vmware::Appliance::Techpreview::Localaccounts::User::NewUserConfig``   class  Structure that defines a new user configuration.
+    # @!attribute [rw] username
+    #     @return [String]
+    #     User login name
+    # @!attribute [rw] role
+    #     @return [Com::Vmware::Appliance::Techpreview::Localaccounts::User::UserRole, nil]
+    #     User roles. The default role is operator.
+    #     role Default role is operator
+    # @!attribute [rw] password
+    #     @return [String]
+    #     User login password In Interactive mode, provide --password as part of the command, and enter the value on the prompt. When accessed remotely, provide --password value as part the command.
+    # @!attribute [rw] fullname
+    #     @return [String, nil]
+    #     User full name
+    #     fullname Optional full name for a person
+    # @!attribute [rw] email
+    #     @return [String, nil]
+    #     Email address of the local account.
+    #     email Optional email
+    class NewUserConfig < VAPI::Bindings::VapiStruct
+      class << self
+        # Holds (gets or creates) the binding type metadata for this structure type.
+        # @scope class
+        # @return [VAPI::Bindings::StructType] the binding type
+        def binding_type
+          @binding_type ||= VAPI::Bindings::StructType.new(
+            'com.vmware.appliance.techpreview.localaccounts.user.new_user_config',
+            {
+              'username' => VAPI::Bindings::StringType.instance,
+              'role' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Appliance::Techpreview::Localaccounts::User::UserRole')),
+              'password' => VAPI::Bindings::SecretType.instance,
+              'fullname' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::StringType.instance),
+              'email' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::StringType.instance)
+            },
+            NewUserConfig,
+            false,
+            nil
+          )
+        end
+      end
+
+      attr_accessor :username,
+                    :role,
+                    :password,
+                    :fullname,
+                    :email
+
+      # Constructs a new instance.
+      # @param ruby_values [Hash] a map of initial property values (optional)
+      # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
+      def initialize(ruby_values = nil, struct_value = nil)
+        super(self.class.binding_type, ruby_values, struct_value)
+      end
+    end
+
+    # ``Com::Vmware::Appliance::Techpreview::Localaccounts::User::UserAccountStatus``   enumerated type  Defines status of user accounts
+    # @!attribute [rw] disabled
+    #     @return [Com::Vmware::Appliance::Techpreview::Localaccounts::User::UserAccountStatus]
+    #     The user account is disabled.
+    # @!attribute [rw] enabled
+    #     @return [Com::Vmware::Appliance::Techpreview::Localaccounts::User::UserAccountStatus]
+    #     The user account is enabled.
+    class UserAccountStatus < VAPI::Bindings::VapiEnum
+      class << self
+        # Holds (gets or creates) the binding type metadata for this enumeration type.
+        # @scope class
+        # @return [VAPI::Bindings::EnumType] the binding type
+        def binding_type
+          @binding_type ||= VAPI::Bindings::EnumType.new(
+            'com.vmware.appliance.techpreview.localaccounts.user.user_account_status',
+            UserAccountStatus
+          )
+        end
+
+        # Converts from a string value (perhaps off the wire) to an instance
+        # of this enum type.
+        # @param value [String] the actual value of the enum instance
+        # @return [UserAccountStatus] the instance found for the value, otherwise
+        #         an unknown instance will be built for the value
+        def from_string(value)
+          const_get(value)
+        rescue NameError
+          UserAccountStatus.send(:new, 'UNKNOWN', value)
+        end
+      end
+
+      # Constructs a new instance.
+      # @param value [String] the actual value of the enum instance
+      # @param unknown [String] the unknown value when value is 'UKNOWN'
+      def initialize(value, unknown = nil)
+        super(self.class.binding_type, value, unknown)
+      end
+
+      private_class_method :new
+
+      # @!attribute [rw] disabled
+      #     @return [Com::Vmware::Appliance::Techpreview::Localaccounts::User::UserAccountStatus]
+      #     The user account is disabled.
+      DISABLED = UserAccountStatus.send(:new, 'DISABLED')
+
+      # @!attribute [rw] enabled
+      #     @return [Com::Vmware::Appliance::Techpreview::Localaccounts::User::UserAccountStatus]
+      #     The user account is enabled.
+      ENABLED = UserAccountStatus.send(:new, 'ENABLED')
+    end
+    # ``Com::Vmware::Appliance::Techpreview::Localaccounts::User::UserPasswordStatus``   enumerated type  Defines state of user password
+    # @!attribute [rw] notset
+    #     @return [Com::Vmware::Appliance::Techpreview::Localaccounts::User::UserPasswordStatus]
+    #     No password has been set
+    # @!attribute [rw] expired
+    #     @return [Com::Vmware::Appliance::Techpreview::Localaccounts::User::UserPasswordStatus]
+    #     The password has expired.
+    # @!attribute [rw] valid
+    #     @return [Com::Vmware::Appliance::Techpreview::Localaccounts::User::UserPasswordStatus]
+    #     The password is still valid.
+    class UserPasswordStatus < VAPI::Bindings::VapiEnum
+      class << self
+        # Holds (gets or creates) the binding type metadata for this enumeration type.
+        # @scope class
+        # @return [VAPI::Bindings::EnumType] the binding type
+        def binding_type
+          @binding_type ||= VAPI::Bindings::EnumType.new(
+            'com.vmware.appliance.techpreview.localaccounts.user.user_password_status',
+            UserPasswordStatus
+          )
+        end
+
+        # Converts from a string value (perhaps off the wire) to an instance
+        # of this enum type.
+        # @param value [String] the actual value of the enum instance
+        # @return [UserPasswordStatus] the instance found for the value, otherwise
+        #         an unknown instance will be built for the value
+        def from_string(value)
+          const_get(value)
+        rescue NameError
+          UserPasswordStatus.send(:new, 'UNKNOWN', value)
+        end
+      end
+
+      # Constructs a new instance.
+      # @param value [String] the actual value of the enum instance
+      # @param unknown [String] the unknown value when value is 'UKNOWN'
+      def initialize(value, unknown = nil)
+        super(self.class.binding_type, value, unknown)
+      end
+
+      private_class_method :new
+
+      # @!attribute [rw] notset
+      #     @return [Com::Vmware::Appliance::Techpreview::Localaccounts::User::UserPasswordStatus]
+      #     No password has been set
+      NOTSET = UserPasswordStatus.send(:new, 'NOTSET')
+
+      # @!attribute [rw] expired
+      #     @return [Com::Vmware::Appliance::Techpreview::Localaccounts::User::UserPasswordStatus]
+      #     The password has expired.
+      EXPIRED = UserPasswordStatus.send(:new, 'EXPIRED')
+
+      # @!attribute [rw] valid
+      #     @return [Com::Vmware::Appliance::Techpreview::Localaccounts::User::UserPasswordStatus]
+      #     The password is still valid.
+      VALID = UserPasswordStatus.send(:new, 'VALID')
+    end
+    # ``Com::Vmware::Appliance::Techpreview::Localaccounts::User::UserRole``   enumerated type  Defines user roles for appliance
+    # @!attribute [rw] admin
+    #     @return [Com::Vmware::Appliance::Techpreview::Localaccounts::User::UserRole]
+    #     Able to configure the appliance.
+    # @!attribute [rw] operator
+    #     @return [Com::Vmware::Appliance::Techpreview::Localaccounts::User::UserRole]
+    #     Able to read the appliance configuration.
+    # @!attribute [rw] super_admin
+    #     @return [Com::Vmware::Appliance::Techpreview::Localaccounts::User::UserRole]
+    #     Able to configure the appliance, manage local accounts and use the BASH shell
+    class UserRole < VAPI::Bindings::VapiEnum
+      class << self
+        # Holds (gets or creates) the binding type metadata for this enumeration type.
+        # @scope class
+        # @return [VAPI::Bindings::EnumType] the binding type
+        def binding_type
+          @binding_type ||= VAPI::Bindings::EnumType.new(
+            'com.vmware.appliance.techpreview.localaccounts.user.user_role',
+            UserRole
+          )
+        end
+
+        # Converts from a string value (perhaps off the wire) to an instance
+        # of this enum type.
+        # @param value [String] the actual value of the enum instance
+        # @return [UserRole] the instance found for the value, otherwise
+        #         an unknown instance will be built for the value
+        def from_string(value)
+          const_get(value)
+        rescue NameError
+          UserRole.send(:new, 'UNKNOWN', value)
+        end
+      end
+
+      # Constructs a new instance.
+      # @param value [String] the actual value of the enum instance
+      # @param unknown [String] the unknown value when value is 'UKNOWN'
+      def initialize(value, unknown = nil)
+        super(self.class.binding_type, value, unknown)
+      end
+
+      private_class_method :new
+
+      # @!attribute [rw] admin
+      #     @return [Com::Vmware::Appliance::Techpreview::Localaccounts::User::UserRole]
+      #     Able to configure the appliance.
+      ADMIN = UserRole.send(:new, 'ADMIN')
+
+      # @!attribute [rw] operator
+      #     @return [Com::Vmware::Appliance::Techpreview::Localaccounts::User::UserRole]
+      #     Able to read the appliance configuration.
+      OPERATOR = UserRole.send(:new, 'OPERATOR')
+
+      # @!attribute [rw] super_admin
+      #     @return [Com::Vmware::Appliance::Techpreview::Localaccounts::User::UserRole]
+      #     Able to configure the appliance, manage local accounts and use the BASH shell
+      SUPER_ADMIN = UserRole.send(:new, 'SUPER_ADMIN')
+    end
+  end
 end

--- a/client/sdk/com/vmware/appliance/techpreview/monitoring.rb
+++ b/client/sdk/com/vmware/appliance/techpreview/monitoring.rb
@@ -1,5 +1,6 @@
 #---------------------------------------------------------------------------
-# Copyright 2016 VMware, Inc.  All rights reserved.
+# Copyright 2017 VMware, Inc.  All rights reserved.
+#
 # AUTO GENERATED FILE -- DO NOT MODIFY!
 #
 # vAPI type descriptors for package com.vmware.appliance.techpreview.monitoring.
@@ -8,1236 +9,1184 @@ require 'vapi'
 
 # declare the module hierarchy before we use the shorthand syntax below
 module Com
-    module Vmware
-        module Appliance
-            module Techpreview
-                module Monitoring
-                end
-            end
+  module Vmware
+    module Appliance
+      module Techpreview
+        module Monitoring
         end
+      end
     end
+  end
 end
 
 module Com::Vmware::Appliance::Techpreview::Monitoring
-
-    # ``Com::Vmware::Appliance::Techpreview::Monitoring::Snmp``   class  provides  methods  SNMP agent operations.
-    class Snmp < VAPI::Bindings::VapiService
-
-        protected
-
-        # static metamodel definitions
-        @@service_id = VAPI::Core::ServiceIdentifier.new('com.vmware.appliance.techpreview.monitoring.snmp')
-
-        @@reset_info = VAPI::Bindings::OperationInfo.new(
-            VAPI::Core::OperationIdentifier.new('reset', @@service_id),
-            VAPI::Bindings::OperationInputType.new,
-            VAPI::Bindings::VoidType.instance,
-            {
-                'com.vmware.vapi.std.errors.error' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Error'),
-
-            },
-            [],
-            [])
-        @@enable_info = VAPI::Bindings::OperationInfo.new(
-            VAPI::Core::OperationIdentifier.new('enable', @@service_id),
-            VAPI::Bindings::OperationInputType.new,
-            VAPI::Bindings::VoidType.instance,
-            {
-                'com.vmware.vapi.std.errors.error' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Error'),
-
-            },
-            [],
-            [])
-        @@hash_info = VAPI::Bindings::OperationInfo.new(
-            VAPI::Core::OperationIdentifier.new('hash', @@service_id),
-            VAPI::Bindings::OperationInputType.new({
-                'config' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Appliance::Techpreview::Monitoring::Snmp::SNMPHashConfig'),
-            }),
-            VAPI::Bindings::ReferenceType.new('Com::Vmware::Appliance::Techpreview::Monitoring::Snmp::SNMPHashResults'),
-            {
-                'com.vmware.vapi.std.errors.error' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Error'),
-
-            },
-            [],
-            [])
-        @@limits_info = VAPI::Bindings::OperationInfo.new(
-            VAPI::Core::OperationIdentifier.new('limits', @@service_id),
-            VAPI::Bindings::OperationInputType.new,
-            VAPI::Bindings::ReferenceType.new('Com::Vmware::Appliance::Techpreview::Monitoring::Snmp::SNMPLimits'),
-            {
-                'com.vmware.vapi.std.errors.error' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Error'),
-
-            },
-            [],
-            [])
-        @@get_info = VAPI::Bindings::OperationInfo.new(
-            VAPI::Core::OperationIdentifier.new('get', @@service_id),
-            VAPI::Bindings::OperationInputType.new,
-            VAPI::Bindings::ReferenceType.new('Com::Vmware::Appliance::Techpreview::Monitoring::Snmp::SNMPConfigReadOnly'),
-            {
-                'com.vmware.vapi.std.errors.error' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Error'),
-
-            },
-            [],
-            [])
-        @@disable_info = VAPI::Bindings::OperationInfo.new(
-            VAPI::Core::OperationIdentifier.new('disable', @@service_id),
-            VAPI::Bindings::OperationInputType.new,
-            VAPI::Bindings::VoidType.instance,
-            {
-                'com.vmware.vapi.std.errors.error' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Error'),
-
-            },
-            [],
-            [])
-        @@set_info = VAPI::Bindings::OperationInfo.new(
-            VAPI::Core::OperationIdentifier.new('set', @@service_id),
-            VAPI::Bindings::OperationInputType.new({
-                'config' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Appliance::Techpreview::Monitoring::Snmp::SNMPConfig'),
-            }),
-            VAPI::Bindings::VoidType.instance,
-            {
-                'com.vmware.vapi.std.errors.error' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Error'),
-
-            },
-            [],
-            [])
-        @@test_info = VAPI::Bindings::OperationInfo.new(
-            VAPI::Core::OperationIdentifier.new('test', @@service_id),
-            VAPI::Bindings::OperationInputType.new,
-            VAPI::Bindings::ReferenceType.new('Com::Vmware::Appliance::Techpreview::Monitoring::Snmp::SNMPTestResults'),
-            {
-                'com.vmware.vapi.std.errors.error' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Error'),
-
-            },
-            [],
-            [])
-        @@stats_info = VAPI::Bindings::OperationInfo.new(
-            VAPI::Core::OperationIdentifier.new('stats', @@service_id),
-            VAPI::Bindings::OperationInputType.new,
-            VAPI::Bindings::ReferenceType.new('Com::Vmware::Appliance::Techpreview::Monitoring::Snmp::SNMPStats'),
-            {
-                'com.vmware.vapi.std.errors.error' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Error'),
-
-            },
-            [],
-            [])
-
-        @@service_info = VAPI::Bindings::ServiceInfo.new(@@service_id, {
-            'reset' => @@reset_info,
-            'enable' => @@enable_info,
-            'hash' => @@hash_info,
-            'limits' => @@limits_info,
-            'get' => @@get_info,
-            'disable' => @@disable_info,
-            'set' => @@set_info,
-            'test' => @@test_info,
-            'stats' => @@stats_info,
-        })
-
-        public
-
-        # Constructs a new instance.
-        #
-        # @param config [VAPI::Bindings::StubConfig] A hash with the api provider details.
-        def initialize(config)
-            super(config, @@service_info)
-        end
-
-
-        # Restore settings to factory defaults.
-        #
-        # @return [Void]
-        # @raise [Com::Vmware::Vapi::Std::Errors::Error]
-        #     Generic error
-        def reset()
-            invoke_with_info(@@reset_info)
-        end
-
-
-        # Start a disabled SNMP agent.
-        #
-        # @return [Void]
-        # @raise [Com::Vmware::Vapi::Std::Errors::Error]
-        #     Generic error
-        def enable()
-            invoke_with_info(@@enable_info)
-        end
-
-
-        # Generate localized keys for secure SNMPv3 communications.
-        #
-        # @param config [Com::Vmware::Appliance::Techpreview::Monitoring::Snmp::SNMPHashConfig]
-        #     SNMP hash configuration.
-        # @return [Com::Vmware::Appliance::Techpreview::Monitoring::Snmp::SNMPHashResults]
-        #     SNMP hash result
-        # @raise [Com::Vmware::Vapi::Std::Errors::Error]
-        #     Generic error
-        def hash(config)
-            invoke_with_info(@@hash_info, {
-                'config' => config,
-            })
-        end
-
-
-        # Get SNMP limits information.
-        #
-        # @return [Com::Vmware::Appliance::Techpreview::Monitoring::Snmp::SNMPLimits]
-        #     SNMP limits structure
-        # @raise [Com::Vmware::Vapi::Std::Errors::Error]
-        #     Generic error
-        def limits()
-            invoke_with_info(@@limits_info)
-        end
-
-
-        # Return an SNMP agent configuration.
-        #
-        # @return [Com::Vmware::Appliance::Techpreview::Monitoring::Snmp::SNMPConfigReadOnly]
-        #     SNMP config structure
-        # @raise [Com::Vmware::Vapi::Std::Errors::Error]
-        #     Generic error
-        def get()
-            invoke_with_info(@@get_info)
-        end
-
-
-        # Stop an enabled SNMP agent.
-        #
-        # @return [Void]
-        # @raise [Com::Vmware::Vapi::Std::Errors::Error]
-        #     Generic error
-        def disable()
-            invoke_with_info(@@disable_info)
-        end
-
-
-        # Set SNMP configuration.
-        #
-        # @param config [Com::Vmware::Appliance::Techpreview::Monitoring::Snmp::SNMPConfig]
-        #     SNMP configuration.
-        # @return [Void]
-        # @raise [Com::Vmware::Vapi::Std::Errors::Error]
-        #     Generic error
-        def set(config)
-            invoke_with_info(@@set_info, {
-                'config' => config,
-            })
-        end
-
-
-        # Send a warmStart notification to all configured traps and inform destinations (see RFC 3418).
-        #
-        # @return [Com::Vmware::Appliance::Techpreview::Monitoring::Snmp::SNMPTestResults]
-        #     SNMP test result
-        # @raise [Com::Vmware::Vapi::Std::Errors::Error]
-        #     Generic error
-        def test()
-            invoke_with_info(@@test_info)
-        end
-
-
-        # Generate diagnostics report for snmp agent.
-        #
-        # @return [Com::Vmware::Appliance::Techpreview::Monitoring::Snmp::SNMPStats]
-        #     SNMP stats
-        # @raise [Com::Vmware::Vapi::Std::Errors::Error]
-        #     Generic error
-        def stats()
-            invoke_with_info(@@stats_info)
-        end
-
-
-
-        # ``Com::Vmware::Appliance::Techpreview::Monitoring::Snmp::SNMPLimits``   class  Structure that provides various limits of the SNMP agent.
-        # @!attribute [rw] max_communities
-        #     @return [Fixnum]
-        #     Set up maximum communities limit
-        # @!attribute [rw] max_trap_destinations_v1
-        #     @return [Fixnum]
-        #     Set up max trap destinations limit
-        # @!attribute [rw] max_destinations_v3
-        #     @return [Fixnum]
-        #     Set up max destinations limit
-        # @!attribute [rw] max_notification_filters
-        #     @return [Fixnum]
-        #     Set up max notification Filters
-        # @!attribute [rw] max_community_length
-        #     @return [Fixnum]
-        #     Set up max community length
-        # @!attribute [rw] max_buffer_size
-        #     @return [Fixnum]
-        #     Set up max buffer size
-        class SNMPLimits < VAPI::Bindings::VapiStruct
-
-            class << self
-                # Holds (gets or creates) the binding type metadata for this structure type.
-                # @scope class
-                # @return [VAPI::Bindings::StructType] the binding type
-                def binding_type
-                    @binding_type ||= VAPI::Bindings::StructType.new(
-                        'com.vmware.appliance.techpreview.monitoring.snmp.SNMP_limits',
-                        {
-                            'max_communities' => VAPI::Bindings::IntegerType.instance,
-                            'max_trap_destinations_v1' => VAPI::Bindings::IntegerType.instance,
-                            'max_destinations_v3' => VAPI::Bindings::IntegerType.instance,
-                            'max_notification_filters' => VAPI::Bindings::IntegerType.instance,
-                            'max_community_length' => VAPI::Bindings::IntegerType.instance,
-                            'max_buffer_size' => VAPI::Bindings::IntegerType.instance,
-                        },
-                        SNMPLimits,
-                        false,
-                        nil)
-                end
-            end
-
-            attr_accessor :max_communities,
-                          :max_trap_destinations_v1,
-                          :max_destinations_v3,
-                          :max_notification_filters,
-                          :max_community_length,
-                          :max_buffer_size
-
-            # Constructs a new instance.
-            # @param ruby_values [Hash] a map of initial property values (optional)
-            # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
-            def initialize(ruby_values=nil, struct_value=nil)
-                super(self.class.binding_type, ruby_values, struct_value)
-            end
-        end
-
-
-        # ``Com::Vmware::Appliance::Techpreview::Monitoring::Snmp::SNMPTestResults``   class  Structure to provide operators diagnostics test results.
-        # @!attribute [rw] success
-        #     @return [Boolean]
-        #     Set success to true/false
-        # @!attribute [rw] message
-        #     @return [String]
-        #     message
-        class SNMPTestResults < VAPI::Bindings::VapiStruct
-
-            class << self
-                # Holds (gets or creates) the binding type metadata for this structure type.
-                # @scope class
-                # @return [VAPI::Bindings::StructType] the binding type
-                def binding_type
-                    @binding_type ||= VAPI::Bindings::StructType.new(
-                        'com.vmware.appliance.techpreview.monitoring.snmp.SNMP_test_results',
-                        {
-                            'success' => VAPI::Bindings::BooleanType.instance,
-                            'message' => VAPI::Bindings::StringType.instance,
-                        },
-                        SNMPTestResults,
-                        false,
-                        nil)
-                end
-            end
-
-            attr_accessor :success,
-                          :message
-
-            # Constructs a new instance.
-            # @param ruby_values [Hash] a map of initial property values (optional)
-            # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
-            def initialize(ruby_values=nil, struct_value=nil)
-                super(self.class.binding_type, ruby_values, struct_value)
-            end
-        end
-
-
-        # ``Com::Vmware::Appliance::Techpreview::Monitoring::Snmp::SNMPStats``   class  Structure to provide operators diagnostics on snmp agent itself.
-        # @!attribute [rw] sysuptime
-        #     @return [String]
-        #     System uptime
-        # @!attribute [rw] worstrtimelast
-        #     @return [String]
-        #     Last updated time
-        # @!attribute [rw] avgresponsetime
-        #     @return [String]
-        #     Average response time
-        # @!attribute [rw] worstresponsetime
-        #     @return [String]
-        #     Response time
-        # @!attribute [rw] inpkts
-        #     @return [Fixnum]
-        #     No of input packets
-        # @!attribute [rw] outpkts
-        #     @return [Fixnum]
-        #     No of output packets
-        # @!attribute [rw] usmstatsnotintimewindows
-        #     @return [Fixnum]
-        #     No of stats not in time window
-        # @!attribute [rw] usmstatsunknownusernames
-        #     @return [Fixnum]
-        #     No of usm stats unknown
-        # @!attribute [rw] usmstatsunknownengineids
-        #     @return [Fixnum]
-        #     No of usm stats unknown engine ids
-        # @!attribute [rw] usmstatswrongdigests
-        #     @return [Fixnum]
-        #     No of wrogn digests
-        # @!attribute [rw] usmstatsdecryptionerrors
-        #     @return [Fixnum]
-        #     No. of decryption errors
-        # @!attribute [rw] inbadversions
-        #     @return [Fixnum]
-        #     No of bad versions
-        # @!attribute [rw] inbadcommunitynames
-        #     @return [Fixnum]
-        #     No of bad community names
-        # @!attribute [rw] inbadcommunityuses
-        #     @return [Fixnum]
-        #     No of bad community uses
-        # @!attribute [rw] inasnparseerrs
-        #     @return [Fixnum]
-        #     No of parse errors
-        # @!attribute [rw] intoobigs
-        #     @return [Fixnum]
-        #     No of too bigs
-        # @!attribute [rw] innosuchnames
-        #     @return [Fixnum]
-        #     No of no such names
-        # @!attribute [rw] inbadvalues
-        #     @return [Fixnum]
-        #     No of bad values
-        # @!attribute [rw] ingenerrs
-        #     @return [Fixnum]
-        #     No of gen errors
-        # @!attribute [rw] outtoobigs
-        #     @return [Fixnum]
-        #     No out output too bigs
-        # @!attribute [rw] outnosuchnames
-        #     @return [Fixnum]
-        #     No of no such names
-        # @!attribute [rw] outbadvalues
-        #     @return [Fixnum]
-        #     No of bad values
-        # @!attribute [rw] outgenerrs
-        #     @return [Fixnum]
-        #     No of gen errors
-        # @!attribute [rw] outtraps
-        #     @return [Fixnum]
-        #     No of output traps
-        # @!attribute [rw] silentdrops
-        #     @return [Fixnum]
-        #     No of silent drops
-        # @!attribute [rw] avgvarbinds
-        #     @return [Fixnum]
-        #     No of ave:rage var binds
-        # @!attribute [rw] maxvarbinds
-        #     @return [Fixnum]
-        #     No of max var binds
-        class SNMPStats < VAPI::Bindings::VapiStruct
-
-            class << self
-                # Holds (gets or creates) the binding type metadata for this structure type.
-                # @scope class
-                # @return [VAPI::Bindings::StructType] the binding type
-                def binding_type
-                    @binding_type ||= VAPI::Bindings::StructType.new(
-                        'com.vmware.appliance.techpreview.monitoring.snmp.SNMP_stats',
-                        {
-                            'sysuptime' => VAPI::Bindings::StringType.instance,
-                            'worstrtimelast' => VAPI::Bindings::StringType.instance,
-                            'avgresponsetime' => VAPI::Bindings::StringType.instance,
-                            'worstresponsetime' => VAPI::Bindings::StringType.instance,
-                            'inpkts' => VAPI::Bindings::IntegerType.instance,
-                            'outpkts' => VAPI::Bindings::IntegerType.instance,
-                            'usmstatsnotintimewindows' => VAPI::Bindings::IntegerType.instance,
-                            'usmstatsunknownusernames' => VAPI::Bindings::IntegerType.instance,
-                            'usmstatsunknownengineids' => VAPI::Bindings::IntegerType.instance,
-                            'usmstatswrongdigests' => VAPI::Bindings::IntegerType.instance,
-                            'usmstatsdecryptionerrors' => VAPI::Bindings::IntegerType.instance,
-                            'inbadversions' => VAPI::Bindings::IntegerType.instance,
-                            'inbadcommunitynames' => VAPI::Bindings::IntegerType.instance,
-                            'inbadcommunityuses' => VAPI::Bindings::IntegerType.instance,
-                            'inasnparseerrs' => VAPI::Bindings::IntegerType.instance,
-                            'intoobigs' => VAPI::Bindings::IntegerType.instance,
-                            'innosuchnames' => VAPI::Bindings::IntegerType.instance,
-                            'inbadvalues' => VAPI::Bindings::IntegerType.instance,
-                            'ingenerrs' => VAPI::Bindings::IntegerType.instance,
-                            'outtoobigs' => VAPI::Bindings::IntegerType.instance,
-                            'outnosuchnames' => VAPI::Bindings::IntegerType.instance,
-                            'outbadvalues' => VAPI::Bindings::IntegerType.instance,
-                            'outgenerrs' => VAPI::Bindings::IntegerType.instance,
-                            'outtraps' => VAPI::Bindings::IntegerType.instance,
-                            'silentdrops' => VAPI::Bindings::IntegerType.instance,
-                            'avgvarbinds' => VAPI::Bindings::IntegerType.instance,
-                            'maxvarbinds' => VAPI::Bindings::IntegerType.instance,
-                        },
-                        SNMPStats,
-                        false,
-                        nil)
-                end
-            end
-
-            attr_accessor :sysuptime,
-                          :worstrtimelast,
-                          :avgresponsetime,
-                          :worstresponsetime,
-                          :inpkts,
-                          :outpkts,
-                          :usmstatsnotintimewindows,
-                          :usmstatsunknownusernames,
-                          :usmstatsunknownengineids,
-                          :usmstatswrongdigests,
-                          :usmstatsdecryptionerrors,
-                          :inbadversions,
-                          :inbadcommunitynames,
-                          :inbadcommunityuses,
-                          :inasnparseerrs,
-                          :intoobigs,
-                          :innosuchnames,
-                          :inbadvalues,
-                          :ingenerrs,
-                          :outtoobigs,
-                          :outnosuchnames,
-                          :outbadvalues,
-                          :outgenerrs,
-                          :outtraps,
-                          :silentdrops,
-                          :avgvarbinds,
-                          :maxvarbinds
-
-            # Constructs a new instance.
-            # @param ruby_values [Hash] a map of initial property values (optional)
-            # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
-            def initialize(ruby_values=nil, struct_value=nil)
-                super(self.class.binding_type, ruby_values, struct_value)
-            end
-        end
-
-
-        # ``Com::Vmware::Appliance::Techpreview::Monitoring::Snmp::SNMPConfig``   class  Structure that defines the SNMP configuration, provided as input to set(), and never the result of get(). See SNMPConfigReadOnly. This structure is used to configure SNMP v1, v2c, and v3.
-        # @!attribute [rw] authentication
-        #     @return [Com::Vmware::Appliance::Techpreview::Monitoring::Snmp::SNMPAuthProto]
-        #     Set the default authentication protocol. Values can be none, MD5, or SHA1.
-        # @!attribute [rw] communities
-        #     @return [Array<String>]
-        #     Set up to ten communities, each of no more than 64 characters long. The format is: community1[,community2,...]. This setting overwrites any previous settings.
-        # @!attribute [rw] engineid
-        #     @return [String]
-        #     Set SNMPv3 engine ID. The engine ID must contain 5 to 32 hexadecimal characters. "0x" and colon (:) are removed from the ID.
-        # @!attribute [rw] loglevel
-        #     @return [String]
-        #     System Agent syslog logging level: debug|info|warning|error.
-        # @!attribute [rw] notraps
-        #     @return [Array<String>]
-        #     Comma-separated list of trap OIDs (object identifiers) for traps not to be sent by the agent. Use 'reset' to clear the setting.
-        # @!attribute [rw] port
-        #     @return [Fixnum]
-        #     Set up a UDP port which the SNMP agent uses to listen on for polling requests. The default UDP port is 161.
-        # @!attribute [rw] privacy
-        #     @return [Com::Vmware::Appliance::Techpreview::Monitoring::Snmp::SNMPPrivProto]
-        #     Set the default privacy protocol. Values: none or AES128.
-        # @!attribute [rw] remoteusers
-        #     @return [Array<String>]
-        #     Set up to five inform user IDs. The format is: user/auth-proto/-|auth-hash/priv-proto/-|priv-hash/engine-id[,...]. Here, user must be maximum 32 characters long; auth-proto is none, MD5 or SHA1; priv-proto is none or AES; '-' indicates no hash; engine-id is a hexadecimal string '0x0-9a-f' and must be up to 32 characters long.
-        # @!attribute [rw] syscontact
-        #     @return [String]
-        #     System contact string as presented in sysContact.0. Up to 255 characters long.
-        # @!attribute [rw] syslocation
-        #     @return [String]
-        #     System location string as presented in sysLocation.0. Up to 255 characters long.
-        # @!attribute [rw] targets
-        #     @return [Array<String>]
-        #     Set up to three targets to which to send SNMPv1 traps. The format is: ip-or-hostname[\@port]/community[,...]. The default port is UDP 162. This setting overwrites any previous settings.
-        # @!attribute [rw] users
-        #     @return [Array<String>]
-        #     Set up to five local users. The format is: user/-|auth-hash/-|priv-hash/model[,...]. Here user is maximum 32 characters long; '-' indicates no hash; model is one of none, auth or priv.
-        # @!attribute [rw] v3targets
-        #     @return [Array<String>]
-        #     Set up to three SNMPv3 notification targets. Format is: ip-or-hostname[\@port]/remote-user/security-level/trap|inform[,...].
-        class SNMPConfig < VAPI::Bindings::VapiStruct
-
-            class << self
-                # Holds (gets or creates) the binding type metadata for this structure type.
-                # @scope class
-                # @return [VAPI::Bindings::StructType] the binding type
-                def binding_type
-                    @binding_type ||= VAPI::Bindings::StructType.new(
-                        'com.vmware.appliance.techpreview.monitoring.snmp.SNMP_config',
-                        {
-                            'authentication' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Appliance::Techpreview::Monitoring::Snmp::SNMPAuthProto'),
-                            'communities' => VAPI::Bindings::ListType.new(VAPI::Bindings::StringType.instance),
-                            'engineid' => VAPI::Bindings::StringType.instance,
-                            'loglevel' => VAPI::Bindings::StringType.instance,
-                            'notraps' => VAPI::Bindings::ListType.new(VAPI::Bindings::StringType.instance),
-                            'port' => VAPI::Bindings::IntegerType.instance,
-                            'privacy' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Appliance::Techpreview::Monitoring::Snmp::SNMPPrivProto'),
-                            'remoteusers' => VAPI::Bindings::ListType.new(VAPI::Bindings::StringType.instance),
-                            'syscontact' => VAPI::Bindings::StringType.instance,
-                            'syslocation' => VAPI::Bindings::StringType.instance,
-                            'targets' => VAPI::Bindings::ListType.new(VAPI::Bindings::StringType.instance),
-                            'users' => VAPI::Bindings::ListType.new(VAPI::Bindings::StringType.instance),
-                            'v3targets' => VAPI::Bindings::ListType.new(VAPI::Bindings::StringType.instance),
-                        },
-                        SNMPConfig,
-                        false,
-                        nil)
-                end
-            end
-
-            attr_accessor :authentication,
-                          :communities,
-                          :engineid,
-                          :loglevel,
-                          :notraps,
-                          :port,
-                          :privacy,
-                          :remoteusers,
-                          :syscontact,
-                          :syslocation,
-                          :targets,
-                          :users,
-                          :v3targets
-
-            # Constructs a new instance.
-            # @param ruby_values [Hash] a map of initial property values (optional)
-            # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
-            def initialize(ruby_values=nil, struct_value=nil)
-                super(self.class.binding_type, ruby_values, struct_value)
-            end
-        end
-
-
-        # ``Com::Vmware::Appliance::Techpreview::Monitoring::Snmp::SNMPUser``   class  Structure that defines information associated with an SNMP user. authKey and privKey are localized keys defined in http://tools.ietf.org/html/rfc3826#section-1.2.
-        # @!attribute [rw] username
-        #     @return [String]
-        #     SNMP Username
-        # @!attribute [rw] sec_level
-        #     @return [Com::Vmware::Appliance::Techpreview::Monitoring::Snmp::SNMPSecLevel]
-        #     SNMP security level
-        # @!attribute [rw] auth_key
-        #     @return [String]
-        #     SNMP authorization key
-        # @!attribute [rw] priv_key
-        #     @return [String]
-        #     SNMP privacy key
-        class SNMPUser < VAPI::Bindings::VapiStruct
-
-            class << self
-                # Holds (gets or creates) the binding type metadata for this structure type.
-                # @scope class
-                # @return [VAPI::Bindings::StructType] the binding type
-                def binding_type
-                    @binding_type ||= VAPI::Bindings::StructType.new(
-                        'com.vmware.appliance.techpreview.monitoring.snmp.SNMP_user',
-                        {
-                            'username' => VAPI::Bindings::StringType.instance,
-                            'sec_level' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Appliance::Techpreview::Monitoring::Snmp::SNMPSecLevel'),
-                            'auth_key' => VAPI::Bindings::StringType.instance,
-                            'priv_key' => VAPI::Bindings::StringType.instance,
-                        },
-                        SNMPUser,
-                        false,
-                        nil)
-                end
-            end
-
-            attr_accessor :username,
-                          :sec_level,
-                          :auth_key,
-                          :priv_key
-
-            # Constructs a new instance.
-            # @param ruby_values [Hash] a map of initial property values (optional)
-            # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
-            def initialize(ruby_values=nil, struct_value=nil)
-                super(self.class.binding_type, ruby_values, struct_value)
-            end
-        end
-
-
-        # ``Com::Vmware::Appliance::Techpreview::Monitoring::Snmp::SNMPv3Target``   class  Structure that defines an SNMP v3 inform or trap target.
-        # @!attribute [rw] type
-        #     @return [Com::Vmware::Appliance::Techpreview::Monitoring::Snmp::SNMPv3Notfication]
-        #     SNMP target type
-        # @!attribute [rw] sec_level
-        #     @return [Com::Vmware::Appliance::Techpreview::Monitoring::Snmp::SNMPSecLevel]
-        #     SNMP security level
-        # @!attribute [rw] ip
-        #     @return [String]
-        #     SNMP target ip
-        # @!attribute [rw] port
-        #     @return [Fixnum]
-        #     SNMP target port
-        # @!attribute [rw] user
-        #     @return [String]
-        #     SNMP User
-        class SNMPv3Target < VAPI::Bindings::VapiStruct
-
-            class << self
-                # Holds (gets or creates) the binding type metadata for this structure type.
-                # @scope class
-                # @return [VAPI::Bindings::StructType] the binding type
-                def binding_type
-                    @binding_type ||= VAPI::Bindings::StructType.new(
-                        'com.vmware.appliance.techpreview.monitoring.snmp.SNM_pv3_target',
-                        {
-                            'type' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Appliance::Techpreview::Monitoring::Snmp::SNMPv3Notfication'),
-                            'sec_level' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Appliance::Techpreview::Monitoring::Snmp::SNMPSecLevel'),
-                            'ip' => VAPI::Bindings::StringType.instance,
-                            'port' => VAPI::Bindings::IntegerType.instance,
-                            'user' => VAPI::Bindings::StringType.instance,
-                        },
-                        SNMPv3Target,
-                        false,
-                        nil)
-                end
-            end
-
-            attr_accessor :type,
-                          :sec_level,
-                          :ip,
-                          :port,
-                          :user
-
-            # Constructs a new instance.
-            # @param ruby_values [Hash] a map of initial property values (optional)
-            # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
-            def initialize(ruby_values=nil, struct_value=nil)
-                super(self.class.binding_type, ruby_values, struct_value)
-            end
-        end
-
-
-        # ``Com::Vmware::Appliance::Techpreview::Monitoring::Snmp::SNMPv1TrapTarget``   class  Structure that defines an SNMP v1/v2c trap target.
-        # @!attribute [rw] ip
-        #     @return [String]
-        #     SNMP target ip
-        # @!attribute [rw] port
-        #     @return [Fixnum]
-        #     SNMP target port
-        # @!attribute [rw] community
-        #     @return [String]
-        #     SNMP target community
-        class SNMPv1TrapTarget < VAPI::Bindings::VapiStruct
-
-            class << self
-                # Holds (gets or creates) the binding type metadata for this structure type.
-                # @scope class
-                # @return [VAPI::Bindings::StructType] the binding type
-                def binding_type
-                    @binding_type ||= VAPI::Bindings::StructType.new(
-                        'com.vmware.appliance.techpreview.monitoring.snmp.SNM_pv1_trap_target',
-                        {
-                            'ip' => VAPI::Bindings::StringType.instance,
-                            'port' => VAPI::Bindings::IntegerType.instance,
-                            'community' => VAPI::Bindings::StringType.instance,
-                        },
-                        SNMPv1TrapTarget,
-                        false,
-                        nil)
-                end
-            end
-
-            attr_accessor :ip,
-                          :port,
-                          :community
-
-            # Constructs a new instance.
-            # @param ruby_values [Hash] a map of initial property values (optional)
-            # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
-            def initialize(ruby_values=nil, struct_value=nil)
-                super(self.class.binding_type, ruby_values, struct_value)
-            end
-        end
-
-
-        # ``Com::Vmware::Appliance::Techpreview::Monitoring::Snmp::SNMPRemoteUser``   class  Structure that defines a user at particular remote SNMPv3 entity needed when using informs. auth_key and priv_key contained localized keys as defined in http://tools.ietf.org/html/rfc3826#section-1.2.
-        # @!attribute [rw] username
-        #     @return [String]
-        #     SNMP Username
-        # @!attribute [rw] sec_level
-        #     @return [Com::Vmware::Appliance::Techpreview::Monitoring::Snmp::SNMPSecLevel]
-        #     SNMP security level
-        # @!attribute [rw] authentication
-        #     @return [Com::Vmware::Appliance::Techpreview::Monitoring::Snmp::SNMPAuthProto]
-        #     SNMP authorization protocol
-        # @!attribute [rw] auth_key
-        #     @return [String]
-        #     SNMP authorization key
-        # @!attribute [rw] privacy
-        #     @return [Com::Vmware::Appliance::Techpreview::Monitoring::Snmp::SNMPPrivProto]
-        #     SNMP privacy protocol
-        # @!attribute [rw] priv_key
-        #     @return [String]
-        #     SNMP privacy key
-        # @!attribute [rw] engineid
-        #     @return [String]
-        #     SNMP v3 engine id
-        class SNMPRemoteUser < VAPI::Bindings::VapiStruct
-
-            class << self
-                # Holds (gets or creates) the binding type metadata for this structure type.
-                # @scope class
-                # @return [VAPI::Bindings::StructType] the binding type
-                def binding_type
-                    @binding_type ||= VAPI::Bindings::StructType.new(
-                        'com.vmware.appliance.techpreview.monitoring.snmp.SNMP_remote_user',
-                        {
-                            'username' => VAPI::Bindings::StringType.instance,
-                            'sec_level' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Appliance::Techpreview::Monitoring::Snmp::SNMPSecLevel'),
-                            'authentication' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Appliance::Techpreview::Monitoring::Snmp::SNMPAuthProto'),
-                            'auth_key' => VAPI::Bindings::StringType.instance,
-                            'privacy' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Appliance::Techpreview::Monitoring::Snmp::SNMPPrivProto'),
-                            'priv_key' => VAPI::Bindings::StringType.instance,
-                            'engineid' => VAPI::Bindings::StringType.instance,
-                        },
-                        SNMPRemoteUser,
-                        false,
-                        nil)
-                end
-            end
-
-            attr_accessor :username,
-                          :sec_level,
-                          :authentication,
-                          :auth_key,
-                          :privacy,
-                          :priv_key,
-                          :engineid
-
-            # Constructs a new instance.
-            # @param ruby_values [Hash] a map of initial property values (optional)
-            # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
-            def initialize(ruby_values=nil, struct_value=nil)
-                super(self.class.binding_type, ruby_values, struct_value)
-            end
-        end
-
-
-        # ``Com::Vmware::Appliance::Techpreview::Monitoring::Snmp::SNMPConfigReadOnly``   class  Structure that defines the SNMP configuration, the result of get(), and never provided as input to set(). This structure differs from SNMPConfig because it contains localized keys (as defined in http://tools.ietf.org/html/rfc3826#section-1.2), instead of raw secret strings. This structure can be used to configure SNMP v1, v2c, and v3. Keep this structure in sync with vmw_snmp.py:_default_config(). Note that if a field if left empty, it is considered unset and will be ignored. Existing array elements below can be unset by sending an element with the string 'reset'.
-        # @!attribute [rw] authentication
-        #     @return [Com::Vmware::Appliance::Techpreview::Monitoring::Snmp::SNMPAuthProto]
-        #     Set the default authentication protocol. Values can be none, MD5, or SHA1.
-        # @!attribute [rw] communities
-        #     @return [Array<String>]
-        #     Set up to ten communities, each of no more than 64 characters long. The format is: community1[,community2,...]. This setting overwrites any previous settings.
-        # @!attribute [rw] enable
-        #     @return [Boolean]
-        #     Set enable to true/false
-        # @!attribute [rw] engineid
-        #     @return [String]
-        #     Set SNMPv3 engine ID.
-        # @!attribute [rw] loglevel
-        #     @return [String]
-        #     System Agent syslog logging level: debug|info|warning|error.
-        # @!attribute [rw] notraps
-        #     @return [Array<String>]
-        #     Comma-separated list of trap OIDs (object identifiers) for traps not to be sent by the agent. Use 'reset' to clear the setting.
-        # @!attribute [rw] port
-        #     @return [Fixnum]
-        #     Set up a UDP port which the SNMP agent uses to listen on for polling requests. The default UDP port is 161.
-        # @!attribute [rw] privacy
-        #     @return [Com::Vmware::Appliance::Techpreview::Monitoring::Snmp::SNMPPrivProto]
-        #     Set the default privacy protocol.
-        # @!attribute [rw] syscontact
-        #     @return [String]
-        #     System contact string as presented in sysContact.0. Up to 255 characters long.
-        # @!attribute [rw] syslocation
-        #     @return [String]
-        #     System location string as presented in sysLocation.0. Up to 255 characters long.
-        # @!attribute [rw] targets
-        #     @return [Array<Com::Vmware::Appliance::Techpreview::Monitoring::Snmp::SNMPv1TrapTarget>]
-        #     Set up to three targets to which to send SNMPv1 traps.
-        # @!attribute [rw] users
-        #     @return [Array<Com::Vmware::Appliance::Techpreview::Monitoring::Snmp::SNMPUser>]
-        #     Set up to five local users.
-        # @!attribute [rw] remoteusers
-        #     @return [Array<Com::Vmware::Appliance::Techpreview::Monitoring::Snmp::SNMPRemoteUser>]
-        #     Set up remote users.
-        # @!attribute [rw] v3targets
-        #     @return [Array<Com::Vmware::Appliance::Techpreview::Monitoring::Snmp::SNMPv3Target>]
-        #     Set up to three SNMPv3 notification targets. Format is: ip-or-hostname[\@port]/remote-user/security-level/trap|inform[,...].
-        # @!attribute [rw] pid
-        #     @return [String]
-        #     Set up pid
-        class SNMPConfigReadOnly < VAPI::Bindings::VapiStruct
-
-            class << self
-                # Holds (gets or creates) the binding type metadata for this structure type.
-                # @scope class
-                # @return [VAPI::Bindings::StructType] the binding type
-                def binding_type
-                    @binding_type ||= VAPI::Bindings::StructType.new(
-                        'com.vmware.appliance.techpreview.monitoring.snmp.SNMP_config_read_only',
-                        {
-                            'authentication' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Appliance::Techpreview::Monitoring::Snmp::SNMPAuthProto'),
-                            'communities' => VAPI::Bindings::ListType.new(VAPI::Bindings::StringType.instance),
-                            'enable' => VAPI::Bindings::BooleanType.instance,
-                            'engineid' => VAPI::Bindings::StringType.instance,
-                            'loglevel' => VAPI::Bindings::StringType.instance,
-                            'notraps' => VAPI::Bindings::ListType.new(VAPI::Bindings::StringType.instance),
-                            'port' => VAPI::Bindings::IntegerType.instance,
-                            'privacy' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Appliance::Techpreview::Monitoring::Snmp::SNMPPrivProto'),
-                            'syscontact' => VAPI::Bindings::StringType.instance,
-                            'syslocation' => VAPI::Bindings::StringType.instance,
-                            'targets' => VAPI::Bindings::ListType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Appliance::Techpreview::Monitoring::Snmp::SNMPv1TrapTarget')),
-                            'users' => VAPI::Bindings::ListType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Appliance::Techpreview::Monitoring::Snmp::SNMPUser')),
-                            'remoteusers' => VAPI::Bindings::ListType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Appliance::Techpreview::Monitoring::Snmp::SNMPRemoteUser')),
-                            'v3targets' => VAPI::Bindings::ListType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Appliance::Techpreview::Monitoring::Snmp::SNMPv3Target')),
-                            'pid' => VAPI::Bindings::StringType.instance,
-                        },
-                        SNMPConfigReadOnly,
-                        false,
-                        nil)
-                end
-            end
-
-            attr_accessor :authentication,
-                          :communities,
-                          :enable,
-                          :engineid,
-                          :loglevel,
-                          :notraps,
-                          :port,
-                          :privacy,
-                          :syscontact,
-                          :syslocation,
-                          :targets,
-                          :users,
-                          :remoteusers,
-                          :v3targets,
-                          :pid
-
-            # Constructs a new instance.
-            # @param ruby_values [Hash] a map of initial property values (optional)
-            # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
-            def initialize(ruby_values=nil, struct_value=nil)
-                super(self.class.binding_type, ruby_values, struct_value)
-            end
-        end
-
-
-        # ``Com::Vmware::Appliance::Techpreview::Monitoring::Snmp::SNMPHashConfig``   class  Structure to provide up to two secrets to combine with the SNMPv3 engine ID and authentication or privacy protocol to form a localized hash. auth_hash is always required, priv_hash can be empty. By default arguments are paths on the local filesystem, raw_secret takes path to be the actual raw secret. First implementation was in ESXi: esxcli system snmp hash --help
-        # @!attribute [rw] auth_hash
-        #     @return [String]
-        #     Provide filename to secret for authentication hash, use in set --users (required secret)
-        # @!attribute [rw] priv_hash
-        #     @return [String]
-        #     Provide filename to secret for privacy hash, use in set --users (secret)
-        # @!attribute [rw] raw_secret
-        #     @return [Boolean]
-        #     Make --auth_path and --priv_path flags read raw secret from command line instead of file.
-        class SNMPHashConfig < VAPI::Bindings::VapiStruct
-
-            class << self
-                # Holds (gets or creates) the binding type metadata for this structure type.
-                # @scope class
-                # @return [VAPI::Bindings::StructType] the binding type
-                def binding_type
-                    @binding_type ||= VAPI::Bindings::StructType.new(
-                        'com.vmware.appliance.techpreview.monitoring.snmp.SNMP_hash_config',
-                        {
-                            'auth_hash' => VAPI::Bindings::StringType.instance,
-                            'priv_hash' => VAPI::Bindings::StringType.instance,
-                            'raw_secret' => VAPI::Bindings::BooleanType.instance,
-                        },
-                        SNMPHashConfig,
-                        false,
-                        nil)
-                end
-            end
-
-            attr_accessor :auth_hash,
-                          :priv_hash,
-                          :raw_secret
-
-            # Constructs a new instance.
-            # @param ruby_values [Hash] a map of initial property values (optional)
-            # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
-            def initialize(ruby_values=nil, struct_value=nil)
-                super(self.class.binding_type, ruby_values, struct_value)
-            end
-        end
-
-
-        # ``Com::Vmware::Appliance::Techpreview::Monitoring::Snmp::SNMPHashResults``   class  Structure to provide operators diagnostics test results.
-        # @!attribute [rw] auth_key
-        #     @return [String]
-        #     SNMP authentication key
-        # @!attribute [rw] priv_key
-        #     @return [String]
-        #     SNMP privacy key
-        class SNMPHashResults < VAPI::Bindings::VapiStruct
-
-            class << self
-                # Holds (gets or creates) the binding type metadata for this structure type.
-                # @scope class
-                # @return [VAPI::Bindings::StructType] the binding type
-                def binding_type
-                    @binding_type ||= VAPI::Bindings::StructType.new(
-                        'com.vmware.appliance.techpreview.monitoring.snmp.SNMP_hash_results',
-                        {
-                            'auth_key' => VAPI::Bindings::StringType.instance,
-                            'priv_key' => VAPI::Bindings::StringType.instance,
-                        },
-                        SNMPHashResults,
-                        false,
-                        nil)
-                end
-            end
-
-            attr_accessor :auth_key,
-                          :priv_key
-
-            # Constructs a new instance.
-            # @param ruby_values [Hash] a map of initial property values (optional)
-            # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
-            def initialize(ruby_values=nil, struct_value=nil)
-                super(self.class.binding_type, ruby_values, struct_value)
-            end
-        end
-
-
-
-        # ``Com::Vmware::Appliance::Techpreview::Monitoring::Snmp::SNMPAuthProto``   enumerated type  Defines SNMP authentication protocols
-        # @!attribute [rw] none
-        #     @return [Com::Vmware::Appliance::Techpreview::Monitoring::Snmp::SNMPAuthProto]
-        #     NONE
-        # @!attribute [rw] sh_a1
-        #     @return [Com::Vmware::Appliance::Techpreview::Monitoring::Snmp::SNMPAuthProto]
-        #     SHA1
-        # @!attribute [rw] m_d5
-        #     @return [Com::Vmware::Appliance::Techpreview::Monitoring::Snmp::SNMPAuthProto]
-        #     MD5
-        class SNMPAuthProto < VAPI::Bindings::VapiEnum
-
-            class << self
-                # Holds (gets or creates) the binding type metadata for this enumeration type.
-                # @scope class
-                # @return [VAPI::Bindings::EnumType] the binding type
-                def binding_type
-                    @binding_type ||= VAPI::Bindings::EnumType.new(
-                        'com.vmware.appliance.techpreview.monitoring.snmp.SNMP_auth_proto',
-                        SNMPAuthProto)
-                end
-
-                # Converts from a string value (perhaps off the wire) to an instance
-                # of this enum type.
-                # @param value [String] the actual value of the enum instance
-                # @return [SNMPAuthProto] the instance found for the value, otherwise
-                #         an unknown instance will be built for the value
-                def from_string(value)
-                    begin
-                        const_get(value)
-                    rescue NameError
-                        SNMPAuthProto.new('UNKNOWN', value)
-                    end
-                end
-            end
-
-            private
-
-            # Constructs a new instance.
-            # @param value [String] the actual value of the enum instance
-            # @param unknown [String] the unknown value when value is 'UKNOWN'
-            def initialize(value, unknown=nil)
-                super(self.class.binding_type, value, unknown)
-            end
-
-            public
-
-            # @!attribute [rw] none
-            #     @return [Com::Vmware::Appliance::Techpreview::Monitoring::Snmp::SNMPAuthProto]
-            #     NONE
-            NONE = SNMPAuthProto.new('NONE')
-
-            # @!attribute [rw] sh_a1
-            #     @return [Com::Vmware::Appliance::Techpreview::Monitoring::Snmp::SNMPAuthProto]
-            #     SHA1
-            SH_A1 = SNMPAuthProto.new('SH_A1')
-
-            # @!attribute [rw] m_d5
-            #     @return [Com::Vmware::Appliance::Techpreview::Monitoring::Snmp::SNMPAuthProto]
-            #     MD5
-            M_D5 = SNMPAuthProto.new('M_D5')
-
-        end
-
-
-        # ``Com::Vmware::Appliance::Techpreview::Monitoring::Snmp::SNMPPrivProto``   enumerated type  Defines SNMP privacy protocols
-        # @!attribute [rw] ae_s128
-        #     @return [Com::Vmware::Appliance::Techpreview::Monitoring::Snmp::SNMPPrivProto]
-        #     AES128
-        # @!attribute [rw] none
-        #     @return [Com::Vmware::Appliance::Techpreview::Monitoring::Snmp::SNMPPrivProto]
-        #     NONE
-        class SNMPPrivProto < VAPI::Bindings::VapiEnum
-
-            class << self
-                # Holds (gets or creates) the binding type metadata for this enumeration type.
-                # @scope class
-                # @return [VAPI::Bindings::EnumType] the binding type
-                def binding_type
-                    @binding_type ||= VAPI::Bindings::EnumType.new(
-                        'com.vmware.appliance.techpreview.monitoring.snmp.SNMP_priv_proto',
-                        SNMPPrivProto)
-                end
-
-                # Converts from a string value (perhaps off the wire) to an instance
-                # of this enum type.
-                # @param value [String] the actual value of the enum instance
-                # @return [SNMPPrivProto] the instance found for the value, otherwise
-                #         an unknown instance will be built for the value
-                def from_string(value)
-                    begin
-                        const_get(value)
-                    rescue NameError
-                        SNMPPrivProto.new('UNKNOWN', value)
-                    end
-                end
-            end
-
-            private
-
-            # Constructs a new instance.
-            # @param value [String] the actual value of the enum instance
-            # @param unknown [String] the unknown value when value is 'UKNOWN'
-            def initialize(value, unknown=nil)
-                super(self.class.binding_type, value, unknown)
-            end
-
-            public
-
-            # @!attribute [rw] ae_s128
-            #     @return [Com::Vmware::Appliance::Techpreview::Monitoring::Snmp::SNMPPrivProto]
-            #     AES128
-            AE_S128 = SNMPPrivProto.new('AE_S128')
-
-            # @!attribute [rw] none
-            #     @return [Com::Vmware::Appliance::Techpreview::Monitoring::Snmp::SNMPPrivProto]
-            #     NONE
-            NONE = SNMPPrivProto.new('NONE')
-
-        end
-
-
-        # ``Com::Vmware::Appliance::Techpreview::Monitoring::Snmp::SNMPSecLevel``   enumerated type  Defines SNMP decurity levels
-        # @!attribute [rw] none
-        #     @return [Com::Vmware::Appliance::Techpreview::Monitoring::Snmp::SNMPSecLevel]
-        #     none
-        # @!attribute [rw] auth
-        #     @return [Com::Vmware::Appliance::Techpreview::Monitoring::Snmp::SNMPSecLevel]
-        #     auth
-        # @!attribute [rw] priv
-        #     @return [Com::Vmware::Appliance::Techpreview::Monitoring::Snmp::SNMPSecLevel]
-        #     priv
-        class SNMPSecLevel < VAPI::Bindings::VapiEnum
-
-            class << self
-                # Holds (gets or creates) the binding type metadata for this enumeration type.
-                # @scope class
-                # @return [VAPI::Bindings::EnumType] the binding type
-                def binding_type
-                    @binding_type ||= VAPI::Bindings::EnumType.new(
-                        'com.vmware.appliance.techpreview.monitoring.snmp.SNMP_sec_level',
-                        SNMPSecLevel)
-                end
-
-                # Converts from a string value (perhaps off the wire) to an instance
-                # of this enum type.
-                # @param value [String] the actual value of the enum instance
-                # @return [SNMPSecLevel] the instance found for the value, otherwise
-                #         an unknown instance will be built for the value
-                def from_string(value)
-                    begin
-                        const_get(value)
-                    rescue NameError
-                        SNMPSecLevel.new('UNKNOWN', value)
-                    end
-                end
-            end
-
-            private
-
-            # Constructs a new instance.
-            # @param value [String] the actual value of the enum instance
-            # @param unknown [String] the unknown value when value is 'UKNOWN'
-            def initialize(value, unknown=nil)
-                super(self.class.binding_type, value, unknown)
-            end
-
-            public
-
-            # @!attribute [rw] none
-            #     @return [Com::Vmware::Appliance::Techpreview::Monitoring::Snmp::SNMPSecLevel]
-            #     none
-            NONE = SNMPSecLevel.new('NONE')
-
-            # @!attribute [rw] auth
-            #     @return [Com::Vmware::Appliance::Techpreview::Monitoring::Snmp::SNMPSecLevel]
-            #     auth
-            AUTH = SNMPSecLevel.new('AUTH')
-
-            # @!attribute [rw] priv
-            #     @return [Com::Vmware::Appliance::Techpreview::Monitoring::Snmp::SNMPSecLevel]
-            #     priv
-            PRIV = SNMPSecLevel.new('PRIV')
-
-        end
-
-
-        # ``Com::Vmware::Appliance::Techpreview::Monitoring::Snmp::SNMPv3Notfication``   enumerated type  Defines SNMP v3 notification types
-        # @!attribute [rw] inform
-        #     @return [Com::Vmware::Appliance::Techpreview::Monitoring::Snmp::SNMPv3Notfication]
-        #     inform
-        # @!attribute [rw] trap
-        #     @return [Com::Vmware::Appliance::Techpreview::Monitoring::Snmp::SNMPv3Notfication]
-        #     trap
-        class SNMPv3Notfication < VAPI::Bindings::VapiEnum
-
-            class << self
-                # Holds (gets or creates) the binding type metadata for this enumeration type.
-                # @scope class
-                # @return [VAPI::Bindings::EnumType] the binding type
-                def binding_type
-                    @binding_type ||= VAPI::Bindings::EnumType.new(
-                        'com.vmware.appliance.techpreview.monitoring.snmp.SNM_pv3_notfication',
-                        SNMPv3Notfication)
-                end
-
-                # Converts from a string value (perhaps off the wire) to an instance
-                # of this enum type.
-                # @param value [String] the actual value of the enum instance
-                # @return [SNMPv3Notfication] the instance found for the value, otherwise
-                #         an unknown instance will be built for the value
-                def from_string(value)
-                    begin
-                        const_get(value)
-                    rescue NameError
-                        SNMPv3Notfication.new('UNKNOWN', value)
-                    end
-                end
-            end
-
-            private
-
-            # Constructs a new instance.
-            # @param value [String] the actual value of the enum instance
-            # @param unknown [String] the unknown value when value is 'UKNOWN'
-            def initialize(value, unknown=nil)
-                super(self.class.binding_type, value, unknown)
-            end
-
-            public
-
-            # @!attribute [rw] inform
-            #     @return [Com::Vmware::Appliance::Techpreview::Monitoring::Snmp::SNMPv3Notfication]
-            #     inform
-            INFORM = SNMPv3Notfication.new('INFORM')
-
-            # @!attribute [rw] trap
-            #     @return [Com::Vmware::Appliance::Techpreview::Monitoring::Snmp::SNMPv3Notfication]
-            #     trap
-            TRAP = SNMPv3Notfication.new('TRAP')
-
-        end
-
-
+  # ``Com::Vmware::Appliance::Techpreview::Monitoring::Snmp``   class  provides  methods  SNMP agent operations.
+  class Snmp < VAPI::Bindings::VapiService
+    # static metamodel definitions
+    SERVICE_ID = VAPI::Core::ServiceIdentifier.new('com.vmware.appliance.techpreview.monitoring.snmp')
+
+    RESET_INFO = VAPI::Bindings::OperationInfo.new(
+      VAPI::Core::OperationIdentifier.new('reset', SERVICE_ID),
+      VAPI::Bindings::OperationInputType.new,
+      VAPI::Bindings::VoidType.instance,
+      {
+        'com.vmware.vapi.std.errors.error' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Error')
+      },
+      [],
+      []
+    )
+
+    ENABLE_INFO = VAPI::Bindings::OperationInfo.new(
+      VAPI::Core::OperationIdentifier.new('enable', SERVICE_ID),
+      VAPI::Bindings::OperationInputType.new,
+      VAPI::Bindings::VoidType.instance,
+      {
+        'com.vmware.vapi.std.errors.error' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Error')
+      },
+      [],
+      []
+    )
+
+    HASH_INFO = VAPI::Bindings::OperationInfo.new(
+      VAPI::Core::OperationIdentifier.new('hash', SERVICE_ID),
+      VAPI::Bindings::OperationInputType.new(
+        'config' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Appliance::Techpreview::Monitoring::Snmp::SNMPHashConfig')
+      ),
+      VAPI::Bindings::ReferenceType.new('Com::Vmware::Appliance::Techpreview::Monitoring::Snmp::SNMPHashResults'),
+      {
+        'com.vmware.vapi.std.errors.error' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Error')
+      },
+      [],
+      []
+    )
+
+    LIMITS_INFO = VAPI::Bindings::OperationInfo.new(
+      VAPI::Core::OperationIdentifier.new('limits', SERVICE_ID),
+      VAPI::Bindings::OperationInputType.new,
+      VAPI::Bindings::ReferenceType.new('Com::Vmware::Appliance::Techpreview::Monitoring::Snmp::SNMPLimits'),
+      {
+        'com.vmware.vapi.std.errors.error' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Error')
+      },
+      [],
+      []
+    )
+
+    GET_INFO = VAPI::Bindings::OperationInfo.new(
+      VAPI::Core::OperationIdentifier.new('get', SERVICE_ID),
+      VAPI::Bindings::OperationInputType.new,
+      VAPI::Bindings::ReferenceType.new('Com::Vmware::Appliance::Techpreview::Monitoring::Snmp::SNMPConfigReadOnly'),
+      {
+        'com.vmware.vapi.std.errors.error' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Error')
+      },
+      [],
+      []
+    )
+
+    DISABLE_INFO = VAPI::Bindings::OperationInfo.new(
+      VAPI::Core::OperationIdentifier.new('disable', SERVICE_ID),
+      VAPI::Bindings::OperationInputType.new,
+      VAPI::Bindings::VoidType.instance,
+      {
+        'com.vmware.vapi.std.errors.error' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Error')
+      },
+      [],
+      []
+    )
+
+    SET_INFO = VAPI::Bindings::OperationInfo.new(
+      VAPI::Core::OperationIdentifier.new('set', SERVICE_ID),
+      VAPI::Bindings::OperationInputType.new(
+        'config' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Appliance::Techpreview::Monitoring::Snmp::SNMPConfig')
+      ),
+      VAPI::Bindings::VoidType.instance,
+      {
+        'com.vmware.vapi.std.errors.error' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Error')
+      },
+      [],
+      []
+    )
+
+    TEST_INFO = VAPI::Bindings::OperationInfo.new(
+      VAPI::Core::OperationIdentifier.new('test', SERVICE_ID),
+      VAPI::Bindings::OperationInputType.new,
+      VAPI::Bindings::ReferenceType.new('Com::Vmware::Appliance::Techpreview::Monitoring::Snmp::SNMPTestResults'),
+      {
+        'com.vmware.vapi.std.errors.error' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Error')
+      },
+      [],
+      []
+    )
+
+    STATS_INFO = VAPI::Bindings::OperationInfo.new(
+      VAPI::Core::OperationIdentifier.new('stats', SERVICE_ID),
+      VAPI::Bindings::OperationInputType.new,
+      VAPI::Bindings::ReferenceType.new('Com::Vmware::Appliance::Techpreview::Monitoring::Snmp::SNMPStats'),
+      {
+        'com.vmware.vapi.std.errors.error' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Error')
+      },
+      [],
+      []
+    )
+
+    SERVICE_INFO = VAPI::Bindings::ServiceInfo.new(
+      SERVICE_ID,
+      'reset' => RESET_INFO,
+      'enable' => ENABLE_INFO,
+      'hash' => HASH_INFO,
+      'limits' => LIMITS_INFO,
+      'get' => GET_INFO,
+      'disable' => DISABLE_INFO,
+      'set' => SET_INFO,
+      'test' => TEST_INFO,
+      'stats' => STATS_INFO
+    )
+
+    # Constructs a new instance.
+    #
+    # @param config [VAPI::Bindings::StubConfig] A hash with the api provider details.
+    def initialize(config)
+      super(config, SERVICE_INFO)
     end
 
+    # Restore settings to factory defaults.
+    #
+    # @return [Void]
+    # @raise [Com::Vmware::Vapi::Std::Errors::Error]
+    #     Generic error
+    def reset
+      invoke_with_info(RESET_INFO)
+    end
 
+    # Start a disabled SNMP agent.
+    #
+    # @return [Void]
+    # @raise [Com::Vmware::Vapi::Std::Errors::Error]
+    #     Generic error
+    def enable
+      invoke_with_info(ENABLE_INFO)
+    end
+
+    # Generate localized keys for secure SNMPv3 communications.
+    #
+    # @param config [Com::Vmware::Appliance::Techpreview::Monitoring::Snmp::SNMPHashConfig]
+    #     SNMP hash configuration.
+    # @return [Com::Vmware::Appliance::Techpreview::Monitoring::Snmp::SNMPHashResults]
+    #     SNMP hash result
+    # @raise [Com::Vmware::Vapi::Std::Errors::Error]
+    #     Generic error
+    def hash(config)
+      invoke_with_info(HASH_INFO,
+                       'config' => config)
+    end
+
+    # Get SNMP limits information.
+    #
+    # @return [Com::Vmware::Appliance::Techpreview::Monitoring::Snmp::SNMPLimits]
+    #     SNMP limits structure
+    # @raise [Com::Vmware::Vapi::Std::Errors::Error]
+    #     Generic error
+    def limits
+      invoke_with_info(LIMITS_INFO)
+    end
+
+    # Return an SNMP agent configuration.
+    #
+    # @return [Com::Vmware::Appliance::Techpreview::Monitoring::Snmp::SNMPConfigReadOnly]
+    #     SNMP config structure
+    # @raise [Com::Vmware::Vapi::Std::Errors::Error]
+    #     Generic error
+    def get
+      invoke_with_info(GET_INFO)
+    end
+
+    # Stop an enabled SNMP agent.
+    #
+    # @return [Void]
+    # @raise [Com::Vmware::Vapi::Std::Errors::Error]
+    #     Generic error
+    def disable
+      invoke_with_info(DISABLE_INFO)
+    end
+
+    # Set SNMP configuration.
+    #
+    # @param config [Com::Vmware::Appliance::Techpreview::Monitoring::Snmp::SNMPConfig]
+    #     SNMP configuration.
+    # @return [Void]
+    # @raise [Com::Vmware::Vapi::Std::Errors::Error]
+    #     Generic error
+    def set(config)
+      invoke_with_info(SET_INFO,
+                       'config' => config)
+    end
+
+    # Send a warmStart notification to all configured traps and inform destinations (see RFC 3418).
+    #
+    # @return [Com::Vmware::Appliance::Techpreview::Monitoring::Snmp::SNMPTestResults]
+    #     SNMP test result
+    # @raise [Com::Vmware::Vapi::Std::Errors::Error]
+    #     Generic error
+    def test
+      invoke_with_info(TEST_INFO)
+    end
+
+    # Generate diagnostics report for snmp agent.
+    #
+    # @return [Com::Vmware::Appliance::Techpreview::Monitoring::Snmp::SNMPStats]
+    #     SNMP stats
+    # @raise [Com::Vmware::Vapi::Std::Errors::Error]
+    #     Generic error
+    def stats
+      invoke_with_info(STATS_INFO)
+    end
+
+    # ``Com::Vmware::Appliance::Techpreview::Monitoring::Snmp::SNMPLimits``   class  Structure that provides various limits of the SNMP agent.
+    # @!attribute [rw] max_communities
+    #     @return [Fixnum]
+    #     Set up maximum communities limit
+    # @!attribute [rw] max_trap_destinations_v1
+    #     @return [Fixnum]
+    #     Set up max trap destinations limit
+    # @!attribute [rw] max_destinations_v3
+    #     @return [Fixnum]
+    #     Set up max destinations limit
+    # @!attribute [rw] max_notification_filters
+    #     @return [Fixnum]
+    #     Set up max notification Filters
+    # @!attribute [rw] max_community_length
+    #     @return [Fixnum]
+    #     Set up max community length
+    # @!attribute [rw] max_buffer_size
+    #     @return [Fixnum]
+    #     Set up max buffer size
+    class SNMPLimits < VAPI::Bindings::VapiStruct
+      class << self
+        # Holds (gets or creates) the binding type metadata for this structure type.
+        # @scope class
+        # @return [VAPI::Bindings::StructType] the binding type
+        def binding_type
+          @binding_type ||= VAPI::Bindings::StructType.new(
+            'com.vmware.appliance.techpreview.monitoring.snmp.SNMP_limits',
+            {
+              'max_communities' => VAPI::Bindings::IntegerType.instance,
+              'max_trap_destinations_v1' => VAPI::Bindings::IntegerType.instance,
+              'max_destinations_v3' => VAPI::Bindings::IntegerType.instance,
+              'max_notification_filters' => VAPI::Bindings::IntegerType.instance,
+              'max_community_length' => VAPI::Bindings::IntegerType.instance,
+              'max_buffer_size' => VAPI::Bindings::IntegerType.instance
+            },
+            SNMPLimits,
+            false,
+            nil
+          )
+        end
+      end
+
+      attr_accessor :max_communities,
+                    :max_trap_destinations_v1,
+                    :max_destinations_v3,
+                    :max_notification_filters,
+                    :max_community_length,
+                    :max_buffer_size
+
+      # Constructs a new instance.
+      # @param ruby_values [Hash] a map of initial property values (optional)
+      # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
+      def initialize(ruby_values = nil, struct_value = nil)
+        super(self.class.binding_type, ruby_values, struct_value)
+      end
+    end
+
+    # ``Com::Vmware::Appliance::Techpreview::Monitoring::Snmp::SNMPTestResults``   class  Structure to provide operators diagnostics test results.
+    # @!attribute [rw] success
+    #     @return [Boolean]
+    #     Set success to true/false
+    # @!attribute [rw] message
+    #     @return [String]
+    #     message
+    class SNMPTestResults < VAPI::Bindings::VapiStruct
+      class << self
+        # Holds (gets or creates) the binding type metadata for this structure type.
+        # @scope class
+        # @return [VAPI::Bindings::StructType] the binding type
+        def binding_type
+          @binding_type ||= VAPI::Bindings::StructType.new(
+            'com.vmware.appliance.techpreview.monitoring.snmp.SNMP_test_results',
+            {
+              'success' => VAPI::Bindings::BooleanType.instance,
+              'message' => VAPI::Bindings::StringType.instance
+            },
+            SNMPTestResults,
+            false,
+            nil
+          )
+        end
+      end
+
+      attr_accessor :success,
+                    :message
+
+      # Constructs a new instance.
+      # @param ruby_values [Hash] a map of initial property values (optional)
+      # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
+      def initialize(ruby_values = nil, struct_value = nil)
+        super(self.class.binding_type, ruby_values, struct_value)
+      end
+    end
+
+    # ``Com::Vmware::Appliance::Techpreview::Monitoring::Snmp::SNMPStats``   class  Structure to provide operators diagnostics on snmp agent itself.
+    # @!attribute [rw] sysuptime
+    #     @return [String]
+    #     System uptime
+    # @!attribute [rw] worstrtimelast
+    #     @return [String]
+    #     Last updated time
+    # @!attribute [rw] avgresponsetime
+    #     @return [String]
+    #     Average response time
+    # @!attribute [rw] worstresponsetime
+    #     @return [String]
+    #     Response time
+    # @!attribute [rw] inpkts
+    #     @return [Fixnum]
+    #     No of input packets
+    # @!attribute [rw] outpkts
+    #     @return [Fixnum]
+    #     No of output packets
+    # @!attribute [rw] usmstatsnotintimewindows
+    #     @return [Fixnum]
+    #     No of stats not in time window
+    # @!attribute [rw] usmstatsunknownusernames
+    #     @return [Fixnum]
+    #     No of usm stats unknown
+    # @!attribute [rw] usmstatsunknownengineids
+    #     @return [Fixnum]
+    #     No of usm stats unknown engine ids
+    # @!attribute [rw] usmstatswrongdigests
+    #     @return [Fixnum]
+    #     No of wrogn digests
+    # @!attribute [rw] usmstatsdecryptionerrors
+    #     @return [Fixnum]
+    #     No. of decryption errors
+    # @!attribute [rw] inbadversions
+    #     @return [Fixnum]
+    #     No of bad versions
+    # @!attribute [rw] inbadcommunitynames
+    #     @return [Fixnum]
+    #     No of bad community names
+    # @!attribute [rw] inbadcommunityuses
+    #     @return [Fixnum]
+    #     No of bad community uses
+    # @!attribute [rw] inasnparseerrs
+    #     @return [Fixnum]
+    #     No of parse errors
+    # @!attribute [rw] intoobigs
+    #     @return [Fixnum]
+    #     No of too bigs
+    # @!attribute [rw] innosuchnames
+    #     @return [Fixnum]
+    #     No of no such names
+    # @!attribute [rw] inbadvalues
+    #     @return [Fixnum]
+    #     No of bad values
+    # @!attribute [rw] ingenerrs
+    #     @return [Fixnum]
+    #     No of gen errors
+    # @!attribute [rw] outtoobigs
+    #     @return [Fixnum]
+    #     No out output too bigs
+    # @!attribute [rw] outnosuchnames
+    #     @return [Fixnum]
+    #     No of no such names
+    # @!attribute [rw] outbadvalues
+    #     @return [Fixnum]
+    #     No of bad values
+    # @!attribute [rw] outgenerrs
+    #     @return [Fixnum]
+    #     No of gen errors
+    # @!attribute [rw] outtraps
+    #     @return [Fixnum]
+    #     No of output traps
+    # @!attribute [rw] silentdrops
+    #     @return [Fixnum]
+    #     No of silent drops
+    # @!attribute [rw] avgvarbinds
+    #     @return [Fixnum]
+    #     No of ave:rage var binds
+    # @!attribute [rw] maxvarbinds
+    #     @return [Fixnum]
+    #     No of max var binds
+    class SNMPStats < VAPI::Bindings::VapiStruct
+      class << self
+        # Holds (gets or creates) the binding type metadata for this structure type.
+        # @scope class
+        # @return [VAPI::Bindings::StructType] the binding type
+        def binding_type
+          @binding_type ||= VAPI::Bindings::StructType.new(
+            'com.vmware.appliance.techpreview.monitoring.snmp.SNMP_stats',
+            {
+              'sysuptime' => VAPI::Bindings::StringType.instance,
+              'worstrtimelast' => VAPI::Bindings::StringType.instance,
+              'avgresponsetime' => VAPI::Bindings::StringType.instance,
+              'worstresponsetime' => VAPI::Bindings::StringType.instance,
+              'inpkts' => VAPI::Bindings::IntegerType.instance,
+              'outpkts' => VAPI::Bindings::IntegerType.instance,
+              'usmstatsnotintimewindows' => VAPI::Bindings::IntegerType.instance,
+              'usmstatsunknownusernames' => VAPI::Bindings::IntegerType.instance,
+              'usmstatsunknownengineids' => VAPI::Bindings::IntegerType.instance,
+              'usmstatswrongdigests' => VAPI::Bindings::IntegerType.instance,
+              'usmstatsdecryptionerrors' => VAPI::Bindings::IntegerType.instance,
+              'inbadversions' => VAPI::Bindings::IntegerType.instance,
+              'inbadcommunitynames' => VAPI::Bindings::IntegerType.instance,
+              'inbadcommunityuses' => VAPI::Bindings::IntegerType.instance,
+              'inasnparseerrs' => VAPI::Bindings::IntegerType.instance,
+              'intoobigs' => VAPI::Bindings::IntegerType.instance,
+              'innosuchnames' => VAPI::Bindings::IntegerType.instance,
+              'inbadvalues' => VAPI::Bindings::IntegerType.instance,
+              'ingenerrs' => VAPI::Bindings::IntegerType.instance,
+              'outtoobigs' => VAPI::Bindings::IntegerType.instance,
+              'outnosuchnames' => VAPI::Bindings::IntegerType.instance,
+              'outbadvalues' => VAPI::Bindings::IntegerType.instance,
+              'outgenerrs' => VAPI::Bindings::IntegerType.instance,
+              'outtraps' => VAPI::Bindings::IntegerType.instance,
+              'silentdrops' => VAPI::Bindings::IntegerType.instance,
+              'avgvarbinds' => VAPI::Bindings::IntegerType.instance,
+              'maxvarbinds' => VAPI::Bindings::IntegerType.instance
+            },
+            SNMPStats,
+            false,
+            nil
+          )
+        end
+      end
+
+      attr_accessor :sysuptime,
+                    :worstrtimelast,
+                    :avgresponsetime,
+                    :worstresponsetime,
+                    :inpkts,
+                    :outpkts,
+                    :usmstatsnotintimewindows,
+                    :usmstatsunknownusernames,
+                    :usmstatsunknownengineids,
+                    :usmstatswrongdigests,
+                    :usmstatsdecryptionerrors,
+                    :inbadversions,
+                    :inbadcommunitynames,
+                    :inbadcommunityuses,
+                    :inasnparseerrs,
+                    :intoobigs,
+                    :innosuchnames,
+                    :inbadvalues,
+                    :ingenerrs,
+                    :outtoobigs,
+                    :outnosuchnames,
+                    :outbadvalues,
+                    :outgenerrs,
+                    :outtraps,
+                    :silentdrops,
+                    :avgvarbinds,
+                    :maxvarbinds
+
+      # Constructs a new instance.
+      # @param ruby_values [Hash] a map of initial property values (optional)
+      # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
+      def initialize(ruby_values = nil, struct_value = nil)
+        super(self.class.binding_type, ruby_values, struct_value)
+      end
+    end
+
+    # ``Com::Vmware::Appliance::Techpreview::Monitoring::Snmp::SNMPConfig``   class  Structure that defines the SNMP configuration, provided as input to set(), and never the result of get(). See SNMPConfigReadOnly. This structure is used to configure SNMP v1, v2c, and v3.
+    # @!attribute [rw] authentication
+    #     @return [Com::Vmware::Appliance::Techpreview::Monitoring::Snmp::SNMPAuthProto]
+    #     Set the default authentication protocol. Values can be none, MD5, or SHA1.
+    # @!attribute [rw] communities
+    #     @return [Array<String>]
+    #     Set up to ten communities, each of no more than 64 characters long. The format is: community1[,community2,...]. This setting overwrites any previous settings.
+    # @!attribute [rw] engineid
+    #     @return [String]
+    #     Set SNMPv3 engine ID. The engine ID must contain 5 to 32 hexadecimal characters. "0x" and colon (:) are removed from the ID.
+    # @!attribute [rw] loglevel
+    #     @return [String]
+    #     System Agent syslog logging level: debug|info|warning|error.
+    # @!attribute [rw] notraps
+    #     @return [Array<String>]
+    #     Comma-separated list of trap OIDs (object identifiers) for traps not to be sent by the agent. Use 'reset' to clear the setting.
+    # @!attribute [rw] port
+    #     @return [Fixnum]
+    #     Set up a UDP port which the SNMP agent uses to listen on for polling requests. The default UDP port is 161.
+    # @!attribute [rw] privacy
+    #     @return [Com::Vmware::Appliance::Techpreview::Monitoring::Snmp::SNMPPrivProto]
+    #     Set the default privacy protocol. Values: none or AES128.
+    # @!attribute [rw] remoteusers
+    #     @return [Array<String>]
+    #     Set up to five inform user IDs. The format is: user/auth-proto/-|auth-hash/priv-proto/-|priv-hash/engine-id[,...]. Here, user must be maximum 32 characters long; auth-proto is none, MD5 or SHA1; priv-proto is none or AES; '-' indicates no hash; engine-id is a hexadecimal string '0x0-9a-f' and must be up to 32 characters long.
+    # @!attribute [rw] syscontact
+    #     @return [String]
+    #     System contact string as presented in sysContact.0. Up to 255 characters long.
+    # @!attribute [rw] syslocation
+    #     @return [String]
+    #     System location string as presented in sysLocation.0. Up to 255 characters long.
+    # @!attribute [rw] targets
+    #     @return [Array<String>]
+    #     Set up to three targets to which to send SNMPv1 traps. The format is: ip-or-hostname[\@port]/community[,...]. The default port is UDP 162. This setting overwrites any previous settings.
+    # @!attribute [rw] users
+    #     @return [Array<String>]
+    #     Set up to five local users. The format is: user/-|auth-hash/-|priv-hash/model[,...]. Here user is maximum 32 characters long; '-' indicates no hash; model is one of none, auth or priv.
+    # @!attribute [rw] v3targets
+    #     @return [Array<String>]
+    #     Set up to three SNMPv3 notification targets. Format is: ip-or-hostname[\@port]/remote-user/security-level/trap|inform[,...].
+    class SNMPConfig < VAPI::Bindings::VapiStruct
+      class << self
+        # Holds (gets or creates) the binding type metadata for this structure type.
+        # @scope class
+        # @return [VAPI::Bindings::StructType] the binding type
+        def binding_type
+          @binding_type ||= VAPI::Bindings::StructType.new(
+            'com.vmware.appliance.techpreview.monitoring.snmp.SNMP_config',
+            {
+              'authentication' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Appliance::Techpreview::Monitoring::Snmp::SNMPAuthProto'),
+              'communities' => VAPI::Bindings::ListType.new(VAPI::Bindings::StringType.instance),
+              'engineid' => VAPI::Bindings::StringType.instance,
+              'loglevel' => VAPI::Bindings::StringType.instance,
+              'notraps' => VAPI::Bindings::ListType.new(VAPI::Bindings::StringType.instance),
+              'port' => VAPI::Bindings::IntegerType.instance,
+              'privacy' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Appliance::Techpreview::Monitoring::Snmp::SNMPPrivProto'),
+              'remoteusers' => VAPI::Bindings::ListType.new(VAPI::Bindings::StringType.instance),
+              'syscontact' => VAPI::Bindings::StringType.instance,
+              'syslocation' => VAPI::Bindings::StringType.instance,
+              'targets' => VAPI::Bindings::ListType.new(VAPI::Bindings::StringType.instance),
+              'users' => VAPI::Bindings::ListType.new(VAPI::Bindings::StringType.instance),
+              'v3targets' => VAPI::Bindings::ListType.new(VAPI::Bindings::StringType.instance)
+            },
+            SNMPConfig,
+            false,
+            nil
+          )
+        end
+      end
+
+      attr_accessor :authentication,
+                    :communities,
+                    :engineid,
+                    :loglevel,
+                    :notraps,
+                    :port,
+                    :privacy,
+                    :remoteusers,
+                    :syscontact,
+                    :syslocation,
+                    :targets,
+                    :users,
+                    :v3targets
+
+      # Constructs a new instance.
+      # @param ruby_values [Hash] a map of initial property values (optional)
+      # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
+      def initialize(ruby_values = nil, struct_value = nil)
+        super(self.class.binding_type, ruby_values, struct_value)
+      end
+    end
+
+    # ``Com::Vmware::Appliance::Techpreview::Monitoring::Snmp::SNMPUser``   class  Structure that defines information associated with an SNMP user. authKey and privKey are localized keys defined in http://tools.ietf.org/html/rfc3826#section-1.2.
+    # @!attribute [rw] username
+    #     @return [String]
+    #     SNMP Username
+    # @!attribute [rw] sec_level
+    #     @return [Com::Vmware::Appliance::Techpreview::Monitoring::Snmp::SNMPSecLevel]
+    #     SNMP security level
+    # @!attribute [rw] auth_key
+    #     @return [String]
+    #     SNMP authorization key
+    # @!attribute [rw] priv_key
+    #     @return [String]
+    #     SNMP privacy key
+    class SNMPUser < VAPI::Bindings::VapiStruct
+      class << self
+        # Holds (gets or creates) the binding type metadata for this structure type.
+        # @scope class
+        # @return [VAPI::Bindings::StructType] the binding type
+        def binding_type
+          @binding_type ||= VAPI::Bindings::StructType.new(
+            'com.vmware.appliance.techpreview.monitoring.snmp.SNMP_user',
+            {
+              'username' => VAPI::Bindings::StringType.instance,
+              'sec_level' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Appliance::Techpreview::Monitoring::Snmp::SNMPSecLevel'),
+              'auth_key' => VAPI::Bindings::StringType.instance,
+              'priv_key' => VAPI::Bindings::StringType.instance
+            },
+            SNMPUser,
+            false,
+            nil
+          )
+        end
+      end
+
+      attr_accessor :username,
+                    :sec_level,
+                    :auth_key,
+                    :priv_key
+
+      # Constructs a new instance.
+      # @param ruby_values [Hash] a map of initial property values (optional)
+      # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
+      def initialize(ruby_values = nil, struct_value = nil)
+        super(self.class.binding_type, ruby_values, struct_value)
+      end
+    end
+
+    # ``Com::Vmware::Appliance::Techpreview::Monitoring::Snmp::SNMPv3Target``   class  Structure that defines an SNMP v3 inform or trap target.
+    # @!attribute [rw] type
+    #     @return [Com::Vmware::Appliance::Techpreview::Monitoring::Snmp::SNMPv3Notfication]
+    #     SNMP target type
+    # @!attribute [rw] sec_level
+    #     @return [Com::Vmware::Appliance::Techpreview::Monitoring::Snmp::SNMPSecLevel]
+    #     SNMP security level
+    # @!attribute [rw] ip
+    #     @return [String]
+    #     SNMP target ip
+    # @!attribute [rw] port
+    #     @return [Fixnum]
+    #     SNMP target port
+    # @!attribute [rw] user
+    #     @return [String]
+    #     SNMP User
+    class SNMPv3Target < VAPI::Bindings::VapiStruct
+      class << self
+        # Holds (gets or creates) the binding type metadata for this structure type.
+        # @scope class
+        # @return [VAPI::Bindings::StructType] the binding type
+        def binding_type
+          @binding_type ||= VAPI::Bindings::StructType.new(
+            'com.vmware.appliance.techpreview.monitoring.snmp.SNM_pv3_target',
+            {
+              'type' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Appliance::Techpreview::Monitoring::Snmp::SNMPv3Notfication'),
+              'sec_level' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Appliance::Techpreview::Monitoring::Snmp::SNMPSecLevel'),
+              'ip' => VAPI::Bindings::StringType.instance,
+              'port' => VAPI::Bindings::IntegerType.instance,
+              'user' => VAPI::Bindings::StringType.instance
+            },
+            SNMPv3Target,
+            false,
+            nil
+          )
+        end
+      end
+
+      attr_accessor :type,
+                    :sec_level,
+                    :ip,
+                    :port,
+                    :user
+
+      # Constructs a new instance.
+      # @param ruby_values [Hash] a map of initial property values (optional)
+      # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
+      def initialize(ruby_values = nil, struct_value = nil)
+        super(self.class.binding_type, ruby_values, struct_value)
+      end
+    end
+
+    # ``Com::Vmware::Appliance::Techpreview::Monitoring::Snmp::SNMPv1TrapTarget``   class  Structure that defines an SNMP v1/v2c trap target.
+    # @!attribute [rw] ip
+    #     @return [String]
+    #     SNMP target ip
+    # @!attribute [rw] port
+    #     @return [Fixnum]
+    #     SNMP target port
+    # @!attribute [rw] community
+    #     @return [String]
+    #     SNMP target community
+    class SNMPv1TrapTarget < VAPI::Bindings::VapiStruct
+      class << self
+        # Holds (gets or creates) the binding type metadata for this structure type.
+        # @scope class
+        # @return [VAPI::Bindings::StructType] the binding type
+        def binding_type
+          @binding_type ||= VAPI::Bindings::StructType.new(
+            'com.vmware.appliance.techpreview.monitoring.snmp.SNM_pv1_trap_target',
+            {
+              'ip' => VAPI::Bindings::StringType.instance,
+              'port' => VAPI::Bindings::IntegerType.instance,
+              'community' => VAPI::Bindings::StringType.instance
+            },
+            SNMPv1TrapTarget,
+            false,
+            nil
+          )
+        end
+      end
+
+      attr_accessor :ip,
+                    :port,
+                    :community
+
+      # Constructs a new instance.
+      # @param ruby_values [Hash] a map of initial property values (optional)
+      # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
+      def initialize(ruby_values = nil, struct_value = nil)
+        super(self.class.binding_type, ruby_values, struct_value)
+      end
+    end
+
+    # ``Com::Vmware::Appliance::Techpreview::Monitoring::Snmp::SNMPRemoteUser``   class  Structure that defines a user at particular remote SNMPv3 entity needed when using informs. auth_key and priv_key contained localized keys as defined in http://tools.ietf.org/html/rfc3826#section-1.2.
+    # @!attribute [rw] username
+    #     @return [String]
+    #     SNMP Username
+    # @!attribute [rw] sec_level
+    #     @return [Com::Vmware::Appliance::Techpreview::Monitoring::Snmp::SNMPSecLevel]
+    #     SNMP security level
+    # @!attribute [rw] authentication
+    #     @return [Com::Vmware::Appliance::Techpreview::Monitoring::Snmp::SNMPAuthProto]
+    #     SNMP authorization protocol
+    # @!attribute [rw] auth_key
+    #     @return [String]
+    #     SNMP authorization key
+    # @!attribute [rw] privacy
+    #     @return [Com::Vmware::Appliance::Techpreview::Monitoring::Snmp::SNMPPrivProto]
+    #     SNMP privacy protocol
+    # @!attribute [rw] priv_key
+    #     @return [String]
+    #     SNMP privacy key
+    # @!attribute [rw] engineid
+    #     @return [String]
+    #     SNMP v3 engine id
+    class SNMPRemoteUser < VAPI::Bindings::VapiStruct
+      class << self
+        # Holds (gets or creates) the binding type metadata for this structure type.
+        # @scope class
+        # @return [VAPI::Bindings::StructType] the binding type
+        def binding_type
+          @binding_type ||= VAPI::Bindings::StructType.new(
+            'com.vmware.appliance.techpreview.monitoring.snmp.SNMP_remote_user',
+            {
+              'username' => VAPI::Bindings::StringType.instance,
+              'sec_level' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Appliance::Techpreview::Monitoring::Snmp::SNMPSecLevel'),
+              'authentication' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Appliance::Techpreview::Monitoring::Snmp::SNMPAuthProto'),
+              'auth_key' => VAPI::Bindings::StringType.instance,
+              'privacy' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Appliance::Techpreview::Monitoring::Snmp::SNMPPrivProto'),
+              'priv_key' => VAPI::Bindings::StringType.instance,
+              'engineid' => VAPI::Bindings::StringType.instance
+            },
+            SNMPRemoteUser,
+            false,
+            nil
+          )
+        end
+      end
+
+      attr_accessor :username,
+                    :sec_level,
+                    :authentication,
+                    :auth_key,
+                    :privacy,
+                    :priv_key,
+                    :engineid
+
+      # Constructs a new instance.
+      # @param ruby_values [Hash] a map of initial property values (optional)
+      # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
+      def initialize(ruby_values = nil, struct_value = nil)
+        super(self.class.binding_type, ruby_values, struct_value)
+      end
+    end
+
+    # ``Com::Vmware::Appliance::Techpreview::Monitoring::Snmp::SNMPConfigReadOnly``   class  Structure that defines the SNMP configuration, the result of get(), and never provided as input to set(). This structure differs from SNMPConfig because it contains localized keys (as defined in http://tools.ietf.org/html/rfc3826#section-1.2), instead of raw secret strings. This structure can be used to configure SNMP v1, v2c, and v3. Keep this structure in sync with vmw_snmp.py:_default_config(). Note that if a field if left empty, it is considered unset and will be ignored. Existing array elements below can be unset by sending an element with the string 'reset'.
+    # @!attribute [rw] authentication
+    #     @return [Com::Vmware::Appliance::Techpreview::Monitoring::Snmp::SNMPAuthProto]
+    #     Set the default authentication protocol. Values can be none, MD5, or SHA1.
+    # @!attribute [rw] communities
+    #     @return [Array<String>]
+    #     Set up to ten communities, each of no more than 64 characters long. The format is: community1[,community2,...]. This setting overwrites any previous settings.
+    # @!attribute [rw] enable
+    #     @return [Boolean]
+    #     Set enable to true/false
+    # @!attribute [rw] engineid
+    #     @return [String]
+    #     Set SNMPv3 engine ID.
+    # @!attribute [rw] loglevel
+    #     @return [String]
+    #     System Agent syslog logging level: debug|info|warning|error.
+    # @!attribute [rw] notraps
+    #     @return [Array<String>]
+    #     Comma-separated list of trap OIDs (object identifiers) for traps not to be sent by the agent. Use 'reset' to clear the setting.
+    # @!attribute [rw] port
+    #     @return [Fixnum]
+    #     Set up a UDP port which the SNMP agent uses to listen on for polling requests. The default UDP port is 161.
+    # @!attribute [rw] privacy
+    #     @return [Com::Vmware::Appliance::Techpreview::Monitoring::Snmp::SNMPPrivProto]
+    #     Set the default privacy protocol.
+    # @!attribute [rw] syscontact
+    #     @return [String]
+    #     System contact string as presented in sysContact.0. Up to 255 characters long.
+    # @!attribute [rw] syslocation
+    #     @return [String]
+    #     System location string as presented in sysLocation.0. Up to 255 characters long.
+    # @!attribute [rw] targets
+    #     @return [Array<Com::Vmware::Appliance::Techpreview::Monitoring::Snmp::SNMPv1TrapTarget>]
+    #     Set up to three targets to which to send SNMPv1 traps.
+    # @!attribute [rw] users
+    #     @return [Array<Com::Vmware::Appliance::Techpreview::Monitoring::Snmp::SNMPUser>]
+    #     Set up to five local users.
+    # @!attribute [rw] remoteusers
+    #     @return [Array<Com::Vmware::Appliance::Techpreview::Monitoring::Snmp::SNMPRemoteUser>]
+    #     Set up remote users.
+    # @!attribute [rw] v3targets
+    #     @return [Array<Com::Vmware::Appliance::Techpreview::Monitoring::Snmp::SNMPv3Target>]
+    #     Set up to three SNMPv3 notification targets. Format is: ip-or-hostname[\@port]/remote-user/security-level/trap|inform[,...].
+    # @!attribute [rw] pid
+    #     @return [String]
+    #     Set up pid
+    class SNMPConfigReadOnly < VAPI::Bindings::VapiStruct
+      class << self
+        # Holds (gets or creates) the binding type metadata for this structure type.
+        # @scope class
+        # @return [VAPI::Bindings::StructType] the binding type
+        def binding_type
+          @binding_type ||= VAPI::Bindings::StructType.new(
+            'com.vmware.appliance.techpreview.monitoring.snmp.SNMP_config_read_only',
+            {
+              'authentication' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Appliance::Techpreview::Monitoring::Snmp::SNMPAuthProto'),
+              'communities' => VAPI::Bindings::ListType.new(VAPI::Bindings::StringType.instance),
+              'enable' => VAPI::Bindings::BooleanType.instance,
+              'engineid' => VAPI::Bindings::StringType.instance,
+              'loglevel' => VAPI::Bindings::StringType.instance,
+              'notraps' => VAPI::Bindings::ListType.new(VAPI::Bindings::StringType.instance),
+              'port' => VAPI::Bindings::IntegerType.instance,
+              'privacy' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Appliance::Techpreview::Monitoring::Snmp::SNMPPrivProto'),
+              'syscontact' => VAPI::Bindings::StringType.instance,
+              'syslocation' => VAPI::Bindings::StringType.instance,
+              'targets' => VAPI::Bindings::ListType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Appliance::Techpreview::Monitoring::Snmp::SNMPv1TrapTarget')),
+              'users' => VAPI::Bindings::ListType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Appliance::Techpreview::Monitoring::Snmp::SNMPUser')),
+              'remoteusers' => VAPI::Bindings::ListType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Appliance::Techpreview::Monitoring::Snmp::SNMPRemoteUser')),
+              'v3targets' => VAPI::Bindings::ListType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Appliance::Techpreview::Monitoring::Snmp::SNMPv3Target')),
+              'pid' => VAPI::Bindings::StringType.instance
+            },
+            SNMPConfigReadOnly,
+            false,
+            nil
+          )
+        end
+      end
+
+      attr_accessor :authentication,
+                    :communities,
+                    :enable,
+                    :engineid,
+                    :loglevel,
+                    :notraps,
+                    :port,
+                    :privacy,
+                    :syscontact,
+                    :syslocation,
+                    :targets,
+                    :users,
+                    :remoteusers,
+                    :v3targets,
+                    :pid
+
+      # Constructs a new instance.
+      # @param ruby_values [Hash] a map of initial property values (optional)
+      # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
+      def initialize(ruby_values = nil, struct_value = nil)
+        super(self.class.binding_type, ruby_values, struct_value)
+      end
+    end
+
+    # ``Com::Vmware::Appliance::Techpreview::Monitoring::Snmp::SNMPHashConfig``   class  Structure to provide up to two secrets to combine with the SNMPv3 engine ID and authentication or privacy protocol to form a localized hash. auth_hash is always required, priv_hash can be empty. By default arguments are paths on the local filesystem, raw_secret takes path to be the actual raw secret. First implementation was in ESXi: esxcli system snmp hash --help
+    # @!attribute [rw] auth_hash
+    #     @return [String]
+    #     Provide filename to secret for authentication hash, use in set --users (required secret)
+    # @!attribute [rw] priv_hash
+    #     @return [String]
+    #     Provide filename to secret for privacy hash, use in set --users (secret)
+    # @!attribute [rw] raw_secret
+    #     @return [Boolean]
+    #     Make --auth_path and --priv_path flags read raw secret from command line instead of file.
+    class SNMPHashConfig < VAPI::Bindings::VapiStruct
+      class << self
+        # Holds (gets or creates) the binding type metadata for this structure type.
+        # @scope class
+        # @return [VAPI::Bindings::StructType] the binding type
+        def binding_type
+          @binding_type ||= VAPI::Bindings::StructType.new(
+            'com.vmware.appliance.techpreview.monitoring.snmp.SNMP_hash_config',
+            {
+              'auth_hash' => VAPI::Bindings::StringType.instance,
+              'priv_hash' => VAPI::Bindings::StringType.instance,
+              'raw_secret' => VAPI::Bindings::BooleanType.instance
+            },
+            SNMPHashConfig,
+            false,
+            nil
+          )
+        end
+      end
+
+      attr_accessor :auth_hash,
+                    :priv_hash,
+                    :raw_secret
+
+      # Constructs a new instance.
+      # @param ruby_values [Hash] a map of initial property values (optional)
+      # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
+      def initialize(ruby_values = nil, struct_value = nil)
+        super(self.class.binding_type, ruby_values, struct_value)
+      end
+    end
+
+    # ``Com::Vmware::Appliance::Techpreview::Monitoring::Snmp::SNMPHashResults``   class  Structure to provide operators diagnostics test results.
+    # @!attribute [rw] auth_key
+    #     @return [String]
+    #     SNMP authentication key
+    # @!attribute [rw] priv_key
+    #     @return [String]
+    #     SNMP privacy key
+    class SNMPHashResults < VAPI::Bindings::VapiStruct
+      class << self
+        # Holds (gets or creates) the binding type metadata for this structure type.
+        # @scope class
+        # @return [VAPI::Bindings::StructType] the binding type
+        def binding_type
+          @binding_type ||= VAPI::Bindings::StructType.new(
+            'com.vmware.appliance.techpreview.monitoring.snmp.SNMP_hash_results',
+            {
+              'auth_key' => VAPI::Bindings::StringType.instance,
+              'priv_key' => VAPI::Bindings::StringType.instance
+            },
+            SNMPHashResults,
+            false,
+            nil
+          )
+        end
+      end
+
+      attr_accessor :auth_key,
+                    :priv_key
+
+      # Constructs a new instance.
+      # @param ruby_values [Hash] a map of initial property values (optional)
+      # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
+      def initialize(ruby_values = nil, struct_value = nil)
+        super(self.class.binding_type, ruby_values, struct_value)
+      end
+    end
+
+    # ``Com::Vmware::Appliance::Techpreview::Monitoring::Snmp::SNMPAuthProto``   enumerated type  Defines SNMP authentication protocols
+    # @!attribute [rw] none
+    #     @return [Com::Vmware::Appliance::Techpreview::Monitoring::Snmp::SNMPAuthProto]
+    #     NONE
+    # @!attribute [rw] sh_a1
+    #     @return [Com::Vmware::Appliance::Techpreview::Monitoring::Snmp::SNMPAuthProto]
+    #     SHA1
+    # @!attribute [rw] m_d5
+    #     @return [Com::Vmware::Appliance::Techpreview::Monitoring::Snmp::SNMPAuthProto]
+    #     MD5
+    class SNMPAuthProto < VAPI::Bindings::VapiEnum
+      class << self
+        # Holds (gets or creates) the binding type metadata for this enumeration type.
+        # @scope class
+        # @return [VAPI::Bindings::EnumType] the binding type
+        def binding_type
+          @binding_type ||= VAPI::Bindings::EnumType.new(
+            'com.vmware.appliance.techpreview.monitoring.snmp.SNMP_auth_proto',
+            SNMPAuthProto
+          )
+        end
+
+        # Converts from a string value (perhaps off the wire) to an instance
+        # of this enum type.
+        # @param value [String] the actual value of the enum instance
+        # @return [SNMPAuthProto] the instance found for the value, otherwise
+        #         an unknown instance will be built for the value
+        def from_string(value)
+          const_get(value)
+        rescue NameError
+          SNMPAuthProto.send(:new, 'UNKNOWN', value)
+        end
+      end
+
+      # Constructs a new instance.
+      # @param value [String] the actual value of the enum instance
+      # @param unknown [String] the unknown value when value is 'UKNOWN'
+      def initialize(value, unknown = nil)
+        super(self.class.binding_type, value, unknown)
+      end
+
+      private_class_method :new
+
+      # @!attribute [rw] none
+      #     @return [Com::Vmware::Appliance::Techpreview::Monitoring::Snmp::SNMPAuthProto]
+      #     NONE
+      NONE = SNMPAuthProto.send(:new, 'NONE')
+
+      # @!attribute [rw] sh_a1
+      #     @return [Com::Vmware::Appliance::Techpreview::Monitoring::Snmp::SNMPAuthProto]
+      #     SHA1
+      SH_A1 = SNMPAuthProto.send(:new, 'SH_A1')
+
+      # @!attribute [rw] m_d5
+      #     @return [Com::Vmware::Appliance::Techpreview::Monitoring::Snmp::SNMPAuthProto]
+      #     MD5
+      M_D5 = SNMPAuthProto.send(:new, 'M_D5')
+    end
+    # ``Com::Vmware::Appliance::Techpreview::Monitoring::Snmp::SNMPPrivProto``   enumerated type  Defines SNMP privacy protocols
+    # @!attribute [rw] ae_s128
+    #     @return [Com::Vmware::Appliance::Techpreview::Monitoring::Snmp::SNMPPrivProto]
+    #     AES128
+    # @!attribute [rw] none
+    #     @return [Com::Vmware::Appliance::Techpreview::Monitoring::Snmp::SNMPPrivProto]
+    #     NONE
+    class SNMPPrivProto < VAPI::Bindings::VapiEnum
+      class << self
+        # Holds (gets or creates) the binding type metadata for this enumeration type.
+        # @scope class
+        # @return [VAPI::Bindings::EnumType] the binding type
+        def binding_type
+          @binding_type ||= VAPI::Bindings::EnumType.new(
+            'com.vmware.appliance.techpreview.monitoring.snmp.SNMP_priv_proto',
+            SNMPPrivProto
+          )
+        end
+
+        # Converts from a string value (perhaps off the wire) to an instance
+        # of this enum type.
+        # @param value [String] the actual value of the enum instance
+        # @return [SNMPPrivProto] the instance found for the value, otherwise
+        #         an unknown instance will be built for the value
+        def from_string(value)
+          const_get(value)
+        rescue NameError
+          SNMPPrivProto.send(:new, 'UNKNOWN', value)
+        end
+      end
+
+      # Constructs a new instance.
+      # @param value [String] the actual value of the enum instance
+      # @param unknown [String] the unknown value when value is 'UKNOWN'
+      def initialize(value, unknown = nil)
+        super(self.class.binding_type, value, unknown)
+      end
+
+      private_class_method :new
+
+      # @!attribute [rw] ae_s128
+      #     @return [Com::Vmware::Appliance::Techpreview::Monitoring::Snmp::SNMPPrivProto]
+      #     AES128
+      AE_S128 = SNMPPrivProto.send(:new, 'AE_S128')
+
+      # @!attribute [rw] none
+      #     @return [Com::Vmware::Appliance::Techpreview::Monitoring::Snmp::SNMPPrivProto]
+      #     NONE
+      NONE = SNMPPrivProto.send(:new, 'NONE')
+    end
+    # ``Com::Vmware::Appliance::Techpreview::Monitoring::Snmp::SNMPSecLevel``   enumerated type  Defines SNMP decurity levels
+    # @!attribute [rw] none
+    #     @return [Com::Vmware::Appliance::Techpreview::Monitoring::Snmp::SNMPSecLevel]
+    #     none
+    # @!attribute [rw] auth
+    #     @return [Com::Vmware::Appliance::Techpreview::Monitoring::Snmp::SNMPSecLevel]
+    #     auth
+    # @!attribute [rw] priv
+    #     @return [Com::Vmware::Appliance::Techpreview::Monitoring::Snmp::SNMPSecLevel]
+    #     priv
+    class SNMPSecLevel < VAPI::Bindings::VapiEnum
+      class << self
+        # Holds (gets or creates) the binding type metadata for this enumeration type.
+        # @scope class
+        # @return [VAPI::Bindings::EnumType] the binding type
+        def binding_type
+          @binding_type ||= VAPI::Bindings::EnumType.new(
+            'com.vmware.appliance.techpreview.monitoring.snmp.SNMP_sec_level',
+            SNMPSecLevel
+          )
+        end
+
+        # Converts from a string value (perhaps off the wire) to an instance
+        # of this enum type.
+        # @param value [String] the actual value of the enum instance
+        # @return [SNMPSecLevel] the instance found for the value, otherwise
+        #         an unknown instance will be built for the value
+        def from_string(value)
+          const_get(value)
+        rescue NameError
+          SNMPSecLevel.send(:new, 'UNKNOWN', value)
+        end
+      end
+
+      # Constructs a new instance.
+      # @param value [String] the actual value of the enum instance
+      # @param unknown [String] the unknown value when value is 'UKNOWN'
+      def initialize(value, unknown = nil)
+        super(self.class.binding_type, value, unknown)
+      end
+
+      private_class_method :new
+
+      # @!attribute [rw] none
+      #     @return [Com::Vmware::Appliance::Techpreview::Monitoring::Snmp::SNMPSecLevel]
+      #     none
+      NONE = SNMPSecLevel.send(:new, 'NONE')
+
+      # @!attribute [rw] auth
+      #     @return [Com::Vmware::Appliance::Techpreview::Monitoring::Snmp::SNMPSecLevel]
+      #     auth
+      AUTH = SNMPSecLevel.send(:new, 'AUTH')
+
+      # @!attribute [rw] priv
+      #     @return [Com::Vmware::Appliance::Techpreview::Monitoring::Snmp::SNMPSecLevel]
+      #     priv
+      PRIV = SNMPSecLevel.send(:new, 'PRIV')
+    end
+    # ``Com::Vmware::Appliance::Techpreview::Monitoring::Snmp::SNMPv3Notfication``   enumerated type  Defines SNMP v3 notification types
+    # @!attribute [rw] inform
+    #     @return [Com::Vmware::Appliance::Techpreview::Monitoring::Snmp::SNMPv3Notfication]
+    #     inform
+    # @!attribute [rw] trap
+    #     @return [Com::Vmware::Appliance::Techpreview::Monitoring::Snmp::SNMPv3Notfication]
+    #     trap
+    class SNMPv3Notfication < VAPI::Bindings::VapiEnum
+      class << self
+        # Holds (gets or creates) the binding type metadata for this enumeration type.
+        # @scope class
+        # @return [VAPI::Bindings::EnumType] the binding type
+        def binding_type
+          @binding_type ||= VAPI::Bindings::EnumType.new(
+            'com.vmware.appliance.techpreview.monitoring.snmp.SNM_pv3_notfication',
+            SNMPv3Notfication
+          )
+        end
+
+        # Converts from a string value (perhaps off the wire) to an instance
+        # of this enum type.
+        # @param value [String] the actual value of the enum instance
+        # @return [SNMPv3Notfication] the instance found for the value, otherwise
+        #         an unknown instance will be built for the value
+        def from_string(value)
+          const_get(value)
+        rescue NameError
+          SNMPv3Notfication.send(:new, 'UNKNOWN', value)
+        end
+      end
+
+      # Constructs a new instance.
+      # @param value [String] the actual value of the enum instance
+      # @param unknown [String] the unknown value when value is 'UKNOWN'
+      def initialize(value, unknown = nil)
+        super(self.class.binding_type, value, unknown)
+      end
+
+      private_class_method :new
+
+      # @!attribute [rw] inform
+      #     @return [Com::Vmware::Appliance::Techpreview::Monitoring::Snmp::SNMPv3Notfication]
+      #     inform
+      INFORM = SNMPv3Notfication.send(:new, 'INFORM')
+
+      # @!attribute [rw] trap
+      #     @return [Com::Vmware::Appliance::Techpreview::Monitoring::Snmp::SNMPv3Notfication]
+      #     trap
+      TRAP = SNMPv3Notfication.send(:new, 'TRAP')
+    end
+  end
 end

--- a/client/sdk/com/vmware/appliance/techpreview/networking.rb
+++ b/client/sdk/com/vmware/appliance/techpreview/networking.rb
@@ -1,5 +1,6 @@
 #---------------------------------------------------------------------------
-# Copyright 2016 VMware, Inc.  All rights reserved.
+# Copyright 2017 VMware, Inc.  All rights reserved.
+#
 # AUTO GENERATED FILE -- DO NOT MODIFY!
 #
 # vAPI type descriptors for package com.vmware.appliance.techpreview.networking.
@@ -8,1867 +9,1736 @@ require 'vapi'
 
 # declare the module hierarchy before we use the shorthand syntax below
 module Com
-    module Vmware
-        module Appliance
-            module Techpreview
-                module Networking
-                end
-            end
+  module Vmware
+    module Appliance
+      module Techpreview
+        module Networking
         end
+      end
     end
+  end
 end
 
 module Com::Vmware::Appliance::Techpreview::Networking
+  # ``Com::Vmware::Appliance::Techpreview::Networking::Ipv4``   class  provides  methods  Performs IPV4 network configuration for interfaces.
+  class Ipv4 < VAPI::Bindings::VapiService
+    # static metamodel definitions
+    SERVICE_ID = VAPI::Core::ServiceIdentifier.new('com.vmware.appliance.techpreview.networking.ipv4')
 
-    # ``Com::Vmware::Appliance::Techpreview::Networking::Ipv4``   class  provides  methods  Performs IPV4 network configuration for interfaces.
-    class Ipv4 < VAPI::Bindings::VapiService
+    RENEW_INFO = VAPI::Bindings::OperationInfo.new(
+      VAPI::Core::OperationIdentifier.new('renew', SERVICE_ID),
+      VAPI::Bindings::OperationInputType.new(
+        'interfaces' => VAPI::Bindings::ListType.new(VAPI::Bindings::StringType.instance)
+      ),
+      VAPI::Bindings::VoidType.instance,
+      {
+        'com.vmware.vapi.std.errors.error' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Error')
+      },
+      [],
+      []
+    )
 
-        protected
+    SET_INFO = VAPI::Bindings::OperationInfo.new(
+      VAPI::Core::OperationIdentifier.new('set', SERVICE_ID),
+      VAPI::Bindings::OperationInputType.new(
+        'config' => VAPI::Bindings::ListType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Appliance::Techpreview::Networking::Ipv4::IPv4Config'))
+      ),
+      VAPI::Bindings::VoidType.instance,
+      {
+        'com.vmware.vapi.std.errors.error' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Error')
+      },
+      [],
+      []
+    )
 
-        # static metamodel definitions
-        @@service_id = VAPI::Core::ServiceIdentifier.new('com.vmware.appliance.techpreview.networking.ipv4')
+    LIST_INFO = VAPI::Bindings::OperationInfo.new(
+      VAPI::Core::OperationIdentifier.new('list', SERVICE_ID),
+      VAPI::Bindings::OperationInputType.new,
+      VAPI::Bindings::ListType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Appliance::Techpreview::Networking::Ipv4::IPv4ConfigReadOnly')),
+      {
+        'com.vmware.vapi.std.errors.error' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Error')
+      },
+      [],
+      []
+    )
 
-        @@renew_info = VAPI::Bindings::OperationInfo.new(
-            VAPI::Core::OperationIdentifier.new('renew', @@service_id),
-            VAPI::Bindings::OperationInputType.new({
-                'interfaces' => VAPI::Bindings::ListType.new(VAPI::Bindings::StringType.instance),
-            }),
-            VAPI::Bindings::VoidType.instance,
-            {
-                'com.vmware.vapi.std.errors.error' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Error'),
+    GET_INFO = VAPI::Bindings::OperationInfo.new(
+      VAPI::Core::OperationIdentifier.new('get', SERVICE_ID),
+      VAPI::Bindings::OperationInputType.new(
+        'interfaces' => VAPI::Bindings::ListType.new(VAPI::Bindings::StringType.instance)
+      ),
+      VAPI::Bindings::ListType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Appliance::Techpreview::Networking::Ipv4::IPv4ConfigReadOnly')),
+      {
+        'com.vmware.vapi.std.errors.error' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Error')
+      },
+      [],
+      []
+    )
 
-            },
-            [],
-            [])
-        @@set_info = VAPI::Bindings::OperationInfo.new(
-            VAPI::Core::OperationIdentifier.new('set', @@service_id),
-            VAPI::Bindings::OperationInputType.new({
-                'config' => VAPI::Bindings::ListType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Appliance::Techpreview::Networking::Ipv4::IPv4Config')),
-            }),
-            VAPI::Bindings::VoidType.instance,
-            {
-                'com.vmware.vapi.std.errors.error' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Error'),
+    SERVICE_INFO = VAPI::Bindings::ServiceInfo.new(
+      SERVICE_ID,
+      'renew' => RENEW_INFO,
+      'set' => SET_INFO,
+      'list' => LIST_INFO,
+      'get' => GET_INFO
+    )
 
-            },
-            [],
-            [])
-        @@list_info = VAPI::Bindings::OperationInfo.new(
-            VAPI::Core::OperationIdentifier.new('list', @@service_id),
-            VAPI::Bindings::OperationInputType.new,
-            VAPI::Bindings::ListType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Appliance::Techpreview::Networking::Ipv4::IPv4ConfigReadOnly')),
-            {
-                'com.vmware.vapi.std.errors.error' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Error'),
-
-            },
-            [],
-            [])
-        @@get_info = VAPI::Bindings::OperationInfo.new(
-            VAPI::Core::OperationIdentifier.new('get', @@service_id),
-            VAPI::Bindings::OperationInputType.new({
-                'interfaces' => VAPI::Bindings::ListType.new(VAPI::Bindings::StringType.instance),
-            }),
-            VAPI::Bindings::ListType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Appliance::Techpreview::Networking::Ipv4::IPv4ConfigReadOnly')),
-            {
-                'com.vmware.vapi.std.errors.error' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Error'),
-
-            },
-            [],
-            [])
-
-        @@service_info = VAPI::Bindings::ServiceInfo.new(@@service_id, {
-            'renew' => @@renew_info,
-            'set' => @@set_info,
-            'list' => @@list_info,
-            'get' => @@get_info,
-        })
-
-        public
-
-        # Constructs a new instance.
-        #
-        # @param config [VAPI::Bindings::StubConfig] A hash with the api provider details.
-        def initialize(config)
-            super(config, @@service_info)
-        end
-
-
-        # Renew IPv4 network configuration on interfaces. If the interface is configured to use DHCP for IP address assignment, the lease of the interface is renewed.
-        #
-        # @param interfaces [Array<String>]
-        #     Interfaces to renew.
-        # @return [Void]
-        # @raise [Com::Vmware::Vapi::Std::Errors::Error]
-        #     Generic error
-        def renew(interfaces)
-            invoke_with_info(@@renew_info, {
-                'interfaces' => interfaces,
-            })
-        end
-
-
-        # Set IPv4 network configuration.
-        #
-        # @param config [Array<Com::Vmware::Appliance::Techpreview::Networking::Ipv4::IPv4Config>]
-        #     List of IPv4 configurations.
-        # @return [Void]
-        # @raise [Com::Vmware::Vapi::Std::Errors::Error]
-        #     Generic error
-        def set(config)
-            invoke_with_info(@@set_info, {
-                'config' => config,
-            })
-        end
-
-
-        # Get IPv4 network configuration for all configured interfaces.
-        #
-        # @return [Array<Com::Vmware::Appliance::Techpreview::Networking::Ipv4::IPv4ConfigReadOnly>]
-        #     IPv4 configuration for each interface.
-        # @raise [Com::Vmware::Vapi::Std::Errors::Error]
-        #     Generic error
-        def list()
-            invoke_with_info(@@list_info)
-        end
-
-
-        # Get IPv4 network configuration for interfaces.
-        #
-        # @param interfaces [Array<String>]
-        #     Network interfaces to query, for example, "nic0".
-        # @return [Array<Com::Vmware::Appliance::Techpreview::Networking::Ipv4::IPv4ConfigReadOnly>]
-        #     IPv4 configuration for each queried interface.
-        # @raise [Com::Vmware::Vapi::Std::Errors::Error]
-        #     Generic error
-        def get(interfaces)
-            invoke_with_info(@@get_info, {
-                'interfaces' => interfaces,
-            })
-        end
-
-
-
-        # ``Com::Vmware::Appliance::Techpreview::Networking::Ipv4::IPv4Config``   class  Structure that defines the IPv4 configuration state of a network interface.
-        # @!attribute [rw] interface_name
-        #     @return [String]
-        #     Interface name, for example, "nic0", "nic1".
-        # @!attribute [rw] mode
-        #     @return [Com::Vmware::Appliance::Techpreview::Networking::Ipv4::IPv4Mode]
-        #     Address assignment mode.
-        # @!attribute [rw] address
-        #     @return [String]
-        #     IPv4 address, for example, "10.20.80.191". Set this argument to an empty string "", if the mode is "unconfigured" or "dhcp".
-        # @!attribute [rw] prefix
-        #     @return [Fixnum]
-        #     IPv4 CIDR prefix, for example , 24. See http://www.oav.net/mirrors/cidr.html for netmask-to-prefix conversion. Set this argument to 0 if the mode is "unconfigured" or "dhcp".
-        # @!attribute [rw] default_gateway
-        #     @return [String]
-        #     IPv4 address of the default gateway. This default gateway value is used if the mode argument is set to "static" This configures the global default gateway on the appliance with the specified gateway address and interface. This gateway replaces the existing default gateway configured on the appliance. However, if the gateway address is link-local, then it is added for that interface. This does not support configuration of multiple global default gateways through different interfaces.
-        class IPv4Config < VAPI::Bindings::VapiStruct
-
-            class << self
-                # Holds (gets or creates) the binding type metadata for this structure type.
-                # @scope class
-                # @return [VAPI::Bindings::StructType] the binding type
-                def binding_type
-                    @binding_type ||= VAPI::Bindings::StructType.new(
-                        'com.vmware.appliance.techpreview.networking.ipv4.I_pv4_config',
-                        {
-                            'interface_name' => VAPI::Bindings::StringType.instance,
-                            'mode' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Appliance::Techpreview::Networking::Ipv4::IPv4Mode'),
-                            'address' => VAPI::Bindings::StringType.instance,
-                            'prefix' => VAPI::Bindings::IntegerType.instance,
-                            'default_gateway' => VAPI::Bindings::StringType.instance,
-                        },
-                        IPv4Config,
-                        false,
-                        nil)
-                end
-            end
-
-            attr_accessor :interface_name,
-                          :mode,
-                          :address,
-                          :prefix,
-                          :default_gateway
-
-            # Constructs a new instance.
-            # @param ruby_values [Hash] a map of initial property values (optional)
-            # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
-            def initialize(ruby_values=nil, struct_value=nil)
-                super(self.class.binding_type, ruby_values, struct_value)
-            end
-        end
-
-
-        # ``Com::Vmware::Appliance::Techpreview::Networking::Ipv4::IPv4ConfigReadOnly``   class  Structure that defines the IPv4 configuration state of a network interface.
-        # @!attribute [rw] interface_name
-        #     @return [String]
-        #     Interface name, for example, "nic0", "nic1".
-        # @!attribute [rw] mode
-        #     @return [Com::Vmware::Appliance::Techpreview::Networking::Ipv4::IPv4Mode]
-        #     Address assignment mode.
-        # @!attribute [rw] address
-        #     @return [String]
-        #     IPv4 address, for example, "10.20.80.191". Set this argument to an empty string "", if the mode is "unconfigured" or "dhcp".
-        # @!attribute [rw] prefix
-        #     @return [Fixnum]
-        #     IPv4 CIDR prefix, for example , 24. See http://www.oav.net/mirrors/cidr.html for netmask-to-prefix conversion. Set this argument to 0 if the mode is "unconfigured" or "dhcp".
-        # @!attribute [rw] default_gateway
-        #     @return [String]
-        #     IPv4 address of the default gateway. This default gateway value is used if the mode argument is set to "static" This configures the global default gateway on the appliance with the specified gateway address and interface. This gateway replaces the existing default gateway configured on the appliance. However, if the gateway address is link-local, then it is added for that interface. This does not support configuration of multiple global default gateways through different interfaces.
-        # @!attribute [rw] updateable
-        #     @return [Boolean]
-        #     This indicates if the network configuration can be updated for the interface.
-        class IPv4ConfigReadOnly < VAPI::Bindings::VapiStruct
-
-            class << self
-                # Holds (gets or creates) the binding type metadata for this structure type.
-                # @scope class
-                # @return [VAPI::Bindings::StructType] the binding type
-                def binding_type
-                    @binding_type ||= VAPI::Bindings::StructType.new(
-                        'com.vmware.appliance.techpreview.networking.ipv4.I_pv4_config_read_only',
-                        {
-                            'interface_name' => VAPI::Bindings::StringType.instance,
-                            'mode' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Appliance::Techpreview::Networking::Ipv4::IPv4Mode'),
-                            'address' => VAPI::Bindings::StringType.instance,
-                            'prefix' => VAPI::Bindings::IntegerType.instance,
-                            'default_gateway' => VAPI::Bindings::StringType.instance,
-                            'updateable' => VAPI::Bindings::BooleanType.instance,
-                        },
-                        IPv4ConfigReadOnly,
-                        false,
-                        nil)
-                end
-            end
-
-            attr_accessor :interface_name,
-                          :mode,
-                          :address,
-                          :prefix,
-                          :default_gateway,
-                          :updateable
-
-            # Constructs a new instance.
-            # @param ruby_values [Hash] a map of initial property values (optional)
-            # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
-            def initialize(ruby_values=nil, struct_value=nil)
-                super(self.class.binding_type, ruby_values, struct_value)
-            end
-        end
-
-
-
-        # ``Com::Vmware::Appliance::Techpreview::Networking::Ipv4::IPv4Mode``   enumerated type  Defines different ipv4 modes
-        # @!attribute [rw] dhcp
-        #     @return [Com::Vmware::Appliance::Techpreview::Networking::Ipv4::IPv4Mode]
-        #     IPv4 address is automatically assigned by a DHCP server.
-        # @!attribute [rw] is_static
-        #     @return [Com::Vmware::Appliance::Techpreview::Networking::Ipv4::IPv4Mode]
-        #     IPv4 address is static.
-        # @!attribute [rw] unconfigured
-        #     @return [Com::Vmware::Appliance::Techpreview::Networking::Ipv4::IPv4Mode]
-        #     The IPv4 protocol is not configured.
-        class IPv4Mode < VAPI::Bindings::VapiEnum
-
-            class << self
-                # Holds (gets or creates) the binding type metadata for this enumeration type.
-                # @scope class
-                # @return [VAPI::Bindings::EnumType] the binding type
-                def binding_type
-                    @binding_type ||= VAPI::Bindings::EnumType.new(
-                        'com.vmware.appliance.techpreview.networking.ipv4.I_pv4_mode',
-                        IPv4Mode)
-                end
-
-                # Converts from a string value (perhaps off the wire) to an instance
-                # of this enum type.
-                # @param value [String] the actual value of the enum instance
-                # @return [IPv4Mode] the instance found for the value, otherwise
-                #         an unknown instance will be built for the value
-                def from_string(value)
-                    begin
-                        const_get(value)
-                    rescue NameError
-                        IPv4Mode.new('UNKNOWN', value)
-                    end
-                end
-            end
-
-            private
-
-            # Constructs a new instance.
-            # @param value [String] the actual value of the enum instance
-            # @param unknown [String] the unknown value when value is 'UKNOWN'
-            def initialize(value, unknown=nil)
-                super(self.class.binding_type, value, unknown)
-            end
-
-            public
-
-            # @!attribute [rw] dhcp
-            #     @return [Com::Vmware::Appliance::Techpreview::Networking::Ipv4::IPv4Mode]
-            #     IPv4 address is automatically assigned by a DHCP server.
-            DHCP = IPv4Mode.new('DHCP')
-
-            # @!attribute [rw] is_static
-            #     @return [Com::Vmware::Appliance::Techpreview::Networking::Ipv4::IPv4Mode]
-            #     IPv4 address is static.
-            IS_STATIC = IPv4Mode.new('IS_STATIC')
-
-            # @!attribute [rw] unconfigured
-            #     @return [Com::Vmware::Appliance::Techpreview::Networking::Ipv4::IPv4Mode]
-            #     The IPv4 protocol is not configured.
-            UNCONFIGURED = IPv4Mode.new('UNCONFIGURED')
-
-        end
-
-
+    # Constructs a new instance.
+    #
+    # @param config [VAPI::Bindings::StubConfig] A hash with the api provider details.
+    def initialize(config)
+      super(config, SERVICE_INFO)
     end
 
-
-    # ``Com::Vmware::Appliance::Techpreview::Networking::Ipv6``   class  provides  methods  Performs IPV4 network configuration for interfaces.
-    class Ipv6 < VAPI::Bindings::VapiService
-
-        protected
-
-        # static metamodel definitions
-        @@service_id = VAPI::Core::ServiceIdentifier.new('com.vmware.appliance.techpreview.networking.ipv6')
-
-        @@set_info = VAPI::Bindings::OperationInfo.new(
-            VAPI::Core::OperationIdentifier.new('set', @@service_id),
-            VAPI::Bindings::OperationInputType.new({
-                'config' => VAPI::Bindings::ListType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Appliance::Techpreview::Networking::Ipv6::IPv6Config')),
-            }),
-            VAPI::Bindings::VoidType.instance,
-            {
-                'com.vmware.vapi.std.errors.error' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Error'),
-
-            },
-            [],
-            [])
-        @@list_info = VAPI::Bindings::OperationInfo.new(
-            VAPI::Core::OperationIdentifier.new('list', @@service_id),
-            VAPI::Bindings::OperationInputType.new,
-            VAPI::Bindings::ListType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Appliance::Techpreview::Networking::Ipv6::IPv6ConfigReadOnly')),
-            {
-                'com.vmware.vapi.std.errors.error' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Error'),
-
-            },
-            [],
-            [])
-        @@get_info = VAPI::Bindings::OperationInfo.new(
-            VAPI::Core::OperationIdentifier.new('get', @@service_id),
-            VAPI::Bindings::OperationInputType.new({
-                'interfaces' => VAPI::Bindings::ListType.new(VAPI::Bindings::StringType.instance),
-            }),
-            VAPI::Bindings::ListType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Appliance::Techpreview::Networking::Ipv6::IPv6ConfigReadOnly')),
-            {
-                'com.vmware.vapi.std.errors.error' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Error'),
-
-            },
-            [],
-            [])
-
-        @@service_info = VAPI::Bindings::ServiceInfo.new(@@service_id, {
-            'set' => @@set_info,
-            'list' => @@list_info,
-            'get' => @@get_info,
-        })
-
-        public
-
-        # Constructs a new instance.
-        #
-        # @param config [VAPI::Bindings::StubConfig] A hash with the api provider details.
-        def initialize(config)
-            super(config, @@service_info)
-        end
-
-
-        # Set IPv6 network configuration.
-        #
-        # @param config [Array<Com::Vmware::Appliance::Techpreview::Networking::Ipv6::IPv6Config>]
-        #     IPv6 configuration.
-        # @return [Void]
-        # @raise [Com::Vmware::Vapi::Std::Errors::Error]
-        #     Generic error
-        def set(config)
-            invoke_with_info(@@set_info, {
-                'config' => config,
-            })
-        end
-
-
-        # Get IPv6 network configuration for all configured interfaces.
-        #
-        # @return [Array<Com::Vmware::Appliance::Techpreview::Networking::Ipv6::IPv6ConfigReadOnly>]
-        #     IPv6 configuration for each interface.
-        # @raise [Com::Vmware::Vapi::Std::Errors::Error]
-        #     Generic error
-        def list()
-            invoke_with_info(@@list_info)
-        end
-
-
-        # Get IPv6 network configuration for interfaces.
-        #
-        # @param interfaces [Array<String>]
-        #     Network interfaces to query, for example, "nic0".
-        # @return [Array<Com::Vmware::Appliance::Techpreview::Networking::Ipv6::IPv6ConfigReadOnly>]
-        #     IPv6 configuration.
-        # @raise [Com::Vmware::Vapi::Std::Errors::Error]
-        #     Generic error
-        def get(interfaces)
-            invoke_with_info(@@get_info, {
-                'interfaces' => interfaces,
-            })
-        end
-
-
-
-        # ``Com::Vmware::Appliance::Techpreview::Networking::Ipv6::IPv6AddressReadOnly``   class  Structure that you can use to get information about an IPv6 address along with its origin and status.
-        # @!attribute [rw] address
-        #     @return [String]
-        #     IPv6 address, for example, fc00:10:20:83:20c:29ff:fe94:bb5a.
-        # @!attribute [rw] prefix
-        #     @return [Fixnum]
-        #     IPv6 CIDR prefix, for example, 64.
-        # @!attribute [rw] origin
-        #     @return [Com::Vmware::Appliance::Techpreview::Networking::Ipv6::IPv6AddressOrigin]
-        #     Origin of the IPv6 address. For more information, see RFC 4293.
-        # @!attribute [rw] status
-        #     @return [Com::Vmware::Appliance::Techpreview::Networking::Ipv6::IPv6AddressStatus]
-        #     Status of the IPv6 address. For more information, see RFC 4293.
-        class IPv6AddressReadOnly < VAPI::Bindings::VapiStruct
-
-            class << self
-                # Holds (gets or creates) the binding type metadata for this structure type.
-                # @scope class
-                # @return [VAPI::Bindings::StructType] the binding type
-                def binding_type
-                    @binding_type ||= VAPI::Bindings::StructType.new(
-                        'com.vmware.appliance.techpreview.networking.ipv6.I_pv6_address_read_only',
-                        {
-                            'address' => VAPI::Bindings::StringType.instance,
-                            'prefix' => VAPI::Bindings::IntegerType.instance,
-                            'origin' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Appliance::Techpreview::Networking::Ipv6::IPv6AddressOrigin'),
-                            'status' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Appliance::Techpreview::Networking::Ipv6::IPv6AddressStatus'),
-                        },
-                        IPv6AddressReadOnly,
-                        false,
-                        nil)
-                end
-            end
-
-            attr_accessor :address,
-                          :prefix,
-                          :origin,
-                          :status
-
-            # Constructs a new instance.
-            # @param ruby_values [Hash] a map of initial property values (optional)
-            # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
-            def initialize(ruby_values=nil, struct_value=nil)
-                super(self.class.binding_type, ruby_values, struct_value)
-            end
-        end
-
-
-        # ``Com::Vmware::Appliance::Techpreview::Networking::Ipv6::IPv6ConfigReadOnly``   class  Structure that defines an existing IPv6 configuration on a particular interface. This structure is read only.
-        # @!attribute [rw] interface_name
-        #     @return [String]
-        #     Network interface, for example, "nic0" queried.
-        # @!attribute [rw] dhcp
-        #     @return [Boolean]
-        #     Address assigned by a DHCP server.
-        # @!attribute [rw] autoconf
-        #     @return [Boolean]
-        #     Address is assigned by Stateless Address Autoconfiguration (SLAAC).
-        # @!attribute [rw] addresses
-        #     @return [Array<Com::Vmware::Appliance::Techpreview::Networking::Ipv6::IPv6AddressReadOnly>]
-        #     A list of all addresses assigned to this interface. The origin field of each address determines how the address was assigned, for example, statically, by DHCP, SLAAC.
-        # @!attribute [rw] default_gateway
-        #     @return [String]
-        #     Default gateway. This configures the global IPv6 default gateway on the appliance with the specified gateway address and interface. This gateway replaces the existing default gateway configured on the appliance. However, if the gateway address is link-local, then it is added for that interface. This does not support configuration of multiple global default gateways through different interfaces.
-        # @!attribute [rw] updateable
-        #     @return [Boolean]
-        #     This indicates if the network configuration can be updated for the interface.
-        class IPv6ConfigReadOnly < VAPI::Bindings::VapiStruct
-
-            class << self
-                # Holds (gets or creates) the binding type metadata for this structure type.
-                # @scope class
-                # @return [VAPI::Bindings::StructType] the binding type
-                def binding_type
-                    @binding_type ||= VAPI::Bindings::StructType.new(
-                        'com.vmware.appliance.techpreview.networking.ipv6.I_pv6_config_read_only',
-                        {
-                            'interface_name' => VAPI::Bindings::StringType.instance,
-                            'dhcp' => VAPI::Bindings::BooleanType.instance,
-                            'autoconf' => VAPI::Bindings::BooleanType.instance,
-                            'addresses' => VAPI::Bindings::ListType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Appliance::Techpreview::Networking::Ipv6::IPv6AddressReadOnly')),
-                            'default_gateway' => VAPI::Bindings::StringType.instance,
-                            'updateable' => VAPI::Bindings::BooleanType.instance,
-                        },
-                        IPv6ConfigReadOnly,
-                        false,
-                        nil)
-                end
-            end
-
-            attr_accessor :interface_name,
-                          :dhcp,
-                          :autoconf,
-                          :addresses,
-                          :default_gateway,
-                          :updateable
-
-            # Constructs a new instance.
-            # @param ruby_values [Hash] a map of initial property values (optional)
-            # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
-            def initialize(ruby_values=nil, struct_value=nil)
-                super(self.class.binding_type, ruby_values, struct_value)
-            end
-        end
-
-
-        # ``Com::Vmware::Appliance::Techpreview::Networking::Ipv6::IPv6Address``   class  Structure used to name an IPv6 address.
-        # @!attribute [rw] address
-        #     @return [String]
-        #     IPv6 address, for example, fc00:10:20:83:20c:29ff:fe94:bb5a.
-        # @!attribute [rw] prefix
-        #     @return [Fixnum]
-        #     IPv6 CIDR prefix, for example, 64.
-        class IPv6Address < VAPI::Bindings::VapiStruct
-
-            class << self
-                # Holds (gets or creates) the binding type metadata for this structure type.
-                # @scope class
-                # @return [VAPI::Bindings::StructType] the binding type
-                def binding_type
-                    @binding_type ||= VAPI::Bindings::StructType.new(
-                        'com.vmware.appliance.techpreview.networking.ipv6.I_pv6_address',
-                        {
-                            'address' => VAPI::Bindings::StringType.instance,
-                            'prefix' => VAPI::Bindings::IntegerType.instance,
-                        },
-                        IPv6Address,
-                        false,
-                        nil)
-                end
-            end
-
-            attr_accessor :address,
-                          :prefix
-
-            # Constructs a new instance.
-            # @param ruby_values [Hash] a map of initial property values (optional)
-            # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
-            def initialize(ruby_values=nil, struct_value=nil)
-                super(self.class.binding_type, ruby_values, struct_value)
-            end
-        end
-
-
-        # ``Com::Vmware::Appliance::Techpreview::Networking::Ipv6::IPv6Config``   class  Structure that you can use to configure IPv6 on a particular interface. Because IPv6 permits multiple addresses per interface, addresses can be assigned by DHCP, SLAAC, and can also be statically assigned.
-        # @!attribute [rw] interface_name
-        #     @return [String]
-        #     Network interface, for example, "nic0" to configure.
-        # @!attribute [rw] dhcp
-        #     @return [Boolean]
-        #     Address assigned by a DHCP server.
-        # @!attribute [rw] autoconf
-        #     @return [Boolean]
-        #     Address is assigned by Stateless Address Autoconfiguration (SLAAC).
-        # @!attribute [rw] addresses
-        #     @return [Array<Com::Vmware::Appliance::Techpreview::Networking::Ipv6::IPv6Address>]
-        #     A list of addresses to be statically assigned.
-        # @!attribute [rw] default_gateway
-        #     @return [String]
-        #     Default gateway for static IP address assignment. This configures the global IPv6 default gateway on the appliance with the specified gateway address and interface. This gateway replaces the existing default gateway configured on the appliance. However, if the gateway address is link-local, then it is added for that interface. This does not support configuration of multiple global default gateways through different interfaces.
-        class IPv6Config < VAPI::Bindings::VapiStruct
-
-            class << self
-                # Holds (gets or creates) the binding type metadata for this structure type.
-                # @scope class
-                # @return [VAPI::Bindings::StructType] the binding type
-                def binding_type
-                    @binding_type ||= VAPI::Bindings::StructType.new(
-                        'com.vmware.appliance.techpreview.networking.ipv6.I_pv6_config',
-                        {
-                            'interface_name' => VAPI::Bindings::StringType.instance,
-                            'dhcp' => VAPI::Bindings::BooleanType.instance,
-                            'autoconf' => VAPI::Bindings::BooleanType.instance,
-                            'addresses' => VAPI::Bindings::ListType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Appliance::Techpreview::Networking::Ipv6::IPv6Address')),
-                            'default_gateway' => VAPI::Bindings::StringType.instance,
-                        },
-                        IPv6Config,
-                        false,
-                        nil)
-                end
-            end
-
-            attr_accessor :interface_name,
-                          :dhcp,
-                          :autoconf,
-                          :addresses,
-                          :default_gateway
-
-            # Constructs a new instance.
-            # @param ruby_values [Hash] a map of initial property values (optional)
-            # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
-            def initialize(ruby_values=nil, struct_value=nil)
-                super(self.class.binding_type, ruby_values, struct_value)
-            end
-        end
-
-
-
-        # ``Com::Vmware::Appliance::Techpreview::Networking::Ipv6::IPv6AddressOrigin``   enumerated type  Defines IPV6 address origin values
-        # @!attribute [rw] dhcp
-        #     @return [Com::Vmware::Appliance::Techpreview::Networking::Ipv6::IPv6AddressOrigin]
-        #     The IPv6 address is assigned by a DHCP server. See RFC 4293.
-        # @!attribute [rw] random
-        #     @return [Com::Vmware::Appliance::Techpreview::Networking::Ipv6::IPv6AddressOrigin]
-        #     The IPv6 address is assigned randomly by the system. See RFC 4293.
-        # @!attribute [rw] manual
-        #     @return [Com::Vmware::Appliance::Techpreview::Networking::Ipv6::IPv6AddressOrigin]
-        #     The IPv6 address was manually configured to a specified address, for, example, by user configuration. See RFC 4293.
-        # @!attribute [rw] other
-        #     @return [Com::Vmware::Appliance::Techpreview::Networking::Ipv6::IPv6AddressOrigin]
-        #     The IPv6 address is assigned by a mechanism other than manual, DHCP, SLAAC, or random. See RFC 4293.
-        # @!attribute [rw] linklayer
-        #     @return [Com::Vmware::Appliance::Techpreview::Networking::Ipv6::IPv6AddressOrigin]
-        #     The IPv6 address is assigned by IPv6 Stateless Address Auto-configuration (SLAAC). See RFC 4293.
-        class IPv6AddressOrigin < VAPI::Bindings::VapiEnum
-
-            class << self
-                # Holds (gets or creates) the binding type metadata for this enumeration type.
-                # @scope class
-                # @return [VAPI::Bindings::EnumType] the binding type
-                def binding_type
-                    @binding_type ||= VAPI::Bindings::EnumType.new(
-                        'com.vmware.appliance.techpreview.networking.ipv6.I_pv6_address_origin',
-                        IPv6AddressOrigin)
-                end
-
-                # Converts from a string value (perhaps off the wire) to an instance
-                # of this enum type.
-                # @param value [String] the actual value of the enum instance
-                # @return [IPv6AddressOrigin] the instance found for the value, otherwise
-                #         an unknown instance will be built for the value
-                def from_string(value)
-                    begin
-                        const_get(value)
-                    rescue NameError
-                        IPv6AddressOrigin.new('UNKNOWN', value)
-                    end
-                end
-            end
-
-            private
-
-            # Constructs a new instance.
-            # @param value [String] the actual value of the enum instance
-            # @param unknown [String] the unknown value when value is 'UKNOWN'
-            def initialize(value, unknown=nil)
-                super(self.class.binding_type, value, unknown)
-            end
-
-            public
-
-            # @!attribute [rw] dhcp
-            #     @return [Com::Vmware::Appliance::Techpreview::Networking::Ipv6::IPv6AddressOrigin]
-            #     The IPv6 address is assigned by a DHCP server. See RFC 4293.
-            DHCP = IPv6AddressOrigin.new('DHCP')
-
-            # @!attribute [rw] random
-            #     @return [Com::Vmware::Appliance::Techpreview::Networking::Ipv6::IPv6AddressOrigin]
-            #     The IPv6 address is assigned randomly by the system. See RFC 4293.
-            RANDOM = IPv6AddressOrigin.new('RANDOM')
-
-            # @!attribute [rw] manual
-            #     @return [Com::Vmware::Appliance::Techpreview::Networking::Ipv6::IPv6AddressOrigin]
-            #     The IPv6 address was manually configured to a specified address, for, example, by user configuration. See RFC 4293.
-            MANUAL = IPv6AddressOrigin.new('MANUAL')
-
-            # @!attribute [rw] other
-            #     @return [Com::Vmware::Appliance::Techpreview::Networking::Ipv6::IPv6AddressOrigin]
-            #     The IPv6 address is assigned by a mechanism other than manual, DHCP, SLAAC, or random. See RFC 4293.
-            OTHER = IPv6AddressOrigin.new('OTHER')
-
-            # @!attribute [rw] linklayer
-            #     @return [Com::Vmware::Appliance::Techpreview::Networking::Ipv6::IPv6AddressOrigin]
-            #     The IPv6 address is assigned by IPv6 Stateless Address Auto-configuration (SLAAC). See RFC 4293.
-            LINKLAYER = IPv6AddressOrigin.new('LINKLAYER')
-
-        end
-
-
-        # ``Com::Vmware::Appliance::Techpreview::Networking::Ipv6::IPv6AddressStatus``   enumerated type  Defines IPV6 address status values
-        # @!attribute [rw] tentative
-        #     @return [Com::Vmware::Appliance::Techpreview::Networking::Ipv6::IPv6AddressStatus]
-        #     This IPv6 address is in the process of being verified as unique. Do not use addresses in this state for general communication. You can use them to determine the uniqueness of the address. See RFC 4293.
-        # @!attribute [rw] unknown
-        #     @return [Com::Vmware::Appliance::Techpreview::Networking::Ipv6::IPv6AddressStatus]
-        #     The status of this address cannot be determined. See RFC 4293.
-        # @!attribute [rw] inaccessible
-        #     @return [Com::Vmware::Appliance::Techpreview::Networking::Ipv6::IPv6AddressStatus]
-        #     This IPv6 address is inaccessible because the interface to which this address is assigned is not operational. See RFC 4293.
-        # @!attribute [rw] invalid
-        #     @return [Com::Vmware::Appliance::Techpreview::Networking::Ipv6::IPv6AddressStatus]
-        #     This IPv6 address is not a valid address. It should not appear as the destination or source address of a packet. See RFC 4293.
-        # @!attribute [rw] duplicate
-        #     @return [Com::Vmware::Appliance::Techpreview::Networking::Ipv6::IPv6AddressStatus]
-        #     This IPv6 address is not unique on the link. Do use this IPv6 address. See RFC 4293.
-        # @!attribute [rw] preferred
-        #     @return [Com::Vmware::Appliance::Techpreview::Networking::Ipv6::IPv6AddressStatus]
-        #     This is a valid IPv6 address that can appear as the destination or source address of a packet. See RFC 4293.
-        # @!attribute [rw] deprecated
-        #     @return [Com::Vmware::Appliance::Techpreview::Networking::Ipv6::IPv6AddressStatus]
-        #     This is a valid but deprecated IPv6 address. Do not use this IPv6 address as a source address in new communications, although packets addressed to such an address are processed as expected. See RFC 4293.
-        # @!attribute [rw] optimistic
-        #     @return [Com::Vmware::Appliance::Techpreview::Networking::Ipv6::IPv6AddressStatus]
-        #     This IPv6 address is available for use, subject to restrictions, while its uniqueness on a link is being verified. See RFC 4293.
-        class IPv6AddressStatus < VAPI::Bindings::VapiEnum
-
-            class << self
-                # Holds (gets or creates) the binding type metadata for this enumeration type.
-                # @scope class
-                # @return [VAPI::Bindings::EnumType] the binding type
-                def binding_type
-                    @binding_type ||= VAPI::Bindings::EnumType.new(
-                        'com.vmware.appliance.techpreview.networking.ipv6.I_pv6_address_status',
-                        IPv6AddressStatus)
-                end
-
-                # Converts from a string value (perhaps off the wire) to an instance
-                # of this enum type.
-                # @param value [String] the actual value of the enum instance
-                # @return [IPv6AddressStatus] the instance found for the value, otherwise
-                #         an unknown instance will be built for the value
-                def from_string(value)
-                    begin
-                        const_get(value)
-                    rescue NameError
-                        IPv6AddressStatus.new('UNKNOWN', value)
-                    end
-                end
-            end
-
-            private
-
-            # Constructs a new instance.
-            # @param value [String] the actual value of the enum instance
-            # @param unknown [String] the unknown value when value is 'UKNOWN'
-            def initialize(value, unknown=nil)
-                super(self.class.binding_type, value, unknown)
-            end
-
-            public
-
-            # @!attribute [rw] tentative
-            #     @return [Com::Vmware::Appliance::Techpreview::Networking::Ipv6::IPv6AddressStatus]
-            #     This IPv6 address is in the process of being verified as unique. Do not use addresses in this state for general communication. You can use them to determine the uniqueness of the address. See RFC 4293.
-            TENTATIVE = IPv6AddressStatus.new('TENTATIVE')
-
-            # @!attribute [rw] unknown
-            #     @return [Com::Vmware::Appliance::Techpreview::Networking::Ipv6::IPv6AddressStatus]
-            #     The status of this address cannot be determined. See RFC 4293.
-            UNKNOWN = IPv6AddressStatus.new('UNKNOWN')
-
-            # @!attribute [rw] inaccessible
-            #     @return [Com::Vmware::Appliance::Techpreview::Networking::Ipv6::IPv6AddressStatus]
-            #     This IPv6 address is inaccessible because the interface to which this address is assigned is not operational. See RFC 4293.
-            INACCESSIBLE = IPv6AddressStatus.new('INACCESSIBLE')
-
-            # @!attribute [rw] invalid
-            #     @return [Com::Vmware::Appliance::Techpreview::Networking::Ipv6::IPv6AddressStatus]
-            #     This IPv6 address is not a valid address. It should not appear as the destination or source address of a packet. See RFC 4293.
-            INVALID = IPv6AddressStatus.new('INVALID')
-
-            # @!attribute [rw] duplicate
-            #     @return [Com::Vmware::Appliance::Techpreview::Networking::Ipv6::IPv6AddressStatus]
-            #     This IPv6 address is not unique on the link. Do use this IPv6 address. See RFC 4293.
-            DUPLICATE = IPv6AddressStatus.new('DUPLICATE')
-
-            # @!attribute [rw] preferred
-            #     @return [Com::Vmware::Appliance::Techpreview::Networking::Ipv6::IPv6AddressStatus]
-            #     This is a valid IPv6 address that can appear as the destination or source address of a packet. See RFC 4293.
-            PREFERRED = IPv6AddressStatus.new('PREFERRED')
-
-            # @!attribute [rw] deprecated
-            #     @return [Com::Vmware::Appliance::Techpreview::Networking::Ipv6::IPv6AddressStatus]
-            #     This is a valid but deprecated IPv6 address. Do not use this IPv6 address as a source address in new communications, although packets addressed to such an address are processed as expected. See RFC 4293.
-            DEPRECATED = IPv6AddressStatus.new('DEPRECATED')
-
-            # @!attribute [rw] optimistic
-            #     @return [Com::Vmware::Appliance::Techpreview::Networking::Ipv6::IPv6AddressStatus]
-            #     This IPv6 address is available for use, subject to restrictions, while its uniqueness on a link is being verified. See RFC 4293.
-            OPTIMISTIC = IPv6AddressStatus.new('OPTIMISTIC')
-
-        end
-
-
+    # Renew IPv4 network configuration on interfaces. If the interface is configured to use DHCP for IP address assignment, the lease of the interface is renewed.
+    #
+    # @param interfaces [Array<String>]
+    #     Interfaces to renew.
+    # @return [Void]
+    # @raise [Com::Vmware::Vapi::Std::Errors::Error]
+    #     Generic error
+    def renew(interfaces)
+      invoke_with_info(RENEW_INFO,
+                       'interfaces' => interfaces)
     end
 
-
-    # ``Com::Vmware::Appliance::Techpreview::Networking::Proxy``   class  provides  methods  Proxy configuration.
-    class Proxy < VAPI::Bindings::VapiService
-
-        protected
-
-        # static metamodel definitions
-        @@service_id = VAPI::Core::ServiceIdentifier.new('com.vmware.appliance.techpreview.networking.proxy')
-
-        @@test_info = VAPI::Bindings::OperationInfo.new(
-            VAPI::Core::OperationIdentifier.new('test', @@service_id),
-            VAPI::Bindings::OperationInputType.new({
-                'config' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Appliance::Techpreview::Networking::Proxy::ProxyConfigTest'),
-            }),
-            VAPI::Bindings::ReferenceType.new('Com::Vmware::Appliance::Techpreview::Networking::Proxy::TestStatusInfo'),
-            {
-                'com.vmware.vapi.std.errors.error' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Error'),
-
-            },
-            [],
-            [])
-        @@set_info = VAPI::Bindings::OperationInfo.new(
-            VAPI::Core::OperationIdentifier.new('set', @@service_id),
-            VAPI::Bindings::OperationInputType.new({
-                'config' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Appliance::Techpreview::Networking::Proxy::ProxyConfigMultiple'),
-            }),
-            VAPI::Bindings::VoidType.instance,
-            {
-                'com.vmware.vapi.std.errors.error' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Error'),
-
-            },
-            [],
-            [])
-        @@delete_info = VAPI::Bindings::OperationInfo.new(
-            VAPI::Core::OperationIdentifier.new('delete', @@service_id),
-            VAPI::Bindings::OperationInputType.new({
-                'protocol' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Appliance::Techpreview::Networking::Proxy::ProxyProtocol'),
-            }),
-            VAPI::Bindings::VoidType.instance,
-            {
-                'com.vmware.vapi.std.errors.error' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Error'),
-
-            },
-            [],
-            [])
-        @@get_info = VAPI::Bindings::OperationInfo.new(
-            VAPI::Core::OperationIdentifier.new('get', @@service_id),
-            VAPI::Bindings::OperationInputType.new,
-            VAPI::Bindings::ReferenceType.new('Com::Vmware::Appliance::Techpreview::Networking::Proxy::ProxyConfigMultiple'),
-            {
-                'com.vmware.vapi.std.errors.error' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Error'),
-
-            },
-            [],
-            [])
-
-        @@service_info = VAPI::Bindings::ServiceInfo.new(@@service_id, {
-            'test' => @@test_info,
-            'set' => @@set_info,
-            'delete' => @@delete_info,
-            'get' => @@get_info,
-        })
-
-        public
-
-        # Constructs a new instance.
-        #
-        # @param config [VAPI::Bindings::StubConfig] A hash with the api provider details.
-        def initialize(config)
-            super(config, @@service_info)
-        end
-
-
-        # Test a Proxy configuration by testing the connection to the proxy server and test host.
-        #
-        # @param config [Com::Vmware::Appliance::Techpreview::Networking::Proxy::ProxyConfigTest]
-        #     Proxy configuration to test
-        # @return [Com::Vmware::Appliance::Techpreview::Networking::Proxy::TestStatusInfo]
-        #     Status of proxy settings.
-        # @raise [Com::Vmware::Vapi::Std::Errors::Error]
-        #     Generic error
-        def test(config)
-            invoke_with_info(@@test_info, {
-                'config' => config,
-            })
-        end
-
-
-        # Set Proxy configuration. In order for this configuration to take effect a logout is required.
-        #
-        # @param config [Com::Vmware::Appliance::Techpreview::Networking::Proxy::ProxyConfigMultiple]
-        #     List of Proxy configurations to be set.
-        # @return [Void]
-        # @raise [Com::Vmware::Vapi::Std::Errors::Error]
-        #     Generic error
-        def set(config)
-            invoke_with_info(@@set_info, {
-                'config' => config,
-            })
-        end
-
-
-        # Delete a Proxy configuration for a specific protocol.
-        #
-        # @param protocol [Com::Vmware::Appliance::Techpreview::Networking::Proxy::ProxyProtocol]
-        #     Protocol to delete proxy of.
-        # @return [Void]
-        # @raise [Com::Vmware::Vapi::Std::Errors::Error]
-        #     Generic error
-        def delete(protocol)
-            invoke_with_info(@@delete_info, {
-                'protocol' => protocol,
-            })
-        end
-
-
-        # Get proxy configuration for all protocols.
-        #
-        # @return [Com::Vmware::Appliance::Techpreview::Networking::Proxy::ProxyConfigMultiple]
-        #     proxy configuration for all protocols.
-        # @raise [Com::Vmware::Vapi::Std::Errors::Error]
-        #     Generic error
-        def get()
-            invoke_with_info(@@get_info)
-        end
-
-
-
-        # ``Com::Vmware::Appliance::Techpreview::Networking::Proxy::Message``   class  Test result and message
-        # @!attribute [rw] message
-        #     @return [String]
-        #     message
-        # @!attribute [rw] result
-        #     @return [Com::Vmware::Appliance::Techpreview::Networking::Proxy::MessageStatus]
-        #     result of the test
-        class Message < VAPI::Bindings::VapiStruct
-
-            class << self
-                # Holds (gets or creates) the binding type metadata for this structure type.
-                # @scope class
-                # @return [VAPI::Bindings::StructType] the binding type
-                def binding_type
-                    @binding_type ||= VAPI::Bindings::StructType.new(
-                        'com.vmware.appliance.techpreview.networking.proxy.message',
-                        {
-                            'message' => VAPI::Bindings::StringType.instance,
-                            'result' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Appliance::Techpreview::Networking::Proxy::MessageStatus'),
-                        },
-                        Message,
-                        false,
-                        nil)
-                end
-            end
-
-            attr_accessor :message,
-                          :result
-
-            # Constructs a new instance.
-            # @param ruby_values [Hash] a map of initial property values (optional)
-            # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
-            def initialize(ruby_values=nil, struct_value=nil)
-                super(self.class.binding_type, ruby_values, struct_value)
-            end
-        end
-
-
-        # ``Com::Vmware::Appliance::Techpreview::Networking::Proxy::TestStatusInfo``   class  Overall test result
-        # @!attribute [rw] status
-        #     @return [Com::Vmware::Appliance::Techpreview::Networking::Proxy::TestStatus]
-        #     Overall status of tests run.
-        # @!attribute [rw] messages
-        #     @return [Array<Com::Vmware::Appliance::Techpreview::Networking::Proxy::Message>]
-        #     messages
-        class TestStatusInfo < VAPI::Bindings::VapiStruct
-
-            class << self
-                # Holds (gets or creates) the binding type metadata for this structure type.
-                # @scope class
-                # @return [VAPI::Bindings::StructType] the binding type
-                def binding_type
-                    @binding_type ||= VAPI::Bindings::StructType.new(
-                        'com.vmware.appliance.techpreview.networking.proxy.test_status_info',
-                        {
-                            'status' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Appliance::Techpreview::Networking::Proxy::TestStatus'),
-                            'messages' => VAPI::Bindings::ListType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Appliance::Techpreview::Networking::Proxy::Message')),
-                        },
-                        TestStatusInfo,
-                        false,
-                        nil)
-                end
-            end
-
-            attr_accessor :status,
-                          :messages
-
-            # Constructs a new instance.
-            # @param ruby_values [Hash] a map of initial property values (optional)
-            # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
-            def initialize(ruby_values=nil, struct_value=nil)
-                super(self.class.binding_type, ruby_values, struct_value)
-            end
-        end
-
-
-        # ``Com::Vmware::Appliance::Techpreview::Networking::Proxy::ProxyConfigTest``   class  Structure that defines proxy configuration.
-        # @!attribute [rw] protocol
-        #     @return [Com::Vmware::Appliance::Techpreview::Networking::Proxy::ProxyProtocol]
-        #     protocol being configured.
-        # @!attribute [rw] server
-        #     @return [String]
-        #     hostname or ip of proxy server
-        # @!attribute [rw] port
-        #     @return [Fixnum]
-        #     port to connect to the proxy server on. A value of -1 indicates that the default port is being used.
-        # @!attribute [rw] username
-        #     @return [String]
-        #     username for proxy server.
-        # @!attribute [rw] password
-        #     @return [String]
-        #     password for proxy server.
-        # @!attribute [rw] testhost
-        #     @return [String]
-        #     Verify that a hostname (www.vmware.com) or IPv4 or Ipv6 address of the testhost is accessible through proxy.
-        class ProxyConfigTest < VAPI::Bindings::VapiStruct
-
-            class << self
-                # Holds (gets or creates) the binding type metadata for this structure type.
-                # @scope class
-                # @return [VAPI::Bindings::StructType] the binding type
-                def binding_type
-                    @binding_type ||= VAPI::Bindings::StructType.new(
-                        'com.vmware.appliance.techpreview.networking.proxy.proxy_config_test',
-                        {
-                            'protocol' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Appliance::Techpreview::Networking::Proxy::ProxyProtocol'),
-                            'server' => VAPI::Bindings::StringType.instance,
-                            'port' => VAPI::Bindings::IntegerType.instance,
-                            'username' => VAPI::Bindings::StringType.instance,
-                            'password' => VAPI::Bindings::SecretType.instance,
-                            'testhost' => VAPI::Bindings::StringType.instance,
-                        },
-                        ProxyConfigTest,
-                        false,
-                        nil)
-                end
-            end
-
-            attr_accessor :protocol,
-                          :server,
-                          :port,
-                          :username,
-                          :password,
-                          :testhost
-
-            # Constructs a new instance.
-            # @param ruby_values [Hash] a map of initial property values (optional)
-            # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
-            def initialize(ruby_values=nil, struct_value=nil)
-                super(self.class.binding_type, ruby_values, struct_value)
-            end
-        end
-
-
-        # ``Com::Vmware::Appliance::Techpreview::Networking::Proxy::ProxyConfig``   class  Structure that defines proxy configuration.
-        # @!attribute [rw] protocol
-        #     @return [Com::Vmware::Appliance::Techpreview::Networking::Proxy::ProxyProtocol]
-        #     protocol being configured.
-        # @!attribute [rw] server
-        #     @return [String]
-        #     hostname or ip of proxy server
-        # @!attribute [rw] port
-        #     @return [Fixnum]
-        #     port to connect to the proxy server on. A value of -1 indicates that the default port is being used.
-        # @!attribute [rw] username
-        #     @return [String]
-        #     username for proxy server.
-        # @!attribute [rw] password
-        #     @return [String]
-        #     password for proxy server.
-        class ProxyConfig < VAPI::Bindings::VapiStruct
-
-            class << self
-                # Holds (gets or creates) the binding type metadata for this structure type.
-                # @scope class
-                # @return [VAPI::Bindings::StructType] the binding type
-                def binding_type
-                    @binding_type ||= VAPI::Bindings::StructType.new(
-                        'com.vmware.appliance.techpreview.networking.proxy.proxy_config',
-                        {
-                            'protocol' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Appliance::Techpreview::Networking::Proxy::ProxyProtocol'),
-                            'server' => VAPI::Bindings::StringType.instance,
-                            'port' => VAPI::Bindings::IntegerType.instance,
-                            'username' => VAPI::Bindings::StringType.instance,
-                            'password' => VAPI::Bindings::SecretType.instance,
-                        },
-                        ProxyConfig,
-                        false,
-                        nil)
-                end
-            end
-
-            attr_accessor :protocol,
-                          :server,
-                          :port,
-                          :username,
-                          :password
-
-            # Constructs a new instance.
-            # @param ruby_values [Hash] a map of initial property values (optional)
-            # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
-            def initialize(ruby_values=nil, struct_value=nil)
-                super(self.class.binding_type, ruby_values, struct_value)
-            end
-        end
-
-
-        # ``Com::Vmware::Appliance::Techpreview::Networking::Proxy::ProxyConfigMultiple``   class  Structure representing multiple proxy configuration.
-        # @!attribute [rw] status
-        #     @return [Com::Vmware::Appliance::Techpreview::Networking::Proxy::ProxyStatus]
-        #     proxy enabled or disabled This sets whether the proxy configuration is used.
-        # @!attribute [rw] configlist
-        #     @return [Array<Com::Vmware::Appliance::Techpreview::Networking::Proxy::ProxyConfig>]
-        #     List of proxy configuration.
-        class ProxyConfigMultiple < VAPI::Bindings::VapiStruct
-
-            class << self
-                # Holds (gets or creates) the binding type metadata for this structure type.
-                # @scope class
-                # @return [VAPI::Bindings::StructType] the binding type
-                def binding_type
-                    @binding_type ||= VAPI::Bindings::StructType.new(
-                        'com.vmware.appliance.techpreview.networking.proxy.proxy_config_multiple',
-                        {
-                            'status' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Appliance::Techpreview::Networking::Proxy::ProxyStatus'),
-                            'configlist' => VAPI::Bindings::ListType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Appliance::Techpreview::Networking::Proxy::ProxyConfig')),
-                        },
-                        ProxyConfigMultiple,
-                        false,
-                        nil)
-                end
-            end
-
-            attr_accessor :status,
-                          :configlist
-
-            # Constructs a new instance.
-            # @param ruby_values [Hash] a map of initial property values (optional)
-            # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
-            def initialize(ruby_values=nil, struct_value=nil)
-                super(self.class.binding_type, ruby_values, struct_value)
-            end
-        end
-
-
-
-        # ``Com::Vmware::Appliance::Techpreview::Networking::Proxy::ProxyProtocol``   enumerated type  Defines different proxy protocols
-        # @!attribute [rw] ftp
-        #     @return [Com::Vmware::Appliance::Techpreview::Networking::Proxy::ProxyProtocol]
-        #     proxy configuration for ftp.
-        # @!attribute [rw] http
-        #     @return [Com::Vmware::Appliance::Techpreview::Networking::Proxy::ProxyProtocol]
-        #     proxy configuration for http.
-        # @!attribute [rw] https
-        #     @return [Com::Vmware::Appliance::Techpreview::Networking::Proxy::ProxyProtocol]
-        #     proxy configuration for https.
-        class ProxyProtocol < VAPI::Bindings::VapiEnum
-
-            class << self
-                # Holds (gets or creates) the binding type metadata for this enumeration type.
-                # @scope class
-                # @return [VAPI::Bindings::EnumType] the binding type
-                def binding_type
-                    @binding_type ||= VAPI::Bindings::EnumType.new(
-                        'com.vmware.appliance.techpreview.networking.proxy.proxy_protocol',
-                        ProxyProtocol)
-                end
-
-                # Converts from a string value (perhaps off the wire) to an instance
-                # of this enum type.
-                # @param value [String] the actual value of the enum instance
-                # @return [ProxyProtocol] the instance found for the value, otherwise
-                #         an unknown instance will be built for the value
-                def from_string(value)
-                    begin
-                        const_get(value)
-                    rescue NameError
-                        ProxyProtocol.new('UNKNOWN', value)
-                    end
-                end
-            end
-
-            private
-
-            # Constructs a new instance.
-            # @param value [String] the actual value of the enum instance
-            # @param unknown [String] the unknown value when value is 'UKNOWN'
-            def initialize(value, unknown=nil)
-                super(self.class.binding_type, value, unknown)
-            end
-
-            public
-
-            # @!attribute [rw] ftp
-            #     @return [Com::Vmware::Appliance::Techpreview::Networking::Proxy::ProxyProtocol]
-            #     proxy configuration for ftp.
-            FTP = ProxyProtocol.new('FTP')
-
-            # @!attribute [rw] http
-            #     @return [Com::Vmware::Appliance::Techpreview::Networking::Proxy::ProxyProtocol]
-            #     proxy configuration for http.
-            HTTP = ProxyProtocol.new('HTTP')
-
-            # @!attribute [rw] https
-            #     @return [Com::Vmware::Appliance::Techpreview::Networking::Proxy::ProxyProtocol]
-            #     proxy configuration for https.
-            HTTPS = ProxyProtocol.new('HTTPS')
-
-        end
-
-
-        # ``Com::Vmware::Appliance::Techpreview::Networking::Proxy::TestStatus``   enumerated type  Health indicator
-        # @!attribute [rw] orange
-        #     @return [Com::Vmware::Appliance::Techpreview::Networking::Proxy::TestStatus]
-        #     In case data has more than one test, this indicates not all tests were successful
-        # @!attribute [rw] green
-        #     @return [Com::Vmware::Appliance::Techpreview::Networking::Proxy::TestStatus]
-        #     All tests were successful for given data
-        # @!attribute [rw] red
-        #     @return [Com::Vmware::Appliance::Techpreview::Networking::Proxy::TestStatus]
-        #     All tests failed for given data
-        class TestStatus < VAPI::Bindings::VapiEnum
-
-            class << self
-                # Holds (gets or creates) the binding type metadata for this enumeration type.
-                # @scope class
-                # @return [VAPI::Bindings::EnumType] the binding type
-                def binding_type
-                    @binding_type ||= VAPI::Bindings::EnumType.new(
-                        'com.vmware.appliance.techpreview.networking.proxy.test_status',
-                        TestStatus)
-                end
-
-                # Converts from a string value (perhaps off the wire) to an instance
-                # of this enum type.
-                # @param value [String] the actual value of the enum instance
-                # @return [TestStatus] the instance found for the value, otherwise
-                #         an unknown instance will be built for the value
-                def from_string(value)
-                    begin
-                        const_get(value)
-                    rescue NameError
-                        TestStatus.new('UNKNOWN', value)
-                    end
-                end
-            end
-
-            private
-
-            # Constructs a new instance.
-            # @param value [String] the actual value of the enum instance
-            # @param unknown [String] the unknown value when value is 'UKNOWN'
-            def initialize(value, unknown=nil)
-                super(self.class.binding_type, value, unknown)
-            end
-
-            public
-
-            # @!attribute [rw] orange
-            #     @return [Com::Vmware::Appliance::Techpreview::Networking::Proxy::TestStatus]
-            #     In case data has more than one test, this indicates not all tests were successful
-            ORANGE = TestStatus.new('ORANGE')
-
-            # @!attribute [rw] green
-            #     @return [Com::Vmware::Appliance::Techpreview::Networking::Proxy::TestStatus]
-            #     All tests were successful for given data
-            GREEN = TestStatus.new('GREEN')
-
-            # @!attribute [rw] red
-            #     @return [Com::Vmware::Appliance::Techpreview::Networking::Proxy::TestStatus]
-            #     All tests failed for given data
-            RED = TestStatus.new('RED')
-
-        end
-
-
-        # ``Com::Vmware::Appliance::Techpreview::Networking::Proxy::MessageStatus``   enumerated type  Individual test result
-        # @!attribute [rw] failure
-        #     @return [Com::Vmware::Appliance::Techpreview::Networking::Proxy::MessageStatus]
-        #     message indicates the test failed.
-        # @!attribute [rw] success
-        #     @return [Com::Vmware::Appliance::Techpreview::Networking::Proxy::MessageStatus]
-        #     message indicates that the test was successful.
-        class MessageStatus < VAPI::Bindings::VapiEnum
-
-            class << self
-                # Holds (gets or creates) the binding type metadata for this enumeration type.
-                # @scope class
-                # @return [VAPI::Bindings::EnumType] the binding type
-                def binding_type
-                    @binding_type ||= VAPI::Bindings::EnumType.new(
-                        'com.vmware.appliance.techpreview.networking.proxy.message_status',
-                        MessageStatus)
-                end
-
-                # Converts from a string value (perhaps off the wire) to an instance
-                # of this enum type.
-                # @param value [String] the actual value of the enum instance
-                # @return [MessageStatus] the instance found for the value, otherwise
-                #         an unknown instance will be built for the value
-                def from_string(value)
-                    begin
-                        const_get(value)
-                    rescue NameError
-                        MessageStatus.new('UNKNOWN', value)
-                    end
-                end
-            end
-
-            private
-
-            # Constructs a new instance.
-            # @param value [String] the actual value of the enum instance
-            # @param unknown [String] the unknown value when value is 'UKNOWN'
-            def initialize(value, unknown=nil)
-                super(self.class.binding_type, value, unknown)
-            end
-
-            public
-
-            # @!attribute [rw] failure
-            #     @return [Com::Vmware::Appliance::Techpreview::Networking::Proxy::MessageStatus]
-            #     message indicates the test failed.
-            FAILURE = MessageStatus.new('FAILURE')
-
-            # @!attribute [rw] success
-            #     @return [Com::Vmware::Appliance::Techpreview::Networking::Proxy::MessageStatus]
-            #     message indicates that the test was successful.
-            SUCCESS = MessageStatus.new('SUCCESS')
-
-        end
-
-
-        # ``Com::Vmware::Appliance::Techpreview::Networking::Proxy::ProxyStatus``   enumerated type  Defines state of proxy
-        # @!attribute [rw] disabled
-        #     @return [Com::Vmware::Appliance::Techpreview::Networking::Proxy::ProxyStatus]
-        #     proxy configuration is disabled
-        # @!attribute [rw] enabled
-        #     @return [Com::Vmware::Appliance::Techpreview::Networking::Proxy::ProxyStatus]
-        #     proxy configuration is enabled
-        class ProxyStatus < VAPI::Bindings::VapiEnum
-
-            class << self
-                # Holds (gets or creates) the binding type metadata for this enumeration type.
-                # @scope class
-                # @return [VAPI::Bindings::EnumType] the binding type
-                def binding_type
-                    @binding_type ||= VAPI::Bindings::EnumType.new(
-                        'com.vmware.appliance.techpreview.networking.proxy.proxy_status',
-                        ProxyStatus)
-                end
-
-                # Converts from a string value (perhaps off the wire) to an instance
-                # of this enum type.
-                # @param value [String] the actual value of the enum instance
-                # @return [ProxyStatus] the instance found for the value, otherwise
-                #         an unknown instance will be built for the value
-                def from_string(value)
-                    begin
-                        const_get(value)
-                    rescue NameError
-                        ProxyStatus.new('UNKNOWN', value)
-                    end
-                end
-            end
-
-            private
-
-            # Constructs a new instance.
-            # @param value [String] the actual value of the enum instance
-            # @param unknown [String] the unknown value when value is 'UKNOWN'
-            def initialize(value, unknown=nil)
-                super(self.class.binding_type, value, unknown)
-            end
-
-            public
-
-            # @!attribute [rw] disabled
-            #     @return [Com::Vmware::Appliance::Techpreview::Networking::Proxy::ProxyStatus]
-            #     proxy configuration is disabled
-            DISABLED = ProxyStatus.new('DISABLED')
-
-            # @!attribute [rw] enabled
-            #     @return [Com::Vmware::Appliance::Techpreview::Networking::Proxy::ProxyStatus]
-            #     proxy configuration is enabled
-            ENABLED = ProxyStatus.new('ENABLED')
-
-        end
-
-
+    # Set IPv4 network configuration.
+    #
+    # @param config [Array<Com::Vmware::Appliance::Techpreview::Networking::Ipv4::IPv4Config>]
+    #     List of IPv4 configurations.
+    # @return [Void]
+    # @raise [Com::Vmware::Vapi::Std::Errors::Error]
+    #     Generic error
+    def set(config)
+      invoke_with_info(SET_INFO,
+                       'config' => config)
     end
 
-
-    # ``Com::Vmware::Appliance::Techpreview::Networking::Routes``   class  provides  methods  Performs networking routes operations.
-    class Routes < VAPI::Bindings::VapiService
-
-        protected
-
-        # static metamodel definitions
-        @@service_id = VAPI::Core::ServiceIdentifier.new('com.vmware.appliance.techpreview.networking.routes')
-
-        @@test_info = VAPI::Bindings::OperationInfo.new(
-            VAPI::Core::OperationIdentifier.new('test', @@service_id),
-            VAPI::Bindings::OperationInputType.new({
-                'gateways' => VAPI::Bindings::ListType.new(VAPI::Bindings::StringType.instance),
-            }),
-            VAPI::Bindings::ReferenceType.new('Com::Vmware::Appliance::Techpreview::Networking::Routes::TestStatusInfo'),
-            {
-                'com.vmware.vapi.std.errors.error' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Error'),
-
-            },
-            [],
-            [])
-        @@add_info = VAPI::Bindings::OperationInfo.new(
-            VAPI::Core::OperationIdentifier.new('add', @@service_id),
-            VAPI::Bindings::OperationInputType.new({
-                'route' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Appliance::Techpreview::Networking::Routes::Route'),
-            }),
-            VAPI::Bindings::VoidType.instance,
-            {
-                'com.vmware.vapi.std.errors.error' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Error'),
-
-            },
-            [],
-            [])
-        @@set_info = VAPI::Bindings::OperationInfo.new(
-            VAPI::Core::OperationIdentifier.new('set', @@service_id),
-            VAPI::Bindings::OperationInputType.new({
-                'routes' => VAPI::Bindings::ListType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Appliance::Techpreview::Networking::Routes::Route')),
-            }),
-            VAPI::Bindings::VoidType.instance,
-            {
-                'com.vmware.vapi.std.errors.error' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Error'),
-
-            },
-            [],
-            [])
-        @@list_info = VAPI::Bindings::OperationInfo.new(
-            VAPI::Core::OperationIdentifier.new('list', @@service_id),
-            VAPI::Bindings::OperationInputType.new,
-            VAPI::Bindings::ListType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Appliance::Techpreview::Networking::Routes::RouteReadOnly')),
-            {
-                'com.vmware.vapi.std.errors.error' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Error'),
-
-            },
-            [],
-            [])
-        @@delete_info = VAPI::Bindings::OperationInfo.new(
-            VAPI::Core::OperationIdentifier.new('delete', @@service_id),
-            VAPI::Bindings::OperationInputType.new({
-                'route' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Appliance::Techpreview::Networking::Routes::Route'),
-            }),
-            VAPI::Bindings::VoidType.instance,
-            {
-                'com.vmware.vapi.std.errors.error' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Error'),
-
-            },
-            [],
-            [])
-
-        @@service_info = VAPI::Bindings::ServiceInfo.new(@@service_id, {
-            'test' => @@test_info,
-            'add' => @@add_info,
-            'set' => @@set_info,
-            'list' => @@list_info,
-            'delete' => @@delete_info,
-        })
-
-        public
-
-        # Constructs a new instance.
-        #
-        # @param config [VAPI::Bindings::StubConfig] A hash with the api provider details.
-        def initialize(config)
-            super(config, @@service_info)
-        end
-
-
-        # Test connection to a list of gateways
-        #
-        # @param gateways [Array<String>]
-        #     list of gateways.
-        # @return [Com::Vmware::Appliance::Techpreview::Networking::Routes::TestStatusInfo]
-        #     connection status
-        # @raise [Com::Vmware::Vapi::Std::Errors::Error]
-        #     Generic error
-        def test(gateways)
-            invoke_with_info(@@test_info, {
-                'gateways' => gateways,
-            })
-        end
-
-
-        # Set static routing rules. A destination of 0.0.0.0 and prefix 0 (for IPv4) or destination of :: and prefix 0 (for IPv6) refers to the default gateway.
-        #
-        # @param route [Com::Vmware::Appliance::Techpreview::Networking::Routes::Route]
-        #     Static routing rule.
-        # @return [Void]
-        # @raise [Com::Vmware::Vapi::Std::Errors::Error]
-        #     Generic error
-        def add(route)
-            invoke_with_info(@@add_info, {
-                'route' => route,
-            })
-        end
-
-
-        # Set static routing rules. A destination of 0.0.0.0 and prefix 0 (for IPv4) or destination of :: and prefix 0 (for IPv6) refers to the default gateway.
-        #
-        # @param routes [Array<Com::Vmware::Appliance::Techpreview::Networking::Routes::Route>]
-        #     Static routing rules.
-        # @return [Void]
-        # @raise [Com::Vmware::Vapi::Std::Errors::Error]
-        #     Generic error
-        def set(routes)
-            invoke_with_info(@@set_info, {
-                'routes' => routes,
-            })
-        end
-
-
-        # Get main routing table. A destination of 0.0.0.0 and prefix 0 (for IPv4) or destination of :: and prefix 0 (for IPv6) refers to the default gateway.
-        #
-        # @return [Array<Com::Vmware::Appliance::Techpreview::Networking::Routes::RouteReadOnly>]
-        #     Routing table.
-        # @raise [Com::Vmware::Vapi::Std::Errors::Error]
-        #     Generic error
-        def list()
-            invoke_with_info(@@list_info)
-        end
-
-
-        # Delete static routing rules.
-        #
-        # @param route [Com::Vmware::Appliance::Techpreview::Networking::Routes::Route]
-        #     Static routing rule.
-        # @return [Void]
-        # @raise [Com::Vmware::Vapi::Std::Errors::Error]
-        #     Generic error
-        def delete(route)
-            invoke_with_info(@@delete_info, {
-                'route' => route,
-            })
-        end
-
-
-
-        # ``Com::Vmware::Appliance::Techpreview::Networking::Routes::RouteReadOnly``   class  Structure that describes how routing is performed for a particular destination and prefix. A destination/prefix of 0.0.0.0/0 ( for IPv4) or ::/0 (for IPv6) refers to the default gateway.
-        # @!attribute [rw] destination
-        #     @return [String]
-        #     Destination address that defines this route.
-        # @!attribute [rw] prefix
-        #     @return [Fixnum]
-        #     Destination CIDR prefix that defines this route. See http://www.oav.net/mirrors/cidr.html for netmask-to-prefix conversion.
-        # @!attribute [rw] gateway
-        #     @return [String]
-        #     Gateway address.
-        # @!attribute [rw] interface_name
-        #     @return [String]
-        #     Output device interface, for example, "nic0".
-        # @!attribute [rw] is_static
-        #     @return [Boolean]
-        #     Static provides information about installation of the route. True indicates the route was installed by the administrator. False indicates the route was autoconfigured
-        class RouteReadOnly < VAPI::Bindings::VapiStruct
-
-            class << self
-                # Holds (gets or creates) the binding type metadata for this structure type.
-                # @scope class
-                # @return [VAPI::Bindings::StructType] the binding type
-                def binding_type
-                    @binding_type ||= VAPI::Bindings::StructType.new(
-                        'com.vmware.appliance.techpreview.networking.routes.route_read_only',
-                        {
-                            'destination' => VAPI::Bindings::StringType.instance,
-                            'prefix' => VAPI::Bindings::IntegerType.instance,
-                            'gateway' => VAPI::Bindings::StringType.instance,
-                            'interface_name' => VAPI::Bindings::StringType.instance,
-                            'is_static' => VAPI::Bindings::BooleanType.instance,
-                        },
-                        RouteReadOnly,
-                        false,
-                        nil)
-                end
-            end
-
-            attr_accessor :destination,
-                          :prefix,
-                          :gateway,
-                          :interface_name,
-                          :is_static
-
-            # Constructs a new instance.
-            # @param ruby_values [Hash] a map of initial property values (optional)
-            # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
-            def initialize(ruby_values=nil, struct_value=nil)
-                super(self.class.binding_type, ruby_values, struct_value)
-            end
-        end
-
-
-        # ``Com::Vmware::Appliance::Techpreview::Networking::Routes::Route``   class  Structure that describes how routing is performed for a particular destination and prefix. A destination/prefix of 0.0.0.0/0 ( for IPv4) or ::/0 (for IPv6) refers to the default gateway.
-        # @!attribute [rw] destination
-        #     @return [String]
-        #     Destination address that defines this route.
-        # @!attribute [rw] prefix
-        #     @return [Fixnum]
-        #     Destination CIDR prefix that defines this route. See http://www.oav.net/mirrors/cidr.html for netmask-to-prefix conversion.
-        # @!attribute [rw] gateway
-        #     @return [String]
-        #     Gateway address.
-        # @!attribute [rw] interface_name
-        #     @return [String]
-        #     Output device interface, for example, "nic0".
-        class Route < VAPI::Bindings::VapiStruct
-
-            class << self
-                # Holds (gets or creates) the binding type metadata for this structure type.
-                # @scope class
-                # @return [VAPI::Bindings::StructType] the binding type
-                def binding_type
-                    @binding_type ||= VAPI::Bindings::StructType.new(
-                        'com.vmware.appliance.techpreview.networking.routes.route',
-                        {
-                            'destination' => VAPI::Bindings::StringType.instance,
-                            'prefix' => VAPI::Bindings::IntegerType.instance,
-                            'gateway' => VAPI::Bindings::StringType.instance,
-                            'interface_name' => VAPI::Bindings::StringType.instance,
-                        },
-                        Route,
-                        false,
-                        nil)
-                end
-            end
-
-            attr_accessor :destination,
-                          :prefix,
-                          :gateway,
-                          :interface_name
-
-            # Constructs a new instance.
-            # @param ruby_values [Hash] a map of initial property values (optional)
-            # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
-            def initialize(ruby_values=nil, struct_value=nil)
-                super(self.class.binding_type, ruby_values, struct_value)
-            end
-        end
-
-
-        # ``Com::Vmware::Appliance::Techpreview::Networking::Routes::Message``   class  Test result and message
-        # @!attribute [rw] message
-        #     @return [String]
-        #     message
-        # @!attribute [rw] result
-        #     @return [Com::Vmware::Appliance::Techpreview::Networking::Routes::MessageStatus]
-        #     result of the test
-        class Message < VAPI::Bindings::VapiStruct
-
-            class << self
-                # Holds (gets or creates) the binding type metadata for this structure type.
-                # @scope class
-                # @return [VAPI::Bindings::StructType] the binding type
-                def binding_type
-                    @binding_type ||= VAPI::Bindings::StructType.new(
-                        'com.vmware.appliance.techpreview.networking.routes.message',
-                        {
-                            'message' => VAPI::Bindings::StringType.instance,
-                            'result' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Appliance::Techpreview::Networking::Routes::MessageStatus'),
-                        },
-                        Message,
-                        false,
-                        nil)
-                end
-            end
-
-            attr_accessor :message,
-                          :result
-
-            # Constructs a new instance.
-            # @param ruby_values [Hash] a map of initial property values (optional)
-            # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
-            def initialize(ruby_values=nil, struct_value=nil)
-                super(self.class.binding_type, ruby_values, struct_value)
-            end
-        end
-
-
-        # ``Com::Vmware::Appliance::Techpreview::Networking::Routes::TestStatusInfo``   class  Overall test result
-        # @!attribute [rw] status
-        #     @return [Com::Vmware::Appliance::Techpreview::Networking::Routes::TestStatus]
-        #     Overall status of tests run.
-        # @!attribute [rw] messages
-        #     @return [Array<Com::Vmware::Appliance::Techpreview::Networking::Routes::Message>]
-        #     messages
-        class TestStatusInfo < VAPI::Bindings::VapiStruct
-
-            class << self
-                # Holds (gets or creates) the binding type metadata for this structure type.
-                # @scope class
-                # @return [VAPI::Bindings::StructType] the binding type
-                def binding_type
-                    @binding_type ||= VAPI::Bindings::StructType.new(
-                        'com.vmware.appliance.techpreview.networking.routes.test_status_info',
-                        {
-                            'status' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Appliance::Techpreview::Networking::Routes::TestStatus'),
-                            'messages' => VAPI::Bindings::ListType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Appliance::Techpreview::Networking::Routes::Message')),
-                        },
-                        TestStatusInfo,
-                        false,
-                        nil)
-                end
-            end
-
-            attr_accessor :status,
-                          :messages
-
-            # Constructs a new instance.
-            # @param ruby_values [Hash] a map of initial property values (optional)
-            # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
-            def initialize(ruby_values=nil, struct_value=nil)
-                super(self.class.binding_type, ruby_values, struct_value)
-            end
-        end
-
-
-
-        # ``Com::Vmware::Appliance::Techpreview::Networking::Routes::TestStatus``   enumerated type  Health indicator
-        # @!attribute [rw] orange
-        #     @return [Com::Vmware::Appliance::Techpreview::Networking::Routes::TestStatus]
-        #     In case data has more than one test, this indicates not all tests were successful
-        # @!attribute [rw] green
-        #     @return [Com::Vmware::Appliance::Techpreview::Networking::Routes::TestStatus]
-        #     All tests were successful for given data
-        # @!attribute [rw] red
-        #     @return [Com::Vmware::Appliance::Techpreview::Networking::Routes::TestStatus]
-        #     All tests failed for given data
-        class TestStatus < VAPI::Bindings::VapiEnum
-
-            class << self
-                # Holds (gets or creates) the binding type metadata for this enumeration type.
-                # @scope class
-                # @return [VAPI::Bindings::EnumType] the binding type
-                def binding_type
-                    @binding_type ||= VAPI::Bindings::EnumType.new(
-                        'com.vmware.appliance.techpreview.networking.routes.test_status',
-                        TestStatus)
-                end
-
-                # Converts from a string value (perhaps off the wire) to an instance
-                # of this enum type.
-                # @param value [String] the actual value of the enum instance
-                # @return [TestStatus] the instance found for the value, otherwise
-                #         an unknown instance will be built for the value
-                def from_string(value)
-                    begin
-                        const_get(value)
-                    rescue NameError
-                        TestStatus.new('UNKNOWN', value)
-                    end
-                end
-            end
-
-            private
-
-            # Constructs a new instance.
-            # @param value [String] the actual value of the enum instance
-            # @param unknown [String] the unknown value when value is 'UKNOWN'
-            def initialize(value, unknown=nil)
-                super(self.class.binding_type, value, unknown)
-            end
-
-            public
-
-            # @!attribute [rw] orange
-            #     @return [Com::Vmware::Appliance::Techpreview::Networking::Routes::TestStatus]
-            #     In case data has more than one test, this indicates not all tests were successful
-            ORANGE = TestStatus.new('ORANGE')
-
-            # @!attribute [rw] green
-            #     @return [Com::Vmware::Appliance::Techpreview::Networking::Routes::TestStatus]
-            #     All tests were successful for given data
-            GREEN = TestStatus.new('GREEN')
-
-            # @!attribute [rw] red
-            #     @return [Com::Vmware::Appliance::Techpreview::Networking::Routes::TestStatus]
-            #     All tests failed for given data
-            RED = TestStatus.new('RED')
-
-        end
-
-
-        # ``Com::Vmware::Appliance::Techpreview::Networking::Routes::MessageStatus``   enumerated type  Individual test result
-        # @!attribute [rw] failure
-        #     @return [Com::Vmware::Appliance::Techpreview::Networking::Routes::MessageStatus]
-        #     message indicates the test failed.
-        # @!attribute [rw] success
-        #     @return [Com::Vmware::Appliance::Techpreview::Networking::Routes::MessageStatus]
-        #     message indicates that the test was successful.
-        class MessageStatus < VAPI::Bindings::VapiEnum
-
-            class << self
-                # Holds (gets or creates) the binding type metadata for this enumeration type.
-                # @scope class
-                # @return [VAPI::Bindings::EnumType] the binding type
-                def binding_type
-                    @binding_type ||= VAPI::Bindings::EnumType.new(
-                        'com.vmware.appliance.techpreview.networking.routes.message_status',
-                        MessageStatus)
-                end
-
-                # Converts from a string value (perhaps off the wire) to an instance
-                # of this enum type.
-                # @param value [String] the actual value of the enum instance
-                # @return [MessageStatus] the instance found for the value, otherwise
-                #         an unknown instance will be built for the value
-                def from_string(value)
-                    begin
-                        const_get(value)
-                    rescue NameError
-                        MessageStatus.new('UNKNOWN', value)
-                    end
-                end
-            end
-
-            private
-
-            # Constructs a new instance.
-            # @param value [String] the actual value of the enum instance
-            # @param unknown [String] the unknown value when value is 'UKNOWN'
-            def initialize(value, unknown=nil)
-                super(self.class.binding_type, value, unknown)
-            end
-
-            public
-
-            # @!attribute [rw] failure
-            #     @return [Com::Vmware::Appliance::Techpreview::Networking::Routes::MessageStatus]
-            #     message indicates the test failed.
-            FAILURE = MessageStatus.new('FAILURE')
-
-            # @!attribute [rw] success
-            #     @return [Com::Vmware::Appliance::Techpreview::Networking::Routes::MessageStatus]
-            #     message indicates that the test was successful.
-            SUCCESS = MessageStatus.new('SUCCESS')
-
-        end
-
-
+    # Get IPv4 network configuration for all configured interfaces.
+    #
+    # @return [Array<Com::Vmware::Appliance::Techpreview::Networking::Ipv4::IPv4ConfigReadOnly>]
+    #     IPv4 configuration for each interface.
+    # @raise [Com::Vmware::Vapi::Std::Errors::Error]
+    #     Generic error
+    def list
+      invoke_with_info(LIST_INFO)
     end
 
+    # Get IPv4 network configuration for interfaces.
+    #
+    # @param interfaces [Array<String>]
+    #     Network interfaces to query, for example, "nic0".
+    # @return [Array<Com::Vmware::Appliance::Techpreview::Networking::Ipv4::IPv4ConfigReadOnly>]
+    #     IPv4 configuration for each queried interface.
+    # @raise [Com::Vmware::Vapi::Std::Errors::Error]
+    #     Generic error
+    def get(interfaces)
+      invoke_with_info(GET_INFO,
+                       'interfaces' => interfaces)
+    end
 
+    # ``Com::Vmware::Appliance::Techpreview::Networking::Ipv4::IPv4Config``   class  Structure that defines the IPv4 configuration state of a network interface.
+    # @!attribute [rw] interface_name
+    #     @return [String]
+    #     Interface name, for example, "nic0", "nic1".
+    # @!attribute [rw] mode
+    #     @return [Com::Vmware::Appliance::Techpreview::Networking::Ipv4::IPv4Mode]
+    #     Address assignment mode.
+    # @!attribute [rw] address
+    #     @return [String]
+    #     IPv4 address, for example, "10.20.80.191". Set this argument to an empty string "", if the mode is "unconfigured" or "dhcp".
+    # @!attribute [rw] prefix
+    #     @return [Fixnum]
+    #     IPv4 CIDR prefix, for example , 24. See http://www.oav.net/mirrors/cidr.html for netmask-to-prefix conversion. Set this argument to 0 if the mode is "unconfigured" or "dhcp".
+    # @!attribute [rw] default_gateway
+    #     @return [String]
+    #     IPv4 address of the default gateway. This default gateway value is used if the mode argument is set to "static" This configures the global default gateway on the appliance with the specified gateway address and interface. This gateway replaces the existing default gateway configured on the appliance. However, if the gateway address is link-local, then it is added for that interface. This does not support configuration of multiple global default gateways through different interfaces.
+    class IPv4Config < VAPI::Bindings::VapiStruct
+      class << self
+        # Holds (gets or creates) the binding type metadata for this structure type.
+        # @scope class
+        # @return [VAPI::Bindings::StructType] the binding type
+        def binding_type
+          @binding_type ||= VAPI::Bindings::StructType.new(
+            'com.vmware.appliance.techpreview.networking.ipv4.I_pv4_config',
+            {
+              'interface_name' => VAPI::Bindings::StringType.instance,
+              'mode' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Appliance::Techpreview::Networking::Ipv4::IPv4Mode'),
+              'address' => VAPI::Bindings::StringType.instance,
+              'prefix' => VAPI::Bindings::IntegerType.instance,
+              'default_gateway' => VAPI::Bindings::StringType.instance
+            },
+            IPv4Config,
+            false,
+            nil
+          )
+        end
+      end
+
+      attr_accessor :interface_name,
+                    :mode,
+                    :address,
+                    :prefix,
+                    :default_gateway
+
+      # Constructs a new instance.
+      # @param ruby_values [Hash] a map of initial property values (optional)
+      # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
+      def initialize(ruby_values = nil, struct_value = nil)
+        super(self.class.binding_type, ruby_values, struct_value)
+      end
+    end
+
+    # ``Com::Vmware::Appliance::Techpreview::Networking::Ipv4::IPv4ConfigReadOnly``   class  Structure that defines the IPv4 configuration state of a network interface.
+    # @!attribute [rw] interface_name
+    #     @return [String]
+    #     Interface name, for example, "nic0", "nic1".
+    # @!attribute [rw] mode
+    #     @return [Com::Vmware::Appliance::Techpreview::Networking::Ipv4::IPv4Mode]
+    #     Address assignment mode.
+    # @!attribute [rw] address
+    #     @return [String]
+    #     IPv4 address, for example, "10.20.80.191". Set this argument to an empty string "", if the mode is "unconfigured" or "dhcp".
+    # @!attribute [rw] prefix
+    #     @return [Fixnum]
+    #     IPv4 CIDR prefix, for example , 24. See http://www.oav.net/mirrors/cidr.html for netmask-to-prefix conversion. Set this argument to 0 if the mode is "unconfigured" or "dhcp".
+    # @!attribute [rw] default_gateway
+    #     @return [String]
+    #     IPv4 address of the default gateway. This default gateway value is used if the mode argument is set to "static" This configures the global default gateway on the appliance with the specified gateway address and interface. This gateway replaces the existing default gateway configured on the appliance. However, if the gateway address is link-local, then it is added for that interface. This does not support configuration of multiple global default gateways through different interfaces.
+    # @!attribute [rw] updateable
+    #     @return [Boolean]
+    #     This indicates if the network configuration can be updated for the interface.
+    class IPv4ConfigReadOnly < VAPI::Bindings::VapiStruct
+      class << self
+        # Holds (gets or creates) the binding type metadata for this structure type.
+        # @scope class
+        # @return [VAPI::Bindings::StructType] the binding type
+        def binding_type
+          @binding_type ||= VAPI::Bindings::StructType.new(
+            'com.vmware.appliance.techpreview.networking.ipv4.I_pv4_config_read_only',
+            {
+              'interface_name' => VAPI::Bindings::StringType.instance,
+              'mode' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Appliance::Techpreview::Networking::Ipv4::IPv4Mode'),
+              'address' => VAPI::Bindings::StringType.instance,
+              'prefix' => VAPI::Bindings::IntegerType.instance,
+              'default_gateway' => VAPI::Bindings::StringType.instance,
+              'updateable' => VAPI::Bindings::BooleanType.instance
+            },
+            IPv4ConfigReadOnly,
+            false,
+            nil
+          )
+        end
+      end
+
+      attr_accessor :interface_name,
+                    :mode,
+                    :address,
+                    :prefix,
+                    :default_gateway,
+                    :updateable
+
+      # Constructs a new instance.
+      # @param ruby_values [Hash] a map of initial property values (optional)
+      # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
+      def initialize(ruby_values = nil, struct_value = nil)
+        super(self.class.binding_type, ruby_values, struct_value)
+      end
+    end
+
+    # ``Com::Vmware::Appliance::Techpreview::Networking::Ipv4::IPv4Mode``   enumerated type  Defines different ipv4 modes
+    # @!attribute [rw] dhcp
+    #     @return [Com::Vmware::Appliance::Techpreview::Networking::Ipv4::IPv4Mode]
+    #     IPv4 address is automatically assigned by a DHCP server.
+    # @!attribute [rw] is_static
+    #     @return [Com::Vmware::Appliance::Techpreview::Networking::Ipv4::IPv4Mode]
+    #     IPv4 address is static.
+    # @!attribute [rw] unconfigured
+    #     @return [Com::Vmware::Appliance::Techpreview::Networking::Ipv4::IPv4Mode]
+    #     The IPv4 protocol is not configured.
+    class IPv4Mode < VAPI::Bindings::VapiEnum
+      class << self
+        # Holds (gets or creates) the binding type metadata for this enumeration type.
+        # @scope class
+        # @return [VAPI::Bindings::EnumType] the binding type
+        def binding_type
+          @binding_type ||= VAPI::Bindings::EnumType.new(
+            'com.vmware.appliance.techpreview.networking.ipv4.I_pv4_mode',
+            IPv4Mode
+          )
+        end
+
+        # Converts from a string value (perhaps off the wire) to an instance
+        # of this enum type.
+        # @param value [String] the actual value of the enum instance
+        # @return [IPv4Mode] the instance found for the value, otherwise
+        #         an unknown instance will be built for the value
+        def from_string(value)
+          const_get(value)
+        rescue NameError
+          IPv4Mode.send(:new, 'UNKNOWN', value)
+        end
+      end
+
+      # Constructs a new instance.
+      # @param value [String] the actual value of the enum instance
+      # @param unknown [String] the unknown value when value is 'UKNOWN'
+      def initialize(value, unknown = nil)
+        super(self.class.binding_type, value, unknown)
+      end
+
+      private_class_method :new
+
+      # @!attribute [rw] dhcp
+      #     @return [Com::Vmware::Appliance::Techpreview::Networking::Ipv4::IPv4Mode]
+      #     IPv4 address is automatically assigned by a DHCP server.
+      DHCP = IPv4Mode.send(:new, 'DHCP')
+
+      # @!attribute [rw] is_static
+      #     @return [Com::Vmware::Appliance::Techpreview::Networking::Ipv4::IPv4Mode]
+      #     IPv4 address is static.
+      IS_STATIC = IPv4Mode.send(:new, 'IS_STATIC')
+
+      # @!attribute [rw] unconfigured
+      #     @return [Com::Vmware::Appliance::Techpreview::Networking::Ipv4::IPv4Mode]
+      #     The IPv4 protocol is not configured.
+      UNCONFIGURED = IPv4Mode.send(:new, 'UNCONFIGURED')
+    end
+  end
+  # ``Com::Vmware::Appliance::Techpreview::Networking::Ipv6``   class  provides  methods  Performs IPV4 network configuration for interfaces.
+  class Ipv6 < VAPI::Bindings::VapiService
+    # static metamodel definitions
+    SERVICE_ID = VAPI::Core::ServiceIdentifier.new('com.vmware.appliance.techpreview.networking.ipv6')
+
+    SET_INFO = VAPI::Bindings::OperationInfo.new(
+      VAPI::Core::OperationIdentifier.new('set', SERVICE_ID),
+      VAPI::Bindings::OperationInputType.new(
+        'config' => VAPI::Bindings::ListType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Appliance::Techpreview::Networking::Ipv6::IPv6Config'))
+      ),
+      VAPI::Bindings::VoidType.instance,
+      {
+        'com.vmware.vapi.std.errors.error' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Error')
+      },
+      [],
+      []
+    )
+
+    LIST_INFO = VAPI::Bindings::OperationInfo.new(
+      VAPI::Core::OperationIdentifier.new('list', SERVICE_ID),
+      VAPI::Bindings::OperationInputType.new,
+      VAPI::Bindings::ListType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Appliance::Techpreview::Networking::Ipv6::IPv6ConfigReadOnly')),
+      {
+        'com.vmware.vapi.std.errors.error' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Error')
+      },
+      [],
+      []
+    )
+
+    GET_INFO = VAPI::Bindings::OperationInfo.new(
+      VAPI::Core::OperationIdentifier.new('get', SERVICE_ID),
+      VAPI::Bindings::OperationInputType.new(
+        'interfaces' => VAPI::Bindings::ListType.new(VAPI::Bindings::StringType.instance)
+      ),
+      VAPI::Bindings::ListType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Appliance::Techpreview::Networking::Ipv6::IPv6ConfigReadOnly')),
+      {
+        'com.vmware.vapi.std.errors.error' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Error')
+      },
+      [],
+      []
+    )
+
+    SERVICE_INFO = VAPI::Bindings::ServiceInfo.new(
+      SERVICE_ID,
+      'set' => SET_INFO,
+      'list' => LIST_INFO,
+      'get' => GET_INFO
+    )
+
+    # Constructs a new instance.
+    #
+    # @param config [VAPI::Bindings::StubConfig] A hash with the api provider details.
+    def initialize(config)
+      super(config, SERVICE_INFO)
+    end
+
+    # Set IPv6 network configuration.
+    #
+    # @param config [Array<Com::Vmware::Appliance::Techpreview::Networking::Ipv6::IPv6Config>]
+    #     IPv6 configuration.
+    # @return [Void]
+    # @raise [Com::Vmware::Vapi::Std::Errors::Error]
+    #     Generic error
+    def set(config)
+      invoke_with_info(SET_INFO,
+                       'config' => config)
+    end
+
+    # Get IPv6 network configuration for all configured interfaces.
+    #
+    # @return [Array<Com::Vmware::Appliance::Techpreview::Networking::Ipv6::IPv6ConfigReadOnly>]
+    #     IPv6 configuration for each interface.
+    # @raise [Com::Vmware::Vapi::Std::Errors::Error]
+    #     Generic error
+    def list
+      invoke_with_info(LIST_INFO)
+    end
+
+    # Get IPv6 network configuration for interfaces.
+    #
+    # @param interfaces [Array<String>]
+    #     Network interfaces to query, for example, "nic0".
+    # @return [Array<Com::Vmware::Appliance::Techpreview::Networking::Ipv6::IPv6ConfigReadOnly>]
+    #     IPv6 configuration.
+    # @raise [Com::Vmware::Vapi::Std::Errors::Error]
+    #     Generic error
+    def get(interfaces)
+      invoke_with_info(GET_INFO,
+                       'interfaces' => interfaces)
+    end
+
+    # ``Com::Vmware::Appliance::Techpreview::Networking::Ipv6::IPv6AddressReadOnly``   class  Structure that you can use to get information about an IPv6 address along with its origin and status.
+    # @!attribute [rw] address
+    #     @return [String]
+    #     IPv6 address, for example, fc00:10:20:83:20c:29ff:fe94:bb5a.
+    # @!attribute [rw] prefix
+    #     @return [Fixnum]
+    #     IPv6 CIDR prefix, for example, 64.
+    # @!attribute [rw] origin
+    #     @return [Com::Vmware::Appliance::Techpreview::Networking::Ipv6::IPv6AddressOrigin]
+    #     Origin of the IPv6 address. For more information, see RFC 4293.
+    # @!attribute [rw] status
+    #     @return [Com::Vmware::Appliance::Techpreview::Networking::Ipv6::IPv6AddressStatus]
+    #     Status of the IPv6 address. For more information, see RFC 4293.
+    class IPv6AddressReadOnly < VAPI::Bindings::VapiStruct
+      class << self
+        # Holds (gets or creates) the binding type metadata for this structure type.
+        # @scope class
+        # @return [VAPI::Bindings::StructType] the binding type
+        def binding_type
+          @binding_type ||= VAPI::Bindings::StructType.new(
+            'com.vmware.appliance.techpreview.networking.ipv6.I_pv6_address_read_only',
+            {
+              'address' => VAPI::Bindings::StringType.instance,
+              'prefix' => VAPI::Bindings::IntegerType.instance,
+              'origin' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Appliance::Techpreview::Networking::Ipv6::IPv6AddressOrigin'),
+              'status' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Appliance::Techpreview::Networking::Ipv6::IPv6AddressStatus')
+            },
+            IPv6AddressReadOnly,
+            false,
+            nil
+          )
+        end
+      end
+
+      attr_accessor :address,
+                    :prefix,
+                    :origin,
+                    :status
+
+      # Constructs a new instance.
+      # @param ruby_values [Hash] a map of initial property values (optional)
+      # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
+      def initialize(ruby_values = nil, struct_value = nil)
+        super(self.class.binding_type, ruby_values, struct_value)
+      end
+    end
+
+    # ``Com::Vmware::Appliance::Techpreview::Networking::Ipv6::IPv6ConfigReadOnly``   class  Structure that defines an existing IPv6 configuration on a particular interface. This structure is read only.
+    # @!attribute [rw] interface_name
+    #     @return [String]
+    #     Network interface, for example, "nic0" queried.
+    # @!attribute [rw] dhcp
+    #     @return [Boolean]
+    #     Address assigned by a DHCP server.
+    # @!attribute [rw] autoconf
+    #     @return [Boolean]
+    #     Address is assigned by Stateless Address Autoconfiguration (SLAAC).
+    # @!attribute [rw] addresses
+    #     @return [Array<Com::Vmware::Appliance::Techpreview::Networking::Ipv6::IPv6AddressReadOnly>]
+    #     A list of all addresses assigned to this interface. The origin field of each address determines how the address was assigned, for example, statically, by DHCP, SLAAC.
+    # @!attribute [rw] default_gateway
+    #     @return [String]
+    #     Default gateway. This configures the global IPv6 default gateway on the appliance with the specified gateway address and interface. This gateway replaces the existing default gateway configured on the appliance. However, if the gateway address is link-local, then it is added for that interface. This does not support configuration of multiple global default gateways through different interfaces.
+    # @!attribute [rw] updateable
+    #     @return [Boolean]
+    #     This indicates if the network configuration can be updated for the interface.
+    class IPv6ConfigReadOnly < VAPI::Bindings::VapiStruct
+      class << self
+        # Holds (gets or creates) the binding type metadata for this structure type.
+        # @scope class
+        # @return [VAPI::Bindings::StructType] the binding type
+        def binding_type
+          @binding_type ||= VAPI::Bindings::StructType.new(
+            'com.vmware.appliance.techpreview.networking.ipv6.I_pv6_config_read_only',
+            {
+              'interface_name' => VAPI::Bindings::StringType.instance,
+              'dhcp' => VAPI::Bindings::BooleanType.instance,
+              'autoconf' => VAPI::Bindings::BooleanType.instance,
+              'addresses' => VAPI::Bindings::ListType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Appliance::Techpreview::Networking::Ipv6::IPv6AddressReadOnly')),
+              'default_gateway' => VAPI::Bindings::StringType.instance,
+              'updateable' => VAPI::Bindings::BooleanType.instance
+            },
+            IPv6ConfigReadOnly,
+            false,
+            nil
+          )
+        end
+      end
+
+      attr_accessor :interface_name,
+                    :dhcp,
+                    :autoconf,
+                    :addresses,
+                    :default_gateway,
+                    :updateable
+
+      # Constructs a new instance.
+      # @param ruby_values [Hash] a map of initial property values (optional)
+      # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
+      def initialize(ruby_values = nil, struct_value = nil)
+        super(self.class.binding_type, ruby_values, struct_value)
+      end
+    end
+
+    # ``Com::Vmware::Appliance::Techpreview::Networking::Ipv6::IPv6Address``   class  Structure used to name an IPv6 address.
+    # @!attribute [rw] address
+    #     @return [String]
+    #     IPv6 address, for example, fc00:10:20:83:20c:29ff:fe94:bb5a.
+    # @!attribute [rw] prefix
+    #     @return [Fixnum]
+    #     IPv6 CIDR prefix, for example, 64.
+    class IPv6Address < VAPI::Bindings::VapiStruct
+      class << self
+        # Holds (gets or creates) the binding type metadata for this structure type.
+        # @scope class
+        # @return [VAPI::Bindings::StructType] the binding type
+        def binding_type
+          @binding_type ||= VAPI::Bindings::StructType.new(
+            'com.vmware.appliance.techpreview.networking.ipv6.I_pv6_address',
+            {
+              'address' => VAPI::Bindings::StringType.instance,
+              'prefix' => VAPI::Bindings::IntegerType.instance
+            },
+            IPv6Address,
+            false,
+            nil
+          )
+        end
+      end
+
+      attr_accessor :address,
+                    :prefix
+
+      # Constructs a new instance.
+      # @param ruby_values [Hash] a map of initial property values (optional)
+      # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
+      def initialize(ruby_values = nil, struct_value = nil)
+        super(self.class.binding_type, ruby_values, struct_value)
+      end
+    end
+
+    # ``Com::Vmware::Appliance::Techpreview::Networking::Ipv6::IPv6Config``   class  Structure that you can use to configure IPv6 on a particular interface. Because IPv6 permits multiple addresses per interface, addresses can be assigned by DHCP, SLAAC, and can also be statically assigned.
+    # @!attribute [rw] interface_name
+    #     @return [String]
+    #     Network interface, for example, "nic0" to configure.
+    # @!attribute [rw] dhcp
+    #     @return [Boolean]
+    #     Address assigned by a DHCP server.
+    # @!attribute [rw] autoconf
+    #     @return [Boolean]
+    #     Address is assigned by Stateless Address Autoconfiguration (SLAAC).
+    # @!attribute [rw] addresses
+    #     @return [Array<Com::Vmware::Appliance::Techpreview::Networking::Ipv6::IPv6Address>]
+    #     A list of addresses to be statically assigned.
+    # @!attribute [rw] default_gateway
+    #     @return [String]
+    #     Default gateway for static IP address assignment. This configures the global IPv6 default gateway on the appliance with the specified gateway address and interface. This gateway replaces the existing default gateway configured on the appliance. However, if the gateway address is link-local, then it is added for that interface. This does not support configuration of multiple global default gateways through different interfaces.
+    class IPv6Config < VAPI::Bindings::VapiStruct
+      class << self
+        # Holds (gets or creates) the binding type metadata for this structure type.
+        # @scope class
+        # @return [VAPI::Bindings::StructType] the binding type
+        def binding_type
+          @binding_type ||= VAPI::Bindings::StructType.new(
+            'com.vmware.appliance.techpreview.networking.ipv6.I_pv6_config',
+            {
+              'interface_name' => VAPI::Bindings::StringType.instance,
+              'dhcp' => VAPI::Bindings::BooleanType.instance,
+              'autoconf' => VAPI::Bindings::BooleanType.instance,
+              'addresses' => VAPI::Bindings::ListType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Appliance::Techpreview::Networking::Ipv6::IPv6Address')),
+              'default_gateway' => VAPI::Bindings::StringType.instance
+            },
+            IPv6Config,
+            false,
+            nil
+          )
+        end
+      end
+
+      attr_accessor :interface_name,
+                    :dhcp,
+                    :autoconf,
+                    :addresses,
+                    :default_gateway
+
+      # Constructs a new instance.
+      # @param ruby_values [Hash] a map of initial property values (optional)
+      # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
+      def initialize(ruby_values = nil, struct_value = nil)
+        super(self.class.binding_type, ruby_values, struct_value)
+      end
+    end
+
+    # ``Com::Vmware::Appliance::Techpreview::Networking::Ipv6::IPv6AddressOrigin``   enumerated type  Defines IPV6 address origin values
+    # @!attribute [rw] dhcp
+    #     @return [Com::Vmware::Appliance::Techpreview::Networking::Ipv6::IPv6AddressOrigin]
+    #     The IPv6 address is assigned by a DHCP server. See RFC 4293.
+    # @!attribute [rw] random
+    #     @return [Com::Vmware::Appliance::Techpreview::Networking::Ipv6::IPv6AddressOrigin]
+    #     The IPv6 address is assigned randomly by the system. See RFC 4293.
+    # @!attribute [rw] manual
+    #     @return [Com::Vmware::Appliance::Techpreview::Networking::Ipv6::IPv6AddressOrigin]
+    #     The IPv6 address was manually configured to a specified address, for, example, by user configuration. See RFC 4293.
+    # @!attribute [rw] other
+    #     @return [Com::Vmware::Appliance::Techpreview::Networking::Ipv6::IPv6AddressOrigin]
+    #     The IPv6 address is assigned by a mechanism other than manual, DHCP, SLAAC, or random. See RFC 4293.
+    # @!attribute [rw] linklayer
+    #     @return [Com::Vmware::Appliance::Techpreview::Networking::Ipv6::IPv6AddressOrigin]
+    #     The IPv6 address is assigned by IPv6 Stateless Address Auto-configuration (SLAAC). See RFC 4293.
+    class IPv6AddressOrigin < VAPI::Bindings::VapiEnum
+      class << self
+        # Holds (gets or creates) the binding type metadata for this enumeration type.
+        # @scope class
+        # @return [VAPI::Bindings::EnumType] the binding type
+        def binding_type
+          @binding_type ||= VAPI::Bindings::EnumType.new(
+            'com.vmware.appliance.techpreview.networking.ipv6.I_pv6_address_origin',
+            IPv6AddressOrigin
+          )
+        end
+
+        # Converts from a string value (perhaps off the wire) to an instance
+        # of this enum type.
+        # @param value [String] the actual value of the enum instance
+        # @return [IPv6AddressOrigin] the instance found for the value, otherwise
+        #         an unknown instance will be built for the value
+        def from_string(value)
+          const_get(value)
+        rescue NameError
+          IPv6AddressOrigin.send(:new, 'UNKNOWN', value)
+        end
+      end
+
+      # Constructs a new instance.
+      # @param value [String] the actual value of the enum instance
+      # @param unknown [String] the unknown value when value is 'UKNOWN'
+      def initialize(value, unknown = nil)
+        super(self.class.binding_type, value, unknown)
+      end
+
+      private_class_method :new
+
+      # @!attribute [rw] dhcp
+      #     @return [Com::Vmware::Appliance::Techpreview::Networking::Ipv6::IPv6AddressOrigin]
+      #     The IPv6 address is assigned by a DHCP server. See RFC 4293.
+      DHCP = IPv6AddressOrigin.send(:new, 'DHCP')
+
+      # @!attribute [rw] random
+      #     @return [Com::Vmware::Appliance::Techpreview::Networking::Ipv6::IPv6AddressOrigin]
+      #     The IPv6 address is assigned randomly by the system. See RFC 4293.
+      RANDOM = IPv6AddressOrigin.send(:new, 'RANDOM')
+
+      # @!attribute [rw] manual
+      #     @return [Com::Vmware::Appliance::Techpreview::Networking::Ipv6::IPv6AddressOrigin]
+      #     The IPv6 address was manually configured to a specified address, for, example, by user configuration. See RFC 4293.
+      MANUAL = IPv6AddressOrigin.send(:new, 'MANUAL')
+
+      # @!attribute [rw] other
+      #     @return [Com::Vmware::Appliance::Techpreview::Networking::Ipv6::IPv6AddressOrigin]
+      #     The IPv6 address is assigned by a mechanism other than manual, DHCP, SLAAC, or random. See RFC 4293.
+      OTHER = IPv6AddressOrigin.send(:new, 'OTHER')
+
+      # @!attribute [rw] linklayer
+      #     @return [Com::Vmware::Appliance::Techpreview::Networking::Ipv6::IPv6AddressOrigin]
+      #     The IPv6 address is assigned by IPv6 Stateless Address Auto-configuration (SLAAC). See RFC 4293.
+      LINKLAYER = IPv6AddressOrigin.send(:new, 'LINKLAYER')
+    end
+    # ``Com::Vmware::Appliance::Techpreview::Networking::Ipv6::IPv6AddressStatus``   enumerated type  Defines IPV6 address status values
+    # @!attribute [rw] tentative
+    #     @return [Com::Vmware::Appliance::Techpreview::Networking::Ipv6::IPv6AddressStatus]
+    #     This IPv6 address is in the process of being verified as unique. Do not use addresses in this state for general communication. You can use them to determine the uniqueness of the address. See RFC 4293.
+    # @!attribute [rw] unknown
+    #     @return [Com::Vmware::Appliance::Techpreview::Networking::Ipv6::IPv6AddressStatus]
+    #     The status of this address cannot be determined. See RFC 4293.
+    # @!attribute [rw] inaccessible
+    #     @return [Com::Vmware::Appliance::Techpreview::Networking::Ipv6::IPv6AddressStatus]
+    #     This IPv6 address is inaccessible because the interface to which this address is assigned is not operational. See RFC 4293.
+    # @!attribute [rw] invalid
+    #     @return [Com::Vmware::Appliance::Techpreview::Networking::Ipv6::IPv6AddressStatus]
+    #     This IPv6 address is not a valid address. It should not appear as the destination or source address of a packet. See RFC 4293.
+    # @!attribute [rw] duplicate
+    #     @return [Com::Vmware::Appliance::Techpreview::Networking::Ipv6::IPv6AddressStatus]
+    #     This IPv6 address is not unique on the link. Do use this IPv6 address. See RFC 4293.
+    # @!attribute [rw] preferred
+    #     @return [Com::Vmware::Appliance::Techpreview::Networking::Ipv6::IPv6AddressStatus]
+    #     This is a valid IPv6 address that can appear as the destination or source address of a packet. See RFC 4293.
+    # @!attribute [rw] deprecated
+    #     @return [Com::Vmware::Appliance::Techpreview::Networking::Ipv6::IPv6AddressStatus]
+    #     This is a valid but deprecated IPv6 address. Do not use this IPv6 address as a source address in new communications, although packets addressed to such an address are processed as expected. See RFC 4293.
+    # @!attribute [rw] optimistic
+    #     @return [Com::Vmware::Appliance::Techpreview::Networking::Ipv6::IPv6AddressStatus]
+    #     This IPv6 address is available for use, subject to restrictions, while its uniqueness on a link is being verified. See RFC 4293.
+    class IPv6AddressStatus < VAPI::Bindings::VapiEnum
+      class << self
+        # Holds (gets or creates) the binding type metadata for this enumeration type.
+        # @scope class
+        # @return [VAPI::Bindings::EnumType] the binding type
+        def binding_type
+          @binding_type ||= VAPI::Bindings::EnumType.new(
+            'com.vmware.appliance.techpreview.networking.ipv6.I_pv6_address_status',
+            IPv6AddressStatus
+          )
+        end
+
+        # Converts from a string value (perhaps off the wire) to an instance
+        # of this enum type.
+        # @param value [String] the actual value of the enum instance
+        # @return [IPv6AddressStatus] the instance found for the value, otherwise
+        #         an unknown instance will be built for the value
+        def from_string(value)
+          const_get(value)
+        rescue NameError
+          IPv6AddressStatus.send(:new, 'UNKNOWN', value)
+        end
+      end
+
+      # Constructs a new instance.
+      # @param value [String] the actual value of the enum instance
+      # @param unknown [String] the unknown value when value is 'UKNOWN'
+      def initialize(value, unknown = nil)
+        super(self.class.binding_type, value, unknown)
+      end
+
+      private_class_method :new
+
+      # @!attribute [rw] tentative
+      #     @return [Com::Vmware::Appliance::Techpreview::Networking::Ipv6::IPv6AddressStatus]
+      #     This IPv6 address is in the process of being verified as unique. Do not use addresses in this state for general communication. You can use them to determine the uniqueness of the address. See RFC 4293.
+      TENTATIVE = IPv6AddressStatus.send(:new, 'TENTATIVE')
+
+      # @!attribute [rw] unknown
+      #     @return [Com::Vmware::Appliance::Techpreview::Networking::Ipv6::IPv6AddressStatus]
+      #     The status of this address cannot be determined. See RFC 4293.
+      UNKNOWN = IPv6AddressStatus.send(:new, 'UNKNOWN')
+
+      # @!attribute [rw] inaccessible
+      #     @return [Com::Vmware::Appliance::Techpreview::Networking::Ipv6::IPv6AddressStatus]
+      #     This IPv6 address is inaccessible because the interface to which this address is assigned is not operational. See RFC 4293.
+      INACCESSIBLE = IPv6AddressStatus.send(:new, 'INACCESSIBLE')
+
+      # @!attribute [rw] invalid
+      #     @return [Com::Vmware::Appliance::Techpreview::Networking::Ipv6::IPv6AddressStatus]
+      #     This IPv6 address is not a valid address. It should not appear as the destination or source address of a packet. See RFC 4293.
+      INVALID = IPv6AddressStatus.send(:new, 'INVALID')
+
+      # @!attribute [rw] duplicate
+      #     @return [Com::Vmware::Appliance::Techpreview::Networking::Ipv6::IPv6AddressStatus]
+      #     This IPv6 address is not unique on the link. Do use this IPv6 address. See RFC 4293.
+      DUPLICATE = IPv6AddressStatus.send(:new, 'DUPLICATE')
+
+      # @!attribute [rw] preferred
+      #     @return [Com::Vmware::Appliance::Techpreview::Networking::Ipv6::IPv6AddressStatus]
+      #     This is a valid IPv6 address that can appear as the destination or source address of a packet. See RFC 4293.
+      PREFERRED = IPv6AddressStatus.send(:new, 'PREFERRED')
+
+      # @!attribute [rw] deprecated
+      #     @return [Com::Vmware::Appliance::Techpreview::Networking::Ipv6::IPv6AddressStatus]
+      #     This is a valid but deprecated IPv6 address. Do not use this IPv6 address as a source address in new communications, although packets addressed to such an address are processed as expected. See RFC 4293.
+      DEPRECATED = IPv6AddressStatus.send(:new, 'DEPRECATED')
+
+      # @!attribute [rw] optimistic
+      #     @return [Com::Vmware::Appliance::Techpreview::Networking::Ipv6::IPv6AddressStatus]
+      #     This IPv6 address is available for use, subject to restrictions, while its uniqueness on a link is being verified. See RFC 4293.
+      OPTIMISTIC = IPv6AddressStatus.send(:new, 'OPTIMISTIC')
+    end
+  end
+  # ``Com::Vmware::Appliance::Techpreview::Networking::Proxy``   class  provides  methods  Proxy configuration.
+  class Proxy < VAPI::Bindings::VapiService
+    # static metamodel definitions
+    SERVICE_ID = VAPI::Core::ServiceIdentifier.new('com.vmware.appliance.techpreview.networking.proxy')
+
+    TEST_INFO = VAPI::Bindings::OperationInfo.new(
+      VAPI::Core::OperationIdentifier.new('test', SERVICE_ID),
+      VAPI::Bindings::OperationInputType.new(
+        'config' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Appliance::Techpreview::Networking::Proxy::ProxyConfigTest')
+      ),
+      VAPI::Bindings::ReferenceType.new('Com::Vmware::Appliance::Techpreview::Networking::Proxy::TestStatusInfo'),
+      {
+        'com.vmware.vapi.std.errors.error' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Error')
+      },
+      [],
+      []
+    )
+
+    SET_INFO = VAPI::Bindings::OperationInfo.new(
+      VAPI::Core::OperationIdentifier.new('set', SERVICE_ID),
+      VAPI::Bindings::OperationInputType.new(
+        'config' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Appliance::Techpreview::Networking::Proxy::ProxyConfigMultiple')
+      ),
+      VAPI::Bindings::VoidType.instance,
+      {
+        'com.vmware.vapi.std.errors.error' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Error')
+      },
+      [],
+      []
+    )
+
+    DELETE_INFO = VAPI::Bindings::OperationInfo.new(
+      VAPI::Core::OperationIdentifier.new('delete', SERVICE_ID),
+      VAPI::Bindings::OperationInputType.new(
+        'protocol' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Appliance::Techpreview::Networking::Proxy::ProxyProtocol')
+      ),
+      VAPI::Bindings::VoidType.instance,
+      {
+        'com.vmware.vapi.std.errors.error' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Error')
+      },
+      [],
+      []
+    )
+
+    GET_INFO = VAPI::Bindings::OperationInfo.new(
+      VAPI::Core::OperationIdentifier.new('get', SERVICE_ID),
+      VAPI::Bindings::OperationInputType.new,
+      VAPI::Bindings::ReferenceType.new('Com::Vmware::Appliance::Techpreview::Networking::Proxy::ProxyConfigMultiple'),
+      {
+        'com.vmware.vapi.std.errors.error' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Error')
+      },
+      [],
+      []
+    )
+
+    SERVICE_INFO = VAPI::Bindings::ServiceInfo.new(
+      SERVICE_ID,
+      'test' => TEST_INFO,
+      'set' => SET_INFO,
+      'delete' => DELETE_INFO,
+      'get' => GET_INFO
+    )
+
+    # Constructs a new instance.
+    #
+    # @param config [VAPI::Bindings::StubConfig] A hash with the api provider details.
+    def initialize(config)
+      super(config, SERVICE_INFO)
+    end
+
+    # Test a Proxy configuration by testing the connection to the proxy server and test host.
+    #
+    # @param config [Com::Vmware::Appliance::Techpreview::Networking::Proxy::ProxyConfigTest]
+    #     Proxy configuration to test
+    # @return [Com::Vmware::Appliance::Techpreview::Networking::Proxy::TestStatusInfo]
+    #     Status of proxy settings.
+    # @raise [Com::Vmware::Vapi::Std::Errors::Error]
+    #     Generic error
+    def test(config)
+      invoke_with_info(TEST_INFO,
+                       'config' => config)
+    end
+
+    # Set Proxy configuration. In order for this configuration to take effect a logout is required.
+    #
+    # @param config [Com::Vmware::Appliance::Techpreview::Networking::Proxy::ProxyConfigMultiple]
+    #     List of Proxy configurations to be set.
+    # @return [Void]
+    # @raise [Com::Vmware::Vapi::Std::Errors::Error]
+    #     Generic error
+    def set(config)
+      invoke_with_info(SET_INFO,
+                       'config' => config)
+    end
+
+    # Delete a Proxy configuration for a specific protocol.
+    #
+    # @param protocol [Com::Vmware::Appliance::Techpreview::Networking::Proxy::ProxyProtocol]
+    #     Protocol to delete proxy of.
+    # @return [Void]
+    # @raise [Com::Vmware::Vapi::Std::Errors::Error]
+    #     Generic error
+    def delete(protocol)
+      invoke_with_info(DELETE_INFO,
+                       'protocol' => protocol)
+    end
+
+    # Get proxy configuration for all protocols.
+    #
+    # @return [Com::Vmware::Appliance::Techpreview::Networking::Proxy::ProxyConfigMultiple]
+    #     proxy configuration for all protocols.
+    # @raise [Com::Vmware::Vapi::Std::Errors::Error]
+    #     Generic error
+    def get
+      invoke_with_info(GET_INFO)
+    end
+
+    # ``Com::Vmware::Appliance::Techpreview::Networking::Proxy::Message``   class  Test result and message
+    # @!attribute [rw] message
+    #     @return [String]
+    #     message
+    # @!attribute [rw] result
+    #     @return [Com::Vmware::Appliance::Techpreview::Networking::Proxy::MessageStatus]
+    #     result of the test
+    class Message < VAPI::Bindings::VapiStruct
+      class << self
+        # Holds (gets or creates) the binding type metadata for this structure type.
+        # @scope class
+        # @return [VAPI::Bindings::StructType] the binding type
+        def binding_type
+          @binding_type ||= VAPI::Bindings::StructType.new(
+            'com.vmware.appliance.techpreview.networking.proxy.message',
+            {
+              'message' => VAPI::Bindings::StringType.instance,
+              'result' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Appliance::Techpreview::Networking::Proxy::MessageStatus')
+            },
+            Message,
+            false,
+            nil
+          )
+        end
+      end
+
+      attr_accessor :message,
+                    :result
+
+      # Constructs a new instance.
+      # @param ruby_values [Hash] a map of initial property values (optional)
+      # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
+      def initialize(ruby_values = nil, struct_value = nil)
+        super(self.class.binding_type, ruby_values, struct_value)
+      end
+    end
+
+    # ``Com::Vmware::Appliance::Techpreview::Networking::Proxy::TestStatusInfo``   class  Overall test result
+    # @!attribute [rw] status
+    #     @return [Com::Vmware::Appliance::Techpreview::Networking::Proxy::TestStatus]
+    #     Overall status of tests run.
+    # @!attribute [rw] messages
+    #     @return [Array<Com::Vmware::Appliance::Techpreview::Networking::Proxy::Message>]
+    #     messages
+    class TestStatusInfo < VAPI::Bindings::VapiStruct
+      class << self
+        # Holds (gets or creates) the binding type metadata for this structure type.
+        # @scope class
+        # @return [VAPI::Bindings::StructType] the binding type
+        def binding_type
+          @binding_type ||= VAPI::Bindings::StructType.new(
+            'com.vmware.appliance.techpreview.networking.proxy.test_status_info',
+            {
+              'status' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Appliance::Techpreview::Networking::Proxy::TestStatus'),
+              'messages' => VAPI::Bindings::ListType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Appliance::Techpreview::Networking::Proxy::Message'))
+            },
+            TestStatusInfo,
+            false,
+            nil
+          )
+        end
+      end
+
+      attr_accessor :status,
+                    :messages
+
+      # Constructs a new instance.
+      # @param ruby_values [Hash] a map of initial property values (optional)
+      # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
+      def initialize(ruby_values = nil, struct_value = nil)
+        super(self.class.binding_type, ruby_values, struct_value)
+      end
+    end
+
+    # ``Com::Vmware::Appliance::Techpreview::Networking::Proxy::ProxyConfigTest``   class  Structure that defines proxy configuration.
+    # @!attribute [rw] protocol
+    #     @return [Com::Vmware::Appliance::Techpreview::Networking::Proxy::ProxyProtocol]
+    #     protocol being configured.
+    # @!attribute [rw] server
+    #     @return [String]
+    #     hostname or ip of proxy server
+    # @!attribute [rw] port
+    #     @return [Fixnum]
+    #     port to connect to the proxy server on. A value of -1 indicates that the default port is being used.
+    # @!attribute [rw] username
+    #     @return [String]
+    #     username for proxy server.
+    # @!attribute [rw] password
+    #     @return [String]
+    #     password for proxy server.
+    # @!attribute [rw] testhost
+    #     @return [String]
+    #     Verify that a hostname (www.vmware.com) or IPv4 or Ipv6 address of the testhost is accessible through proxy.
+    class ProxyConfigTest < VAPI::Bindings::VapiStruct
+      class << self
+        # Holds (gets or creates) the binding type metadata for this structure type.
+        # @scope class
+        # @return [VAPI::Bindings::StructType] the binding type
+        def binding_type
+          @binding_type ||= VAPI::Bindings::StructType.new(
+            'com.vmware.appliance.techpreview.networking.proxy.proxy_config_test',
+            {
+              'protocol' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Appliance::Techpreview::Networking::Proxy::ProxyProtocol'),
+              'server' => VAPI::Bindings::StringType.instance,
+              'port' => VAPI::Bindings::IntegerType.instance,
+              'username' => VAPI::Bindings::StringType.instance,
+              'password' => VAPI::Bindings::SecretType.instance,
+              'testhost' => VAPI::Bindings::StringType.instance
+            },
+            ProxyConfigTest,
+            false,
+            nil
+          )
+        end
+      end
+
+      attr_accessor :protocol,
+                    :server,
+                    :port,
+                    :username,
+                    :password,
+                    :testhost
+
+      # Constructs a new instance.
+      # @param ruby_values [Hash] a map of initial property values (optional)
+      # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
+      def initialize(ruby_values = nil, struct_value = nil)
+        super(self.class.binding_type, ruby_values, struct_value)
+      end
+    end
+
+    # ``Com::Vmware::Appliance::Techpreview::Networking::Proxy::ProxyConfig``   class  Structure that defines proxy configuration.
+    # @!attribute [rw] protocol
+    #     @return [Com::Vmware::Appliance::Techpreview::Networking::Proxy::ProxyProtocol]
+    #     protocol being configured.
+    # @!attribute [rw] server
+    #     @return [String]
+    #     hostname or ip of proxy server
+    # @!attribute [rw] port
+    #     @return [Fixnum]
+    #     port to connect to the proxy server on. A value of -1 indicates that the default port is being used.
+    # @!attribute [rw] username
+    #     @return [String]
+    #     username for proxy server.
+    # @!attribute [rw] password
+    #     @return [String]
+    #     password for proxy server.
+    class ProxyConfig < VAPI::Bindings::VapiStruct
+      class << self
+        # Holds (gets or creates) the binding type metadata for this structure type.
+        # @scope class
+        # @return [VAPI::Bindings::StructType] the binding type
+        def binding_type
+          @binding_type ||= VAPI::Bindings::StructType.new(
+            'com.vmware.appliance.techpreview.networking.proxy.proxy_config',
+            {
+              'protocol' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Appliance::Techpreview::Networking::Proxy::ProxyProtocol'),
+              'server' => VAPI::Bindings::StringType.instance,
+              'port' => VAPI::Bindings::IntegerType.instance,
+              'username' => VAPI::Bindings::StringType.instance,
+              'password' => VAPI::Bindings::SecretType.instance
+            },
+            ProxyConfig,
+            false,
+            nil
+          )
+        end
+      end
+
+      attr_accessor :protocol,
+                    :server,
+                    :port,
+                    :username,
+                    :password
+
+      # Constructs a new instance.
+      # @param ruby_values [Hash] a map of initial property values (optional)
+      # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
+      def initialize(ruby_values = nil, struct_value = nil)
+        super(self.class.binding_type, ruby_values, struct_value)
+      end
+    end
+
+    # ``Com::Vmware::Appliance::Techpreview::Networking::Proxy::ProxyConfigMultiple``   class  Structure representing multiple proxy configuration.
+    # @!attribute [rw] status
+    #     @return [Com::Vmware::Appliance::Techpreview::Networking::Proxy::ProxyStatus]
+    #     proxy enabled or disabled This sets whether the proxy configuration is used.
+    # @!attribute [rw] configlist
+    #     @return [Array<Com::Vmware::Appliance::Techpreview::Networking::Proxy::ProxyConfig>]
+    #     List of proxy configuration.
+    class ProxyConfigMultiple < VAPI::Bindings::VapiStruct
+      class << self
+        # Holds (gets or creates) the binding type metadata for this structure type.
+        # @scope class
+        # @return [VAPI::Bindings::StructType] the binding type
+        def binding_type
+          @binding_type ||= VAPI::Bindings::StructType.new(
+            'com.vmware.appliance.techpreview.networking.proxy.proxy_config_multiple',
+            {
+              'status' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Appliance::Techpreview::Networking::Proxy::ProxyStatus'),
+              'configlist' => VAPI::Bindings::ListType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Appliance::Techpreview::Networking::Proxy::ProxyConfig'))
+            },
+            ProxyConfigMultiple,
+            false,
+            nil
+          )
+        end
+      end
+
+      attr_accessor :status,
+                    :configlist
+
+      # Constructs a new instance.
+      # @param ruby_values [Hash] a map of initial property values (optional)
+      # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
+      def initialize(ruby_values = nil, struct_value = nil)
+        super(self.class.binding_type, ruby_values, struct_value)
+      end
+    end
+
+    # ``Com::Vmware::Appliance::Techpreview::Networking::Proxy::ProxyProtocol``   enumerated type  Defines different proxy protocols
+    # @!attribute [rw] ftp
+    #     @return [Com::Vmware::Appliance::Techpreview::Networking::Proxy::ProxyProtocol]
+    #     proxy configuration for ftp.
+    # @!attribute [rw] http
+    #     @return [Com::Vmware::Appliance::Techpreview::Networking::Proxy::ProxyProtocol]
+    #     proxy configuration for http.
+    # @!attribute [rw] https
+    #     @return [Com::Vmware::Appliance::Techpreview::Networking::Proxy::ProxyProtocol]
+    #     proxy configuration for https.
+    class ProxyProtocol < VAPI::Bindings::VapiEnum
+      class << self
+        # Holds (gets or creates) the binding type metadata for this enumeration type.
+        # @scope class
+        # @return [VAPI::Bindings::EnumType] the binding type
+        def binding_type
+          @binding_type ||= VAPI::Bindings::EnumType.new(
+            'com.vmware.appliance.techpreview.networking.proxy.proxy_protocol',
+            ProxyProtocol
+          )
+        end
+
+        # Converts from a string value (perhaps off the wire) to an instance
+        # of this enum type.
+        # @param value [String] the actual value of the enum instance
+        # @return [ProxyProtocol] the instance found for the value, otherwise
+        #         an unknown instance will be built for the value
+        def from_string(value)
+          const_get(value)
+        rescue NameError
+          ProxyProtocol.send(:new, 'UNKNOWN', value)
+        end
+      end
+
+      # Constructs a new instance.
+      # @param value [String] the actual value of the enum instance
+      # @param unknown [String] the unknown value when value is 'UKNOWN'
+      def initialize(value, unknown = nil)
+        super(self.class.binding_type, value, unknown)
+      end
+
+      private_class_method :new
+
+      # @!attribute [rw] ftp
+      #     @return [Com::Vmware::Appliance::Techpreview::Networking::Proxy::ProxyProtocol]
+      #     proxy configuration for ftp.
+      FTP = ProxyProtocol.send(:new, 'FTP')
+
+      # @!attribute [rw] http
+      #     @return [Com::Vmware::Appliance::Techpreview::Networking::Proxy::ProxyProtocol]
+      #     proxy configuration for http.
+      HTTP = ProxyProtocol.send(:new, 'HTTP')
+
+      # @!attribute [rw] https
+      #     @return [Com::Vmware::Appliance::Techpreview::Networking::Proxy::ProxyProtocol]
+      #     proxy configuration for https.
+      HTTPS = ProxyProtocol.send(:new, 'HTTPS')
+    end
+    # ``Com::Vmware::Appliance::Techpreview::Networking::Proxy::TestStatus``   enumerated type  Health indicator
+    # @!attribute [rw] orange
+    #     @return [Com::Vmware::Appliance::Techpreview::Networking::Proxy::TestStatus]
+    #     In case data has more than one test, this indicates not all tests were successful
+    # @!attribute [rw] green
+    #     @return [Com::Vmware::Appliance::Techpreview::Networking::Proxy::TestStatus]
+    #     All tests were successful for given data
+    # @!attribute [rw] red
+    #     @return [Com::Vmware::Appliance::Techpreview::Networking::Proxy::TestStatus]
+    #     All tests failed for given data
+    class TestStatus < VAPI::Bindings::VapiEnum
+      class << self
+        # Holds (gets or creates) the binding type metadata for this enumeration type.
+        # @scope class
+        # @return [VAPI::Bindings::EnumType] the binding type
+        def binding_type
+          @binding_type ||= VAPI::Bindings::EnumType.new(
+            'com.vmware.appliance.techpreview.networking.proxy.test_status',
+            TestStatus
+          )
+        end
+
+        # Converts from a string value (perhaps off the wire) to an instance
+        # of this enum type.
+        # @param value [String] the actual value of the enum instance
+        # @return [TestStatus] the instance found for the value, otherwise
+        #         an unknown instance will be built for the value
+        def from_string(value)
+          const_get(value)
+        rescue NameError
+          TestStatus.send(:new, 'UNKNOWN', value)
+        end
+      end
+
+      # Constructs a new instance.
+      # @param value [String] the actual value of the enum instance
+      # @param unknown [String] the unknown value when value is 'UKNOWN'
+      def initialize(value, unknown = nil)
+        super(self.class.binding_type, value, unknown)
+      end
+
+      private_class_method :new
+
+      # @!attribute [rw] orange
+      #     @return [Com::Vmware::Appliance::Techpreview::Networking::Proxy::TestStatus]
+      #     In case data has more than one test, this indicates not all tests were successful
+      ORANGE = TestStatus.send(:new, 'ORANGE')
+
+      # @!attribute [rw] green
+      #     @return [Com::Vmware::Appliance::Techpreview::Networking::Proxy::TestStatus]
+      #     All tests were successful for given data
+      GREEN = TestStatus.send(:new, 'GREEN')
+
+      # @!attribute [rw] red
+      #     @return [Com::Vmware::Appliance::Techpreview::Networking::Proxy::TestStatus]
+      #     All tests failed for given data
+      RED = TestStatus.send(:new, 'RED')
+    end
+    # ``Com::Vmware::Appliance::Techpreview::Networking::Proxy::MessageStatus``   enumerated type  Individual test result
+    # @!attribute [rw] failure
+    #     @return [Com::Vmware::Appliance::Techpreview::Networking::Proxy::MessageStatus]
+    #     message indicates the test failed.
+    # @!attribute [rw] success
+    #     @return [Com::Vmware::Appliance::Techpreview::Networking::Proxy::MessageStatus]
+    #     message indicates that the test was successful.
+    class MessageStatus < VAPI::Bindings::VapiEnum
+      class << self
+        # Holds (gets or creates) the binding type metadata for this enumeration type.
+        # @scope class
+        # @return [VAPI::Bindings::EnumType] the binding type
+        def binding_type
+          @binding_type ||= VAPI::Bindings::EnumType.new(
+            'com.vmware.appliance.techpreview.networking.proxy.message_status',
+            MessageStatus
+          )
+        end
+
+        # Converts from a string value (perhaps off the wire) to an instance
+        # of this enum type.
+        # @param value [String] the actual value of the enum instance
+        # @return [MessageStatus] the instance found for the value, otherwise
+        #         an unknown instance will be built for the value
+        def from_string(value)
+          const_get(value)
+        rescue NameError
+          MessageStatus.send(:new, 'UNKNOWN', value)
+        end
+      end
+
+      # Constructs a new instance.
+      # @param value [String] the actual value of the enum instance
+      # @param unknown [String] the unknown value when value is 'UKNOWN'
+      def initialize(value, unknown = nil)
+        super(self.class.binding_type, value, unknown)
+      end
+
+      private_class_method :new
+
+      # @!attribute [rw] failure
+      #     @return [Com::Vmware::Appliance::Techpreview::Networking::Proxy::MessageStatus]
+      #     message indicates the test failed.
+      FAILURE = MessageStatus.send(:new, 'FAILURE')
+
+      # @!attribute [rw] success
+      #     @return [Com::Vmware::Appliance::Techpreview::Networking::Proxy::MessageStatus]
+      #     message indicates that the test was successful.
+      SUCCESS = MessageStatus.send(:new, 'SUCCESS')
+    end
+    # ``Com::Vmware::Appliance::Techpreview::Networking::Proxy::ProxyStatus``   enumerated type  Defines state of proxy
+    # @!attribute [rw] disabled
+    #     @return [Com::Vmware::Appliance::Techpreview::Networking::Proxy::ProxyStatus]
+    #     proxy configuration is disabled
+    # @!attribute [rw] enabled
+    #     @return [Com::Vmware::Appliance::Techpreview::Networking::Proxy::ProxyStatus]
+    #     proxy configuration is enabled
+    class ProxyStatus < VAPI::Bindings::VapiEnum
+      class << self
+        # Holds (gets or creates) the binding type metadata for this enumeration type.
+        # @scope class
+        # @return [VAPI::Bindings::EnumType] the binding type
+        def binding_type
+          @binding_type ||= VAPI::Bindings::EnumType.new(
+            'com.vmware.appliance.techpreview.networking.proxy.proxy_status',
+            ProxyStatus
+          )
+        end
+
+        # Converts from a string value (perhaps off the wire) to an instance
+        # of this enum type.
+        # @param value [String] the actual value of the enum instance
+        # @return [ProxyStatus] the instance found for the value, otherwise
+        #         an unknown instance will be built for the value
+        def from_string(value)
+          const_get(value)
+        rescue NameError
+          ProxyStatus.send(:new, 'UNKNOWN', value)
+        end
+      end
+
+      # Constructs a new instance.
+      # @param value [String] the actual value of the enum instance
+      # @param unknown [String] the unknown value when value is 'UKNOWN'
+      def initialize(value, unknown = nil)
+        super(self.class.binding_type, value, unknown)
+      end
+
+      private_class_method :new
+
+      # @!attribute [rw] disabled
+      #     @return [Com::Vmware::Appliance::Techpreview::Networking::Proxy::ProxyStatus]
+      #     proxy configuration is disabled
+      DISABLED = ProxyStatus.send(:new, 'DISABLED')
+
+      # @!attribute [rw] enabled
+      #     @return [Com::Vmware::Appliance::Techpreview::Networking::Proxy::ProxyStatus]
+      #     proxy configuration is enabled
+      ENABLED = ProxyStatus.send(:new, 'ENABLED')
+    end
+  end
+  # ``Com::Vmware::Appliance::Techpreview::Networking::Routes``   class  provides  methods  Performs networking routes operations.
+  class Routes < VAPI::Bindings::VapiService
+    # static metamodel definitions
+    SERVICE_ID = VAPI::Core::ServiceIdentifier.new('com.vmware.appliance.techpreview.networking.routes')
+
+    TEST_INFO = VAPI::Bindings::OperationInfo.new(
+      VAPI::Core::OperationIdentifier.new('test', SERVICE_ID),
+      VAPI::Bindings::OperationInputType.new(
+        'gateways' => VAPI::Bindings::ListType.new(VAPI::Bindings::StringType.instance)
+      ),
+      VAPI::Bindings::ReferenceType.new('Com::Vmware::Appliance::Techpreview::Networking::Routes::TestStatusInfo'),
+      {
+        'com.vmware.vapi.std.errors.error' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Error')
+      },
+      [],
+      []
+    )
+
+    ADD_INFO = VAPI::Bindings::OperationInfo.new(
+      VAPI::Core::OperationIdentifier.new('add', SERVICE_ID),
+      VAPI::Bindings::OperationInputType.new(
+        'route' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Appliance::Techpreview::Networking::Routes::Route')
+      ),
+      VAPI::Bindings::VoidType.instance,
+      {
+        'com.vmware.vapi.std.errors.error' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Error')
+      },
+      [],
+      []
+    )
+
+    SET_INFO = VAPI::Bindings::OperationInfo.new(
+      VAPI::Core::OperationIdentifier.new('set', SERVICE_ID),
+      VAPI::Bindings::OperationInputType.new(
+        'routes' => VAPI::Bindings::ListType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Appliance::Techpreview::Networking::Routes::Route'))
+      ),
+      VAPI::Bindings::VoidType.instance,
+      {
+        'com.vmware.vapi.std.errors.error' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Error')
+      },
+      [],
+      []
+    )
+
+    LIST_INFO = VAPI::Bindings::OperationInfo.new(
+      VAPI::Core::OperationIdentifier.new('list', SERVICE_ID),
+      VAPI::Bindings::OperationInputType.new,
+      VAPI::Bindings::ListType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Appliance::Techpreview::Networking::Routes::RouteReadOnly')),
+      {
+        'com.vmware.vapi.std.errors.error' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Error')
+      },
+      [],
+      []
+    )
+
+    DELETE_INFO = VAPI::Bindings::OperationInfo.new(
+      VAPI::Core::OperationIdentifier.new('delete', SERVICE_ID),
+      VAPI::Bindings::OperationInputType.new(
+        'route' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Appliance::Techpreview::Networking::Routes::Route')
+      ),
+      VAPI::Bindings::VoidType.instance,
+      {
+        'com.vmware.vapi.std.errors.error' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Error')
+      },
+      [],
+      []
+    )
+
+    SERVICE_INFO = VAPI::Bindings::ServiceInfo.new(
+      SERVICE_ID,
+      'test' => TEST_INFO,
+      'add' => ADD_INFO,
+      'set' => SET_INFO,
+      'list' => LIST_INFO,
+      'delete' => DELETE_INFO
+    )
+
+    # Constructs a new instance.
+    #
+    # @param config [VAPI::Bindings::StubConfig] A hash with the api provider details.
+    def initialize(config)
+      super(config, SERVICE_INFO)
+    end
+
+    # Test connection to a list of gateways
+    #
+    # @param gateways [Array<String>]
+    #     list of gateways.
+    # @return [Com::Vmware::Appliance::Techpreview::Networking::Routes::TestStatusInfo]
+    #     connection status
+    # @raise [Com::Vmware::Vapi::Std::Errors::Error]
+    #     Generic error
+    def test(gateways)
+      invoke_with_info(TEST_INFO,
+                       'gateways' => gateways)
+    end
+
+    # Set static routing rules. A destination of 0.0.0.0 and prefix 0 (for IPv4) or destination of :: and prefix 0 (for IPv6) refers to the default gateway.
+    #
+    # @param route [Com::Vmware::Appliance::Techpreview::Networking::Routes::Route]
+    #     Static routing rule.
+    # @return [Void]
+    # @raise [Com::Vmware::Vapi::Std::Errors::Error]
+    #     Generic error
+    def add(route)
+      invoke_with_info(ADD_INFO,
+                       'route' => route)
+    end
+
+    # Set static routing rules. A destination of 0.0.0.0 and prefix 0 (for IPv4) or destination of :: and prefix 0 (for IPv6) refers to the default gateway.
+    #
+    # @param routes [Array<Com::Vmware::Appliance::Techpreview::Networking::Routes::Route>]
+    #     Static routing rules.
+    # @return [Void]
+    # @raise [Com::Vmware::Vapi::Std::Errors::Error]
+    #     Generic error
+    def set(routes)
+      invoke_with_info(SET_INFO,
+                       'routes' => routes)
+    end
+
+    # Get main routing table. A destination of 0.0.0.0 and prefix 0 (for IPv4) or destination of :: and prefix 0 (for IPv6) refers to the default gateway.
+    #
+    # @return [Array<Com::Vmware::Appliance::Techpreview::Networking::Routes::RouteReadOnly>]
+    #     Routing table.
+    # @raise [Com::Vmware::Vapi::Std::Errors::Error]
+    #     Generic error
+    def list
+      invoke_with_info(LIST_INFO)
+    end
+
+    # Delete static routing rules.
+    #
+    # @param route [Com::Vmware::Appliance::Techpreview::Networking::Routes::Route]
+    #     Static routing rule.
+    # @return [Void]
+    # @raise [Com::Vmware::Vapi::Std::Errors::Error]
+    #     Generic error
+    def delete(route)
+      invoke_with_info(DELETE_INFO,
+                       'route' => route)
+    end
+
+    # ``Com::Vmware::Appliance::Techpreview::Networking::Routes::RouteReadOnly``   class  Structure that describes how routing is performed for a particular destination and prefix. A destination/prefix of 0.0.0.0/0 ( for IPv4) or ::/0 (for IPv6) refers to the default gateway.
+    # @!attribute [rw] destination
+    #     @return [String]
+    #     Destination address that defines this route.
+    # @!attribute [rw] prefix
+    #     @return [Fixnum]
+    #     Destination CIDR prefix that defines this route. See http://www.oav.net/mirrors/cidr.html for netmask-to-prefix conversion.
+    # @!attribute [rw] gateway
+    #     @return [String]
+    #     Gateway address.
+    # @!attribute [rw] interface_name
+    #     @return [String]
+    #     Output device interface, for example, "nic0".
+    # @!attribute [rw] is_static
+    #     @return [Boolean]
+    #     Static provides information about installation of the route. True indicates the route was installed by the administrator. False indicates the route was autoconfigured
+    class RouteReadOnly < VAPI::Bindings::VapiStruct
+      class << self
+        # Holds (gets or creates) the binding type metadata for this structure type.
+        # @scope class
+        # @return [VAPI::Bindings::StructType] the binding type
+        def binding_type
+          @binding_type ||= VAPI::Bindings::StructType.new(
+            'com.vmware.appliance.techpreview.networking.routes.route_read_only',
+            {
+              'destination' => VAPI::Bindings::StringType.instance,
+              'prefix' => VAPI::Bindings::IntegerType.instance,
+              'gateway' => VAPI::Bindings::StringType.instance,
+              'interface_name' => VAPI::Bindings::StringType.instance,
+              'is_static' => VAPI::Bindings::BooleanType.instance
+            },
+            RouteReadOnly,
+            false,
+            nil
+          )
+        end
+      end
+
+      attr_accessor :destination,
+                    :prefix,
+                    :gateway,
+                    :interface_name,
+                    :is_static
+
+      # Constructs a new instance.
+      # @param ruby_values [Hash] a map of initial property values (optional)
+      # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
+      def initialize(ruby_values = nil, struct_value = nil)
+        super(self.class.binding_type, ruby_values, struct_value)
+      end
+    end
+
+    # ``Com::Vmware::Appliance::Techpreview::Networking::Routes::Route``   class  Structure that describes how routing is performed for a particular destination and prefix. A destination/prefix of 0.0.0.0/0 ( for IPv4) or ::/0 (for IPv6) refers to the default gateway.
+    # @!attribute [rw] destination
+    #     @return [String]
+    #     Destination address that defines this route.
+    # @!attribute [rw] prefix
+    #     @return [Fixnum]
+    #     Destination CIDR prefix that defines this route. See http://www.oav.net/mirrors/cidr.html for netmask-to-prefix conversion.
+    # @!attribute [rw] gateway
+    #     @return [String]
+    #     Gateway address.
+    # @!attribute [rw] interface_name
+    #     @return [String]
+    #     Output device interface, for example, "nic0".
+    class Route < VAPI::Bindings::VapiStruct
+      class << self
+        # Holds (gets or creates) the binding type metadata for this structure type.
+        # @scope class
+        # @return [VAPI::Bindings::StructType] the binding type
+        def binding_type
+          @binding_type ||= VAPI::Bindings::StructType.new(
+            'com.vmware.appliance.techpreview.networking.routes.route',
+            {
+              'destination' => VAPI::Bindings::StringType.instance,
+              'prefix' => VAPI::Bindings::IntegerType.instance,
+              'gateway' => VAPI::Bindings::StringType.instance,
+              'interface_name' => VAPI::Bindings::StringType.instance
+            },
+            Route,
+            false,
+            nil
+          )
+        end
+      end
+
+      attr_accessor :destination,
+                    :prefix,
+                    :gateway,
+                    :interface_name
+
+      # Constructs a new instance.
+      # @param ruby_values [Hash] a map of initial property values (optional)
+      # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
+      def initialize(ruby_values = nil, struct_value = nil)
+        super(self.class.binding_type, ruby_values, struct_value)
+      end
+    end
+
+    # ``Com::Vmware::Appliance::Techpreview::Networking::Routes::Message``   class  Test result and message
+    # @!attribute [rw] message
+    #     @return [String]
+    #     message
+    # @!attribute [rw] result
+    #     @return [Com::Vmware::Appliance::Techpreview::Networking::Routes::MessageStatus]
+    #     result of the test
+    class Message < VAPI::Bindings::VapiStruct
+      class << self
+        # Holds (gets or creates) the binding type metadata for this structure type.
+        # @scope class
+        # @return [VAPI::Bindings::StructType] the binding type
+        def binding_type
+          @binding_type ||= VAPI::Bindings::StructType.new(
+            'com.vmware.appliance.techpreview.networking.routes.message',
+            {
+              'message' => VAPI::Bindings::StringType.instance,
+              'result' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Appliance::Techpreview::Networking::Routes::MessageStatus')
+            },
+            Message,
+            false,
+            nil
+          )
+        end
+      end
+
+      attr_accessor :message,
+                    :result
+
+      # Constructs a new instance.
+      # @param ruby_values [Hash] a map of initial property values (optional)
+      # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
+      def initialize(ruby_values = nil, struct_value = nil)
+        super(self.class.binding_type, ruby_values, struct_value)
+      end
+    end
+
+    # ``Com::Vmware::Appliance::Techpreview::Networking::Routes::TestStatusInfo``   class  Overall test result
+    # @!attribute [rw] status
+    #     @return [Com::Vmware::Appliance::Techpreview::Networking::Routes::TestStatus]
+    #     Overall status of tests run.
+    # @!attribute [rw] messages
+    #     @return [Array<Com::Vmware::Appliance::Techpreview::Networking::Routes::Message>]
+    #     messages
+    class TestStatusInfo < VAPI::Bindings::VapiStruct
+      class << self
+        # Holds (gets or creates) the binding type metadata for this structure type.
+        # @scope class
+        # @return [VAPI::Bindings::StructType] the binding type
+        def binding_type
+          @binding_type ||= VAPI::Bindings::StructType.new(
+            'com.vmware.appliance.techpreview.networking.routes.test_status_info',
+            {
+              'status' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Appliance::Techpreview::Networking::Routes::TestStatus'),
+              'messages' => VAPI::Bindings::ListType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Appliance::Techpreview::Networking::Routes::Message'))
+            },
+            TestStatusInfo,
+            false,
+            nil
+          )
+        end
+      end
+
+      attr_accessor :status,
+                    :messages
+
+      # Constructs a new instance.
+      # @param ruby_values [Hash] a map of initial property values (optional)
+      # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
+      def initialize(ruby_values = nil, struct_value = nil)
+        super(self.class.binding_type, ruby_values, struct_value)
+      end
+    end
+
+    # ``Com::Vmware::Appliance::Techpreview::Networking::Routes::TestStatus``   enumerated type  Health indicator
+    # @!attribute [rw] orange
+    #     @return [Com::Vmware::Appliance::Techpreview::Networking::Routes::TestStatus]
+    #     In case data has more than one test, this indicates not all tests were successful
+    # @!attribute [rw] green
+    #     @return [Com::Vmware::Appliance::Techpreview::Networking::Routes::TestStatus]
+    #     All tests were successful for given data
+    # @!attribute [rw] red
+    #     @return [Com::Vmware::Appliance::Techpreview::Networking::Routes::TestStatus]
+    #     All tests failed for given data
+    class TestStatus < VAPI::Bindings::VapiEnum
+      class << self
+        # Holds (gets or creates) the binding type metadata for this enumeration type.
+        # @scope class
+        # @return [VAPI::Bindings::EnumType] the binding type
+        def binding_type
+          @binding_type ||= VAPI::Bindings::EnumType.new(
+            'com.vmware.appliance.techpreview.networking.routes.test_status',
+            TestStatus
+          )
+        end
+
+        # Converts from a string value (perhaps off the wire) to an instance
+        # of this enum type.
+        # @param value [String] the actual value of the enum instance
+        # @return [TestStatus] the instance found for the value, otherwise
+        #         an unknown instance will be built for the value
+        def from_string(value)
+          const_get(value)
+        rescue NameError
+          TestStatus.send(:new, 'UNKNOWN', value)
+        end
+      end
+
+      # Constructs a new instance.
+      # @param value [String] the actual value of the enum instance
+      # @param unknown [String] the unknown value when value is 'UKNOWN'
+      def initialize(value, unknown = nil)
+        super(self.class.binding_type, value, unknown)
+      end
+
+      private_class_method :new
+
+      # @!attribute [rw] orange
+      #     @return [Com::Vmware::Appliance::Techpreview::Networking::Routes::TestStatus]
+      #     In case data has more than one test, this indicates not all tests were successful
+      ORANGE = TestStatus.send(:new, 'ORANGE')
+
+      # @!attribute [rw] green
+      #     @return [Com::Vmware::Appliance::Techpreview::Networking::Routes::TestStatus]
+      #     All tests were successful for given data
+      GREEN = TestStatus.send(:new, 'GREEN')
+
+      # @!attribute [rw] red
+      #     @return [Com::Vmware::Appliance::Techpreview::Networking::Routes::TestStatus]
+      #     All tests failed for given data
+      RED = TestStatus.send(:new, 'RED')
+    end
+    # ``Com::Vmware::Appliance::Techpreview::Networking::Routes::MessageStatus``   enumerated type  Individual test result
+    # @!attribute [rw] failure
+    #     @return [Com::Vmware::Appliance::Techpreview::Networking::Routes::MessageStatus]
+    #     message indicates the test failed.
+    # @!attribute [rw] success
+    #     @return [Com::Vmware::Appliance::Techpreview::Networking::Routes::MessageStatus]
+    #     message indicates that the test was successful.
+    class MessageStatus < VAPI::Bindings::VapiEnum
+      class << self
+        # Holds (gets or creates) the binding type metadata for this enumeration type.
+        # @scope class
+        # @return [VAPI::Bindings::EnumType] the binding type
+        def binding_type
+          @binding_type ||= VAPI::Bindings::EnumType.new(
+            'com.vmware.appliance.techpreview.networking.routes.message_status',
+            MessageStatus
+          )
+        end
+
+        # Converts from a string value (perhaps off the wire) to an instance
+        # of this enum type.
+        # @param value [String] the actual value of the enum instance
+        # @return [MessageStatus] the instance found for the value, otherwise
+        #         an unknown instance will be built for the value
+        def from_string(value)
+          const_get(value)
+        rescue NameError
+          MessageStatus.send(:new, 'UNKNOWN', value)
+        end
+      end
+
+      # Constructs a new instance.
+      # @param value [String] the actual value of the enum instance
+      # @param unknown [String] the unknown value when value is 'UKNOWN'
+      def initialize(value, unknown = nil)
+        super(self.class.binding_type, value, unknown)
+      end
+
+      private_class_method :new
+
+      # @!attribute [rw] failure
+      #     @return [Com::Vmware::Appliance::Techpreview::Networking::Routes::MessageStatus]
+      #     message indicates the test failed.
+      FAILURE = MessageStatus.send(:new, 'FAILURE')
+
+      # @!attribute [rw] success
+      #     @return [Com::Vmware::Appliance::Techpreview::Networking::Routes::MessageStatus]
+      #     message indicates that the test was successful.
+      SUCCESS = MessageStatus.send(:new, 'SUCCESS')
+    end
+  end
 end

--- a/client/sdk/com/vmware/appliance/techpreview/networking/firewall/addr.rb
+++ b/client/sdk/com/vmware/appliance/techpreview/networking/firewall/addr.rb
@@ -1,5 +1,6 @@
 #---------------------------------------------------------------------------
-# Copyright 2016 VMware, Inc.  All rights reserved.
+# Copyright 2017 VMware, Inc.  All rights reserved.
+#
 # AUTO GENERATED FILE -- DO NOT MODIFY!
 #
 # vAPI type descriptors for package com.vmware.appliance.techpreview.networking.firewall.addr.
@@ -8,297 +9,274 @@ require 'vapi'
 
 # declare the module hierarchy before we use the shorthand syntax below
 module Com
-    module Vmware
-        module Appliance
-            module Techpreview
-                module Networking
-                    module Firewall
-                        module Addr
-                        end
-                    end
-                end
+  module Vmware
+    module Appliance
+      module Techpreview
+        module Networking
+          module Firewall
+            module Addr
             end
+          end
         end
+      end
     end
+  end
 end
 
 module Com::Vmware::Appliance::Techpreview::Networking::Firewall::Addr
+  # ``Com::Vmware::Appliance::Techpreview::Networking::Firewall::Addr::Inbound``   class  provides  methods  Operations for Firewall rules.
+  class Inbound < VAPI::Bindings::VapiService
+    # static metamodel definitions
+    SERVICE_ID = VAPI::Core::ServiceIdentifier.new('com.vmware.appliance.techpreview.networking.firewall.addr.inbound')
 
-    # ``Com::Vmware::Appliance::Techpreview::Networking::Firewall::Addr::Inbound``   class  provides  methods  Operations for Firewall rules.
-    class Inbound < VAPI::Bindings::VapiService
+    ADD_INFO = VAPI::Bindings::OperationInfo.new(
+      VAPI::Core::OperationIdentifier.new('add', SERVICE_ID),
+      VAPI::Bindings::OperationInputType.new(
+        'pos' => VAPI::Bindings::IntegerType.instance,
+        'rule' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Appliance::Techpreview::Networking::Firewall::Addr::Inbound::FirewallAddressRule')
+      ),
+      VAPI::Bindings::VoidType.instance,
+      {
+        'com.vmware.vapi.std.errors.error' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Error')
+      },
+      [],
+      []
+    )
 
-        protected
+    SET_INFO = VAPI::Bindings::OperationInfo.new(
+      VAPI::Core::OperationIdentifier.new('set', SERVICE_ID),
+      VAPI::Bindings::OperationInputType.new(
+        'rules' => VAPI::Bindings::ListType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Appliance::Techpreview::Networking::Firewall::Addr::Inbound::FirewallAddressRule'))
+      ),
+      VAPI::Bindings::VoidType.instance,
+      {
+        'com.vmware.vapi.std.errors.error' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Error')
+      },
+      [],
+      []
+    )
 
-        # static metamodel definitions
-        @@service_id = VAPI::Core::ServiceIdentifier.new('com.vmware.appliance.techpreview.networking.firewall.addr.inbound')
+    LIST_INFO = VAPI::Bindings::OperationInfo.new(
+      VAPI::Core::OperationIdentifier.new('list', SERVICE_ID),
+      VAPI::Bindings::OperationInputType.new,
+      VAPI::Bindings::ListType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Appliance::Techpreview::Networking::Firewall::Addr::Inbound::FirewallAddressRule')),
+      {
+        'com.vmware.vapi.std.errors.error' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Error')
+      },
+      [],
+      []
+    )
 
-        @@add_info = VAPI::Bindings::OperationInfo.new(
-            VAPI::Core::OperationIdentifier.new('add', @@service_id),
-            VAPI::Bindings::OperationInputType.new({
-                'pos' => VAPI::Bindings::IntegerType.instance,
-                'rule' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Appliance::Techpreview::Networking::Firewall::Addr::Inbound::FirewallAddressRule'),
-            }),
-            VAPI::Bindings::VoidType.instance,
-            {
-                'com.vmware.vapi.std.errors.error' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Error'),
+    DELETE_INFO = VAPI::Bindings::OperationInfo.new(
+      VAPI::Core::OperationIdentifier.new('delete', SERVICE_ID),
+      VAPI::Bindings::OperationInputType.new(
+        'config' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Appliance::Techpreview::Networking::Firewall::Addr::Inbound::DeleteFirewallRule')
+      ),
+      VAPI::Bindings::VoidType.instance,
+      {
+        'com.vmware.vapi.std.errors.error' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Error')
+      },
+      [],
+      []
+    )
 
-            },
-            [],
-            [])
-        @@set_info = VAPI::Bindings::OperationInfo.new(
-            VAPI::Core::OperationIdentifier.new('set', @@service_id),
-            VAPI::Bindings::OperationInputType.new({
-                'rules' => VAPI::Bindings::ListType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Appliance::Techpreview::Networking::Firewall::Addr::Inbound::FirewallAddressRule')),
-            }),
-            VAPI::Bindings::VoidType.instance,
-            {
-                'com.vmware.vapi.std.errors.error' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Error'),
+    SERVICE_INFO = VAPI::Bindings::ServiceInfo.new(
+      SERVICE_ID,
+      'add' => ADD_INFO,
+      'set' => SET_INFO,
+      'list' => LIST_INFO,
+      'delete' => DELETE_INFO
+    )
 
-            },
-            [],
-            [])
-        @@list_info = VAPI::Bindings::OperationInfo.new(
-            VAPI::Core::OperationIdentifier.new('list', @@service_id),
-            VAPI::Bindings::OperationInputType.new,
-            VAPI::Bindings::ListType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Appliance::Techpreview::Networking::Firewall::Addr::Inbound::FirewallAddressRule')),
-            {
-                'com.vmware.vapi.std.errors.error' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Error'),
-
-            },
-            [],
-            [])
-        @@delete_info = VAPI::Bindings::OperationInfo.new(
-            VAPI::Core::OperationIdentifier.new('delete', @@service_id),
-            VAPI::Bindings::OperationInputType.new({
-                'config' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Appliance::Techpreview::Networking::Firewall::Addr::Inbound::DeleteFirewallRule'),
-            }),
-            VAPI::Bindings::VoidType.instance,
-            {
-                'com.vmware.vapi.std.errors.error' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Error'),
-
-            },
-            [],
-            [])
-
-        @@service_info = VAPI::Bindings::ServiceInfo.new(@@service_id, {
-            'add' => @@add_info,
-            'set' => @@set_info,
-            'list' => @@list_info,
-            'delete' => @@delete_info,
-        })
-
-        public
-
-        # Constructs a new instance.
-        #
-        # @param config [VAPI::Bindings::StubConfig] A hash with the api provider details.
-        def initialize(config)
-            super(config, @@service_info)
-        end
-
-
-        # Add a firewall rule to allow or deny traffic from incoming IP address.
-        #
-        # @param pos [Fixnum]
-        #     Position before which to insert the rule (zero-based). If you try to insert the rule in a position whose number is greater than the number of rules, the firewall rule is inserted at the end of the list.
-        # @param rule [Com::Vmware::Appliance::Techpreview::Networking::Firewall::Addr::Inbound::FirewallAddressRule]
-        #     Firewall IP-based rule.
-        # @return [Void]
-        # @raise [Com::Vmware::Vapi::Std::Errors::Error]
-        #     Generic error
-        def add(pos, rule)
-            invoke_with_info(@@add_info, {
-                'pos' => pos,
-                'rule' => rule,
-            })
-        end
-
-
-        # Set list of inbound IP addresses to allow or deny by firewall. This replaces all existing rules. Firewall rules have no impact on closed ports because these ports are closed for all traffic.
-        #
-        # @param rules [Array<Com::Vmware::Appliance::Techpreview::Networking::Firewall::Addr::Inbound::FirewallAddressRule>]
-        #     List of address-based firewall rules.
-        # @return [Void]
-        # @raise [Com::Vmware::Vapi::Std::Errors::Error]
-        #     Generic error
-        def set(rules)
-            invoke_with_info(@@set_info, {
-                'rules' => rules,
-            })
-        end
-
-
-        # Get ordered list of inbound IP addresses that are allowed or denied by firewall.
-        #
-        # @return [Array<Com::Vmware::Appliance::Techpreview::Networking::Firewall::Addr::Inbound::FirewallAddressRule>]
-        #     List of address-based firewall rules.
-        # @raise [Com::Vmware::Vapi::Std::Errors::Error]
-        #     Generic error
-        def list()
-            invoke_with_info(@@list_info)
-        end
-
-
-        # Delete specific rule at a given position or delete all rules.
-        #
-        # @param config [Com::Vmware::Appliance::Techpreview::Networking::Firewall::Addr::Inbound::DeleteFirewallRule]
-        #     Delete a firewall rule
-        # @return [Void]
-        # @raise [Com::Vmware::Vapi::Std::Errors::Error]
-        #     Generic error
-        def delete(config)
-            invoke_with_info(@@delete_info, {
-                'config' => config,
-            })
-        end
-
-
-
-        # ``Com::Vmware::Appliance::Techpreview::Networking::Firewall::Addr::Inbound::FirewallAddressRule``   class  Structure that defines a single address-based firewall rule.
-        # @!attribute [rw] address
-        #     @return [String]
-        #     IPv4 or IPv6 address.
-        # @!attribute [rw] prefix
-        #     @return [Fixnum]
-        #     CIDR prefix used to mask address. For example, an IPv4 prefix of 24 ignores the low-order 8 bits of address.
-        # @!attribute [rw] policy
-        #     @return [Com::Vmware::Appliance::Techpreview::Networking::Firewall::Addr::Inbound::FirewallRulePolicy]
-        #     The allow or deny policy of this rule.
-        # @!attribute [rw] interface_name
-        #     @return [String]
-        #     The interface to which this rule applies. An empty string or "\*" indicates that the rule applies to all interfaces.
-        class FirewallAddressRule < VAPI::Bindings::VapiStruct
-
-            class << self
-                # Holds (gets or creates) the binding type metadata for this structure type.
-                # @scope class
-                # @return [VAPI::Bindings::StructType] the binding type
-                def binding_type
-                    @binding_type ||= VAPI::Bindings::StructType.new(
-                        'com.vmware.appliance.techpreview.networking.firewall.addr.inbound.firewall_address_rule',
-                        {
-                            'address' => VAPI::Bindings::StringType.instance,
-                            'prefix' => VAPI::Bindings::IntegerType.instance,
-                            'policy' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Appliance::Techpreview::Networking::Firewall::Addr::Inbound::FirewallRulePolicy'),
-                            'interface_name' => VAPI::Bindings::StringType.instance,
-                        },
-                        FirewallAddressRule,
-                        false,
-                        nil)
-                end
-            end
-
-            attr_accessor :address,
-                          :prefix,
-                          :policy,
-                          :interface_name
-
-            # Constructs a new instance.
-            # @param ruby_values [Hash] a map of initial property values (optional)
-            # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
-            def initialize(ruby_values=nil, struct_value=nil)
-                super(self.class.binding_type, ruby_values, struct_value)
-            end
-        end
-
-
-        # ``Com::Vmware::Appliance::Techpreview::Networking::Firewall::Addr::Inbound::DeleteFirewallRule``   class  Structure that defines networking.firewall.addr.inbound.delete api input argument
-        # @!attribute [rw] position
-        #     @return [Fixnum]
-        #     Position before which to insert the rule (zero-based). If you try to insert the rule in a position whose number is greater than the number of rules, the firewall rule is inserted at the end of the list.
-        # @!attribute [rw] all
-        #     @return [Boolean]
-        #     Delete all firewall rules. Set all argument to "true" to delete all rules or set the all argument to "false" to delete a single rule.
-        class DeleteFirewallRule < VAPI::Bindings::VapiStruct
-
-            class << self
-                # Holds (gets or creates) the binding type metadata for this structure type.
-                # @scope class
-                # @return [VAPI::Bindings::StructType] the binding type
-                def binding_type
-                    @binding_type ||= VAPI::Bindings::StructType.new(
-                        'com.vmware.appliance.techpreview.networking.firewall.addr.inbound.delete_firewall_rule',
-                        {
-                            'position' => VAPI::Bindings::IntegerType.instance,
-                            'all' => VAPI::Bindings::BooleanType.instance,
-                        },
-                        DeleteFirewallRule,
-                        false,
-                        nil)
-                end
-            end
-
-            attr_accessor :position,
-                          :all
-
-            # Constructs a new instance.
-            # @param ruby_values [Hash] a map of initial property values (optional)
-            # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
-            def initialize(ruby_values=nil, struct_value=nil)
-                super(self.class.binding_type, ruby_values, struct_value)
-            end
-        end
-
-
-
-        # ``Com::Vmware::Appliance::Techpreview::Networking::Firewall::Addr::Inbound::FirewallRulePolicy``   enumerated type  Defines firewall rule policies
-        # @!attribute [rw] deny
-        #     @return [Com::Vmware::Appliance::Techpreview::Networking::Firewall::Addr::Inbound::FirewallRulePolicy]
-        #     Deny packet with correpsonding address.
-        # @!attribute [rw] allow
-        #     @return [Com::Vmware::Appliance::Techpreview::Networking::Firewall::Addr::Inbound::FirewallRulePolicy]
-        #     Allow packet with corresponding address.
-        class FirewallRulePolicy < VAPI::Bindings::VapiEnum
-
-            class << self
-                # Holds (gets or creates) the binding type metadata for this enumeration type.
-                # @scope class
-                # @return [VAPI::Bindings::EnumType] the binding type
-                def binding_type
-                    @binding_type ||= VAPI::Bindings::EnumType.new(
-                        'com.vmware.appliance.techpreview.networking.firewall.addr.inbound.firewall_rule_policy',
-                        FirewallRulePolicy)
-                end
-
-                # Converts from a string value (perhaps off the wire) to an instance
-                # of this enum type.
-                # @param value [String] the actual value of the enum instance
-                # @return [FirewallRulePolicy] the instance found for the value, otherwise
-                #         an unknown instance will be built for the value
-                def from_string(value)
-                    begin
-                        const_get(value)
-                    rescue NameError
-                        FirewallRulePolicy.new('UNKNOWN', value)
-                    end
-                end
-            end
-
-            private
-
-            # Constructs a new instance.
-            # @param value [String] the actual value of the enum instance
-            # @param unknown [String] the unknown value when value is 'UKNOWN'
-            def initialize(value, unknown=nil)
-                super(self.class.binding_type, value, unknown)
-            end
-
-            public
-
-            # @!attribute [rw] deny
-            #     @return [Com::Vmware::Appliance::Techpreview::Networking::Firewall::Addr::Inbound::FirewallRulePolicy]
-            #     Deny packet with correpsonding address.
-            DENY = FirewallRulePolicy.new('DENY')
-
-            # @!attribute [rw] allow
-            #     @return [Com::Vmware::Appliance::Techpreview::Networking::Firewall::Addr::Inbound::FirewallRulePolicy]
-            #     Allow packet with corresponding address.
-            ALLOW = FirewallRulePolicy.new('ALLOW')
-
-        end
-
-
+    # Constructs a new instance.
+    #
+    # @param config [VAPI::Bindings::StubConfig] A hash with the api provider details.
+    def initialize(config)
+      super(config, SERVICE_INFO)
     end
 
+    # Add a firewall rule to allow or deny traffic from incoming IP address.
+    #
+    # @param pos [Fixnum]
+    #     Position before which to insert the rule (zero-based). If you try to insert the rule in a position whose number is greater than the number of rules, the firewall rule is inserted at the end of the list.
+    # @param rule [Com::Vmware::Appliance::Techpreview::Networking::Firewall::Addr::Inbound::FirewallAddressRule]
+    #     Firewall IP-based rule.
+    # @return [Void]
+    # @raise [Com::Vmware::Vapi::Std::Errors::Error]
+    #     Generic error
+    def add(pos, rule)
+      invoke_with_info(ADD_INFO,
+                       'pos' => pos,
+                       'rule' => rule)
+    end
 
+    # Set list of inbound IP addresses to allow or deny by firewall. This replaces all existing rules. Firewall rules have no impact on closed ports because these ports are closed for all traffic.
+    #
+    # @param rules [Array<Com::Vmware::Appliance::Techpreview::Networking::Firewall::Addr::Inbound::FirewallAddressRule>]
+    #     List of address-based firewall rules.
+    # @return [Void]
+    # @raise [Com::Vmware::Vapi::Std::Errors::Error]
+    #     Generic error
+    def set(rules)
+      invoke_with_info(SET_INFO,
+                       'rules' => rules)
+    end
+
+    # Get ordered list of inbound IP addresses that are allowed or denied by firewall.
+    #
+    # @return [Array<Com::Vmware::Appliance::Techpreview::Networking::Firewall::Addr::Inbound::FirewallAddressRule>]
+    #     List of address-based firewall rules.
+    # @raise [Com::Vmware::Vapi::Std::Errors::Error]
+    #     Generic error
+    def list
+      invoke_with_info(LIST_INFO)
+    end
+
+    # Delete specific rule at a given position or delete all rules.
+    #
+    # @param config [Com::Vmware::Appliance::Techpreview::Networking::Firewall::Addr::Inbound::DeleteFirewallRule]
+    #     Delete a firewall rule
+    # @return [Void]
+    # @raise [Com::Vmware::Vapi::Std::Errors::Error]
+    #     Generic error
+    def delete(config)
+      invoke_with_info(DELETE_INFO,
+                       'config' => config)
+    end
+
+    # ``Com::Vmware::Appliance::Techpreview::Networking::Firewall::Addr::Inbound::FirewallAddressRule``   class  Structure that defines a single address-based firewall rule.
+    # @!attribute [rw] address
+    #     @return [String]
+    #     IPv4 or IPv6 address.
+    # @!attribute [rw] prefix
+    #     @return [Fixnum]
+    #     CIDR prefix used to mask address. For example, an IPv4 prefix of 24 ignores the low-order 8 bits of address.
+    # @!attribute [rw] policy
+    #     @return [Com::Vmware::Appliance::Techpreview::Networking::Firewall::Addr::Inbound::FirewallRulePolicy]
+    #     The allow or deny policy of this rule.
+    # @!attribute [rw] interface_name
+    #     @return [String]
+    #     The interface to which this rule applies. An empty string or "\*" indicates that the rule applies to all interfaces.
+    class FirewallAddressRule < VAPI::Bindings::VapiStruct
+      class << self
+        # Holds (gets or creates) the binding type metadata for this structure type.
+        # @scope class
+        # @return [VAPI::Bindings::StructType] the binding type
+        def binding_type
+          @binding_type ||= VAPI::Bindings::StructType.new(
+            'com.vmware.appliance.techpreview.networking.firewall.addr.inbound.firewall_address_rule',
+            {
+              'address' => VAPI::Bindings::StringType.instance,
+              'prefix' => VAPI::Bindings::IntegerType.instance,
+              'policy' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Appliance::Techpreview::Networking::Firewall::Addr::Inbound::FirewallRulePolicy'),
+              'interface_name' => VAPI::Bindings::StringType.instance
+            },
+            FirewallAddressRule,
+            false,
+            nil
+          )
+        end
+      end
+
+      attr_accessor :address,
+                    :prefix,
+                    :policy,
+                    :interface_name
+
+      # Constructs a new instance.
+      # @param ruby_values [Hash] a map of initial property values (optional)
+      # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
+      def initialize(ruby_values = nil, struct_value = nil)
+        super(self.class.binding_type, ruby_values, struct_value)
+      end
+    end
+
+    # ``Com::Vmware::Appliance::Techpreview::Networking::Firewall::Addr::Inbound::DeleteFirewallRule``   class  Structure that defines networking.firewall.addr.inbound.delete api input argument
+    # @!attribute [rw] position
+    #     @return [Fixnum]
+    #     Position before which to insert the rule (zero-based). If you try to insert the rule in a position whose number is greater than the number of rules, the firewall rule is inserted at the end of the list.
+    # @!attribute [rw] all
+    #     @return [Boolean]
+    #     Delete all firewall rules. Set all argument to "true" to delete all rules or set the all argument to "false" to delete a single rule.
+    class DeleteFirewallRule < VAPI::Bindings::VapiStruct
+      class << self
+        # Holds (gets or creates) the binding type metadata for this structure type.
+        # @scope class
+        # @return [VAPI::Bindings::StructType] the binding type
+        def binding_type
+          @binding_type ||= VAPI::Bindings::StructType.new(
+            'com.vmware.appliance.techpreview.networking.firewall.addr.inbound.delete_firewall_rule',
+            {
+              'position' => VAPI::Bindings::IntegerType.instance,
+              'all' => VAPI::Bindings::BooleanType.instance
+            },
+            DeleteFirewallRule,
+            false,
+            nil
+          )
+        end
+      end
+
+      attr_accessor :position,
+                    :all
+
+      # Constructs a new instance.
+      # @param ruby_values [Hash] a map of initial property values (optional)
+      # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
+      def initialize(ruby_values = nil, struct_value = nil)
+        super(self.class.binding_type, ruby_values, struct_value)
+      end
+    end
+
+    # ``Com::Vmware::Appliance::Techpreview::Networking::Firewall::Addr::Inbound::FirewallRulePolicy``   enumerated type  Defines firewall rule policies
+    # @!attribute [rw] deny
+    #     @return [Com::Vmware::Appliance::Techpreview::Networking::Firewall::Addr::Inbound::FirewallRulePolicy]
+    #     Deny packet with correpsonding address.
+    # @!attribute [rw] allow
+    #     @return [Com::Vmware::Appliance::Techpreview::Networking::Firewall::Addr::Inbound::FirewallRulePolicy]
+    #     Allow packet with corresponding address.
+    class FirewallRulePolicy < VAPI::Bindings::VapiEnum
+      class << self
+        # Holds (gets or creates) the binding type metadata for this enumeration type.
+        # @scope class
+        # @return [VAPI::Bindings::EnumType] the binding type
+        def binding_type
+          @binding_type ||= VAPI::Bindings::EnumType.new(
+            'com.vmware.appliance.techpreview.networking.firewall.addr.inbound.firewall_rule_policy',
+            FirewallRulePolicy
+          )
+        end
+
+        # Converts from a string value (perhaps off the wire) to an instance
+        # of this enum type.
+        # @param value [String] the actual value of the enum instance
+        # @return [FirewallRulePolicy] the instance found for the value, otherwise
+        #         an unknown instance will be built for the value
+        def from_string(value)
+          const_get(value)
+        rescue NameError
+          FirewallRulePolicy.send(:new, 'UNKNOWN', value)
+        end
+      end
+
+      # Constructs a new instance.
+      # @param value [String] the actual value of the enum instance
+      # @param unknown [String] the unknown value when value is 'UKNOWN'
+      def initialize(value, unknown = nil)
+        super(self.class.binding_type, value, unknown)
+      end
+
+      private_class_method :new
+
+      # @!attribute [rw] deny
+      #     @return [Com::Vmware::Appliance::Techpreview::Networking::Firewall::Addr::Inbound::FirewallRulePolicy]
+      #     Deny packet with correpsonding address.
+      DENY = FirewallRulePolicy.send(:new, 'DENY')
+
+      # @!attribute [rw] allow
+      #     @return [Com::Vmware::Appliance::Techpreview::Networking::Firewall::Addr::Inbound::FirewallRulePolicy]
+      #     Allow packet with corresponding address.
+      ALLOW = FirewallRulePolicy.send(:new, 'ALLOW')
+    end
+  end
 end

--- a/client/sdk/com/vmware/appliance/techpreview/ntp.rb
+++ b/client/sdk/com/vmware/appliance/techpreview/ntp.rb
@@ -1,5 +1,6 @@
 #---------------------------------------------------------------------------
-# Copyright 2016 VMware, Inc.  All rights reserved.
+# Copyright 2017 VMware, Inc.  All rights reserved.
+#
 # AUTO GENERATED FILE -- DO NOT MODIFY!
 #
 # vAPI type descriptors for package com.vmware.appliance.techpreview.ntp.
@@ -8,122 +9,110 @@ require 'vapi'
 
 # declare the module hierarchy before we use the shorthand syntax below
 module Com
-    module Vmware
-        module Appliance
-            module Techpreview
-                module Ntp
-                end
-            end
+  module Vmware
+    module Appliance
+      module Techpreview
+        module Ntp
         end
+      end
     end
+  end
 end
 
 module Com::Vmware::Appliance::Techpreview::Ntp
+  # ``Com::Vmware::Appliance::Techpreview::Ntp::Server``   class  provides  methods  Performs NTP configuration.
+  class Server < VAPI::Bindings::VapiService
+    # static metamodel definitions
+    SERVICE_ID = VAPI::Core::ServiceIdentifier.new('com.vmware.appliance.techpreview.ntp.server')
 
-    # ``Com::Vmware::Appliance::Techpreview::Ntp::Server``   class  provides  methods  Performs NTP configuration.
-    class Server < VAPI::Bindings::VapiService
+    ADD_INFO = VAPI::Bindings::OperationInfo.new(
+      VAPI::Core::OperationIdentifier.new('add', SERVICE_ID),
+      VAPI::Bindings::OperationInputType.new(
+        'servers' => VAPI::Bindings::ListType.new(VAPI::Bindings::StringType.instance)
+      ),
+      VAPI::Bindings::VoidType.instance,
+      {
+        'com.vmware.vapi.std.errors.error' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Error')
+      },
+      [],
+      []
+    )
 
-        protected
+    SET_INFO = VAPI::Bindings::OperationInfo.new(
+      VAPI::Core::OperationIdentifier.new('set', SERVICE_ID),
+      VAPI::Bindings::OperationInputType.new(
+        'servers' => VAPI::Bindings::ListType.new(VAPI::Bindings::StringType.instance)
+      ),
+      VAPI::Bindings::VoidType.instance,
+      {
+        'com.vmware.vapi.std.errors.error' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Error')
+      },
+      [],
+      []
+    )
 
-        # static metamodel definitions
-        @@service_id = VAPI::Core::ServiceIdentifier.new('com.vmware.appliance.techpreview.ntp.server')
+    DELETE_INFO = VAPI::Bindings::OperationInfo.new(
+      VAPI::Core::OperationIdentifier.new('delete', SERVICE_ID),
+      VAPI::Bindings::OperationInputType.new(
+        'servers' => VAPI::Bindings::ListType.new(VAPI::Bindings::StringType.instance)
+      ),
+      VAPI::Bindings::VoidType.instance,
+      {
+        'com.vmware.vapi.std.errors.error' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Error')
+      },
+      [],
+      []
+    )
 
-        @@add_info = VAPI::Bindings::OperationInfo.new(
-            VAPI::Core::OperationIdentifier.new('add', @@service_id),
-            VAPI::Bindings::OperationInputType.new({
-                'servers' => VAPI::Bindings::ListType.new(VAPI::Bindings::StringType.instance),
-            }),
-            VAPI::Bindings::VoidType.instance,
-            {
-                'com.vmware.vapi.std.errors.error' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Error'),
+    SERVICE_INFO = VAPI::Bindings::ServiceInfo.new(
+      SERVICE_ID,
+      'add' => ADD_INFO,
+      'set' => SET_INFO,
+      'delete' => DELETE_INFO
+    )
 
-            },
-            [],
-            [])
-        @@set_info = VAPI::Bindings::OperationInfo.new(
-            VAPI::Core::OperationIdentifier.new('set', @@service_id),
-            VAPI::Bindings::OperationInputType.new({
-                'servers' => VAPI::Bindings::ListType.new(VAPI::Bindings::StringType.instance),
-            }),
-            VAPI::Bindings::VoidType.instance,
-            {
-                'com.vmware.vapi.std.errors.error' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Error'),
-
-            },
-            [],
-            [])
-        @@delete_info = VAPI::Bindings::OperationInfo.new(
-            VAPI::Core::OperationIdentifier.new('delete', @@service_id),
-            VAPI::Bindings::OperationInputType.new({
-                'servers' => VAPI::Bindings::ListType.new(VAPI::Bindings::StringType.instance),
-            }),
-            VAPI::Bindings::VoidType.instance,
-            {
-                'com.vmware.vapi.std.errors.error' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Error'),
-
-            },
-            [],
-            [])
-
-        @@service_info = VAPI::Bindings::ServiceInfo.new(@@service_id, {
-            'add' => @@add_info,
-            'set' => @@set_info,
-            'delete' => @@delete_info,
-        })
-
-        public
-
-        # Constructs a new instance.
-        #
-        # @param config [VAPI::Bindings::StubConfig] A hash with the api provider details.
-        def initialize(config)
-            super(config, @@service_info)
-        end
-
-
-        # Add NTP servers. This command adds NTP servers to the configuration. If the time synchronization is NTP-based, then NTP daemon is restarted to reload the new NTP servers. Otherwise, this command just adds servers to the NTP configuration.
-        #
-        # @param servers [Array<String>]
-        #     List of host names or IP addresses of NTP servers.
-        # @return [Void]
-        # @raise [Com::Vmware::Vapi::Std::Errors::Error]
-        #     Generic error
-        def add(servers)
-            invoke_with_info(@@add_info, {
-                'servers' => servers,
-            })
-        end
-
-
-        # Set NTP servers. This command deletes old NTP servers from the configuration and sets the input NTP servers in the configuration. If the time synchronization is NTP-based, the NTP daemon is restarted to reload the new NTP configuration. Otherwise, this command just replaces servers in the NTP configuration.
-        #
-        # @param servers [Array<String>]
-        #     List of host names or ip addresses of ntp servers.
-        # @return [Void]
-        # @raise [Com::Vmware::Vapi::Std::Errors::Error]
-        #     Generic error
-        def set(servers)
-            invoke_with_info(@@set_info, {
-                'servers' => servers,
-            })
-        end
-
-
-        # Delete NTP servers. This command deletes NTP servers from the configuration. If the time synchronization mode is NTP-based, the NTP daemon is restarted to reload the new NTP configuration. Otherwise, this command just deletes servers from the NTP configuration.
-        #
-        # @param servers [Array<String>]
-        #     List of host name or ip addresses of ntp servers.
-        # @return [Void]
-        # @raise [Com::Vmware::Vapi::Std::Errors::Error]
-        #     Generic error
-        def delete(servers)
-            invoke_with_info(@@delete_info, {
-                'servers' => servers,
-            })
-        end
-
-
+    # Constructs a new instance.
+    #
+    # @param config [VAPI::Bindings::StubConfig] A hash with the api provider details.
+    def initialize(config)
+      super(config, SERVICE_INFO)
     end
 
+    # Add NTP servers. This command adds NTP servers to the configuration. If the time synchronization is NTP-based, then NTP daemon is restarted to reload the new NTP servers. Otherwise, this command just adds servers to the NTP configuration.
+    #
+    # @param servers [Array<String>]
+    #     List of host names or IP addresses of NTP servers.
+    # @return [Void]
+    # @raise [Com::Vmware::Vapi::Std::Errors::Error]
+    #     Generic error
+    def add(servers)
+      invoke_with_info(ADD_INFO,
+                       'servers' => servers)
+    end
 
+    # Set NTP servers. This command deletes old NTP servers from the configuration and sets the input NTP servers in the configuration. If the time synchronization is NTP-based, the NTP daemon is restarted to reload the new NTP configuration. Otherwise, this command just replaces servers in the NTP configuration.
+    #
+    # @param servers [Array<String>]
+    #     List of host names or ip addresses of ntp servers.
+    # @return [Void]
+    # @raise [Com::Vmware::Vapi::Std::Errors::Error]
+    #     Generic error
+    def set(servers)
+      invoke_with_info(SET_INFO,
+                       'servers' => servers)
+    end
+
+    # Delete NTP servers. This command deletes NTP servers from the configuration. If the time synchronization mode is NTP-based, the NTP daemon is restarted to reload the new NTP configuration. Otherwise, this command just deletes servers from the NTP configuration.
+    #
+    # @param servers [Array<String>]
+    #     List of host name or ip addresses of ntp servers.
+    # @return [Void]
+    # @raise [Com::Vmware::Vapi::Std::Errors::Error]
+    #     Generic error
+    def delete(servers)
+      invoke_with_info(DELETE_INFO,
+                       'servers' => servers)
+    end
+
+  end
 end

--- a/client/sdk/com/vmware/appliance/techpreview/services.rb
+++ b/client/sdk/com/vmware/appliance/techpreview/services.rb
@@ -1,5 +1,6 @@
 #---------------------------------------------------------------------------
-# Copyright 2016 VMware, Inc.  All rights reserved.
+# Copyright 2017 VMware, Inc.  All rights reserved.
+#
 # AUTO GENERATED FILE -- DO NOT MODIFY!
 #
 # vAPI type descriptors for package com.vmware.appliance.techpreview.services.
@@ -8,131 +9,113 @@ require 'vapi'
 
 # declare the module hierarchy before we use the shorthand syntax below
 module Com
-    module Vmware
-        module Appliance
-            module Techpreview
-                module Services
-                end
-            end
+  module Vmware
+    module Appliance
+      module Techpreview
+        module Services
         end
+      end
     end
+  end
 end
 
 module Com::Vmware::Appliance::Techpreview::Services
+  # ``Com::Vmware::Appliance::Techpreview::Services::Status``   class  provides  methods  Get status of a service.
+  class Status < VAPI::Bindings::VapiService
+    # static metamodel definitions
+    SERVICE_ID = VAPI::Core::ServiceIdentifier.new('com.vmware.appliance.techpreview.services.status')
 
-    # ``Com::Vmware::Appliance::Techpreview::Services::Status``   class  provides  methods  Get status of a service.
-    class Status < VAPI::Bindings::VapiService
+    GET_INFO = VAPI::Bindings::OperationInfo.new(
+      VAPI::Core::OperationIdentifier.new('get', SERVICE_ID),
+      VAPI::Bindings::OperationInputType.new(
+        'name' => VAPI::Bindings::StringType.instance,
+        'timeout' => VAPI::Bindings::IntegerType.instance
+      ),
+      VAPI::Bindings::ReferenceType.new('Com::Vmware::Appliance::Techpreview::Services::Status::ServiceStatus'),
+      {
+        'com.vmware.vapi.std.errors.error' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Error')
+      },
+      [],
+      []
+    )
 
-        protected
+    SERVICE_INFO = VAPI::Bindings::ServiceInfo.new(
+      SERVICE_ID,
+      'get' => GET_INFO
+    )
 
-        # static metamodel definitions
-        @@service_id = VAPI::Core::ServiceIdentifier.new('com.vmware.appliance.techpreview.services.status')
-
-        @@get_info = VAPI::Bindings::OperationInfo.new(
-            VAPI::Core::OperationIdentifier.new('get', @@service_id),
-            VAPI::Bindings::OperationInputType.new({
-                'name' => VAPI::Bindings::StringType.instance,
-                'timeout' => VAPI::Bindings::IntegerType.instance,
-            }),
-            VAPI::Bindings::ReferenceType.new('Com::Vmware::Appliance::Techpreview::Services::Status::ServiceStatus'),
-            {
-                'com.vmware.vapi.std.errors.error' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Error'),
-
-            },
-            [],
-            [])
-
-        @@service_info = VAPI::Bindings::ServiceInfo.new(@@service_id, {
-            'get' => @@get_info,
-        })
-
-        public
-
-        # Constructs a new instance.
-        #
-        # @param config [VAPI::Bindings::StubConfig] A hash with the api provider details.
-        def initialize(config)
-            super(config, @@service_info)
-        end
-
-
-        # Get status of a service.
-        #
-        # @param name [String]
-        #     Name of a service.
-        # @param timeout [Fixnum]
-        #     Timeout in seconds. Zero (0) means no timeout.
-        # @return [Com::Vmware::Appliance::Techpreview::Services::Status::ServiceStatus]
-        #     Status of the service.
-        # @raise [Com::Vmware::Vapi::Std::Errors::Error]
-        #     Generic error
-        def get(name, timeout)
-            invoke_with_info(@@get_info, {
-                'name' => name,
-                'timeout' => timeout,
-            })
-        end
-
-
-
-        # ``Com::Vmware::Appliance::Techpreview::Services::Status::ServiceStatus``   enumerated type  Defines service status
-        # @!attribute [rw] down
-        #     @return [Com::Vmware::Appliance::Techpreview::Services::Status::ServiceStatus]
-        #     Service is not running.
-        # @!attribute [rw] up
-        #     @return [Com::Vmware::Appliance::Techpreview::Services::Status::ServiceStatus]
-        #     Service is running.
-        class ServiceStatus < VAPI::Bindings::VapiEnum
-
-            class << self
-                # Holds (gets or creates) the binding type metadata for this enumeration type.
-                # @scope class
-                # @return [VAPI::Bindings::EnumType] the binding type
-                def binding_type
-                    @binding_type ||= VAPI::Bindings::EnumType.new(
-                        'com.vmware.appliance.techpreview.services.status.service_status',
-                        ServiceStatus)
-                end
-
-                # Converts from a string value (perhaps off the wire) to an instance
-                # of this enum type.
-                # @param value [String] the actual value of the enum instance
-                # @return [ServiceStatus] the instance found for the value, otherwise
-                #         an unknown instance will be built for the value
-                def from_string(value)
-                    begin
-                        const_get(value)
-                    rescue NameError
-                        ServiceStatus.new('UNKNOWN', value)
-                    end
-                end
-            end
-
-            private
-
-            # Constructs a new instance.
-            # @param value [String] the actual value of the enum instance
-            # @param unknown [String] the unknown value when value is 'UKNOWN'
-            def initialize(value, unknown=nil)
-                super(self.class.binding_type, value, unknown)
-            end
-
-            public
-
-            # @!attribute [rw] down
-            #     @return [Com::Vmware::Appliance::Techpreview::Services::Status::ServiceStatus]
-            #     Service is not running.
-            DOWN = ServiceStatus.new('DOWN')
-
-            # @!attribute [rw] up
-            #     @return [Com::Vmware::Appliance::Techpreview::Services::Status::ServiceStatus]
-            #     Service is running.
-            UP = ServiceStatus.new('UP')
-
-        end
-
-
+    # Constructs a new instance.
+    #
+    # @param config [VAPI::Bindings::StubConfig] A hash with the api provider details.
+    def initialize(config)
+      super(config, SERVICE_INFO)
     end
 
+    # Get status of a service.
+    #
+    # @param name [String]
+    #     Name of a service.
+    # @param timeout [Fixnum]
+    #     Timeout in seconds. Zero (0) means no timeout.
+    # @return [Com::Vmware::Appliance::Techpreview::Services::Status::ServiceStatus]
+    #     Status of the service.
+    # @raise [Com::Vmware::Vapi::Std::Errors::Error]
+    #     Generic error
+    def get(name, timeout)
+      invoke_with_info(GET_INFO,
+                       'name' => name,
+                       'timeout' => timeout)
+    end
 
+    # ``Com::Vmware::Appliance::Techpreview::Services::Status::ServiceStatus``   enumerated type  Defines service status
+    # @!attribute [rw] down
+    #     @return [Com::Vmware::Appliance::Techpreview::Services::Status::ServiceStatus]
+    #     Service is not running.
+    # @!attribute [rw] up
+    #     @return [Com::Vmware::Appliance::Techpreview::Services::Status::ServiceStatus]
+    #     Service is running.
+    class ServiceStatus < VAPI::Bindings::VapiEnum
+      class << self
+        # Holds (gets or creates) the binding type metadata for this enumeration type.
+        # @scope class
+        # @return [VAPI::Bindings::EnumType] the binding type
+        def binding_type
+          @binding_type ||= VAPI::Bindings::EnumType.new(
+            'com.vmware.appliance.techpreview.services.status.service_status',
+            ServiceStatus
+          )
+        end
+
+        # Converts from a string value (perhaps off the wire) to an instance
+        # of this enum type.
+        # @param value [String] the actual value of the enum instance
+        # @return [ServiceStatus] the instance found for the value, otherwise
+        #         an unknown instance will be built for the value
+        def from_string(value)
+          const_get(value)
+        rescue NameError
+          ServiceStatus.send(:new, 'UNKNOWN', value)
+        end
+      end
+
+      # Constructs a new instance.
+      # @param value [String] the actual value of the enum instance
+      # @param unknown [String] the unknown value when value is 'UKNOWN'
+      def initialize(value, unknown = nil)
+        super(self.class.binding_type, value, unknown)
+      end
+
+      private_class_method :new
+
+      # @!attribute [rw] down
+      #     @return [Com::Vmware::Appliance::Techpreview::Services::Status::ServiceStatus]
+      #     Service is not running.
+      DOWN = ServiceStatus.send(:new, 'DOWN')
+
+      # @!attribute [rw] up
+      #     @return [Com::Vmware::Appliance::Techpreview::Services::Status::ServiceStatus]
+      #     Service is running.
+      UP = ServiceStatus.send(:new, 'UP')
+    end
+  end
 end

--- a/client/sdk/com/vmware/appliance/techpreview/system.rb
+++ b/client/sdk/com/vmware/appliance/techpreview/system.rb
@@ -1,5 +1,6 @@
 #---------------------------------------------------------------------------
-# Copyright 2016 VMware, Inc.  All rights reserved.
+# Copyright 2017 VMware, Inc.  All rights reserved.
+#
 # AUTO GENERATED FILE -- DO NOT MODIFY!
 #
 # vAPI type descriptors for package com.vmware.appliance.techpreview.system.
@@ -8,385 +9,357 @@ require 'vapi'
 
 # declare the module hierarchy before we use the shorthand syntax below
 module Com
-    module Vmware
-        module Appliance
-            module Techpreview
-                module System
-                end
-            end
+  module Vmware
+    module Appliance
+      module Techpreview
+        module System
         end
+      end
     end
+  end
 end
 
 module Com::Vmware::Appliance::Techpreview::System
+  # ``Com::Vmware::Appliance::Techpreview::System::Update``   class  provides  methods  Performs update repository configuration.
+  class Update < VAPI::Bindings::VapiService
+    # static metamodel definitions
+    SERVICE_ID = VAPI::Core::ServiceIdentifier.new('com.vmware.appliance.techpreview.system.update')
 
-    # ``Com::Vmware::Appliance::Techpreview::System::Update``   class  provides  methods  Performs update repository configuration.
-    class Update < VAPI::Bindings::VapiService
+    SET_INFO = VAPI::Bindings::OperationInfo.new(
+      VAPI::Core::OperationIdentifier.new('set', SERVICE_ID),
+      VAPI::Bindings::OperationInputType.new(
+        'config' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Appliance::Techpreview::System::Update::UpdateStructSet')
+      ),
+      VAPI::Bindings::VoidType.instance,
+      {
+        'com.vmware.vapi.std.errors.error' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Error')
+      },
+      [],
+      []
+    )
 
-        protected
+    GET_INFO = VAPI::Bindings::OperationInfo.new(
+      VAPI::Core::OperationIdentifier.new('get', SERVICE_ID),
+      VAPI::Bindings::OperationInputType.new,
+      VAPI::Bindings::ReferenceType.new('Com::Vmware::Appliance::Techpreview::System::Update::UpdateStructGet'),
+      {
+        'com.vmware.vapi.std.errors.error' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Error')
+      },
+      [],
+      []
+    )
 
-        # static metamodel definitions
-        @@service_id = VAPI::Core::ServiceIdentifier.new('com.vmware.appliance.techpreview.system.update')
+    SERVICE_INFO = VAPI::Bindings::ServiceInfo.new(
+      SERVICE_ID,
+      'set' => SET_INFO,
+      'get' => GET_INFO
+    )
 
-        @@set_info = VAPI::Bindings::OperationInfo.new(
-            VAPI::Core::OperationIdentifier.new('set', @@service_id),
-            VAPI::Bindings::OperationInputType.new({
-                'config' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Appliance::Techpreview::System::Update::UpdateStructSet'),
-            }),
-            VAPI::Bindings::VoidType.instance,
-            {
-                'com.vmware.vapi.std.errors.error' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Error'),
-
-            },
-            [],
-            [])
-        @@get_info = VAPI::Bindings::OperationInfo.new(
-            VAPI::Core::OperationIdentifier.new('get', @@service_id),
-            VAPI::Bindings::OperationInputType.new,
-            VAPI::Bindings::ReferenceType.new('Com::Vmware::Appliance::Techpreview::System::Update::UpdateStructGet'),
-            {
-                'com.vmware.vapi.std.errors.error' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Error'),
-
-            },
-            [],
-            [])
-
-        @@service_info = VAPI::Bindings::ServiceInfo.new(@@service_id, {
-            'set' => @@set_info,
-            'get' => @@get_info,
-        })
-
-        public
-
-        # Constructs a new instance.
-        #
-        # @param config [VAPI::Bindings::StubConfig] A hash with the api provider details.
-        def initialize(config)
-            super(config, @@service_info)
-        end
-
-
-        # Set update repository configuration.
-        #
-        # @param config [Com::Vmware::Appliance::Techpreview::System::Update::UpdateStructSet]
-        #     update related configuration
-        # @return [Void]
-        # @raise [Com::Vmware::Vapi::Std::Errors::Error]
-        #     Generic error
-        def set(config)
-            invoke_with_info(@@set_info, {
-                'config' => config,
-            })
-        end
-
-
-        # Get update repository configuration.
-        #
-        # @return [Com::Vmware::Appliance::Techpreview::System::Update::UpdateStructGet]
-        #     update related configuration
-        # @raise [Com::Vmware::Vapi::Std::Errors::Error]
-        #     Generic error
-        def get()
-            invoke_with_info(@@get_info)
-        end
-
-
-
-        # ``Com::Vmware::Appliance::Techpreview::System::Update::UpdateStructSet``   class  Structure to set url update repository.
-        # @!attribute [rw] current_url
-        #     @return [String]
-        #     Current appliance update repository URL. Enter "default" to reset the url to the default url.
-        # @!attribute [rw] check_updates
-        #     @return [Com::Vmware::Appliance::Techpreview::System::Update::AutoUpdateNotification]
-        #     Check for update at the pre-configured repository URL.
-        # @!attribute [rw] time
-        #     @return [String]
-        #     time to query for updates Format: HH:MM:SS Military (24 hour) Time Format
-        # @!attribute [rw] day
-        #     @return [Com::Vmware::Appliance::Techpreview::System::Update::UpdateDay]
-        #     day to query for updates
-        # @!attribute [rw] username
-        #     @return [String]
-        #     username for the url update repository
-        # @!attribute [rw] password
-        #     @return [String]
-        #     password for the url update repository
-        class UpdateStructSet < VAPI::Bindings::VapiStruct
-
-            class << self
-                # Holds (gets or creates) the binding type metadata for this structure type.
-                # @scope class
-                # @return [VAPI::Bindings::StructType] the binding type
-                def binding_type
-                    @binding_type ||= VAPI::Bindings::StructType.new(
-                        'com.vmware.appliance.techpreview.system.update.update_struct_set',
-                        {
-                            'current_URL' => VAPI::Bindings::StringType.instance,
-                            'check_updates' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Appliance::Techpreview::System::Update::AutoUpdateNotification'),
-                            'time' => VAPI::Bindings::StringType.instance,
-                            'day' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Appliance::Techpreview::System::Update::UpdateDay'),
-                            'username' => VAPI::Bindings::StringType.instance,
-                            'password' => VAPI::Bindings::SecretType.instance,
-                        },
-                        UpdateStructSet,
-                        false,
-                        nil)
-                end
-            end
-
-            attr_accessor :current_url,
-                          :check_updates,
-                          :time,
-                          :day,
-                          :username,
-                          :password
-
-            # Constructs a new instance.
-            # @param ruby_values [Hash] a map of initial property values (optional)
-            # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
-            def initialize(ruby_values=nil, struct_value=nil)
-                super(self.class.binding_type, ruby_values, struct_value)
-            end
-        end
-
-
-        # ``Com::Vmware::Appliance::Techpreview::System::Update::UpdateStructGet``   class  Structure to get url update repository.
-        # @!attribute [rw] current_url
-        #     @return [String]
-        #     Current appliance update repository URL.
-        # @!attribute [rw] default_url
-        #     @return [String]
-        #     Default appliance update repository URL.
-        # @!attribute [rw] check_updates
-        #     @return [Com::Vmware::Appliance::Techpreview::System::Update::AutoUpdateNotification]
-        #     Check for update at the pre-configured repository URL.
-        # @!attribute [rw] time
-        #     @return [String]
-        #     time to query for updates Format: HH:MM:SS Military (24 hour) Time Format
-        # @!attribute [rw] day
-        #     @return [Com::Vmware::Appliance::Techpreview::System::Update::UpdateDay]
-        #     day to query for updates
-        # @!attribute [rw] latest_update_install_time
-        #     @return [String]
-        #     timestamp of latest update installation
-        # @!attribute [rw] latest_update_query_time
-        #     @return [String]
-        #     timestamp of latest query to update repository
-        # @!attribute [rw] username
-        #     @return [String]
-        #     username for the url update repository
-        # @!attribute [rw] password
-        #     @return [String]
-        #     password for the url update repository
-        class UpdateStructGet < VAPI::Bindings::VapiStruct
-
-            class << self
-                # Holds (gets or creates) the binding type metadata for this structure type.
-                # @scope class
-                # @return [VAPI::Bindings::StructType] the binding type
-                def binding_type
-                    @binding_type ||= VAPI::Bindings::StructType.new(
-                        'com.vmware.appliance.techpreview.system.update.update_struct_get',
-                        {
-                            'current_URL' => VAPI::Bindings::StringType.instance,
-                            'default_URL' => VAPI::Bindings::StringType.instance,
-                            'check_updates' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Appliance::Techpreview::System::Update::AutoUpdateNotification'),
-                            'time' => VAPI::Bindings::StringType.instance,
-                            'day' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Appliance::Techpreview::System::Update::UpdateDay'),
-                            'latest_update_install_time' => VAPI::Bindings::StringType.instance,
-                            'latest_update_query_time' => VAPI::Bindings::StringType.instance,
-                            'username' => VAPI::Bindings::StringType.instance,
-                            'password' => VAPI::Bindings::StringType.instance,
-                        },
-                        UpdateStructGet,
-                        false,
-                        nil)
-                end
-            end
-
-            attr_accessor :current_url,
-                          :default_url,
-                          :check_updates,
-                          :time,
-                          :day,
-                          :latest_update_install_time,
-                          :latest_update_query_time,
-                          :username,
-                          :password
-
-            # Constructs a new instance.
-            # @param ruby_values [Hash] a map of initial property values (optional)
-            # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
-            def initialize(ruby_values=nil, struct_value=nil)
-                super(self.class.binding_type, ruby_values, struct_value)
-            end
-        end
-
-
-
-        # ``Com::Vmware::Appliance::Techpreview::System::Update::AutoUpdateNotification``   enumerated type  Defines state for automatic update notification
-        # @!attribute [rw] disabled
-        #     @return [Com::Vmware::Appliance::Techpreview::System::Update::AutoUpdateNotification]
-        #     Automatic update notification is disabled. Disable periodically query the configured url for updates.
-        # @!attribute [rw] enabled
-        #     @return [Com::Vmware::Appliance::Techpreview::System::Update::AutoUpdateNotification]
-        #     Automatic update notification is enabled. Enable periodically query the configured url for updates.
-        class AutoUpdateNotification < VAPI::Bindings::VapiEnum
-
-            class << self
-                # Holds (gets or creates) the binding type metadata for this enumeration type.
-                # @scope class
-                # @return [VAPI::Bindings::EnumType] the binding type
-                def binding_type
-                    @binding_type ||= VAPI::Bindings::EnumType.new(
-                        'com.vmware.appliance.techpreview.system.update.auto_update_notification',
-                        AutoUpdateNotification)
-                end
-
-                # Converts from a string value (perhaps off the wire) to an instance
-                # of this enum type.
-                # @param value [String] the actual value of the enum instance
-                # @return [AutoUpdateNotification] the instance found for the value, otherwise
-                #         an unknown instance will be built for the value
-                def from_string(value)
-                    begin
-                        const_get(value)
-                    rescue NameError
-                        AutoUpdateNotification.new('UNKNOWN', value)
-                    end
-                end
-            end
-
-            private
-
-            # Constructs a new instance.
-            # @param value [String] the actual value of the enum instance
-            # @param unknown [String] the unknown value when value is 'UKNOWN'
-            def initialize(value, unknown=nil)
-                super(self.class.binding_type, value, unknown)
-            end
-
-            public
-
-            # @!attribute [rw] disabled
-            #     @return [Com::Vmware::Appliance::Techpreview::System::Update::AutoUpdateNotification]
-            #     Automatic update notification is disabled. Disable periodically query the configured url for updates.
-            DISABLED = AutoUpdateNotification.new('DISABLED')
-
-            # @!attribute [rw] enabled
-            #     @return [Com::Vmware::Appliance::Techpreview::System::Update::AutoUpdateNotification]
-            #     Automatic update notification is enabled. Enable periodically query the configured url for updates.
-            ENABLED = AutoUpdateNotification.new('ENABLED')
-
-        end
-
-
-        # ``Com::Vmware::Appliance::Techpreview::System::Update::UpdateDay``   enumerated type  Defines days to query for updates
-        # @!attribute [rw] monday
-        #     @return [Com::Vmware::Appliance::Techpreview::System::Update::UpdateDay]
-        #     query for updates on Monday
-        # @!attribute [rw] tuesday
-        #     @return [Com::Vmware::Appliance::Techpreview::System::Update::UpdateDay]
-        #     query for updates on Tuesday
-        # @!attribute [rw] friday
-        #     @return [Com::Vmware::Appliance::Techpreview::System::Update::UpdateDay]
-        #     query for updates on Friday
-        # @!attribute [rw] wednesday
-        #     @return [Com::Vmware::Appliance::Techpreview::System::Update::UpdateDay]
-        #     query for updates on Wednesday
-        # @!attribute [rw] thursday
-        #     @return [Com::Vmware::Appliance::Techpreview::System::Update::UpdateDay]
-        #     query for updates on Thursday
-        # @!attribute [rw] saturday
-        #     @return [Com::Vmware::Appliance::Techpreview::System::Update::UpdateDay]
-        #     query for updates on Saturday
-        # @!attribute [rw] sunday
-        #     @return [Com::Vmware::Appliance::Techpreview::System::Update::UpdateDay]
-        #     query for updates on Sunday
-        # @!attribute [rw] everyday
-        #     @return [Com::Vmware::Appliance::Techpreview::System::Update::UpdateDay]
-        #     query for updates everyday
-        class UpdateDay < VAPI::Bindings::VapiEnum
-
-            class << self
-                # Holds (gets or creates) the binding type metadata for this enumeration type.
-                # @scope class
-                # @return [VAPI::Bindings::EnumType] the binding type
-                def binding_type
-                    @binding_type ||= VAPI::Bindings::EnumType.new(
-                        'com.vmware.appliance.techpreview.system.update.update_day',
-                        UpdateDay)
-                end
-
-                # Converts from a string value (perhaps off the wire) to an instance
-                # of this enum type.
-                # @param value [String] the actual value of the enum instance
-                # @return [UpdateDay] the instance found for the value, otherwise
-                #         an unknown instance will be built for the value
-                def from_string(value)
-                    begin
-                        const_get(value)
-                    rescue NameError
-                        UpdateDay.new('UNKNOWN', value)
-                    end
-                end
-            end
-
-            private
-
-            # Constructs a new instance.
-            # @param value [String] the actual value of the enum instance
-            # @param unknown [String] the unknown value when value is 'UKNOWN'
-            def initialize(value, unknown=nil)
-                super(self.class.binding_type, value, unknown)
-            end
-
-            public
-
-            # @!attribute [rw] monday
-            #     @return [Com::Vmware::Appliance::Techpreview::System::Update::UpdateDay]
-            #     query for updates on Monday
-            MONDAY = UpdateDay.new('MONDAY')
-
-            # @!attribute [rw] tuesday
-            #     @return [Com::Vmware::Appliance::Techpreview::System::Update::UpdateDay]
-            #     query for updates on Tuesday
-            TUESDAY = UpdateDay.new('TUESDAY')
-
-            # @!attribute [rw] friday
-            #     @return [Com::Vmware::Appliance::Techpreview::System::Update::UpdateDay]
-            #     query for updates on Friday
-            FRIDAY = UpdateDay.new('FRIDAY')
-
-            # @!attribute [rw] wednesday
-            #     @return [Com::Vmware::Appliance::Techpreview::System::Update::UpdateDay]
-            #     query for updates on Wednesday
-            WEDNESDAY = UpdateDay.new('WEDNESDAY')
-
-            # @!attribute [rw] thursday
-            #     @return [Com::Vmware::Appliance::Techpreview::System::Update::UpdateDay]
-            #     query for updates on Thursday
-            THURSDAY = UpdateDay.new('THURSDAY')
-
-            # @!attribute [rw] saturday
-            #     @return [Com::Vmware::Appliance::Techpreview::System::Update::UpdateDay]
-            #     query for updates on Saturday
-            SATURDAY = UpdateDay.new('SATURDAY')
-
-            # @!attribute [rw] sunday
-            #     @return [Com::Vmware::Appliance::Techpreview::System::Update::UpdateDay]
-            #     query for updates on Sunday
-            SUNDAY = UpdateDay.new('SUNDAY')
-
-            # @!attribute [rw] everyday
-            #     @return [Com::Vmware::Appliance::Techpreview::System::Update::UpdateDay]
-            #     query for updates everyday
-            EVERYDAY = UpdateDay.new('EVERYDAY')
-
-        end
-
-
+    # Constructs a new instance.
+    #
+    # @param config [VAPI::Bindings::StubConfig] A hash with the api provider details.
+    def initialize(config)
+      super(config, SERVICE_INFO)
     end
 
+    # Set update repository configuration.
+    #
+    # @param config [Com::Vmware::Appliance::Techpreview::System::Update::UpdateStructSet]
+    #     update related configuration
+    # @return [Void]
+    # @raise [Com::Vmware::Vapi::Std::Errors::Error]
+    #     Generic error
+    def set(config)
+      invoke_with_info(SET_INFO,
+                       'config' => config)
+    end
 
+    # Get update repository configuration.
+    #
+    # @return [Com::Vmware::Appliance::Techpreview::System::Update::UpdateStructGet]
+    #     update related configuration
+    # @raise [Com::Vmware::Vapi::Std::Errors::Error]
+    #     Generic error
+    def get
+      invoke_with_info(GET_INFO)
+    end
+
+    # ``Com::Vmware::Appliance::Techpreview::System::Update::UpdateStructSet``   class  Structure to set url update repository.
+    # @!attribute [rw] current_url
+    #     @return [String]
+    #     Current appliance update repository URL. Enter "default" to reset the url to the default url.
+    # @!attribute [rw] check_updates
+    #     @return [Com::Vmware::Appliance::Techpreview::System::Update::AutoUpdateNotification]
+    #     Check for update at the pre-configured repository URL.
+    # @!attribute [rw] time
+    #     @return [String]
+    #     time to query for updates Format: HH:MM:SS Military (24 hour) Time Format
+    # @!attribute [rw] day
+    #     @return [Com::Vmware::Appliance::Techpreview::System::Update::UpdateDay]
+    #     day to query for updates
+    # @!attribute [rw] username
+    #     @return [String]
+    #     username for the url update repository
+    # @!attribute [rw] password
+    #     @return [String]
+    #     password for the url update repository
+    class UpdateStructSet < VAPI::Bindings::VapiStruct
+      class << self
+        # Holds (gets or creates) the binding type metadata for this structure type.
+        # @scope class
+        # @return [VAPI::Bindings::StructType] the binding type
+        def binding_type
+          @binding_type ||= VAPI::Bindings::StructType.new(
+            'com.vmware.appliance.techpreview.system.update.update_struct_set',
+            {
+              'current_URL' => VAPI::Bindings::StringType.instance,
+              'check_updates' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Appliance::Techpreview::System::Update::AutoUpdateNotification'),
+              'time' => VAPI::Bindings::StringType.instance,
+              'day' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Appliance::Techpreview::System::Update::UpdateDay'),
+              'username' => VAPI::Bindings::StringType.instance,
+              'password' => VAPI::Bindings::SecretType.instance
+            },
+            UpdateStructSet,
+            false,
+            nil
+          )
+        end
+      end
+
+      attr_accessor :current_url,
+                    :check_updates,
+                    :time,
+                    :day,
+                    :username,
+                    :password
+
+      # Constructs a new instance.
+      # @param ruby_values [Hash] a map of initial property values (optional)
+      # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
+      def initialize(ruby_values = nil, struct_value = nil)
+        super(self.class.binding_type, ruby_values, struct_value)
+      end
+    end
+
+    # ``Com::Vmware::Appliance::Techpreview::System::Update::UpdateStructGet``   class  Structure to get url update repository.
+    # @!attribute [rw] current_url
+    #     @return [String]
+    #     Current appliance update repository URL.
+    # @!attribute [rw] default_url
+    #     @return [String]
+    #     Default appliance update repository URL.
+    # @!attribute [rw] check_updates
+    #     @return [Com::Vmware::Appliance::Techpreview::System::Update::AutoUpdateNotification]
+    #     Check for update at the pre-configured repository URL.
+    # @!attribute [rw] time
+    #     @return [String]
+    #     time to query for updates Format: HH:MM:SS Military (24 hour) Time Format
+    # @!attribute [rw] day
+    #     @return [Com::Vmware::Appliance::Techpreview::System::Update::UpdateDay]
+    #     day to query for updates
+    # @!attribute [rw] latest_update_install_time
+    #     @return [String]
+    #     timestamp of latest update installation
+    # @!attribute [rw] latest_update_query_time
+    #     @return [String]
+    #     timestamp of latest query to update repository
+    # @!attribute [rw] username
+    #     @return [String]
+    #     username for the url update repository
+    # @!attribute [rw] password
+    #     @return [String]
+    #     password for the url update repository
+    class UpdateStructGet < VAPI::Bindings::VapiStruct
+      class << self
+        # Holds (gets or creates) the binding type metadata for this structure type.
+        # @scope class
+        # @return [VAPI::Bindings::StructType] the binding type
+        def binding_type
+          @binding_type ||= VAPI::Bindings::StructType.new(
+            'com.vmware.appliance.techpreview.system.update.update_struct_get',
+            {
+              'current_URL' => VAPI::Bindings::StringType.instance,
+              'default_URL' => VAPI::Bindings::StringType.instance,
+              'check_updates' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Appliance::Techpreview::System::Update::AutoUpdateNotification'),
+              'time' => VAPI::Bindings::StringType.instance,
+              'day' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Appliance::Techpreview::System::Update::UpdateDay'),
+              'latest_update_install_time' => VAPI::Bindings::StringType.instance,
+              'latest_update_query_time' => VAPI::Bindings::StringType.instance,
+              'username' => VAPI::Bindings::StringType.instance,
+              'password' => VAPI::Bindings::StringType.instance
+            },
+            UpdateStructGet,
+            false,
+            nil
+          )
+        end
+      end
+
+      attr_accessor :current_url,
+                    :default_url,
+                    :check_updates,
+                    :time,
+                    :day,
+                    :latest_update_install_time,
+                    :latest_update_query_time,
+                    :username,
+                    :password
+
+      # Constructs a new instance.
+      # @param ruby_values [Hash] a map of initial property values (optional)
+      # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
+      def initialize(ruby_values = nil, struct_value = nil)
+        super(self.class.binding_type, ruby_values, struct_value)
+      end
+    end
+
+    # ``Com::Vmware::Appliance::Techpreview::System::Update::AutoUpdateNotification``   enumerated type  Defines state for automatic update notification
+    # @!attribute [rw] disabled
+    #     @return [Com::Vmware::Appliance::Techpreview::System::Update::AutoUpdateNotification]
+    #     Automatic update notification is disabled. Disable periodically query the configured url for updates.
+    # @!attribute [rw] enabled
+    #     @return [Com::Vmware::Appliance::Techpreview::System::Update::AutoUpdateNotification]
+    #     Automatic update notification is enabled. Enable periodically query the configured url for updates.
+    class AutoUpdateNotification < VAPI::Bindings::VapiEnum
+      class << self
+        # Holds (gets or creates) the binding type metadata for this enumeration type.
+        # @scope class
+        # @return [VAPI::Bindings::EnumType] the binding type
+        def binding_type
+          @binding_type ||= VAPI::Bindings::EnumType.new(
+            'com.vmware.appliance.techpreview.system.update.auto_update_notification',
+            AutoUpdateNotification
+          )
+        end
+
+        # Converts from a string value (perhaps off the wire) to an instance
+        # of this enum type.
+        # @param value [String] the actual value of the enum instance
+        # @return [AutoUpdateNotification] the instance found for the value, otherwise
+        #         an unknown instance will be built for the value
+        def from_string(value)
+          const_get(value)
+        rescue NameError
+          AutoUpdateNotification.send(:new, 'UNKNOWN', value)
+        end
+      end
+
+      # Constructs a new instance.
+      # @param value [String] the actual value of the enum instance
+      # @param unknown [String] the unknown value when value is 'UKNOWN'
+      def initialize(value, unknown = nil)
+        super(self.class.binding_type, value, unknown)
+      end
+
+      private_class_method :new
+
+      # @!attribute [rw] disabled
+      #     @return [Com::Vmware::Appliance::Techpreview::System::Update::AutoUpdateNotification]
+      #     Automatic update notification is disabled. Disable periodically query the configured url for updates.
+      DISABLED = AutoUpdateNotification.send(:new, 'DISABLED')
+
+      # @!attribute [rw] enabled
+      #     @return [Com::Vmware::Appliance::Techpreview::System::Update::AutoUpdateNotification]
+      #     Automatic update notification is enabled. Enable periodically query the configured url for updates.
+      ENABLED = AutoUpdateNotification.send(:new, 'ENABLED')
+    end
+    # ``Com::Vmware::Appliance::Techpreview::System::Update::UpdateDay``   enumerated type  Defines days to query for updates
+    # @!attribute [rw] monday
+    #     @return [Com::Vmware::Appliance::Techpreview::System::Update::UpdateDay]
+    #     query for updates on Monday
+    # @!attribute [rw] tuesday
+    #     @return [Com::Vmware::Appliance::Techpreview::System::Update::UpdateDay]
+    #     query for updates on Tuesday
+    # @!attribute [rw] friday
+    #     @return [Com::Vmware::Appliance::Techpreview::System::Update::UpdateDay]
+    #     query for updates on Friday
+    # @!attribute [rw] wednesday
+    #     @return [Com::Vmware::Appliance::Techpreview::System::Update::UpdateDay]
+    #     query for updates on Wednesday
+    # @!attribute [rw] thursday
+    #     @return [Com::Vmware::Appliance::Techpreview::System::Update::UpdateDay]
+    #     query for updates on Thursday
+    # @!attribute [rw] saturday
+    #     @return [Com::Vmware::Appliance::Techpreview::System::Update::UpdateDay]
+    #     query for updates on Saturday
+    # @!attribute [rw] sunday
+    #     @return [Com::Vmware::Appliance::Techpreview::System::Update::UpdateDay]
+    #     query for updates on Sunday
+    # @!attribute [rw] everyday
+    #     @return [Com::Vmware::Appliance::Techpreview::System::Update::UpdateDay]
+    #     query for updates everyday
+    class UpdateDay < VAPI::Bindings::VapiEnum
+      class << self
+        # Holds (gets or creates) the binding type metadata for this enumeration type.
+        # @scope class
+        # @return [VAPI::Bindings::EnumType] the binding type
+        def binding_type
+          @binding_type ||= VAPI::Bindings::EnumType.new(
+            'com.vmware.appliance.techpreview.system.update.update_day',
+            UpdateDay
+          )
+        end
+
+        # Converts from a string value (perhaps off the wire) to an instance
+        # of this enum type.
+        # @param value [String] the actual value of the enum instance
+        # @return [UpdateDay] the instance found for the value, otherwise
+        #         an unknown instance will be built for the value
+        def from_string(value)
+          const_get(value)
+        rescue NameError
+          UpdateDay.send(:new, 'UNKNOWN', value)
+        end
+      end
+
+      # Constructs a new instance.
+      # @param value [String] the actual value of the enum instance
+      # @param unknown [String] the unknown value when value is 'UKNOWN'
+      def initialize(value, unknown = nil)
+        super(self.class.binding_type, value, unknown)
+      end
+
+      private_class_method :new
+
+      # @!attribute [rw] monday
+      #     @return [Com::Vmware::Appliance::Techpreview::System::Update::UpdateDay]
+      #     query for updates on Monday
+      MONDAY = UpdateDay.send(:new, 'MONDAY')
+
+      # @!attribute [rw] tuesday
+      #     @return [Com::Vmware::Appliance::Techpreview::System::Update::UpdateDay]
+      #     query for updates on Tuesday
+      TUESDAY = UpdateDay.send(:new, 'TUESDAY')
+
+      # @!attribute [rw] friday
+      #     @return [Com::Vmware::Appliance::Techpreview::System::Update::UpdateDay]
+      #     query for updates on Friday
+      FRIDAY = UpdateDay.send(:new, 'FRIDAY')
+
+      # @!attribute [rw] wednesday
+      #     @return [Com::Vmware::Appliance::Techpreview::System::Update::UpdateDay]
+      #     query for updates on Wednesday
+      WEDNESDAY = UpdateDay.send(:new, 'WEDNESDAY')
+
+      # @!attribute [rw] thursday
+      #     @return [Com::Vmware::Appliance::Techpreview::System::Update::UpdateDay]
+      #     query for updates on Thursday
+      THURSDAY = UpdateDay.send(:new, 'THURSDAY')
+
+      # @!attribute [rw] saturday
+      #     @return [Com::Vmware::Appliance::Techpreview::System::Update::UpdateDay]
+      #     query for updates on Saturday
+      SATURDAY = UpdateDay.send(:new, 'SATURDAY')
+
+      # @!attribute [rw] sunday
+      #     @return [Com::Vmware::Appliance::Techpreview::System::Update::UpdateDay]
+      #     query for updates on Sunday
+      SUNDAY = UpdateDay.send(:new, 'SUNDAY')
+
+      # @!attribute [rw] everyday
+      #     @return [Com::Vmware::Appliance::Techpreview::System::Update::UpdateDay]
+      #     query for updates everyday
+      EVERYDAY = UpdateDay.send(:new, 'EVERYDAY')
+    end
+  end
 end

--- a/client/sdk/com/vmware/appliance/vapi.rb
+++ b/client/sdk/com/vmware/appliance/vapi.rb
@@ -1,5 +1,6 @@
 #---------------------------------------------------------------------------
-# Copyright 2016 VMware, Inc.  All rights reserved.
+# Copyright 2017 VMware, Inc.  All rights reserved.
+#
 # AUTO GENERATED FILE -- DO NOT MODIFY!
 #---------------------------------------------------------------------------
 require 'vapi'

--- a/client/sdk/com/vmware/appliance/vmon.rb
+++ b/client/sdk/com/vmware/appliance/vmon.rb
@@ -1,5 +1,6 @@
 #---------------------------------------------------------------------------
-# Copyright 2016 VMware, Inc.  All rights reserved.
+# Copyright 2017 VMware, Inc.  All rights reserved.
+#
 # AUTO GENERATED FILE -- DO NOT MODIFY!
 #
 # vAPI type descriptors for package com.vmware.appliance.vmon.
@@ -8,540 +9,501 @@ require 'vapi'
 
 # declare the module hierarchy before we use the shorthand syntax below
 module Com
-    module Vmware
-        module Appliance
-            module Vmon
-            end
-        end
+  module Vmware
+    module Appliance
+      module Vmon
+      end
     end
+  end
 end
 
 # The  ``com.vmware.appliance.vmon``   package  provides  classs  to manage a set of services that are part of the vCenter Server.
 module Com::Vmware::Appliance::Vmon
-
-    # The  ``Com::Vmware::Appliance::Vmon::Service``   class  provides  methods  to manage a single/set of services that are managed by vMon.
-    class Service < VAPI::Bindings::VapiService
-
-        protected
-
-        # static metamodel definitions
-        @@service_id = VAPI::Core::ServiceIdentifier.new('com.vmware.appliance.vmon.service')
-
-        @@start_info = VAPI::Bindings::OperationInfo.new(
-            VAPI::Core::OperationIdentifier.new('start', @@service_id),
-            VAPI::Bindings::OperationInputType.new({
-                'service' => VAPI::Bindings::IdType.new(resource_types='com.vmware.appliance.vmon.Service'),
-            }),
-            VAPI::Bindings::VoidType.instance,
-            {
-                'com.vmware.vapi.std.errors.not_found' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::NotFound'),
-                'com.vmware.vapi.std.errors.not_allowed_in_current_state' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::NotAllowedInCurrentState'),
-                'com.vmware.vapi.std.errors.timed_out' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::TimedOut'),
-                'com.vmware.vapi.std.errors.error' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Error'),
-
-            },
-            [],
-            [])
-        @@stop_info = VAPI::Bindings::OperationInfo.new(
-            VAPI::Core::OperationIdentifier.new('stop', @@service_id),
-            VAPI::Bindings::OperationInputType.new({
-                'service' => VAPI::Bindings::IdType.new(resource_types='com.vmware.appliance.vmon.Service'),
-            }),
-            VAPI::Bindings::VoidType.instance,
-            {
-                'com.vmware.vapi.std.errors.not_found' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::NotFound'),
-                'com.vmware.vapi.std.errors.error' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Error'),
-                'com.vmware.vapi.std.errors.not_allowed_in_current_state' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::NotAllowedInCurrentState'),
-
-            },
-            [],
-            [])
-        @@restart_info = VAPI::Bindings::OperationInfo.new(
-            VAPI::Core::OperationIdentifier.new('restart', @@service_id),
-            VAPI::Bindings::OperationInputType.new({
-                'service' => VAPI::Bindings::IdType.new(resource_types='com.vmware.appliance.vmon.Service'),
-            }),
-            VAPI::Bindings::VoidType.instance,
-            {
-                'com.vmware.vapi.std.errors.not_found' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::NotFound'),
-                'com.vmware.vapi.std.errors.timed_out' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::TimedOut'),
-                'com.vmware.vapi.std.errors.not_allowed_in_current_state' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::NotAllowedInCurrentState'),
-                'com.vmware.vapi.std.errors.error' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Error'),
-
-            },
-            [],
-            [])
-        @@get_info = VAPI::Bindings::OperationInfo.new(
-            VAPI::Core::OperationIdentifier.new('get', @@service_id),
-            VAPI::Bindings::OperationInputType.new({
-                'service' => VAPI::Bindings::IdType.new(resource_types='com.vmware.appliance.vmon.Service'),
-            }),
-            VAPI::Bindings::ReferenceType.new('Com::Vmware::Appliance::Vmon::Service::Info'),
-            {
-                'com.vmware.vapi.std.errors.not_found' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::NotFound'),
-                'com.vmware.vapi.std.errors.error' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Error'),
-
-            },
-            [],
-            [])
-        @@update_info = VAPI::Bindings::OperationInfo.new(
-            VAPI::Core::OperationIdentifier.new('update', @@service_id),
-            VAPI::Bindings::OperationInputType.new({
-                'service' => VAPI::Bindings::IdType.new(resource_types='com.vmware.appliance.vmon.Service'),
-                'spec' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Appliance::Vmon::Service::UpdateSpec'),
-            }),
-            VAPI::Bindings::VoidType.instance,
-            {
-                'com.vmware.vapi.std.errors.not_found' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::NotFound'),
-                'com.vmware.vapi.std.errors.error' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Error'),
-                'com.vmware.vapi.std.errors.not_allowed_in_current_state' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::NotAllowedInCurrentState'),
-
-            },
-            [],
-            [])
-        @@list_details_info = VAPI::Bindings::OperationInfo.new(
-            VAPI::Core::OperationIdentifier.new('list_details', @@service_id),
-            VAPI::Bindings::OperationInputType.new,
-            VAPI::Bindings::MapType.new(VAPI::Bindings::IdType.new, VAPI::Bindings::ReferenceType.new('Com::Vmware::Appliance::Vmon::Service::Info')),
-            {
-                'com.vmware.vapi.std.errors.error' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Error'),
-
-            },
-            [],
-            [])
-
-        @@service_info = VAPI::Bindings::ServiceInfo.new(@@service_id, {
-            'start' => @@start_info,
-            'stop' => @@stop_info,
-            'restart' => @@restart_info,
-            'get' => @@get_info,
-            'update' => @@update_info,
-            'list_details' => @@list_details_info,
-        })
-
-        public
-
-        # Constructs a new instance.
-        #
-        # @param config [VAPI::Bindings::StubConfig] A hash with the api provider details.
-        def initialize(config)
-            super(config, @@service_info)
-        end
-
-
-        # Starts a service
-        #
-        # @param service [String]
-        #     identifier of the service to start
-        # @return [Void]
-        # @raise [Com::Vmware::Vapi::Std::Errors::NotFound]
-        #     if the service associated with  ``service``  does not exist.
-        # @raise [Com::Vmware::Vapi::Std::Errors::NotAllowedInCurrentState]
-        #     if the operation is denied in the current state of the service. If a stop or restart operation is in progress, the start operation will not be allowed.
-        # @raise [Com::Vmware::Vapi::Std::Errors::NotAllowedInCurrentState]
-        #     if start operation is issued on a service which has startup type   :attr:`Com::Vmware::Appliance::Vmon::Service::StartupType.DISABLED`  .
-        # @raise [Com::Vmware::Vapi::Std::Errors::TimedOut]
-        #     if any timeout occurs during the execution of the start operation. Timeout occurs when the service takes longer than StartTimeout to start.
-        # @raise [Com::Vmware::Vapi::Std::Errors::Error]
-        #     if any other error occurs during the execution of the operation.
-        def start(service)
-            invoke_with_info(@@start_info, {
-                'service' => service,
-            })
-        end
-
-
-        # Stops a service
-        #
-        # @param service [String]
-        #     identifier of the service to stop
-        # @return [Void]
-        # @raise [Com::Vmware::Vapi::Std::Errors::NotFound]
-        #     if the service associated with  ``service``  does not exist.
-        # @raise [Com::Vmware::Vapi::Std::Errors::Error]
-        #     if any other error occurs during the execution of the operation.
-        # @raise [Com::Vmware::Vapi::Std::Errors::NotAllowedInCurrentState]
-        #     if the operation is denied in the current state of the service. If a stop operation is in progress, issuing another stop operation will lead to this error.
-        def stop(service)
-            invoke_with_info(@@stop_info, {
-                'service' => service,
-            })
-        end
-
-
-        # Restarts a service
-        #
-        # @param service [String]
-        #     identifier of the service to restart
-        # @return [Void]
-        # @raise [Com::Vmware::Vapi::Std::Errors::NotFound]
-        #     if the service associated with  ``service``  does not exist.
-        # @raise [Com::Vmware::Vapi::Std::Errors::TimedOut]
-        #     if any timeout occurs during the execution of the restart operation.
-        # @raise [Com::Vmware::Vapi::Std::Errors::NotAllowedInCurrentState]
-        #     if the operation is denied in the current state of the service. If a stop or start operation is in progress, issuing a restart operation will lead to this error.
-        # @raise [Com::Vmware::Vapi::Std::Errors::NotAllowedInCurrentState]
-        #     if a restart operation is issued on a service which has startup type   :attr:`Com::Vmware::Appliance::Vmon::Service::StartupType.DISABLED` 
-        # @raise [Com::Vmware::Vapi::Std::Errors::Error]
-        #     if any other error occurs during the execution of the operation.
-        def restart(service)
-            invoke_with_info(@@restart_info, {
-                'service' => service,
-            })
-        end
-
-
-        # Returns the state of a service.
-        #
-        # @param service [String]
-        #     identifier of the service whose state is being queried.
-        # @return [Com::Vmware::Appliance::Vmon::Service::Info]
-        #     Service Info structure.
-        # @raise [Com::Vmware::Vapi::Std::Errors::NotFound]
-        #     if the service associated with  ``service``  does not exist.
-        # @raise [Com::Vmware::Vapi::Std::Errors::Error]
-        #     if any other error occurs during the execution of the operation.
-        def get(service)
-            invoke_with_info(@@get_info, {
-                'service' => service,
-            })
-        end
-
-
-        # Updates the properties of a service.
-        #
-        # @param service [String]
-        #     identifier of the service whose properties are being updated.
-        # @param spec [Com::Vmware::Appliance::Vmon::Service::UpdateSpec]
-        #     Service Update specification.
-        # @return [Void]
-        # @raise [Com::Vmware::Vapi::Std::Errors::NotFound]
-        #     if the service associated with  ``service``  does not exist.
-        # @raise [Com::Vmware::Vapi::Std::Errors::Error]
-        #     if any other error occurs during the execution of the operation.
-        # @raise [Com::Vmware::Vapi::Std::Errors::NotAllowedInCurrentState]
-        #     if the operation is denied in the current state of the service. If a start, stop or restart operation is in progress, update operation will fail with this error.
-        # @raise [Com::Vmware::Vapi::Std::Errors::NotAllowedInCurrentState]
-        #     if a request to set the   :attr:`Com::Vmware::Appliance::Vmon::Service::UpdateSpec.startup_type`    field  of  ``spec``  to   :attr:`Com::Vmware::Appliance::Vmon::Service::StartupType.DISABLED`   comes in for a service that is not in   :attr:`Com::Vmware::Appliance::Vmon::Service::State.STOPPED`   state.
-        def update(service, spec)
-            invoke_with_info(@@update_info, {
-                'service' => service,
-                'spec' => spec,
-            })
-        end
-
-
-        # Lists details of services managed by vMon.
-        #
-        # @return [Hash<String, Com::Vmware::Appliance::Vmon::Service::Info>]
-        #     Map of service identifiers to service Info structures.
-        # @raise [Com::Vmware::Vapi::Std::Errors::Error]
-        #     if any error occurs during the execution of the operation.
-        def list_details()
-            invoke_with_info(@@list_details_info)
-        end
-
-
-
-        # The  ``Com::Vmware::Appliance::Vmon::Service::Info``   class  contains information about a service.
-        # @!attribute [rw] name_key
-        #     @return [String]
-        #     Service name key. Can be used to lookup resource bundle
-        # @!attribute [rw] description_key
-        #     @return [String]
-        #     Service description key. Can be used to lookup resource bundle
-        # @!attribute [rw] startup_type
-        #     @return [Com::Vmware::Appliance::Vmon::Service::StartupType]
-        #     Startup Type.
-        # @!attribute [rw] state
-        #     @return [Com::Vmware::Appliance::Vmon::Service::State]
-        #     Running State.
-        # @!attribute [rw] health
-        #     @return [Com::Vmware::Appliance::Vmon::Service::Health]
-        #     Health of service.
-        #     This  field  is optional and it is only relevant when the value of  ``state``  is   :attr:`Com::Vmware::Appliance::Vmon::Service::State.STARTED`  .
-        # @!attribute [rw] health_messages
-        #     @return [Array<Com::Vmware::Vapi::Std::LocalizableMessage>]
-        #     Localizable messages associated with the health of the service
-        #     This  field  is optional and it is only relevant when the value of  ``state``  is   :attr:`Com::Vmware::Appliance::Vmon::Service::State.STARTED`  .
-        class Info < VAPI::Bindings::VapiStruct
-
-            class << self
-                # Holds (gets or creates) the binding type metadata for this structure type.
-                # @scope class
-                # @return [VAPI::Bindings::StructType] the binding type
-                def binding_type
-                    @binding_type ||= VAPI::Bindings::StructType.new(
-                        'com.vmware.appliance.vmon.service.info',
-                        {
-                            'name_key' => VAPI::Bindings::StringType.instance,
-                            'description_key' => VAPI::Bindings::StringType.instance,
-                            'startup_type' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Appliance::Vmon::Service::StartupType'),
-                            'state' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Appliance::Vmon::Service::State'),
-                            'health' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Appliance::Vmon::Service::Health')),
-                            'health_messages' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::ListType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::LocalizableMessage'))),
-                        },
-                        Info,
-                        false,
-                        nil)
-                end
-            end
-
-            attr_accessor :name_key,
-                          :description_key,
-                          :startup_type,
-                          :state,
-                          :health,
-                          :health_messages
-
-            # Constructs a new instance.
-            # @param ruby_values [Hash] a map of initial property values (optional)
-            # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
-            def initialize(ruby_values=nil, struct_value=nil)
-                super(self.class.binding_type, ruby_values, struct_value)
-            end
-        end
-
-
-        # The  ``Com::Vmware::Appliance::Vmon::Service::UpdateSpec``   class  describes the changes to be made to the configuration of the service.
-        # @!attribute [rw] startup_type
-        #     @return [Com::Vmware::Appliance::Vmon::Service::StartupType, nil]
-        #     Startup Type
-        #     If unspecified, leaves value unchanged.
-        class UpdateSpec < VAPI::Bindings::VapiStruct
-
-            class << self
-                # Holds (gets or creates) the binding type metadata for this structure type.
-                # @scope class
-                # @return [VAPI::Bindings::StructType] the binding type
-                def binding_type
-                    @binding_type ||= VAPI::Bindings::StructType.new(
-                        'com.vmware.appliance.vmon.service.update_spec',
-                        {
-                            'startup_type' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Appliance::Vmon::Service::StartupType')),
-                        },
-                        UpdateSpec,
-                        false,
-                        nil)
-                end
-            end
-
-            attr_accessor :startup_type
-
-            # Constructs a new instance.
-            # @param ruby_values [Hash] a map of initial property values (optional)
-            # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
-            def initialize(ruby_values=nil, struct_value=nil)
-                super(self.class.binding_type, ruby_values, struct_value)
-            end
-        end
-
-
-
-        # The  ``Com::Vmware::Appliance::Vmon::Service::StartupType``   enumerated type  defines valid Startup Type for services managed by vMon.
-        # @!attribute [rw] manual
-        #     @return [Com::Vmware::Appliance::Vmon::Service::StartupType]
-        #     Service Startup type is Manual, thus issuing an explicit start on the service will start it.
-        # @!attribute [rw] automatic
-        #     @return [Com::Vmware::Appliance::Vmon::Service::StartupType]
-        #     Service Startup type is Automatic, thus during starting all services or issuing explicit start on the service will start it.
-        # @!attribute [rw] disabled
-        #     @return [Com::Vmware::Appliance::Vmon::Service::StartupType]
-        #     Service Startup type is Disabled, thus it will not start unless the startup type changes to manual or automatic.
-        class StartupType < VAPI::Bindings::VapiEnum
-
-            class << self
-                # Holds (gets or creates) the binding type metadata for this enumeration type.
-                # @scope class
-                # @return [VAPI::Bindings::EnumType] the binding type
-                def binding_type
-                    @binding_type ||= VAPI::Bindings::EnumType.new(
-                        'com.vmware.appliance.vmon.service.startup_type',
-                        StartupType)
-                end
-
-                # Converts from a string value (perhaps off the wire) to an instance
-                # of this enum type.
-                # @param value [String] the actual value of the enum instance
-                # @return [StartupType] the instance found for the value, otherwise
-                #         an unknown instance will be built for the value
-                def from_string(value)
-                    begin
-                        const_get(value)
-                    rescue NameError
-                        StartupType.new('UNKNOWN', value)
-                    end
-                end
-            end
-
-            private
-
-            # Constructs a new instance.
-            # @param value [String] the actual value of the enum instance
-            # @param unknown [String] the unknown value when value is 'UKNOWN'
-            def initialize(value, unknown=nil)
-                super(self.class.binding_type, value, unknown)
-            end
-
-            public
-
-            # @!attribute [rw] manual
-            #     @return [Com::Vmware::Appliance::Vmon::Service::StartupType]
-            #     Service Startup type is Manual, thus issuing an explicit start on the service will start it.
-            MANUAL = StartupType.new('MANUAL')
-
-            # @!attribute [rw] automatic
-            #     @return [Com::Vmware::Appliance::Vmon::Service::StartupType]
-            #     Service Startup type is Automatic, thus during starting all services or issuing explicit start on the service will start it.
-            AUTOMATIC = StartupType.new('AUTOMATIC')
-
-            # @!attribute [rw] disabled
-            #     @return [Com::Vmware::Appliance::Vmon::Service::StartupType]
-            #     Service Startup type is Disabled, thus it will not start unless the startup type changes to manual or automatic.
-            DISABLED = StartupType.new('DISABLED')
-
-        end
-
-
-        # The  ``Com::Vmware::Appliance::Vmon::Service::State``   enumerated type  defines valid Run State for services.
-        # @!attribute [rw] starting
-        #     @return [Com::Vmware::Appliance::Vmon::Service::State]
-        #     Service Run State is Starting, it is still not functional
-        # @!attribute [rw] stopping
-        #     @return [Com::Vmware::Appliance::Vmon::Service::State]
-        #     Service Run State is Stopping, it is not functional
-        # @!attribute [rw] started
-        #     @return [Com::Vmware::Appliance::Vmon::Service::State]
-        #     Service Run State is Started, it is fully functional
-        # @!attribute [rw] stopped
-        #     @return [Com::Vmware::Appliance::Vmon::Service::State]
-        #     Service Run State is Stopped
-        class State < VAPI::Bindings::VapiEnum
-
-            class << self
-                # Holds (gets or creates) the binding type metadata for this enumeration type.
-                # @scope class
-                # @return [VAPI::Bindings::EnumType] the binding type
-                def binding_type
-                    @binding_type ||= VAPI::Bindings::EnumType.new(
-                        'com.vmware.appliance.vmon.service.state',
-                        State)
-                end
-
-                # Converts from a string value (perhaps off the wire) to an instance
-                # of this enum type.
-                # @param value [String] the actual value of the enum instance
-                # @return [State] the instance found for the value, otherwise
-                #         an unknown instance will be built for the value
-                def from_string(value)
-                    begin
-                        const_get(value)
-                    rescue NameError
-                        State.new('UNKNOWN', value)
-                    end
-                end
-            end
-
-            private
-
-            # Constructs a new instance.
-            # @param value [String] the actual value of the enum instance
-            # @param unknown [String] the unknown value when value is 'UKNOWN'
-            def initialize(value, unknown=nil)
-                super(self.class.binding_type, value, unknown)
-            end
-
-            public
-
-            # @!attribute [rw] starting
-            #     @return [Com::Vmware::Appliance::Vmon::Service::State]
-            #     Service Run State is Starting, it is still not functional
-            STARTING = State.new('STARTING')
-
-            # @!attribute [rw] stopping
-            #     @return [Com::Vmware::Appliance::Vmon::Service::State]
-            #     Service Run State is Stopping, it is not functional
-            STOPPING = State.new('STOPPING')
-
-            # @!attribute [rw] started
-            #     @return [Com::Vmware::Appliance::Vmon::Service::State]
-            #     Service Run State is Started, it is fully functional
-            STARTED = State.new('STARTED')
-
-            # @!attribute [rw] stopped
-            #     @return [Com::Vmware::Appliance::Vmon::Service::State]
-            #     Service Run State is Stopped
-            STOPPED = State.new('STOPPED')
-
-        end
-
-
-        # The  ``Com::Vmware::Appliance::Vmon::Service::Health``   enumerated type  defines the possible values for health of a service.
-        # @!attribute [rw] degraded
-        #     @return [Com::Vmware::Appliance::Vmon::Service::Health]
-        #     Service is in degraded state, it is not functional.
-        # @!attribute [rw] healthy
-        #     @return [Com::Vmware::Appliance::Vmon::Service::Health]
-        #     Service is in a healthy state and is fully functional.
-        # @!attribute [rw] healthy_with_warnings
-        #     @return [Com::Vmware::Appliance::Vmon::Service::Health]
-        #     Service is healthy with warnings.
-        class Health < VAPI::Bindings::VapiEnum
-
-            class << self
-                # Holds (gets or creates) the binding type metadata for this enumeration type.
-                # @scope class
-                # @return [VAPI::Bindings::EnumType] the binding type
-                def binding_type
-                    @binding_type ||= VAPI::Bindings::EnumType.new(
-                        'com.vmware.appliance.vmon.service.health',
-                        Health)
-                end
-
-                # Converts from a string value (perhaps off the wire) to an instance
-                # of this enum type.
-                # @param value [String] the actual value of the enum instance
-                # @return [Health] the instance found for the value, otherwise
-                #         an unknown instance will be built for the value
-                def from_string(value)
-                    begin
-                        const_get(value)
-                    rescue NameError
-                        Health.new('UNKNOWN', value)
-                    end
-                end
-            end
-
-            private
-
-            # Constructs a new instance.
-            # @param value [String] the actual value of the enum instance
-            # @param unknown [String] the unknown value when value is 'UKNOWN'
-            def initialize(value, unknown=nil)
-                super(self.class.binding_type, value, unknown)
-            end
-
-            public
-
-            # @!attribute [rw] degraded
-            #     @return [Com::Vmware::Appliance::Vmon::Service::Health]
-            #     Service is in degraded state, it is not functional.
-            DEGRADED = Health.new('DEGRADED')
-
-            # @!attribute [rw] healthy
-            #     @return [Com::Vmware::Appliance::Vmon::Service::Health]
-            #     Service is in a healthy state and is fully functional.
-            HEALTHY = Health.new('HEALTHY')
-
-            # @!attribute [rw] healthy_with_warnings
-            #     @return [Com::Vmware::Appliance::Vmon::Service::Health]
-            #     Service is healthy with warnings.
-            HEALTHY_WITH_WARNINGS = Health.new('HEALTHY_WITH_WARNINGS')
-
-        end
-
-
+  # The  ``Com::Vmware::Appliance::Vmon::Service``   class  provides  methods  to manage a single/set of services that are managed by vMon.
+  class Service < VAPI::Bindings::VapiService
+    # static metamodel definitions
+    SERVICE_ID = VAPI::Core::ServiceIdentifier.new('com.vmware.appliance.vmon.service')
+
+    START_INFO = VAPI::Bindings::OperationInfo.new(
+      VAPI::Core::OperationIdentifier.new('start', SERVICE_ID),
+      VAPI::Bindings::OperationInputType.new(
+        'service' => VAPI::Bindings::IdType.new('com.vmware.appliance.vmon.Service')
+      ),
+      VAPI::Bindings::VoidType.instance,
+      {
+        'com.vmware.vapi.std.errors.not_found' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::NotFound'),
+        'com.vmware.vapi.std.errors.not_allowed_in_current_state' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::NotAllowedInCurrentState'),
+        'com.vmware.vapi.std.errors.timed_out' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::TimedOut'),
+        'com.vmware.vapi.std.errors.error' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Error')
+      },
+      [],
+      []
+    )
+
+    STOP_INFO = VAPI::Bindings::OperationInfo.new(
+      VAPI::Core::OperationIdentifier.new('stop', SERVICE_ID),
+      VAPI::Bindings::OperationInputType.new(
+        'service' => VAPI::Bindings::IdType.new('com.vmware.appliance.vmon.Service')
+      ),
+      VAPI::Bindings::VoidType.instance,
+      {
+        'com.vmware.vapi.std.errors.not_found' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::NotFound'),
+        'com.vmware.vapi.std.errors.error' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Error'),
+        'com.vmware.vapi.std.errors.not_allowed_in_current_state' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::NotAllowedInCurrentState')
+      },
+      [],
+      []
+    )
+
+    RESTART_INFO = VAPI::Bindings::OperationInfo.new(
+      VAPI::Core::OperationIdentifier.new('restart', SERVICE_ID),
+      VAPI::Bindings::OperationInputType.new(
+        'service' => VAPI::Bindings::IdType.new('com.vmware.appliance.vmon.Service')
+      ),
+      VAPI::Bindings::VoidType.instance,
+      {
+        'com.vmware.vapi.std.errors.not_found' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::NotFound'),
+        'com.vmware.vapi.std.errors.timed_out' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::TimedOut'),
+        'com.vmware.vapi.std.errors.not_allowed_in_current_state' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::NotAllowedInCurrentState'),
+        'com.vmware.vapi.std.errors.error' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Error')
+      },
+      [],
+      []
+    )
+
+    GET_INFO = VAPI::Bindings::OperationInfo.new(
+      VAPI::Core::OperationIdentifier.new('get', SERVICE_ID),
+      VAPI::Bindings::OperationInputType.new(
+        'service' => VAPI::Bindings::IdType.new('com.vmware.appliance.vmon.Service')
+      ),
+      VAPI::Bindings::ReferenceType.new('Com::Vmware::Appliance::Vmon::Service::Info'),
+      {
+        'com.vmware.vapi.std.errors.not_found' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::NotFound'),
+        'com.vmware.vapi.std.errors.error' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Error')
+      },
+      [],
+      []
+    )
+
+    UPDATE_INFO = VAPI::Bindings::OperationInfo.new(
+      VAPI::Core::OperationIdentifier.new('update', SERVICE_ID),
+      VAPI::Bindings::OperationInputType.new(
+        'service' => VAPI::Bindings::IdType.new('com.vmware.appliance.vmon.Service'),
+        'spec' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Appliance::Vmon::Service::UpdateSpec')
+      ),
+      VAPI::Bindings::VoidType.instance,
+      {
+        'com.vmware.vapi.std.errors.not_found' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::NotFound'),
+        'com.vmware.vapi.std.errors.error' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Error'),
+        'com.vmware.vapi.std.errors.not_allowed_in_current_state' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::NotAllowedInCurrentState')
+      },
+      [],
+      []
+    )
+
+    LIST_DETAILS_INFO = VAPI::Bindings::OperationInfo.new(
+      VAPI::Core::OperationIdentifier.new('list_details', SERVICE_ID),
+      VAPI::Bindings::OperationInputType.new,
+      VAPI::Bindings::MapType.new(VAPI::Bindings::IdType.new, VAPI::Bindings::ReferenceType.new('Com::Vmware::Appliance::Vmon::Service::Info')),
+      {
+        'com.vmware.vapi.std.errors.error' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Error')
+      },
+      [],
+      []
+    )
+
+    SERVICE_INFO = VAPI::Bindings::ServiceInfo.new(
+      SERVICE_ID,
+      'start' => START_INFO,
+      'stop' => STOP_INFO,
+      'restart' => RESTART_INFO,
+      'get' => GET_INFO,
+      'update' => UPDATE_INFO,
+      'list_details' => LIST_DETAILS_INFO
+    )
+
+    # Constructs a new instance.
+    #
+    # @param config [VAPI::Bindings::StubConfig] A hash with the api provider details.
+    def initialize(config)
+      super(config, SERVICE_INFO)
     end
 
+    # Starts a service
+    #
+    # @param service [String]
+    #     identifier of the service to start
+    # @return [Void]
+    # @raise [Com::Vmware::Vapi::Std::Errors::NotFound]
+    #     if the service associated with  ``service``  does not exist.
+    # @raise [Com::Vmware::Vapi::Std::Errors::NotAllowedInCurrentState]
+    #     if the operation is denied in the current state of the service. If a stop or restart operation is in progress, the start operation will not be allowed.
+    # @raise [Com::Vmware::Vapi::Std::Errors::NotAllowedInCurrentState]
+    #     if start operation is issued on a service which has startup type   :attr:`Com::Vmware::Appliance::Vmon::Service::StartupType.DISABLED`  .
+    # @raise [Com::Vmware::Vapi::Std::Errors::TimedOut]
+    #     if any timeout occurs during the execution of the start operation. Timeout occurs when the service takes longer than StartTimeout to start.
+    # @raise [Com::Vmware::Vapi::Std::Errors::Error]
+    #     if any other error occurs during the execution of the operation.
+    def start(service)
+      invoke_with_info(START_INFO,
+                       'service' => service)
+    end
 
+    # Stops a service
+    #
+    # @param service [String]
+    #     identifier of the service to stop
+    # @return [Void]
+    # @raise [Com::Vmware::Vapi::Std::Errors::NotFound]
+    #     if the service associated with  ``service``  does not exist.
+    # @raise [Com::Vmware::Vapi::Std::Errors::Error]
+    #     if any other error occurs during the execution of the operation.
+    # @raise [Com::Vmware::Vapi::Std::Errors::NotAllowedInCurrentState]
+    #     if the operation is denied in the current state of the service. If a stop operation is in progress, issuing another stop operation will lead to this error.
+    def stop(service)
+      invoke_with_info(STOP_INFO,
+                       'service' => service)
+    end
+
+    # Restarts a service
+    #
+    # @param service [String]
+    #     identifier of the service to restart
+    # @return [Void]
+    # @raise [Com::Vmware::Vapi::Std::Errors::NotFound]
+    #     if the service associated with  ``service``  does not exist.
+    # @raise [Com::Vmware::Vapi::Std::Errors::TimedOut]
+    #     if any timeout occurs during the execution of the restart operation.
+    # @raise [Com::Vmware::Vapi::Std::Errors::NotAllowedInCurrentState]
+    #     if the operation is denied in the current state of the service. If a stop or start operation is in progress, issuing a restart operation will lead to this error.
+    # @raise [Com::Vmware::Vapi::Std::Errors::NotAllowedInCurrentState]
+    #     if a restart operation is issued on a service which has startup type   :attr:`Com::Vmware::Appliance::Vmon::Service::StartupType.DISABLED` 
+    # @raise [Com::Vmware::Vapi::Std::Errors::Error]
+    #     if any other error occurs during the execution of the operation.
+    def restart(service)
+      invoke_with_info(RESTART_INFO,
+                       'service' => service)
+    end
+
+    # Returns the state of a service.
+    #
+    # @param service [String]
+    #     identifier of the service whose state is being queried.
+    # @return [Com::Vmware::Appliance::Vmon::Service::Info]
+    #     Service Info structure.
+    # @raise [Com::Vmware::Vapi::Std::Errors::NotFound]
+    #     if the service associated with  ``service``  does not exist.
+    # @raise [Com::Vmware::Vapi::Std::Errors::Error]
+    #     if any other error occurs during the execution of the operation.
+    def get(service)
+      invoke_with_info(GET_INFO,
+                       'service' => service)
+    end
+
+    # Updates the properties of a service.
+    #
+    # @param service [String]
+    #     identifier of the service whose properties are being updated.
+    # @param spec [Com::Vmware::Appliance::Vmon::Service::UpdateSpec]
+    #     Service Update specification.
+    # @return [Void]
+    # @raise [Com::Vmware::Vapi::Std::Errors::NotFound]
+    #     if the service associated with  ``service``  does not exist.
+    # @raise [Com::Vmware::Vapi::Std::Errors::Error]
+    #     if any other error occurs during the execution of the operation.
+    # @raise [Com::Vmware::Vapi::Std::Errors::NotAllowedInCurrentState]
+    #     if the operation is denied in the current state of the service. If a start, stop or restart operation is in progress, update operation will fail with this error.
+    # @raise [Com::Vmware::Vapi::Std::Errors::NotAllowedInCurrentState]
+    #     if a request to set the   :attr:`Com::Vmware::Appliance::Vmon::Service::UpdateSpec.startup_type`    field  of  ``spec``  to   :attr:`Com::Vmware::Appliance::Vmon::Service::StartupType.DISABLED`   comes in for a service that is not in   :attr:`Com::Vmware::Appliance::Vmon::Service::State.STOPPED`   state.
+    def update(service, spec)
+      invoke_with_info(UPDATE_INFO,
+                       'service' => service,
+                       'spec' => spec)
+    end
+
+    # Lists details of services managed by vMon.
+    #
+    # @return [Hash<String, Com::Vmware::Appliance::Vmon::Service::Info>]
+    #     Map of service identifiers to service Info structures.
+    # @raise [Com::Vmware::Vapi::Std::Errors::Error]
+    #     if any error occurs during the execution of the operation.
+    def list_details
+      invoke_with_info(LIST_DETAILS_INFO)
+    end
+
+    # The  ``Com::Vmware::Appliance::Vmon::Service::Info``   class  contains information about a service.
+    # @!attribute [rw] name_key
+    #     @return [String]
+    #     Service name key. Can be used to lookup resource bundle
+    # @!attribute [rw] description_key
+    #     @return [String]
+    #     Service description key. Can be used to lookup resource bundle
+    # @!attribute [rw] startup_type
+    #     @return [Com::Vmware::Appliance::Vmon::Service::StartupType]
+    #     Startup Type.
+    # @!attribute [rw] state
+    #     @return [Com::Vmware::Appliance::Vmon::Service::State]
+    #     Running State.
+    # @!attribute [rw] health
+    #     @return [Com::Vmware::Appliance::Vmon::Service::Health]
+    #     Health of service.
+    #     This  field  is optional and it is only relevant when the value of  ``state``  is   :attr:`Com::Vmware::Appliance::Vmon::Service::State.STARTED`  .
+    # @!attribute [rw] health_messages
+    #     @return [Array<Com::Vmware::Vapi::Std::LocalizableMessage>]
+    #     Localizable messages associated with the health of the service
+    #     This  field  is optional and it is only relevant when the value of  ``state``  is   :attr:`Com::Vmware::Appliance::Vmon::Service::State.STARTED`  .
+    class Info < VAPI::Bindings::VapiStruct
+      class << self
+        # Holds (gets or creates) the binding type metadata for this structure type.
+        # @scope class
+        # @return [VAPI::Bindings::StructType] the binding type
+        def binding_type
+          @binding_type ||= VAPI::Bindings::StructType.new(
+            'com.vmware.appliance.vmon.service.info',
+            {
+              'name_key' => VAPI::Bindings::StringType.instance,
+              'description_key' => VAPI::Bindings::StringType.instance,
+              'startup_type' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Appliance::Vmon::Service::StartupType'),
+              'state' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Appliance::Vmon::Service::State'),
+              'health' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Appliance::Vmon::Service::Health')),
+              'health_messages' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::ListType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::LocalizableMessage')))
+            },
+            Info,
+            false,
+            nil
+          )
+        end
+      end
+
+      attr_accessor :name_key,
+                    :description_key,
+                    :startup_type,
+                    :state,
+                    :health,
+                    :health_messages
+
+      # Constructs a new instance.
+      # @param ruby_values [Hash] a map of initial property values (optional)
+      # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
+      def initialize(ruby_values = nil, struct_value = nil)
+        super(self.class.binding_type, ruby_values, struct_value)
+      end
+    end
+
+    # The  ``Com::Vmware::Appliance::Vmon::Service::UpdateSpec``   class  describes the changes to be made to the configuration of the service.
+    # @!attribute [rw] startup_type
+    #     @return [Com::Vmware::Appliance::Vmon::Service::StartupType, nil]
+    #     Startup Type
+    #     If unspecified, leaves value unchanged.
+    class UpdateSpec < VAPI::Bindings::VapiStruct
+      class << self
+        # Holds (gets or creates) the binding type metadata for this structure type.
+        # @scope class
+        # @return [VAPI::Bindings::StructType] the binding type
+        def binding_type
+          @binding_type ||= VAPI::Bindings::StructType.new(
+            'com.vmware.appliance.vmon.service.update_spec',
+            {
+              'startup_type' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Appliance::Vmon::Service::StartupType'))
+            },
+            UpdateSpec,
+            false,
+            nil
+          )
+        end
+      end
+
+      attr_accessor :startup_type
+
+      # Constructs a new instance.
+      # @param ruby_values [Hash] a map of initial property values (optional)
+      # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
+      def initialize(ruby_values = nil, struct_value = nil)
+        super(self.class.binding_type, ruby_values, struct_value)
+      end
+    end
+
+    # The  ``Com::Vmware::Appliance::Vmon::Service::StartupType``   enumerated type  defines valid Startup Type for services managed by vMon.
+    # @!attribute [rw] manual
+    #     @return [Com::Vmware::Appliance::Vmon::Service::StartupType]
+    #     Service Startup type is Manual, thus issuing an explicit start on the service will start it.
+    # @!attribute [rw] automatic
+    #     @return [Com::Vmware::Appliance::Vmon::Service::StartupType]
+    #     Service Startup type is Automatic, thus during starting all services or issuing explicit start on the service will start it.
+    # @!attribute [rw] disabled
+    #     @return [Com::Vmware::Appliance::Vmon::Service::StartupType]
+    #     Service Startup type is Disabled, thus it will not start unless the startup type changes to manual or automatic.
+    class StartupType < VAPI::Bindings::VapiEnum
+      class << self
+        # Holds (gets or creates) the binding type metadata for this enumeration type.
+        # @scope class
+        # @return [VAPI::Bindings::EnumType] the binding type
+        def binding_type
+          @binding_type ||= VAPI::Bindings::EnumType.new(
+            'com.vmware.appliance.vmon.service.startup_type',
+            StartupType
+          )
+        end
+
+        # Converts from a string value (perhaps off the wire) to an instance
+        # of this enum type.
+        # @param value [String] the actual value of the enum instance
+        # @return [StartupType] the instance found for the value, otherwise
+        #         an unknown instance will be built for the value
+        def from_string(value)
+          const_get(value)
+        rescue NameError
+          StartupType.send(:new, 'UNKNOWN', value)
+        end
+      end
+
+      # Constructs a new instance.
+      # @param value [String] the actual value of the enum instance
+      # @param unknown [String] the unknown value when value is 'UKNOWN'
+      def initialize(value, unknown = nil)
+        super(self.class.binding_type, value, unknown)
+      end
+
+      private_class_method :new
+
+      # @!attribute [rw] manual
+      #     @return [Com::Vmware::Appliance::Vmon::Service::StartupType]
+      #     Service Startup type is Manual, thus issuing an explicit start on the service will start it.
+      MANUAL = StartupType.send(:new, 'MANUAL')
+
+      # @!attribute [rw] automatic
+      #     @return [Com::Vmware::Appliance::Vmon::Service::StartupType]
+      #     Service Startup type is Automatic, thus during starting all services or issuing explicit start on the service will start it.
+      AUTOMATIC = StartupType.send(:new, 'AUTOMATIC')
+
+      # @!attribute [rw] disabled
+      #     @return [Com::Vmware::Appliance::Vmon::Service::StartupType]
+      #     Service Startup type is Disabled, thus it will not start unless the startup type changes to manual or automatic.
+      DISABLED = StartupType.send(:new, 'DISABLED')
+    end
+    # The  ``Com::Vmware::Appliance::Vmon::Service::State``   enumerated type  defines valid Run State for services.
+    # @!attribute [rw] starting
+    #     @return [Com::Vmware::Appliance::Vmon::Service::State]
+    #     Service Run State is Starting, it is still not functional
+    # @!attribute [rw] stopping
+    #     @return [Com::Vmware::Appliance::Vmon::Service::State]
+    #     Service Run State is Stopping, it is not functional
+    # @!attribute [rw] started
+    #     @return [Com::Vmware::Appliance::Vmon::Service::State]
+    #     Service Run State is Started, it is fully functional
+    # @!attribute [rw] stopped
+    #     @return [Com::Vmware::Appliance::Vmon::Service::State]
+    #     Service Run State is Stopped
+    class State < VAPI::Bindings::VapiEnum
+      class << self
+        # Holds (gets or creates) the binding type metadata for this enumeration type.
+        # @scope class
+        # @return [VAPI::Bindings::EnumType] the binding type
+        def binding_type
+          @binding_type ||= VAPI::Bindings::EnumType.new(
+            'com.vmware.appliance.vmon.service.state',
+            State
+          )
+        end
+
+        # Converts from a string value (perhaps off the wire) to an instance
+        # of this enum type.
+        # @param value [String] the actual value of the enum instance
+        # @return [State] the instance found for the value, otherwise
+        #         an unknown instance will be built for the value
+        def from_string(value)
+          const_get(value)
+        rescue NameError
+          State.send(:new, 'UNKNOWN', value)
+        end
+      end
+
+      # Constructs a new instance.
+      # @param value [String] the actual value of the enum instance
+      # @param unknown [String] the unknown value when value is 'UKNOWN'
+      def initialize(value, unknown = nil)
+        super(self.class.binding_type, value, unknown)
+      end
+
+      private_class_method :new
+
+      # @!attribute [rw] starting
+      #     @return [Com::Vmware::Appliance::Vmon::Service::State]
+      #     Service Run State is Starting, it is still not functional
+      STARTING = State.send(:new, 'STARTING')
+
+      # @!attribute [rw] stopping
+      #     @return [Com::Vmware::Appliance::Vmon::Service::State]
+      #     Service Run State is Stopping, it is not functional
+      STOPPING = State.send(:new, 'STOPPING')
+
+      # @!attribute [rw] started
+      #     @return [Com::Vmware::Appliance::Vmon::Service::State]
+      #     Service Run State is Started, it is fully functional
+      STARTED = State.send(:new, 'STARTED')
+
+      # @!attribute [rw] stopped
+      #     @return [Com::Vmware::Appliance::Vmon::Service::State]
+      #     Service Run State is Stopped
+      STOPPED = State.send(:new, 'STOPPED')
+    end
+    # The  ``Com::Vmware::Appliance::Vmon::Service::Health``   enumerated type  defines the possible values for health of a service.
+    # @!attribute [rw] degraded
+    #     @return [Com::Vmware::Appliance::Vmon::Service::Health]
+    #     Service is in degraded state, it is not functional.
+    # @!attribute [rw] healthy
+    #     @return [Com::Vmware::Appliance::Vmon::Service::Health]
+    #     Service is in a healthy state and is fully functional.
+    # @!attribute [rw] healthy_with_warnings
+    #     @return [Com::Vmware::Appliance::Vmon::Service::Health]
+    #     Service is healthy with warnings.
+    class Health < VAPI::Bindings::VapiEnum
+      class << self
+        # Holds (gets or creates) the binding type metadata for this enumeration type.
+        # @scope class
+        # @return [VAPI::Bindings::EnumType] the binding type
+        def binding_type
+          @binding_type ||= VAPI::Bindings::EnumType.new(
+            'com.vmware.appliance.vmon.service.health',
+            Health
+          )
+        end
+
+        # Converts from a string value (perhaps off the wire) to an instance
+        # of this enum type.
+        # @param value [String] the actual value of the enum instance
+        # @return [Health] the instance found for the value, otherwise
+        #         an unknown instance will be built for the value
+        def from_string(value)
+          const_get(value)
+        rescue NameError
+          Health.send(:new, 'UNKNOWN', value)
+        end
+      end
+
+      # Constructs a new instance.
+      # @param value [String] the actual value of the enum instance
+      # @param unknown [String] the unknown value when value is 'UKNOWN'
+      def initialize(value, unknown = nil)
+        super(self.class.binding_type, value, unknown)
+      end
+
+      private_class_method :new
+
+      # @!attribute [rw] degraded
+      #     @return [Com::Vmware::Appliance::Vmon::Service::Health]
+      #     Service is in degraded state, it is not functional.
+      DEGRADED = Health.send(:new, 'DEGRADED')
+
+      # @!attribute [rw] healthy
+      #     @return [Com::Vmware::Appliance::Vmon::Service::Health]
+      #     Service is in a healthy state and is fully functional.
+      HEALTHY = Health.send(:new, 'HEALTHY')
+
+      # @!attribute [rw] healthy_with_warnings
+      #     @return [Com::Vmware::Appliance::Vmon::Service::Health]
+      #     Service is healthy with warnings.
+      HEALTHY_WITH_WARNINGS = Health.send(:new, 'HEALTHY_WITH_WARNINGS')
+    end
+  end
 end

--- a/client/sdk/com/vmware/appliance/vmon/vapi.rb
+++ b/client/sdk/com/vmware/appliance/vmon/vapi.rb
@@ -1,5 +1,6 @@
 #---------------------------------------------------------------------------
-# Copyright 2016 VMware, Inc.  All rights reserved.
+# Copyright 2017 VMware, Inc.  All rights reserved.
+#
 # AUTO GENERATED FILE -- DO NOT MODIFY!
 #---------------------------------------------------------------------------
 require 'vapi'

--- a/client/sdk/com/vmware/cis.rb
+++ b/client/sdk/com/vmware/cis.rb
@@ -1,5 +1,6 @@
 #---------------------------------------------------------------------------
-# Copyright 2016 VMware, Inc.  All rights reserved.
+# Copyright 2017 VMware, Inc.  All rights reserved.
+#
 # AUTO GENERATED FILE -- DO NOT MODIFY!
 #
 # vAPI type descriptors for package com.vmware.cis.
@@ -8,218 +9,207 @@ require 'vapi'
 
 # declare the module hierarchy before we use the shorthand syntax below
 module Com
-    module Vmware
-        module Cis
-        end
+  module Vmware
+    module Cis
     end
+  end
 end
 
 module Com::Vmware::Cis
+  # The  ``Com::Vmware::Cis::Session``   class  allows API clients to manage session tokens including creating, deleting and obtaining information about sessions.  
+  # 
+  #   
+  # 
+  #   * The   :func:`Com::Vmware::Cis::Session.create`    method  creates session token in exchange for another authentication token.
+  #    * The   :func:`Com::Vmware::Cis::Session.delete`    method  invalidates a session token.
+  #    * The   :func:`Com::Vmware::Cis::Session.get`   retrieves information about a session token.
+  #   
+  #    
+  # 
+  #  The call to the   :func:`Com::Vmware::Cis::Session.create`    method  is part of the overall authentication process for API clients. For example, the sequence of steps for establishing a session with SAML token is:  
+  # 
+  #   * Connect to lookup service.
+  #    * Discover the secure token service (STS) endpoint URL.
+  #    * Connect to the secure token service to obtain a SAML token.
+  #    * Authenticate to the lookup service using the obtained SAML token.
+  #    * Discover the API endpoint URL from lookup service.
+  #    * Call the   :func:`Com::Vmware::Cis::Session.create`    method . The   :func:`Com::Vmware::Cis::Session.create`   call must include the SAML token.
+  #   
+  #    
+  # 
+  #  See the programming guide and samples for additional information about establishing API sessions.  
+  # 
+  #   **Execution Context and Security Context**   
+  # 
+  #  To use session based authentication a client should supply the session token obtained through the   :func:`Com::Vmware::Cis::Session.create`    method . The client should add the session token in the security context when using SDK classes. Clients using the REST API should supply the session token as a HTTP header.  
+  # 
+  #   **Session Lifetime**   
+  # 
+  #  A session begins with call to the   :func:`Com::Vmware::Cis::Session.create`    method  to exchange a SAML token for a API session token. A session ends under the following circumstances:  
+  # 
+  #   * Call to the   :func:`Com::Vmware::Cis::Session.delete`    method .
+  #    * The session expires. Session expiration may be caused by one of the following situations:  
+  # 
+  #       * Client inactivity - For a particular session identified by client requests that specify the associated session ID, the lapsed time since the last request exceeds the maximum interval between requests.
+  #        * Unconditional or absolute session expiration time: At the beginning of the session, the session logic uses the SAML token and the system configuration to calculate absolute expiration time.
+  #   
+  #   
+  #   
+  #    
+  # 
+  #  When a session ends, the authentication logic will reject any subsequent client requests that specify that session. Any operations in progress will continue to completion.  
+  # 
+  #   **Error Handling**   
+  # 
+  #  The   :class:`Com::Vmware::Cis::Session`   returns the following  errors :  
+  # 
+  #   *  :class:`Com::Vmware::Vapi::Std::Errors::Unauthenticated`    error  for any  errors  related to the request.
+  #    *  :class:`Com::Vmware::Vapi::Std::Errors::ServiceUnavailable`    error  for all  errors  caused by internal service failure.
+  #   
+  class Session < VAPI::Bindings::VapiService
+    # static metamodel definitions
+    SERVICE_ID = VAPI::Core::ServiceIdentifier.new('com.vmware.cis.session')
 
-    # The  ``Com::Vmware::Cis::Session``   class  allows API clients to manage session tokens including creating, deleting and obtaining information about sessions.  
-    # 
-    #   
-    # 
-    #   * The   :func:`Com::Vmware::Cis::Session.create`    method  creates session token in exchange for another authentication token.
-    #    * The   :func:`Com::Vmware::Cis::Session.delete`    method  invalidates a session token.
-    #    * The   :func:`Com::Vmware::Cis::Session.get`   retrieves information about a session token.
-    #   
-    #    
-    # 
-    #  The call to the   :func:`Com::Vmware::Cis::Session.create`    method  is part of the overall authentication process for API clients. For example, the sequence of steps for establishing a session with SAML token is:  
-    # 
-    #   * Connect to lookup service.
-    #    * Discover the secure token service (STS) endpoint URL.
-    #    * Connect to the secure token service to obtain a SAML token.
-    #    * Authenticate to the lookup service using the obtained SAML token.
-    #    * Discover the API endpoint URL from lookup service.
-    #    * Call the   :func:`Com::Vmware::Cis::Session.create`    method . The   :func:`Com::Vmware::Cis::Session.create`   call must include the SAML token.
-    #   
-    #    
-    # 
-    #  See the programming guide and samples for additional information about establishing API sessions.  
-    # 
-    #   **Execution Context and Security Context**   
-    # 
-    #  To use session based authentication a client should supply the session token obtained through the   :func:`Com::Vmware::Cis::Session.create`    method . The client should add the session token in the security context when using SDK classes. Clients using the REST API should supply the session token as a HTTP header.  
-    # 
-    #   **Session Lifetime**   
-    # 
-    #  A session begins with call to the   :func:`Com::Vmware::Cis::Session.create`    method  to exchange a SAML token for a API session token. A session ends under the following circumstances:  
-    # 
-    #   * Call to the   :func:`Com::Vmware::Cis::Session.delete`    method .
-    #    * The session expires. Session expiration may be caused by one of the following situations:  
-    # 
-    #       * Client inactivity - For a particular session identified by client requests that specify the associated session ID, the lapsed time since the last request exceeds the maximum interval between requests.
-    #        * Unconditional or absolute session expiration time: At the beginning of the session, the session logic uses the SAML token and the system configuration to calculate absolute expiration time.
-    #   
-    #   
-    #   
-    #    
-    # 
-    #  When a session ends, the authentication logic will reject any subsequent client requests that specify that session. Any operations in progress will continue to completion.  
-    # 
-    #   **Error Handling**   
-    # 
-    #  The   :class:`Com::Vmware::Cis::Session`   returns the following  errors :  
-    # 
-    #   *  :class:`Com::Vmware::Vapi::Std::Errors::Unauthenticated`    error  for any  errors  related to the request.
-    #    *  :class:`Com::Vmware::Vapi::Std::Errors::ServiceUnavailable`    error  for all  errors  caused by internal service failure.
-    #   
-    class Session < VAPI::Bindings::VapiService
+    CREATE_INFO = VAPI::Bindings::OperationInfo.new(
+      VAPI::Core::OperationIdentifier.new('create', SERVICE_ID),
+      VAPI::Bindings::OperationInputType.new,
+      VAPI::Bindings::SecretType.instance,
+      {
+        'com.vmware.vapi.std.errors.unauthenticated' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Unauthenticated'),
+        'com.vmware.vapi.std.errors.service_unavailable' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::ServiceUnavailable')
+      },
+      [],
+      []
+    )
 
-        protected
+    DELETE_INFO = VAPI::Bindings::OperationInfo.new(
+      VAPI::Core::OperationIdentifier.new('delete', SERVICE_ID),
+      VAPI::Bindings::OperationInputType.new,
+      VAPI::Bindings::VoidType.instance,
+      {
+        'com.vmware.vapi.std.errors.unauthenticated' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Unauthenticated'),
+        'com.vmware.vapi.std.errors.service_unavailable' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::ServiceUnavailable')
+      },
+      [],
+      []
+    )
 
-        # static metamodel definitions
-        @@service_id = VAPI::Core::ServiceIdentifier.new('com.vmware.cis.session')
+    GET_INFO = VAPI::Bindings::OperationInfo.new(
+      VAPI::Core::OperationIdentifier.new('get', SERVICE_ID),
+      VAPI::Bindings::OperationInputType.new,
+      VAPI::Bindings::ReferenceType.new('Com::Vmware::Cis::Session::Info'),
+      {
+        'com.vmware.vapi.std.errors.unauthenticated' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Unauthenticated'),
+        'com.vmware.vapi.std.errors.service_unavailable' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::ServiceUnavailable')
+      },
+      [],
+      []
+    )
 
-        @@create_info = VAPI::Bindings::OperationInfo.new(
-            VAPI::Core::OperationIdentifier.new('create', @@service_id),
-            VAPI::Bindings::OperationInputType.new,
-            VAPI::Bindings::SecretType.instance,
-            {
-                'com.vmware.vapi.std.errors.unauthenticated' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Unauthenticated'),
-                'com.vmware.vapi.std.errors.service_unavailable' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::ServiceUnavailable'),
+    SERVICE_INFO = VAPI::Bindings::ServiceInfo.new(
+      SERVICE_ID,
+      'create' => CREATE_INFO,
+      'delete' => DELETE_INFO,
+      'get' => GET_INFO
+    )
 
-            },
-            [],
-            [])
-        @@delete_info = VAPI::Bindings::OperationInfo.new(
-            VAPI::Core::OperationIdentifier.new('delete', @@service_id),
-            VAPI::Bindings::OperationInputType.new,
-            VAPI::Bindings::VoidType.instance,
-            {
-                'com.vmware.vapi.std.errors.unauthenticated' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Unauthenticated'),
-                'com.vmware.vapi.std.errors.service_unavailable' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::ServiceUnavailable'),
-
-            },
-            [],
-            [])
-        @@get_info = VAPI::Bindings::OperationInfo.new(
-            VAPI::Core::OperationIdentifier.new('get', @@service_id),
-            VAPI::Bindings::OperationInputType.new,
-            VAPI::Bindings::ReferenceType.new('Com::Vmware::Cis::Session::Info'),
-            {
-                'com.vmware.vapi.std.errors.unauthenticated' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Unauthenticated'),
-                'com.vmware.vapi.std.errors.service_unavailable' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::ServiceUnavailable'),
-
-            },
-            [],
-            [])
-
-        @@service_info = VAPI::Bindings::ServiceInfo.new(@@service_id, {
-            'create' => @@create_info,
-            'delete' => @@delete_info,
-            'get' => @@get_info,
-        })
-
-        public
-
-        # Constructs a new instance.
-        #
-        # @param config [VAPI::Bindings::StubConfig] A hash with the api provider details.
-        def initialize(config)
-            super(config, @@service_info)
-        end
-
-
-        # Creates a session with the API. This is the equivalent of login. This  method  exchanges user credentials supplied in the security context for a session identifier that is to be used for authenticating subsequent calls. To authenticate subsequent calls clients are expected to include the session key.
-        #
-        # @return [String]
-        #     Newly created session identifier to be used for authenticating further requests.
-        # @raise [Com::Vmware::Vapi::Std::Errors::Unauthenticated]
-        #      if the session creation fails due to request specific issues. Due to the security nature of the API the details of the error are not disclosed.  
-        #     
-        #      Please check the following preconditions if using a SAML token to authenticate:  
-        #     
-        #       * the supplied token is delegate-able.
-        #        * the time of client and server system are synchronized.
-        #        * the token supplied is valid.
-        #        * if bearer tokens are used check that system configuration allows the API endpoint to accept such tokens.
-        #       
-        # @raise [Com::Vmware::Vapi::Std::Errors::ServiceUnavailable]
-        #      if session creation fails due to server specific issues, for example connection to a back end component is failing. Due to the security nature of this API further details will not be disclosed in the  error . Please refer to component health information, administrative logs and product specific documentation for possible causes.
-        def create()
-            invoke_with_info(@@create_info)
-        end
-
-
-        # Terminates the validity of a session token. This is the equivalent of log out.  
-        # 
-        #  A session identifier is expected as part of the request.  
-        #
-        # @return [Void]
-        # @raise [Com::Vmware::Vapi::Std::Errors::Unauthenticated]
-        #      if the session id is missing from the request or the corresponding session object cannot be found.
-        # @raise [Com::Vmware::Vapi::Std::Errors::ServiceUnavailable]
-        #      if session deletion fails due to server specific issues, for example connection to a back end component is failing. Due to the security nature of this API further details will not be disclosed in the  error . Please refer to component health information, administrative logs and product specific documentation for possible causes.
-        def delete()
-            invoke_with_info(@@delete_info)
-        end
-
-
-        # Returns information about the current session. This  method  expects a valid session identifier to be supplied.  
-        # 
-        #  A side effect of invoking this  method  may be a change to the session's last accessed time to the current time if this is supported by the session implementation. Invoking any other  method  in the API will also update the session's last accessed time.  
-        # 
-        #  This API is meant to serve the needs of various front end projects that may want to display the name of the user. Examples of this include various web based user interfaces and logging facilities.
-        #
-        # @return [Com::Vmware::Cis::Session::Info]
-        #     Information about the session.
-        # @raise [Com::Vmware::Vapi::Std::Errors::Unauthenticated]
-        #      if the session id is missing from the request or the corresponding session object cannot be found.
-        # @raise [Com::Vmware::Vapi::Std::Errors::ServiceUnavailable]
-        #      if session retrieval fails due to server specific issues e.g. connection to back end component is failing. Due to the security nature of this API further details will not be disclosed in the error. Please refer to component health information, administrative logs and product specific documentation for possible causes.
-        def get()
-            invoke_with_info(@@get_info)
-        end
-
-
-
-        # Represents data associated with an API session.
-        # @!attribute [rw] user
-        #     @return [String]
-        #     Fully qualified name of the end user that created the session, for example Administrator\@vsphere.local. A typical use case for this information is in Graphical User Interfaces (GUI) or logging systems to visualize the identity of the current user.
-        # @!attribute [rw] created_time
-        #     @return [DateTime]
-        #     Time when the session was created.
-        # @!attribute [rw] last_accessed_time
-        #     @return [DateTime]
-        #     Last time this session was used by passing the session key for invoking an API.
-        class Info < VAPI::Bindings::VapiStruct
-
-            class << self
-                # Holds (gets or creates) the binding type metadata for this structure type.
-                # @scope class
-                # @return [VAPI::Bindings::StructType] the binding type
-                def binding_type
-                    @binding_type ||= VAPI::Bindings::StructType.new(
-                        'com.vmware.cis.session.info',
-                        {
-                            'user' => VAPI::Bindings::StringType.instance,
-                            'created_time' => VAPI::Bindings::DateTimeType.instance,
-                            'last_accessed_time' => VAPI::Bindings::DateTimeType.instance,
-                        },
-                        Info,
-                        false,
-                        nil)
-                end
-            end
-
-            attr_accessor :user,
-                          :created_time,
-                          :last_accessed_time
-
-            # Constructs a new instance.
-            # @param ruby_values [Hash] a map of initial property values (optional)
-            # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
-            def initialize(ruby_values=nil, struct_value=nil)
-                super(self.class.binding_type, ruby_values, struct_value)
-            end
-        end
-
-
+    # Constructs a new instance.
+    #
+    # @param config [VAPI::Bindings::StubConfig] A hash with the api provider details.
+    def initialize(config)
+      super(config, SERVICE_INFO)
     end
 
+    # Creates a session with the API. This is the equivalent of login. This  method  exchanges user credentials supplied in the security context for a session identifier that is to be used for authenticating subsequent calls. To authenticate subsequent calls clients are expected to include the session key.
+    #
+    # @return [String]
+    #     Newly created session identifier to be used for authenticating further requests.
+    # @raise [Com::Vmware::Vapi::Std::Errors::Unauthenticated]
+    #      if the session creation fails due to request specific issues. Due to the security nature of the API the details of the error are not disclosed.  
+    #     
+    #      Please check the following preconditions if using a SAML token to authenticate:  
+    #     
+    #       * the supplied token is delegate-able.
+    #        * the time of client and server system are synchronized.
+    #        * the token supplied is valid.
+    #        * if bearer tokens are used check that system configuration allows the API endpoint to accept such tokens.
+    #       
+    # @raise [Com::Vmware::Vapi::Std::Errors::ServiceUnavailable]
+    #      if session creation fails due to server specific issues, for example connection to a back end component is failing. Due to the security nature of this API further details will not be disclosed in the  error . Please refer to component health information, administrative logs and product specific documentation for possible causes.
+    def create
+      invoke_with_info(CREATE_INFO)
+    end
 
+    # Terminates the validity of a session token. This is the equivalent of log out.  
+    # 
+    #  A session identifier is expected as part of the request.  
+    #
+    # @return [Void]
+    # @raise [Com::Vmware::Vapi::Std::Errors::Unauthenticated]
+    #      if the session id is missing from the request or the corresponding session object cannot be found.
+    # @raise [Com::Vmware::Vapi::Std::Errors::ServiceUnavailable]
+    #      if session deletion fails due to server specific issues, for example connection to a back end component is failing. Due to the security nature of this API further details will not be disclosed in the  error . Please refer to component health information, administrative logs and product specific documentation for possible causes.
+    def delete
+      invoke_with_info(DELETE_INFO)
+    end
+
+    # Returns information about the current session. This  method  expects a valid session identifier to be supplied.  
+    # 
+    #  A side effect of invoking this  method  may be a change to the session's last accessed time to the current time if this is supported by the session implementation. Invoking any other  method  in the API will also update the session's last accessed time.  
+    # 
+    #  This API is meant to serve the needs of various front end projects that may want to display the name of the user. Examples of this include various web based user interfaces and logging facilities.
+    #
+    # @return [Com::Vmware::Cis::Session::Info]
+    #     Information about the session.
+    # @raise [Com::Vmware::Vapi::Std::Errors::Unauthenticated]
+    #      if the session id is missing from the request or the corresponding session object cannot be found.
+    # @raise [Com::Vmware::Vapi::Std::Errors::ServiceUnavailable]
+    #      if session retrieval fails due to server specific issues e.g. connection to back end component is failing. Due to the security nature of this API further details will not be disclosed in the error. Please refer to component health information, administrative logs and product specific documentation for possible causes.
+    def get
+      invoke_with_info(GET_INFO)
+    end
+
+    # Represents data associated with an API session.
+    # @!attribute [rw] user
+    #     @return [String]
+    #     Fully qualified name of the end user that created the session, for example Administrator\@vsphere.local. A typical use case for this information is in Graphical User Interfaces (GUI) or logging systems to visualize the identity of the current user.
+    # @!attribute [rw] created_time
+    #     @return [DateTime]
+    #     Time when the session was created.
+    # @!attribute [rw] last_accessed_time
+    #     @return [DateTime]
+    #     Last time this session was used by passing the session key for invoking an API.
+    class Info < VAPI::Bindings::VapiStruct
+      class << self
+        # Holds (gets or creates) the binding type metadata for this structure type.
+        # @scope class
+        # @return [VAPI::Bindings::StructType] the binding type
+        def binding_type
+          @binding_type ||= VAPI::Bindings::StructType.new(
+            'com.vmware.cis.session.info',
+            {
+              'user' => VAPI::Bindings::StringType.instance,
+              'created_time' => VAPI::Bindings::DateTimeType.instance,
+              'last_accessed_time' => VAPI::Bindings::DateTimeType.instance
+            },
+            Info,
+            false,
+            nil
+          )
+        end
+      end
+
+      attr_accessor :user,
+                    :created_time,
+                    :last_accessed_time
+
+      # Constructs a new instance.
+      # @param ruby_values [Hash] a map of initial property values (optional)
+      # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
+      def initialize(ruby_values = nil, struct_value = nil)
+        super(self.class.binding_type, ruby_values, struct_value)
+      end
+    end
+
+  end
 end

--- a/client/sdk/com/vmware/cis/tagging.rb
+++ b/client/sdk/com/vmware/cis/tagging.rb
@@ -1,5 +1,6 @@
 #---------------------------------------------------------------------------
-# Copyright 2016 VMware, Inc.  All rights reserved.
+# Copyright 2017 VMware, Inc.  All rights reserved.
+#
 # AUTO GENERATED FILE -- DO NOT MODIFY!
 #
 # vAPI type descriptors for package com.vmware.cis.tagging.
@@ -8,1325 +9,302 @@ require 'vapi'
 
 # declare the module hierarchy before we use the shorthand syntax below
 module Com
-    module Vmware
-        module Cis
-            module Tagging
-            end
-        end
+  module Vmware
+    module Cis
+      module Tagging
+      end
     end
+  end
 end
 
-# Copyright 2013-2014 VMware, Inc. All rights reserved. -- VMware Confidential Copyright 2013-2014 VMware, Inc. All rights reserved. -- VMware Confidential Copyright 2013-2014 VMware, Inc. All rights reserved. -- VMware Confidential Copyright 2013-2015 VMware, Inc. All rights reserved. -- VMware Confidential Copyright 2013-2014 VMware, Inc. All rights reserved. -- VMware Confidential The  ``com.vmware.cis.tagging``   component  provides  methods  and  classes  to attach metadata, by means of tags, to vSphere objects to make these objects more sortable and searchable. You can use it to create, manage, and enumerate tags and their categories (the group a tag belongs to). You can also query the attached tags and attached objects.
+# The  ``com.vmware.cis.tagging``   component  provides  methods  and  classes  to attach metadata, by means of tags, to vSphere objects to make these objects more sortable and searchable. You can use it to create, manage, and enumerate tags and their categories (the group a tag belongs to). You can also query the attached tags and attached objects. Copyright 2013-2014 VMware, Inc. All rights reserved. -- VMware Confidential Copyright 2013-2014 VMware, Inc. All rights reserved. -- VMware Confidential Copyright 2013-2014 VMware, Inc. All rights reserved. -- VMware Confidential Copyright 2013-2015 VMware, Inc. All rights reserved. -- VMware Confidential Copyright 2013-2014 VMware, Inc. All rights reserved. -- VMware Confidential
 module Com::Vmware::Cis::Tagging
+  # The  ``Com::Vmware::Cis::Tagging::Category``   class  provides  methods  to create, read, update, delete, and enumerate categories.
+  class Category < VAPI::Bindings::VapiService
+    # static metamodel definitions
+    SERVICE_ID = VAPI::Core::ServiceIdentifier.new('com.vmware.cis.tagging.category')
 
-    # The  ``Com::Vmware::Cis::Tagging::Category``   class  provides  methods  to create, read, update, delete, and enumerate categories.
-    class Category < VAPI::Bindings::VapiService
+    CREATE_INFO = VAPI::Bindings::OperationInfo.new(
+      VAPI::Core::OperationIdentifier.new('create', SERVICE_ID),
+      VAPI::Bindings::OperationInputType.new(
+        'create_spec' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Cis::Tagging::Category::CreateSpec')
+      ),
+      VAPI::Bindings::IdType.new('com.vmware.cis.tagging.Category'),
+      {
+        'com.vmware.vapi.std.errors.already_exists' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::AlreadyExists'),
+        'com.vmware.vapi.std.errors.invalid_argument' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::InvalidArgument'),
+        'com.vmware.vapi.std.errors.unauthorized' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Unauthorized')
+      },
+      [],
+      []
+    )
 
-        protected
+    GET_INFO = VAPI::Bindings::OperationInfo.new(
+      VAPI::Core::OperationIdentifier.new('get', SERVICE_ID),
+      VAPI::Bindings::OperationInputType.new(
+        'category_id' => VAPI::Bindings::IdType.new('com.vmware.cis.tagging.Category')
+      ),
+      VAPI::Bindings::ReferenceType.new('Com::Vmware::Cis::Tagging::CategoryModel'),
+      {
+        'com.vmware.vapi.std.errors.not_found' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::NotFound'),
+        'com.vmware.vapi.std.errors.unauthorized' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Unauthorized')
+      },
+      [],
+      []
+    )
 
-        # static metamodel definitions
-        @@service_id = VAPI::Core::ServiceIdentifier.new('com.vmware.cis.tagging.category')
+    UPDATE_INFO = VAPI::Bindings::OperationInfo.new(
+      VAPI::Core::OperationIdentifier.new('update', SERVICE_ID),
+      VAPI::Bindings::OperationInputType.new(
+        'category_id' => VAPI::Bindings::IdType.new('com.vmware.cis.tagging.Category'),
+        'update_spec' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Cis::Tagging::Category::UpdateSpec')
+      ),
+      VAPI::Bindings::VoidType.instance,
+      {
+        'com.vmware.vapi.std.errors.already_exists' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::AlreadyExists'),
+        'com.vmware.vapi.std.errors.invalid_argument' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::InvalidArgument'),
+        'com.vmware.vapi.std.errors.not_found' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::NotFound'),
+        'com.vmware.vapi.std.errors.unauthorized' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Unauthorized')
+      },
+      [],
+      []
+    )
 
-        @@create_info = VAPI::Bindings::OperationInfo.new(
-            VAPI::Core::OperationIdentifier.new('create', @@service_id),
-            VAPI::Bindings::OperationInputType.new({
-                'create_spec' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Cis::Tagging::Category::CreateSpec'),
-            }),
-            VAPI::Bindings::IdType.new(resource_types='com.vmware.cis.tagging.Category'),
-            {
-                'com.vmware.vapi.std.errors.already_exists' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::AlreadyExists'),
-                'com.vmware.vapi.std.errors.invalid_argument' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::InvalidArgument'),
-                'com.vmware.vapi.std.errors.unauthorized' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Unauthorized'),
+    DELETE_INFO = VAPI::Bindings::OperationInfo.new(
+      VAPI::Core::OperationIdentifier.new('delete', SERVICE_ID),
+      VAPI::Bindings::OperationInputType.new(
+        'category_id' => VAPI::Bindings::IdType.new('com.vmware.cis.tagging.Category')
+      ),
+      VAPI::Bindings::VoidType.instance,
+      {
+        'com.vmware.vapi.std.errors.not_found' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::NotFound'),
+        'com.vmware.vapi.std.errors.unauthorized' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Unauthorized')
+      },
+      [],
+      []
+    )
 
-            },
-            [],
-            [])
-        @@get_info = VAPI::Bindings::OperationInfo.new(
-            VAPI::Core::OperationIdentifier.new('get', @@service_id),
-            VAPI::Bindings::OperationInputType.new({
-                'category_id' => VAPI::Bindings::IdType.new(resource_types='com.vmware.cis.tagging.Category'),
-            }),
-            VAPI::Bindings::ReferenceType.new('Com::Vmware::Cis::Tagging::CategoryModel'),
-            {
-                'com.vmware.vapi.std.errors.not_found' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::NotFound'),
-                'com.vmware.vapi.std.errors.unauthorized' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Unauthorized'),
+    LIST_INFO = VAPI::Bindings::OperationInfo.new(
+      VAPI::Core::OperationIdentifier.new('list', SERVICE_ID),
+      VAPI::Bindings::OperationInputType.new,
+      VAPI::Bindings::ListType.new(VAPI::Bindings::IdType.new),
+      {},
+      [],
+      []
+    )
 
-            },
-            [],
-            [])
-        @@update_info = VAPI::Bindings::OperationInfo.new(
-            VAPI::Core::OperationIdentifier.new('update', @@service_id),
-            VAPI::Bindings::OperationInputType.new({
-                'category_id' => VAPI::Bindings::IdType.new(resource_types='com.vmware.cis.tagging.Category'),
-                'update_spec' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Cis::Tagging::Category::UpdateSpec'),
-            }),
-            VAPI::Bindings::VoidType.instance,
-            {
-                'com.vmware.vapi.std.errors.already_exists' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::AlreadyExists'),
-                'com.vmware.vapi.std.errors.invalid_argument' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::InvalidArgument'),
-                'com.vmware.vapi.std.errors.not_found' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::NotFound'),
-                'com.vmware.vapi.std.errors.unauthorized' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Unauthorized'),
+    LIST_USED_CATEGORIES_INFO = VAPI::Bindings::OperationInfo.new(
+      VAPI::Core::OperationIdentifier.new('list_used_categories', SERVICE_ID),
+      VAPI::Bindings::OperationInputType.new(
+        'used_by_entity' => VAPI::Bindings::StringType.instance
+      ),
+      VAPI::Bindings::ListType.new(VAPI::Bindings::IdType.new),
+      {},
+      [],
+      []
+    )
 
-            },
-            [],
-            [])
-        @@delete_info = VAPI::Bindings::OperationInfo.new(
-            VAPI::Core::OperationIdentifier.new('delete', @@service_id),
-            VAPI::Bindings::OperationInputType.new({
-                'category_id' => VAPI::Bindings::IdType.new(resource_types='com.vmware.cis.tagging.Category'),
-            }),
-            VAPI::Bindings::VoidType.instance,
-            {
-                'com.vmware.vapi.std.errors.not_found' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::NotFound'),
-                'com.vmware.vapi.std.errors.unauthorized' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Unauthorized'),
+    ADD_TO_USED_BY_INFO = VAPI::Bindings::OperationInfo.new(
+      VAPI::Core::OperationIdentifier.new('add_to_used_by', SERVICE_ID),
+      VAPI::Bindings::OperationInputType.new(
+        'category_id' => VAPI::Bindings::IdType.new('com.vmware.cis.tagging.Category'),
+        'used_by_entity' => VAPI::Bindings::StringType.instance
+      ),
+      VAPI::Bindings::VoidType.instance,
+      {
+        'com.vmware.vapi.std.errors.not_found' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::NotFound'),
+        'com.vmware.vapi.std.errors.unauthorized' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Unauthorized')
+      },
+      [],
+      []
+    )
 
-            },
-            [],
-            [])
-        @@list_info = VAPI::Bindings::OperationInfo.new(
-            VAPI::Core::OperationIdentifier.new('list', @@service_id),
-            VAPI::Bindings::OperationInputType.new,
-            VAPI::Bindings::ListType.new(VAPI::Bindings::IdType.new),
-            {},
-            [],
-            [])
-        @@list_used_categories_info = VAPI::Bindings::OperationInfo.new(
-            VAPI::Core::OperationIdentifier.new('list_used_categories', @@service_id),
-            VAPI::Bindings::OperationInputType.new({
-                'used_by_entity' => VAPI::Bindings::StringType.instance,
-            }),
-            VAPI::Bindings::ListType.new(VAPI::Bindings::IdType.new),
-            {},
-            [],
-            [])
-        @@add_to_used_by_info = VAPI::Bindings::OperationInfo.new(
-            VAPI::Core::OperationIdentifier.new('add_to_used_by', @@service_id),
-            VAPI::Bindings::OperationInputType.new({
-                'category_id' => VAPI::Bindings::IdType.new(resource_types='com.vmware.cis.tagging.Category'),
-                'used_by_entity' => VAPI::Bindings::StringType.instance,
-            }),
-            VAPI::Bindings::VoidType.instance,
-            {
-                'com.vmware.vapi.std.errors.not_found' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::NotFound'),
-                'com.vmware.vapi.std.errors.unauthorized' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Unauthorized'),
+    REMOVE_FROM_USED_BY_INFO = VAPI::Bindings::OperationInfo.new(
+      VAPI::Core::OperationIdentifier.new('remove_from_used_by', SERVICE_ID),
+      VAPI::Bindings::OperationInputType.new(
+        'category_id' => VAPI::Bindings::IdType.new('com.vmware.cis.tagging.Category'),
+        'used_by_entity' => VAPI::Bindings::StringType.instance
+      ),
+      VAPI::Bindings::VoidType.instance,
+      {
+        'com.vmware.vapi.std.errors.not_found' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::NotFound'),
+        'com.vmware.vapi.std.errors.unauthorized' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Unauthorized')
+      },
+      [],
+      []
+    )
 
-            },
-            [],
-            [])
-        @@remove_from_used_by_info = VAPI::Bindings::OperationInfo.new(
-            VAPI::Core::OperationIdentifier.new('remove_from_used_by', @@service_id),
-            VAPI::Bindings::OperationInputType.new({
-                'category_id' => VAPI::Bindings::IdType.new(resource_types='com.vmware.cis.tagging.Category'),
-                'used_by_entity' => VAPI::Bindings::StringType.instance,
-            }),
-            VAPI::Bindings::VoidType.instance,
-            {
-                'com.vmware.vapi.std.errors.not_found' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::NotFound'),
-                'com.vmware.vapi.std.errors.unauthorized' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Unauthorized'),
+    REVOKE_PROPAGATING_PERMISSIONS_INFO = VAPI::Bindings::OperationInfo.new(
+      VAPI::Core::OperationIdentifier.new('revoke_propagating_permissions', SERVICE_ID),
+      VAPI::Bindings::OperationInputType.new(
+        'category_id' => VAPI::Bindings::IdType.new('com.vmware.cis.tagging.Category')
+      ),
+      VAPI::Bindings::VoidType.instance,
+      {
+        'com.vmware.vapi.std.errors.not_found' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::NotFound'),
+        'com.vmware.vapi.std.errors.unauthorized' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Unauthorized')
+      },
+      [],
+      []
+    )
 
-            },
-            [],
-            [])
-        @@revoke_propagating_permissions_info = VAPI::Bindings::OperationInfo.new(
-            VAPI::Core::OperationIdentifier.new('revoke_propagating_permissions', @@service_id),
-            VAPI::Bindings::OperationInputType.new({
-                'category_id' => VAPI::Bindings::IdType.new(resource_types='com.vmware.cis.tagging.Category'),
-            }),
-            VAPI::Bindings::VoidType.instance,
-            {
-                'com.vmware.vapi.std.errors.not_found' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::NotFound'),
-                'com.vmware.vapi.std.errors.unauthorized' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Unauthorized'),
+    SERVICE_INFO = VAPI::Bindings::ServiceInfo.new(
+      SERVICE_ID,
+      'create' => CREATE_INFO,
+      'get' => GET_INFO,
+      'update' => UPDATE_INFO,
+      'delete' => DELETE_INFO,
+      'list' => LIST_INFO,
+      'list_used_categories' => LIST_USED_CATEGORIES_INFO,
+      'add_to_used_by' => ADD_TO_USED_BY_INFO,
+      'remove_from_used_by' => REMOVE_FROM_USED_BY_INFO,
+      'revoke_propagating_permissions' => REVOKE_PROPAGATING_PERMISSIONS_INFO
+    )
 
-            },
-            [],
-            [])
-
-        @@service_info = VAPI::Bindings::ServiceInfo.new(@@service_id, {
-            'create' => @@create_info,
-            'get' => @@get_info,
-            'update' => @@update_info,
-            'delete' => @@delete_info,
-            'list' => @@list_info,
-            'list_used_categories' => @@list_used_categories_info,
-            'add_to_used_by' => @@add_to_used_by_info,
-            'remove_from_used_by' => @@remove_from_used_by_info,
-            'revoke_propagating_permissions' => @@revoke_propagating_permissions_info,
-        })
-
-        public
-
-        # Constructs a new instance.
-        #
-        # @param config [VAPI::Bindings::StubConfig] A hash with the api provider details.
-        def initialize(config)
-            super(config, @@service_info)
-        end
-
-
-        # Creates a category. To invoke this  method , you need the create category privilege.
-        #
-        # @param create_spec [Com::Vmware::Cis::Tagging::Category::CreateSpec]
-        #      Specification for the new category to be created.
-        # @return [String]
-        #     The identifier of the created category.
-        # @raise [Com::Vmware::Vapi::Std::Errors::AlreadyExists]
-        #      if the   :attr:`Com::Vmware::Cis::Tagging::Category::CreateSpec.name`   provided in the  ``create_spec``  is the name of an already existing category.
-        # @raise [Com::Vmware::Vapi::Std::Errors::InvalidArgument]
-        #      if any of the information in the  ``create_spec``  is invalid.
-        # @raise [Com::Vmware::Vapi::Std::Errors::Unauthorized]
-        #      if you do not have the privilege to create a category.
-        def create(create_spec)
-            invoke_with_info(@@create_info, {
-                'create_spec' => create_spec,
-            })
-        end
-
-
-        # Fetches the category information for the given category identifier. In order to view the category information, you need the read privilege on the category.
-        #
-        # @param category_id [String]
-        #      The identifier of the input category.
-        # @return [Com::Vmware::Cis::Tagging::CategoryModel]
-        #     The   :class:`Com::Vmware::Cis::Tagging::CategoryModel`   that corresponds to  ``category_id`` .
-        # @raise [Com::Vmware::Vapi::Std::Errors::NotFound]
-        #      if the category for the given  ``category_id``  does not exist in the system.
-        # @raise [Com::Vmware::Vapi::Std::Errors::Unauthorized]
-        #      if you do not have the privilege to read the category.
-        def get(category_id)
-            invoke_with_info(@@get_info, {
-                'category_id' => category_id,
-            })
-        end
-
-
-        # Updates an existing category. To invoke this  method , you need the edit privilege on the category.
-        #
-        # @param category_id [String]
-        #      The identifier of the category to be updated.
-        # @param update_spec [Com::Vmware::Cis::Tagging::Category::UpdateSpec]
-        #      Specification to update the category.
-        # @return [Void]
-        # @raise [Com::Vmware::Vapi::Std::Errors::AlreadyExists]
-        #      if the   :attr:`Com::Vmware::Cis::Tagging::Category::UpdateSpec.name`   provided in the  ``update_spec``  is the name of an already existing category.
-        # @raise [Com::Vmware::Vapi::Std::Errors::InvalidArgument]
-        #      if any of the information in the  ``update_spec``  is invalid.
-        # @raise [Com::Vmware::Vapi::Std::Errors::NotFound]
-        #      if the category for the given  ``category_id``  does not exist in the system.
-        # @raise [Com::Vmware::Vapi::Std::Errors::Unauthorized]
-        #      if you do not have the privilege to update the category.
-        def update(category_id, update_spec)
-            invoke_with_info(@@update_info, {
-                'category_id' => category_id,
-                'update_spec' => update_spec,
-            })
-        end
-
-
-        # Deletes an existing category. To invoke this  method , you need the delete privilege on the category.
-        #
-        # @param category_id [String]
-        #      The identifier of category to be deleted.
-        # @return [Void]
-        # @raise [Com::Vmware::Vapi::Std::Errors::NotFound]
-        #      if the category for the given  ``category_id``  does not exist in the system.
-        # @raise [Com::Vmware::Vapi::Std::Errors::Unauthorized]
-        #      if you do not have the privilege to delete the category.
-        def delete(category_id)
-            invoke_with_info(@@delete_info, {
-                'category_id' => category_id,
-            })
-        end
-
-
-        # Enumerates the categories in the system. To invoke this  method , you need the read privilege on the individual categories. The  list  will only contain those categories for which you have read privileges.
-        #
-        # @return [Array<String>]
-        #     The  list  of resource identifiers for the categories in the system.
-        def list()
-            invoke_with_info(@@list_info)
-        end
-
-
-        # Enumerates all categories for which the  ``used_by_entity``  is part of the   :attr:`Com::Vmware::Cis::Tagging::CategoryModel.used_by`   subscribers  set . To invoke this  method , you need the read privilege on the individual categories.
-        #
-        # @param used_by_entity [String]
-        #      The field on which the results will be filtered.
-        # @return [Array<String>]
-        #     The  list  of resource identifiers for the categories in the system that are used by  ``used_by_entity`` .
-        def list_used_categories(used_by_entity)
-            invoke_with_info(@@list_used_categories_info, {
-                'used_by_entity' => used_by_entity,
-            })
-        end
-
-
-        # Adds the  ``used_by_entity``  to the   :attr:`Com::Vmware::Cis::Tagging::CategoryModel.used_by`   subscribers  set  for the specified category. If the  ``used_by_entity``  is already in the  set , then this becomes an idempotent no-op. To invoke this  method , you need the modify   :attr:`Com::Vmware::Cis::Tagging::CategoryModel.used_by`   privilege on the category.
-        #
-        # @param category_id [String]
-        #      The identifier of the input category.
-        # @param used_by_entity [String]
-        #      The name of the user to be added to the   :attr:`Com::Vmware::Cis::Tagging::CategoryModel.used_by`    set .
-        # @return [Void]
-        # @raise [Com::Vmware::Vapi::Std::Errors::NotFound]
-        #      if the category for the given  ``category_id``  does not exist in the system.
-        # @raise [Com::Vmware::Vapi::Std::Errors::Unauthorized]
-        #      if you do not have the privilege to add an entity to the   :attr:`Com::Vmware::Cis::Tagging::CategoryModel.used_by`   field.
-        def add_to_used_by(category_id, used_by_entity)
-            invoke_with_info(@@add_to_used_by_info, {
-                'category_id' => category_id,
-                'used_by_entity' => used_by_entity,
-            })
-        end
-
-
-        # Removes the  ``used_by_entity``  from the   :attr:`Com::Vmware::Cis::Tagging::CategoryModel.used_by`   subscribers  set . If the  ``used_by_entity``  is not using this category, then this becomes a no-op. To invoke this  method , you need the modify   :attr:`Com::Vmware::Cis::Tagging::CategoryModel.used_by`   privilege on the category.
-        #
-        # @param category_id [String]
-        #      The identifier of the input category.
-        # @param used_by_entity [String]
-        #      The name of the user to be removed from the   :attr:`Com::Vmware::Cis::Tagging::CategoryModel.used_by`    set .
-        # @return [Void]
-        # @raise [Com::Vmware::Vapi::Std::Errors::NotFound]
-        #      if the category for the given  ``category_id``  does not exist in the system.
-        # @raise [Com::Vmware::Vapi::Std::Errors::Unauthorized]
-        #      if you do not have the privilege to remove an entity from the   :attr:`Com::Vmware::Cis::Tagging::CategoryModel.used_by`   field.
-        def remove_from_used_by(category_id, used_by_entity)
-            invoke_with_info(@@remove_from_used_by_info, {
-                'category_id' => category_id,
-                'used_by_entity' => used_by_entity,
-            })
-        end
-
-
-        # Revokes all propagating permissions on the given category. You should then attach a direct permission with tagging privileges on the given category. To invoke this  method , you need category related privileges (direct or propagating) on the concerned category.
-        #
-        # @param category_id [String]
-        #      The identifier of the input category.
-        # @return [Void]
-        # @raise [Com::Vmware::Vapi::Std::Errors::NotFound]
-        #      if the category for the given  ``category_id``  does not exist in the system.
-        # @raise [Com::Vmware::Vapi::Std::Errors::Unauthorized]
-        #      if you do not have the privilege to revoke propagating permissions on the category.
-        def revoke_propagating_permissions(category_id)
-            invoke_with_info(@@revoke_propagating_permissions_info, {
-                'category_id' => category_id,
-            })
-        end
-
-
-
-        # The  ``Com::Vmware::Cis::Tagging::Category::CreateSpec``   class  is used to create a category.  
-        # 
-        #  Use the   :func:`Com::Vmware::Cis::Tagging::Category.create`    method  to create a category defined by the create specification.
-        # @!attribute [rw] name
-        #     @return [String]
-        #     The display name of the category.
-        # @!attribute [rw] description
-        #     @return [String]
-        #     The description of the category.
-        # @!attribute [rw] cardinality
-        #     @return [Com::Vmware::Cis::Tagging::CategoryModel::Cardinality]
-        #     The associated cardinality ( ``SINGLE``, ``MULTIPLE`` ) of the category.
-        # @!attribute [rw] associable_types
-        #     @return [Set<String>]
-        #     Object types to which this category's tags can be attached.
-        class CreateSpec < VAPI::Bindings::VapiStruct
-
-            class << self
-                # Holds (gets or creates) the binding type metadata for this structure type.
-                # @scope class
-                # @return [VAPI::Bindings::StructType] the binding type
-                def binding_type
-                    @binding_type ||= VAPI::Bindings::StructType.new(
-                        'com.vmware.cis.tagging.category.create_spec',
-                        {
-                            'name' => VAPI::Bindings::StringType.instance,
-                            'description' => VAPI::Bindings::StringType.instance,
-                            'cardinality' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Cis::Tagging::CategoryModel::Cardinality'),
-                            'associable_types' => VAPI::Bindings::SetType.new(VAPI::Bindings::StringType.instance),
-                        },
-                        CreateSpec,
-                        false,
-                        nil)
-                end
-            end
-
-            attr_accessor :name,
-                          :description,
-                          :cardinality,
-                          :associable_types
-
-            # Constructs a new instance.
-            # @param ruby_values [Hash] a map of initial property values (optional)
-            # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
-            def initialize(ruby_values=nil, struct_value=nil)
-                super(self.class.binding_type, ruby_values, struct_value)
-            end
-        end
-
-
-        # The  ``Com::Vmware::Cis::Tagging::Category::UpdateSpec``   class  describes the updates to be made to an existing category.  
-        # 
-        #  Use the   :func:`Com::Vmware::Cis::Tagging::Category.update`    method  to modify a category. When you call the  method , specify the category identifier. You obtain the category identifier when you call the   :func:`Com::Vmware::Cis::Tagging::Category.create`    method . You can also retrieve an identifier by using the   :func:`Com::Vmware::Cis::Tagging::Category.list`    method .
-        # @!attribute [rw] name
-        #     @return [String, nil]
-        #     The display name of the category.
-        #     If  nil  the name will not be modified.
-        # @!attribute [rw] description
-        #     @return [String, nil]
-        #     The description of the category.
-        #     If  nil  the description will not be modified.
-        # @!attribute [rw] cardinality
-        #     @return [Com::Vmware::Cis::Tagging::CategoryModel::Cardinality, nil]
-        #     The associated cardinality ( ``SINGLE``, ``MULTIPLE`` ) of the category.
-        #     If  nil  the cardinality will not be modified.
-        # @!attribute [rw] associable_types
-        #     @return [Set<String>, nil]
-        #     Object types to which this category's tags can be attached.  
-        #     
-        #      The  set  of associable types cannot be updated incrementally. For example, if   :attr:`Com::Vmware::Cis::Tagging::Category::UpdateSpec.associable_types`   originally contains {A,B,C} and you want to add D, then you need to pass {A,B,C,D} in your update specification. You also cannot remove any item from this  set . For example, if you have {A,B,C}, then you cannot remove say {A} from it. Similarly, if you start with an empty  set , then that implies that you can tag any object and hence you cannot later pass say {A}, because that would be restricting the type of objects you want to tag. Thus, associable types can only grow and not shrink.
-        #     If  nil  the associable types will not be modified.
-        class UpdateSpec < VAPI::Bindings::VapiStruct
-
-            class << self
-                # Holds (gets or creates) the binding type metadata for this structure type.
-                # @scope class
-                # @return [VAPI::Bindings::StructType] the binding type
-                def binding_type
-                    @binding_type ||= VAPI::Bindings::StructType.new(
-                        'com.vmware.cis.tagging.category.update_spec',
-                        {
-                            'name' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::StringType.instance),
-                            'description' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::StringType.instance),
-                            'cardinality' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Cis::Tagging::CategoryModel::Cardinality')),
-                            'associable_types' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::SetType.new(VAPI::Bindings::StringType.instance)),
-                        },
-                        UpdateSpec,
-                        false,
-                        nil)
-                end
-            end
-
-            attr_accessor :name,
-                          :description,
-                          :cardinality,
-                          :associable_types
-
-            # Constructs a new instance.
-            # @param ruby_values [Hash] a map of initial property values (optional)
-            # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
-            def initialize(ruby_values=nil, struct_value=nil)
-                super(self.class.binding_type, ruby_values, struct_value)
-            end
-        end
-
-
+    # Constructs a new instance.
+    #
+    # @param config [VAPI::Bindings::StubConfig] A hash with the api provider details.
+    def initialize(config)
+      super(config, SERVICE_INFO)
     end
 
-
-    # The  ``Com::Vmware::Cis::Tagging::Tag``   class  provides  methods  to create, read, update, delete, and enumerate tags.
-    class Tag < VAPI::Bindings::VapiService
-
-        protected
-
-        # static metamodel definitions
-        @@service_id = VAPI::Core::ServiceIdentifier.new('com.vmware.cis.tagging.tag')
-
-        @@create_info = VAPI::Bindings::OperationInfo.new(
-            VAPI::Core::OperationIdentifier.new('create', @@service_id),
-            VAPI::Bindings::OperationInputType.new({
-                'create_spec' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Cis::Tagging::Tag::CreateSpec'),
-            }),
-            VAPI::Bindings::IdType.new(resource_types='com.vmware.cis.tagging.Tag'),
-            {
-                'com.vmware.vapi.std.errors.already_exists' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::AlreadyExists'),
-                'com.vmware.vapi.std.errors.invalid_argument' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::InvalidArgument'),
-                'com.vmware.vapi.std.errors.not_found' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::NotFound'),
-                'com.vmware.vapi.std.errors.unauthorized' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Unauthorized'),
-
-            },
-            [],
-            [])
-        @@get_info = VAPI::Bindings::OperationInfo.new(
-            VAPI::Core::OperationIdentifier.new('get', @@service_id),
-            VAPI::Bindings::OperationInputType.new({
-                'tag_id' => VAPI::Bindings::IdType.new(resource_types='com.vmware.cis.tagging.Tag'),
-            }),
-            VAPI::Bindings::ReferenceType.new('Com::Vmware::Cis::Tagging::TagModel'),
-            {
-                'com.vmware.vapi.std.errors.not_found' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::NotFound'),
-                'com.vmware.vapi.std.errors.unauthorized' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Unauthorized'),
-
-            },
-            [],
-            [])
-        @@update_info = VAPI::Bindings::OperationInfo.new(
-            VAPI::Core::OperationIdentifier.new('update', @@service_id),
-            VAPI::Bindings::OperationInputType.new({
-                'tag_id' => VAPI::Bindings::IdType.new(resource_types='com.vmware.cis.tagging.Tag'),
-                'update_spec' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Cis::Tagging::Tag::UpdateSpec'),
-            }),
-            VAPI::Bindings::VoidType.instance,
-            {
-                'com.vmware.vapi.std.errors.already_exists' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::AlreadyExists'),
-                'com.vmware.vapi.std.errors.invalid_argument' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::InvalidArgument'),
-                'com.vmware.vapi.std.errors.not_found' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::NotFound'),
-                'com.vmware.vapi.std.errors.unauthorized' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Unauthorized'),
-
-            },
-            [],
-            [])
-        @@delete_info = VAPI::Bindings::OperationInfo.new(
-            VAPI::Core::OperationIdentifier.new('delete', @@service_id),
-            VAPI::Bindings::OperationInputType.new({
-                'tag_id' => VAPI::Bindings::IdType.new(resource_types='com.vmware.cis.tagging.Tag'),
-            }),
-            VAPI::Bindings::VoidType.instance,
-            {
-                'com.vmware.vapi.std.errors.not_found' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::NotFound'),
-                'com.vmware.vapi.std.errors.unauthorized' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Unauthorized'),
-
-            },
-            [],
-            [])
-        @@list_info = VAPI::Bindings::OperationInfo.new(
-            VAPI::Core::OperationIdentifier.new('list', @@service_id),
-            VAPI::Bindings::OperationInputType.new,
-            VAPI::Bindings::ListType.new(VAPI::Bindings::IdType.new),
-            {},
-            [],
-            [])
-        @@list_used_tags_info = VAPI::Bindings::OperationInfo.new(
-            VAPI::Core::OperationIdentifier.new('list_used_tags', @@service_id),
-            VAPI::Bindings::OperationInputType.new({
-                'used_by_entity' => VAPI::Bindings::StringType.instance,
-            }),
-            VAPI::Bindings::ListType.new(VAPI::Bindings::IdType.new),
-            {},
-            [],
-            [])
-        @@list_tags_for_category_info = VAPI::Bindings::OperationInfo.new(
-            VAPI::Core::OperationIdentifier.new('list_tags_for_category', @@service_id),
-            VAPI::Bindings::OperationInputType.new({
-                'category_id' => VAPI::Bindings::IdType.new(resource_types='com.vmware.cis.tagging.Category'),
-            }),
-            VAPI::Bindings::ListType.new(VAPI::Bindings::IdType.new),
-            {
-                'com.vmware.vapi.std.errors.not_found' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::NotFound'),
-                'com.vmware.vapi.std.errors.unauthorized' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Unauthorized'),
-
-            },
-            [],
-            [])
-        @@add_to_used_by_info = VAPI::Bindings::OperationInfo.new(
-            VAPI::Core::OperationIdentifier.new('add_to_used_by', @@service_id),
-            VAPI::Bindings::OperationInputType.new({
-                'tag_id' => VAPI::Bindings::IdType.new(resource_types='com.vmware.cis.tagging.Tag'),
-                'used_by_entity' => VAPI::Bindings::StringType.instance,
-            }),
-            VAPI::Bindings::VoidType.instance,
-            {
-                'com.vmware.vapi.std.errors.not_found' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::NotFound'),
-                'com.vmware.vapi.std.errors.unauthorized' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Unauthorized'),
-
-            },
-            [],
-            [])
-        @@remove_from_used_by_info = VAPI::Bindings::OperationInfo.new(
-            VAPI::Core::OperationIdentifier.new('remove_from_used_by', @@service_id),
-            VAPI::Bindings::OperationInputType.new({
-                'tag_id' => VAPI::Bindings::IdType.new(resource_types='com.vmware.cis.tagging.Tag'),
-                'used_by_entity' => VAPI::Bindings::StringType.instance,
-            }),
-            VAPI::Bindings::VoidType.instance,
-            {
-                'com.vmware.vapi.std.errors.not_found' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::NotFound'),
-                'com.vmware.vapi.std.errors.unauthorized' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Unauthorized'),
-
-            },
-            [],
-            [])
-        @@revoke_propagating_permissions_info = VAPI::Bindings::OperationInfo.new(
-            VAPI::Core::OperationIdentifier.new('revoke_propagating_permissions', @@service_id),
-            VAPI::Bindings::OperationInputType.new({
-                'tag_id' => VAPI::Bindings::IdType.new(resource_types='com.vmware.cis.tagging.Tag'),
-            }),
-            VAPI::Bindings::VoidType.instance,
-            {
-                'com.vmware.vapi.std.errors.not_found' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::NotFound'),
-                'com.vmware.vapi.std.errors.unauthorized' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Unauthorized'),
-
-            },
-            [],
-            [])
-
-        @@service_info = VAPI::Bindings::ServiceInfo.new(@@service_id, {
-            'create' => @@create_info,
-            'get' => @@get_info,
-            'update' => @@update_info,
-            'delete' => @@delete_info,
-            'list' => @@list_info,
-            'list_used_tags' => @@list_used_tags_info,
-            'list_tags_for_category' => @@list_tags_for_category_info,
-            'add_to_used_by' => @@add_to_used_by_info,
-            'remove_from_used_by' => @@remove_from_used_by_info,
-            'revoke_propagating_permissions' => @@revoke_propagating_permissions_info,
-        })
-
-        public
-
-        # Constructs a new instance.
-        #
-        # @param config [VAPI::Bindings::StubConfig] A hash with the api provider details.
-        def initialize(config)
-            super(config, @@service_info)
-        end
-
-
-        # Creates a tag. To invoke this  method , you need the create tag privilege on the input category.
-        #
-        # @param create_spec [Com::Vmware::Cis::Tagging::Tag::CreateSpec]
-        #      Specification for the new tag to be created.
-        # @return [String]
-        #     The identifier of the created tag.
-        # @raise [Com::Vmware::Vapi::Std::Errors::AlreadyExists]
-        #      if the   :attr:`Com::Vmware::Cis::Tagging::Tag::CreateSpec.name`   provided in the  ``create_spec``  is the name of an already existing tag in the input category.
-        # @raise [Com::Vmware::Vapi::Std::Errors::InvalidArgument]
-        #      if any of the input information in the  ``create_spec``  is invalid.
-        # @raise [Com::Vmware::Vapi::Std::Errors::NotFound]
-        #      if the category for in the given  ``create_spec``  does not exist in the system.
-        # @raise [Com::Vmware::Vapi::Std::Errors::Unauthorized]
-        #      if you do not have the privilege to create tag.
-        def create(create_spec)
-            invoke_with_info(@@create_info, {
-                'create_spec' => create_spec,
-            })
-        end
-
-
-        # Fetches the tag information for the given tag identifier. To invoke this  method , you need the read privilege on the tag in order to view the tag info.
-        #
-        # @param tag_id [String]
-        #      The identifier of the input tag.
-        # @return [Com::Vmware::Cis::Tagging::TagModel]
-        #     The   :class:`Com::Vmware::Cis::Tagging::TagModel`   that corresponds to  ``tag_id`` .
-        # @raise [Com::Vmware::Vapi::Std::Errors::NotFound]
-        #      if the tag for the given  ``tag_id``  does not exist in the system.
-        # @raise [Com::Vmware::Vapi::Std::Errors::Unauthorized]
-        #      if the user does not have the privilege to read the tag.
-        def get(tag_id)
-            invoke_with_info(@@get_info, {
-                'tag_id' => tag_id,
-            })
-        end
-
-
-        # Updates an existing tag. To invoke this  method , you need the edit privilege on the tag.
-        #
-        # @param tag_id [String]
-        #      The identifier of the input tag.
-        # @param update_spec [Com::Vmware::Cis::Tagging::Tag::UpdateSpec]
-        #      Specification to update the tag.
-        # @return [Void]
-        # @raise [Com::Vmware::Vapi::Std::Errors::AlreadyExists]
-        #      if the   :attr:`Com::Vmware::Cis::Tagging::Tag::UpdateSpec.name`   provided in the  ``update_spec``  is the name of an already existing tag in the same category.
-        # @raise [Com::Vmware::Vapi::Std::Errors::InvalidArgument]
-        #      if any of the input information in the  ``update_spec``  is invalid.
-        # @raise [Com::Vmware::Vapi::Std::Errors::NotFound]
-        #      if the tag for the given  ``tag_id``  does not exist in the system.
-        # @raise [Com::Vmware::Vapi::Std::Errors::Unauthorized]
-        #      if you do not have the privilege to update the tag.
-        def update(tag_id, update_spec)
-            invoke_with_info(@@update_info, {
-                'tag_id' => tag_id,
-                'update_spec' => update_spec,
-            })
-        end
-
-
-        # Deletes an existing tag. To invoke this  method , you need the delete privilege on the tag.
-        #
-        # @param tag_id [String]
-        #      The identifier of the input tag.
-        # @return [Void]
-        # @raise [Com::Vmware::Vapi::Std::Errors::NotFound]
-        #      if the tag for the given  ``tag_id``  does not exist in the system.
-        # @raise [Com::Vmware::Vapi::Std::Errors::Unauthorized]
-        #      if you do not have the privilege to delete the tag.
-        def delete(tag_id)
-            invoke_with_info(@@delete_info, {
-                'tag_id' => tag_id,
-            })
-        end
-
-
-        # Enumerates the tags in the system. To invoke this  method , you need read privilege on the individual tags. The  list  will only contain tags for which you have read privileges.
-        #
-        # @return [Array<String>]
-        #     The  list  of resource identifiers for the tags in the system.
-        def list()
-            invoke_with_info(@@list_info)
-        end
-
-
-        # Enumerates all tags for which the  ``used_by_entity``  is part of the   :attr:`Com::Vmware::Cis::Tagging::TagModel.used_by`   subscribers  set . To invoke this  method , you need the read privilege on the individual tags.
-        #
-        # @param used_by_entity [String]
-        #      The field on which the results will be filtered.
-        # @return [Array<String>]
-        #     The  list  of resource identifiers for the tags in the system that are used by  ``used_by_entity`` .
-        def list_used_tags(used_by_entity)
-            invoke_with_info(@@list_used_tags_info, {
-                'used_by_entity' => used_by_entity,
-            })
-        end
-
-
-        # Enumerates all tags for the given category. To invoke this  method , you need the read privilege on the given category and the individual tags in that category.
-        #
-        # @param category_id [String]
-        #      The identifier of the input category.
-        # @return [Array<String>]
-        #     The  list  of resource identifiers for the tags in the given input category.
-        # @raise [Com::Vmware::Vapi::Std::Errors::NotFound]
-        #      if the category for the given  ``category_id``  does not exist in the system.
-        # @raise [Com::Vmware::Vapi::Std::Errors::Unauthorized]
-        #      if you do not have the privilege to read the category.
-        def list_tags_for_category(category_id)
-            invoke_with_info(@@list_tags_for_category_info, {
-                'category_id' => category_id,
-            })
-        end
-
-
-        # Adds the  ``used_by_entity``  to the   :attr:`Com::Vmware::Cis::Tagging::TagModel.used_by`   subscribers  set . If the  ``used_by_entity``  is already in the  set , then this becomes a no-op. To invoke this  method , you need the modify   :attr:`Com::Vmware::Cis::Tagging::TagModel.used_by`   privilege on the tag.
-        #
-        # @param tag_id [String]
-        #      The identifier of the input tag.
-        # @param used_by_entity [String]
-        #      The name of the user to be added to the   :attr:`Com::Vmware::Cis::Tagging::TagModel.used_by`    set .
-        # @return [Void]
-        # @raise [Com::Vmware::Vapi::Std::Errors::NotFound]
-        #      if the tag for the given  ``tag_id``  does not exist in the system.
-        # @raise [Com::Vmware::Vapi::Std::Errors::Unauthorized]
-        #      if you do not have the privilege to add an entity to the   :attr:`Com::Vmware::Cis::Tagging::TagModel.used_by`   field.
-        def add_to_used_by(tag_id, used_by_entity)
-            invoke_with_info(@@add_to_used_by_info, {
-                'tag_id' => tag_id,
-                'used_by_entity' => used_by_entity,
-            })
-        end
-
-
-        # Removes the  ``used_by_entity``  from the   :attr:`Com::Vmware::Cis::Tagging::TagModel.used_by`   subscribers set. If the  ``used_by_entity``  is not using this tag, then this becomes a no-op. To invoke this  method , you need modify   :attr:`Com::Vmware::Cis::Tagging::TagModel.used_by`   privilege on the tag.
-        #
-        # @param tag_id [String]
-        #      The identifier of the input tag.
-        # @param used_by_entity [String]
-        #      The name of the user to be removed from the   :attr:`Com::Vmware::Cis::Tagging::TagModel.used_by`    set .
-        # @return [Void]
-        # @raise [Com::Vmware::Vapi::Std::Errors::NotFound]
-        #      if the tag for the given  ``tag_id``  does not exist in the system.
-        # @raise [Com::Vmware::Vapi::Std::Errors::Unauthorized]
-        #      if you do not have the privilege to remove an entity from the   :attr:`Com::Vmware::Cis::Tagging::TagModel.used_by`   field.
-        def remove_from_used_by(tag_id, used_by_entity)
-            invoke_with_info(@@remove_from_used_by_info, {
-                'tag_id' => tag_id,
-                'used_by_entity' => used_by_entity,
-            })
-        end
-
-
-        # Revokes all propagating permissions on the given tag. You should then attach a direct permission with tagging privileges on the given tag. To invoke this  method , you need tag related privileges (direct or propagating) on the concerned tag.
-        #
-        # @param tag_id [String]
-        #      The identifier of the input tag.
-        # @return [Void]
-        # @raise [Com::Vmware::Vapi::Std::Errors::NotFound]
-        #      if the tag for the given  ``tag_id``  does not exist in the system.
-        # @raise [Com::Vmware::Vapi::Std::Errors::Unauthorized]
-        #      if you do not have the privilege to revoke propagating permissions on the tag.
-        def revoke_propagating_permissions(tag_id)
-            invoke_with_info(@@revoke_propagating_permissions_info, {
-                'tag_id' => tag_id,
-            })
-        end
-
-
-
-        # The  ``Com::Vmware::Cis::Tagging::Tag::CreateSpec``   class  describes a tag.  
-        # 
-        #  Use the   :func:`Com::Vmware::Cis::Tagging::Tag.create`    method  to create a tag defined by the create specification.
-        # @!attribute [rw] name
-        #     @return [String]
-        #     The display name of the tag. The name must be unique within its category.
-        # @!attribute [rw] description
-        #     @return [String]
-        #     The description of the tag.
-        # @!attribute [rw] category_id
-        #     @return [String]
-        #     The unique identifier of the parent category in which this tag will be created.
-        class CreateSpec < VAPI::Bindings::VapiStruct
-
-            class << self
-                # Holds (gets or creates) the binding type metadata for this structure type.
-                # @scope class
-                # @return [VAPI::Bindings::StructType] the binding type
-                def binding_type
-                    @binding_type ||= VAPI::Bindings::StructType.new(
-                        'com.vmware.cis.tagging.tag.create_spec',
-                        {
-                            'name' => VAPI::Bindings::StringType.instance,
-                            'description' => VAPI::Bindings::StringType.instance,
-                            'category_id' => VAPI::Bindings::IdType.new(resource_types='com.vmware.cis.tagging.Category'),
-                        },
-                        CreateSpec,
-                        false,
-                        nil)
-                end
-            end
-
-            attr_accessor :name,
-                          :description,
-                          :category_id
-
-            # Constructs a new instance.
-            # @param ruby_values [Hash] a map of initial property values (optional)
-            # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
-            def initialize(ruby_values=nil, struct_value=nil)
-                super(self.class.binding_type, ruby_values, struct_value)
-            end
-        end
-
-
-        # The  ``Com::Vmware::Cis::Tagging::Tag::UpdateSpec``   class  describes the updates to be made to an existing tag.  
-        # 
-        #  Use the   :func:`Com::Vmware::Cis::Tagging::Tag.update`    method  to modify a tag. When you call the  method , you specify the tag identifier. You obtain the tag identifier when you call the   :func:`Com::Vmware::Cis::Tagging::Tag.create`    method . You can also retrieve an identifier by using the   :func:`Com::Vmware::Cis::Tagging::Tag.list`    method .
-        # @!attribute [rw] name
-        #     @return [String, nil]
-        #     The display name of the tag.
-        #     If  nil  the name will not be modified.
-        # @!attribute [rw] description
-        #     @return [String, nil]
-        #     The description of the tag.
-        #     If  nil  the description will not be modified.
-        class UpdateSpec < VAPI::Bindings::VapiStruct
-
-            class << self
-                # Holds (gets or creates) the binding type metadata for this structure type.
-                # @scope class
-                # @return [VAPI::Bindings::StructType] the binding type
-                def binding_type
-                    @binding_type ||= VAPI::Bindings::StructType.new(
-                        'com.vmware.cis.tagging.tag.update_spec',
-                        {
-                            'name' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::StringType.instance),
-                            'description' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::StringType.instance),
-                        },
-                        UpdateSpec,
-                        false,
-                        nil)
-                end
-            end
-
-            attr_accessor :name,
-                          :description
-
-            # Constructs a new instance.
-            # @param ruby_values [Hash] a map of initial property values (optional)
-            # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
-            def initialize(ruby_values=nil, struct_value=nil)
-                super(self.class.binding_type, ruby_values, struct_value)
-            end
-        end
-
-
+    # Creates a category. To invoke this  method , you need the create category privilege.
+    #
+    # @param create_spec [Com::Vmware::Cis::Tagging::Category::CreateSpec]
+    #      Specification for the new category to be created.
+    # @return [String]
+    #     The identifier of the created category.
+    # @raise [Com::Vmware::Vapi::Std::Errors::AlreadyExists]
+    #      if the   :attr:`Com::Vmware::Cis::Tagging::Category::CreateSpec.name`   provided in the  ``create_spec``  is the name of an already existing category.
+    # @raise [Com::Vmware::Vapi::Std::Errors::InvalidArgument]
+    #      if any of the information in the  ``create_spec``  is invalid.
+    # @raise [Com::Vmware::Vapi::Std::Errors::Unauthorized]
+    #      if you do not have the privilege to create a category.
+    def create(create_spec)
+      invoke_with_info(CREATE_INFO,
+                       'create_spec' => create_spec)
     end
 
-
-    # The  ``Com::Vmware::Cis::Tagging::TagAssociation``   class  provides  methods  to attach, detach, and query tags.
-    class TagAssociation < VAPI::Bindings::VapiService
-
-        protected
-
-        # static metamodel definitions
-        @@service_id = VAPI::Core::ServiceIdentifier.new('com.vmware.cis.tagging.tag_association')
-
-        @@attach_info = VAPI::Bindings::OperationInfo.new(
-            VAPI::Core::OperationIdentifier.new('attach', @@service_id),
-            VAPI::Bindings::OperationInputType.new({
-                'tag_id' => VAPI::Bindings::IdType.new(resource_types='com.vmware.cis.tagging.Tag'),
-                'object_id' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::DynamicID'),
-            }),
-            VAPI::Bindings::VoidType.instance,
-            {
-                'com.vmware.vapi.std.errors.not_found' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::NotFound'),
-                'com.vmware.vapi.std.errors.invalid_argument' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::InvalidArgument'),
-                'com.vmware.vapi.std.errors.unauthorized' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Unauthorized'),
-
-            },
-            [],
-            [])
-        @@attach_multiple_tags_to_object_info = VAPI::Bindings::OperationInfo.new(
-            VAPI::Core::OperationIdentifier.new('attach_multiple_tags_to_object', @@service_id),
-            VAPI::Bindings::OperationInputType.new({
-                'object_id' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::DynamicID'),
-                'tag_ids' => VAPI::Bindings::ListType.new(VAPI::Bindings::IdType.new),
-            }),
-            VAPI::Bindings::ReferenceType.new('Com::Vmware::Cis::Tagging::TagAssociation::BatchResult'),
-            {
-                'com.vmware.vapi.std.errors.unauthorized' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Unauthorized'),
-
-            },
-            [],
-            [])
-        @@attach_tag_to_multiple_objects_info = VAPI::Bindings::OperationInfo.new(
-            VAPI::Core::OperationIdentifier.new('attach_tag_to_multiple_objects', @@service_id),
-            VAPI::Bindings::OperationInputType.new({
-                'tag_id' => VAPI::Bindings::IdType.new(resource_types='com.vmware.cis.tagging.Tag'),
-                'object_ids' => VAPI::Bindings::ListType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::DynamicID')),
-            }),
-            VAPI::Bindings::ReferenceType.new('Com::Vmware::Cis::Tagging::TagAssociation::BatchResult'),
-            {
-                'com.vmware.vapi.std.errors.not_found' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::NotFound'),
-                'com.vmware.vapi.std.errors.unauthorized' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Unauthorized'),
-
-            },
-            [],
-            [])
-        @@detach_info = VAPI::Bindings::OperationInfo.new(
-            VAPI::Core::OperationIdentifier.new('detach', @@service_id),
-            VAPI::Bindings::OperationInputType.new({
-                'tag_id' => VAPI::Bindings::IdType.new(resource_types='com.vmware.cis.tagging.Tag'),
-                'object_id' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::DynamicID'),
-            }),
-            VAPI::Bindings::VoidType.instance,
-            {
-                'com.vmware.vapi.std.errors.not_found' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::NotFound'),
-                'com.vmware.vapi.std.errors.unauthorized' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Unauthorized'),
-
-            },
-            [],
-            [])
-        @@detach_multiple_tags_from_object_info = VAPI::Bindings::OperationInfo.new(
-            VAPI::Core::OperationIdentifier.new('detach_multiple_tags_from_object', @@service_id),
-            VAPI::Bindings::OperationInputType.new({
-                'object_id' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::DynamicID'),
-                'tag_ids' => VAPI::Bindings::ListType.new(VAPI::Bindings::IdType.new),
-            }),
-            VAPI::Bindings::ReferenceType.new('Com::Vmware::Cis::Tagging::TagAssociation::BatchResult'),
-            {
-                'com.vmware.vapi.std.errors.unauthorized' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Unauthorized'),
-
-            },
-            [],
-            [])
-        @@detach_tag_from_multiple_objects_info = VAPI::Bindings::OperationInfo.new(
-            VAPI::Core::OperationIdentifier.new('detach_tag_from_multiple_objects', @@service_id),
-            VAPI::Bindings::OperationInputType.new({
-                'tag_id' => VAPI::Bindings::IdType.new(resource_types='com.vmware.cis.tagging.Tag'),
-                'object_ids' => VAPI::Bindings::ListType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::DynamicID')),
-            }),
-            VAPI::Bindings::ReferenceType.new('Com::Vmware::Cis::Tagging::TagAssociation::BatchResult'),
-            {
-                'com.vmware.vapi.std.errors.not_found' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::NotFound'),
-                'com.vmware.vapi.std.errors.unauthorized' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Unauthorized'),
-
-            },
-            [],
-            [])
-        @@list_attached_objects_info = VAPI::Bindings::OperationInfo.new(
-            VAPI::Core::OperationIdentifier.new('list_attached_objects', @@service_id),
-            VAPI::Bindings::OperationInputType.new({
-                'tag_id' => VAPI::Bindings::IdType.new(resource_types='com.vmware.cis.tagging.Tag'),
-            }),
-            VAPI::Bindings::ListType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::DynamicID')),
-            {
-                'com.vmware.vapi.std.errors.not_found' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::NotFound'),
-                'com.vmware.vapi.std.errors.unauthorized' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Unauthorized'),
-
-            },
-            [],
-            [])
-        @@list_attached_objects_on_tags_info = VAPI::Bindings::OperationInfo.new(
-            VAPI::Core::OperationIdentifier.new('list_attached_objects_on_tags', @@service_id),
-            VAPI::Bindings::OperationInputType.new({
-                'tag_ids' => VAPI::Bindings::ListType.new(VAPI::Bindings::IdType.new),
-            }),
-            VAPI::Bindings::ListType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Cis::Tagging::TagAssociation::TagToObjects')),
-            {},
-            [],
-            [])
-        @@list_attached_tags_info = VAPI::Bindings::OperationInfo.new(
-            VAPI::Core::OperationIdentifier.new('list_attached_tags', @@service_id),
-            VAPI::Bindings::OperationInputType.new({
-                'object_id' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::DynamicID'),
-            }),
-            VAPI::Bindings::ListType.new(VAPI::Bindings::IdType.new),
-            {
-                'com.vmware.vapi.std.errors.unauthorized' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Unauthorized'),
-
-            },
-            [],
-            [])
-        @@list_attached_tags_on_objects_info = VAPI::Bindings::OperationInfo.new(
-            VAPI::Core::OperationIdentifier.new('list_attached_tags_on_objects', @@service_id),
-            VAPI::Bindings::OperationInputType.new({
-                'object_ids' => VAPI::Bindings::ListType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::DynamicID')),
-            }),
-            VAPI::Bindings::ListType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Cis::Tagging::TagAssociation::ObjectToTags')),
-            {},
-            [],
-            [])
-        @@list_attachable_tags_info = VAPI::Bindings::OperationInfo.new(
-            VAPI::Core::OperationIdentifier.new('list_attachable_tags', @@service_id),
-            VAPI::Bindings::OperationInputType.new({
-                'object_id' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::DynamicID'),
-            }),
-            VAPI::Bindings::ListType.new(VAPI::Bindings::IdType.new),
-            {
-                'com.vmware.vapi.std.errors.unauthorized' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Unauthorized'),
-
-            },
-            [],
-            [])
-
-        @@service_info = VAPI::Bindings::ServiceInfo.new(@@service_id, {
-            'attach' => @@attach_info,
-            'attach_multiple_tags_to_object' => @@attach_multiple_tags_to_object_info,
-            'attach_tag_to_multiple_objects' => @@attach_tag_to_multiple_objects_info,
-            'detach' => @@detach_info,
-            'detach_multiple_tags_from_object' => @@detach_multiple_tags_from_object_info,
-            'detach_tag_from_multiple_objects' => @@detach_tag_from_multiple_objects_info,
-            'list_attached_objects' => @@list_attached_objects_info,
-            'list_attached_objects_on_tags' => @@list_attached_objects_on_tags_info,
-            'list_attached_tags' => @@list_attached_tags_info,
-            'list_attached_tags_on_objects' => @@list_attached_tags_on_objects_info,
-            'list_attachable_tags' => @@list_attachable_tags_info,
-        })
-
-        public
-
-        # Constructs a new instance.
-        #
-        # @param config [VAPI::Bindings::StubConfig] A hash with the api provider details.
-        def initialize(config)
-            super(config, @@service_info)
-        end
-
-
-        # Attaches the given tag to the input object. The tag needs to meet the cardinality (  :attr:`Com::Vmware::Cis::Tagging::CategoryModel.cardinality`  ) and associability (  :attr:`Com::Vmware::Cis::Tagging::CategoryModel.associable_types`  ) criteria in order to be eligible for attachment. If the tag is already attached to the object, then this  method  is a no-op and an error will not be thrown. To invoke this  method , you need the attach tag privilege on the tag and the read privilege on the object.
-        #
-        # @param tag_id [String]
-        #      The identifier of the input tag.
-        # @param object_id [Com::Vmware::Vapi::Std::DynamicID]
-        #      The identifier of the input object.
-        # @return [Void]
-        # @raise [Com::Vmware::Vapi::Std::Errors::NotFound]
-        #      if the tag for the given  ``tag_id``  does not exist in the system.
-        # @raise [Com::Vmware::Vapi::Std::Errors::InvalidArgument]
-        #      if the input tag is not eligible to be attached to this object or if the  ``object_id``  is not valid.
-        # @raise [Com::Vmware::Vapi::Std::Errors::Unauthorized]
-        #      if you do not have the privilege to attach the tag or do not have the privilege to read the object.
-        def attach(tag_id, object_id)
-            invoke_with_info(@@attach_info, {
-                'tag_id' => tag_id,
-                'object_id' => object_id,
-            })
-        end
-
-
-        # Attaches the given tags to the input object. If a tag is already attached to the object, then the individual  method  is a no-op and an error will not be added to   :attr:`Com::Vmware::Cis::Tagging::TagAssociation::BatchResult.error_messages`  . To invoke this  method , you need the read privilege on the object and the attach tag privilege on each tag.
-        #
-        # @param object_id [Com::Vmware::Vapi::Std::DynamicID]
-        #      The identifier of the input object.
-        # @param tag_ids [Array<String>]
-        #      The identifiers of the input tags.
-        # @return [Com::Vmware::Cis::Tagging::TagAssociation::BatchResult]
-        #     The outcome of the batch  method  and the  list  of error messages (  :attr:`Com::Vmware::Cis::Tagging::TagAssociation::BatchResult.error_messages`  ) describing attachment failures.
-        # @raise [Com::Vmware::Vapi::Std::Errors::Unauthorized]
-        #      if you do not have the privilege to read the object.
-        def attach_multiple_tags_to_object(object_id, tag_ids)
-            invoke_with_info(@@attach_multiple_tags_to_object_info, {
-                'object_id' => object_id,
-                'tag_ids' => tag_ids,
-            })
-        end
-
-
-        # Attaches the given tag to the input objects. If a tag is already attached to the object, then the individual  method  is a no-op and an error will not be added to   :attr:`Com::Vmware::Cis::Tagging::TagAssociation::BatchResult.error_messages`  . To invoke this  method , you need the attach tag privilege on the tag and the read privilege on each object.
-        #
-        # @param tag_id [String]
-        #      The identifier of the input tag.
-        # @param object_ids [Array<Com::Vmware::Vapi::Std::DynamicID>]
-        #      The identifiers of the input objects.
-        # @return [Com::Vmware::Cis::Tagging::TagAssociation::BatchResult]
-        #     The outcome of the batch  method  and the  list  of error messages (  :attr:`Com::Vmware::Cis::Tagging::TagAssociation::BatchResult.error_messages`  ) describing attachment failures.
-        # @raise [Com::Vmware::Vapi::Std::Errors::NotFound]
-        #      if the tag for the given  ``tag_id``  does not exist in the system.
-        # @raise [Com::Vmware::Vapi::Std::Errors::Unauthorized]
-        #      if you do not have the attach tag privilege on the tag.
-        def attach_tag_to_multiple_objects(tag_id, object_ids)
-            invoke_with_info(@@attach_tag_to_multiple_objects_info, {
-                'tag_id' => tag_id,
-                'object_ids' => object_ids,
-            })
-        end
-
-
-        # Detaches the tag from the given object. If the tag is already removed from the object, then this  method  is a no-op and an error will not be thrown. To invoke this  method , you need the attach tag privilege on the tag and the read privilege on the object.
-        #
-        # @param tag_id [String]
-        #      The identifier of the input tag.
-        # @param object_id [Com::Vmware::Vapi::Std::DynamicID]
-        #      The identifier of the input object.
-        # @return [Void]
-        # @raise [Com::Vmware::Vapi::Std::Errors::NotFound]
-        #      if the tag for the given  ``tag_id``  does not exist in the system.
-        # @raise [Com::Vmware::Vapi::Std::Errors::Unauthorized]
-        #      if you do not have the privilege to detach the tag or do not have the privilege to read the given object.
-        def detach(tag_id, object_id)
-            invoke_with_info(@@detach_info, {
-                'tag_id' => tag_id,
-                'object_id' => object_id,
-            })
-        end
-
-
-        # Detaches the given tags from the input object. If a tag is already removed from the object, then the individual  method  is a no-op and an error will not be added to   :attr:`Com::Vmware::Cis::Tagging::TagAssociation::BatchResult.error_messages`  . To invoke this  method , you need the read privilege on the object and the attach tag privilege each tag.
-        #
-        # @param object_id [Com::Vmware::Vapi::Std::DynamicID]
-        #      The identifier of the input object.
-        # @param tag_ids [Array<String>]
-        #      The identifiers of the input tags.
-        # @return [Com::Vmware::Cis::Tagging::TagAssociation::BatchResult]
-        #     The outcome of the batch  method  and the  list  of error messages (  :attr:`Com::Vmware::Cis::Tagging::TagAssociation::BatchResult.error_messages`  ) describing detachment failures.
-        # @raise [Com::Vmware::Vapi::Std::Errors::Unauthorized]
-        #      if you do not have the privilege to read the object.
-        def detach_multiple_tags_from_object(object_id, tag_ids)
-            invoke_with_info(@@detach_multiple_tags_from_object_info, {
-                'object_id' => object_id,
-                'tag_ids' => tag_ids,
-            })
-        end
-
-
-        # Detaches the given tag from the input objects. If a tag is already removed from the object, then the individual  method  is a no-op and an error will not be added to   :attr:`Com::Vmware::Cis::Tagging::TagAssociation::BatchResult.error_messages`  . To invoke this  method , you need the attach tag privilege on the tag and the read privilege on each object.
-        #
-        # @param tag_id [String]
-        #      The identifier of the input tag.
-        # @param object_ids [Array<Com::Vmware::Vapi::Std::DynamicID>]
-        #      The identifiers of the input objects.
-        # @return [Com::Vmware::Cis::Tagging::TagAssociation::BatchResult]
-        #     The outcome of the batch  method  and the  list  of error messages (  :attr:`Com::Vmware::Cis::Tagging::TagAssociation::BatchResult.error_messages`  ) describing detachment failures.
-        # @raise [Com::Vmware::Vapi::Std::Errors::NotFound]
-        #      if the tag for the given tag does not exist in the system.
-        # @raise [Com::Vmware::Vapi::Std::Errors::Unauthorized]
-        #      if you do not have the attach tag privilege on the tag.
-        def detach_tag_from_multiple_objects(tag_id, object_ids)
-            invoke_with_info(@@detach_tag_from_multiple_objects_info, {
-                'tag_id' => tag_id,
-                'object_ids' => object_ids,
-            })
-        end
-
-
-        # Fetches the  list  of attached objects for the given tag. To invoke this  method , you need the read privilege on the input tag. Only those objects for which you have the read privilege will be returned.
-        #
-        # @param tag_id [String]
-        #      The identifier of the input tag.
-        # @return [Array<Com::Vmware::Vapi::Std::DynamicID>]
-        #     The  list  of attached object identifiers.
-        # @raise [Com::Vmware::Vapi::Std::Errors::NotFound]
-        #      if the tag for the given  ``tag_id``  does not exist in the system.
-        # @raise [Com::Vmware::Vapi::Std::Errors::Unauthorized]
-        #      if you do not have the privilege to read the tag.
-        def list_attached_objects(tag_id)
-            invoke_with_info(@@list_attached_objects_info, {
-                'tag_id' => tag_id,
-            })
-        end
-
-
-        # Fetches the  list  of   :class:`Com::Vmware::Cis::Tagging::TagAssociation::TagToObjects`   describing the input tag identifiers and the objects they are attached to. To invoke this  method , you need the read privilege on each input tag. The   :attr:`Com::Vmware::Cis::Tagging::TagAssociation::TagToObjects.object_ids`   will only contain those objects for which you have the read privilege.
-        #
-        # @param tag_ids [Array<String>]
-        #      The identifiers of the input tags.
-        # @return [Array<Com::Vmware::Cis::Tagging::TagAssociation::TagToObjects>]
-        #     The  list  of the tag identifiers to all object identifiers that each tag is attached to.
-        def list_attached_objects_on_tags(tag_ids)
-            invoke_with_info(@@list_attached_objects_on_tags_info, {
-                'tag_ids' => tag_ids,
-            })
-        end
-
-
-        # Fetches the  list  of tags attached to the given object. To invoke this  method , you need the read privilege on the input object. The  list  will only contain those tags for which you have the read privileges.
-        #
-        # @param object_id [Com::Vmware::Vapi::Std::DynamicID]
-        #      The identifier of the input object.
-        # @return [Array<String>]
-        #     The  list  of all tag identifiers that correspond to the tags attached to the given object.
-        # @raise [Com::Vmware::Vapi::Std::Errors::Unauthorized]
-        #      if you do not have the privilege to read the object.
-        def list_attached_tags(object_id)
-            invoke_with_info(@@list_attached_tags_info, {
-                'object_id' => object_id,
-            })
-        end
-
-
-        # Fetches the  list  of   :class:`Com::Vmware::Cis::Tagging::TagAssociation::ObjectToTags`   describing the input object identifiers and the tags attached to each object. To invoke this  method , you need the read privilege on each input object. The   :attr:`Com::Vmware::Cis::Tagging::TagAssociation::ObjectToTags.tag_ids`   will only contain those tags for which you have the read privilege.
-        #
-        # @param object_ids [Array<Com::Vmware::Vapi::Std::DynamicID>]
-        #      The identifiers of the input objects.
-        # @return [Array<Com::Vmware::Cis::Tagging::TagAssociation::ObjectToTags>]
-        #     The  list  of the object identifiers to all tag identifiers that are attached to that object.
-        def list_attached_tags_on_objects(object_ids)
-            invoke_with_info(@@list_attached_tags_on_objects_info, {
-                'object_ids' => object_ids,
-            })
-        end
-
-
-        # Fetches the  list  of attachable tags for the given object, omitting the tags that have already been attached. Criteria for attachability is calculated based on tagging cardinality (  :attr:`Com::Vmware::Cis::Tagging::CategoryModel.cardinality`  ) and associability (  :attr:`Com::Vmware::Cis::Tagging::CategoryModel.associable_types`  ) constructs. To invoke this  method , you need the read privilege on the input object. The  list  will only contain those tags for which you have read privileges.
-        #
-        # @param object_id [Com::Vmware::Vapi::Std::DynamicID]
-        #      The identifier of the input object.
-        # @return [Array<String>]
-        #     The  list  of tag identifiers that are eligible to be attached to the given object.
-        # @raise [Com::Vmware::Vapi::Std::Errors::Unauthorized]
-        #      if you do not have the privilege to read the object.
-        def list_attachable_tags(object_id)
-            invoke_with_info(@@list_attachable_tags_info, {
-                'object_id' => object_id,
-            })
-        end
-
-
-
-        # The  ``Com::Vmware::Cis::Tagging::TagAssociation::BatchResult``   class  describes the result of performing the same  method  on several tags or objects in a single invocation.
-        # @!attribute [rw] success
-        #     @return [Boolean]
-        #     This is true if the batch  method  completed without any errors. Otherwise it is false and all or some  methods  have failed.
-        # @!attribute [rw] error_messages
-        #     @return [Array<Com::Vmware::Vapi::Std::LocalizableMessage>]
-        #     The  list  of error messages.
-        class BatchResult < VAPI::Bindings::VapiStruct
-
-            class << self
-                # Holds (gets or creates) the binding type metadata for this structure type.
-                # @scope class
-                # @return [VAPI::Bindings::StructType] the binding type
-                def binding_type
-                    @binding_type ||= VAPI::Bindings::StructType.new(
-                        'com.vmware.cis.tagging.tag_association.batch_result',
-                        {
-                            'success' => VAPI::Bindings::BooleanType.instance,
-                            'error_messages' => VAPI::Bindings::ListType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::LocalizableMessage')),
-                        },
-                        BatchResult,
-                        false,
-                        nil)
-                end
-            end
-
-            attr_accessor :success,
-                          :error_messages
-
-            # Constructs a new instance.
-            # @param ruby_values [Hash] a map of initial property values (optional)
-            # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
-            def initialize(ruby_values=nil, struct_value=nil)
-                super(self.class.binding_type, ruby_values, struct_value)
-            end
-        end
-
-
-        # The  ``Com::Vmware::Cis::Tagging::TagAssociation::TagToObjects``   class  describes a tag and its related objects. Use the   :func:`Com::Vmware::Cis::Tagging::TagAssociation.list_attached_objects_on_tags`    method  to retrieve a  list  with each element containing a tag and the objects to which it is attached.
-        # @!attribute [rw] tag_id
-        #     @return [String]
-        #     The identifier of the tag.
-        # @!attribute [rw] object_ids
-        #     @return [Array<Com::Vmware::Vapi::Std::DynamicID>]
-        #     The identifiers of the related objects.
-        class TagToObjects < VAPI::Bindings::VapiStruct
-
-            class << self
-                # Holds (gets or creates) the binding type metadata for this structure type.
-                # @scope class
-                # @return [VAPI::Bindings::StructType] the binding type
-                def binding_type
-                    @binding_type ||= VAPI::Bindings::StructType.new(
-                        'com.vmware.cis.tagging.tag_association.tag_to_objects',
-                        {
-                            'tag_id' => VAPI::Bindings::IdType.new(resource_types='com.vmware.cis.tagging.Tag'),
-                            'object_ids' => VAPI::Bindings::ListType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::DynamicID')),
-                        },
-                        TagToObjects,
-                        false,
-                        nil)
-                end
-            end
-
-            attr_accessor :tag_id,
-                          :object_ids
-
-            # Constructs a new instance.
-            # @param ruby_values [Hash] a map of initial property values (optional)
-            # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
-            def initialize(ruby_values=nil, struct_value=nil)
-                super(self.class.binding_type, ruby_values, struct_value)
-            end
-        end
-
-
-        # The  ``Com::Vmware::Cis::Tagging::TagAssociation::ObjectToTags``   class  describes an object and its related tags. Use the   :func:`Com::Vmware::Cis::Tagging::TagAssociation.list_attached_tags_on_objects`    method  to retrieve a  list  with each element containing an object and the tags attached to it.
-        # @!attribute [rw] object_id
-        #     @return [Com::Vmware::Vapi::Std::DynamicID]
-        #     The identifier of the object.
-        # @!attribute [rw] tag_ids
-        #     @return [Array<String>]
-        #     The identifiers of the related tags.
-        class ObjectToTags < VAPI::Bindings::VapiStruct
-
-            class << self
-                # Holds (gets or creates) the binding type metadata for this structure type.
-                # @scope class
-                # @return [VAPI::Bindings::StructType] the binding type
-                def binding_type
-                    @binding_type ||= VAPI::Bindings::StructType.new(
-                        'com.vmware.cis.tagging.tag_association.object_to_tags',
-                        {
-                            'object_id' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::DynamicID'),
-                            'tag_ids' => VAPI::Bindings::ListType.new(VAPI::Bindings::IdType.new),
-                        },
-                        ObjectToTags,
-                        false,
-                        nil)
-                end
-            end
-
-            attr_accessor :object_id,
-                          :tag_ids
-
-            # Constructs a new instance.
-            # @param ruby_values [Hash] a map of initial property values (optional)
-            # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
-            def initialize(ruby_values=nil, struct_value=nil)
-                super(self.class.binding_type, ruby_values, struct_value)
-            end
-        end
-
-
+    # Fetches the category information for the given category identifier. In order to view the category information, you need the read privilege on the category.
+    #
+    # @param category_id [String]
+    #      The identifier of the input category.
+    # @return [Com::Vmware::Cis::Tagging::CategoryModel]
+    #     The   :class:`Com::Vmware::Cis::Tagging::CategoryModel`   that corresponds to  ``category_id`` .
+    # @raise [Com::Vmware::Vapi::Std::Errors::NotFound]
+    #      if the category for the given  ``category_id``  does not exist in the system.
+    # @raise [Com::Vmware::Vapi::Std::Errors::Unauthorized]
+    #      if you do not have the privilege to read the category.
+    def get(category_id)
+      invoke_with_info(GET_INFO,
+                       'category_id' => category_id)
     end
 
+    # Updates an existing category. To invoke this  method , you need the edit privilege on the category.
+    #
+    # @param category_id [String]
+    #      The identifier of the category to be updated.
+    # @param update_spec [Com::Vmware::Cis::Tagging::Category::UpdateSpec]
+    #      Specification to update the category.
+    # @return [Void]
+    # @raise [Com::Vmware::Vapi::Std::Errors::AlreadyExists]
+    #      if the   :attr:`Com::Vmware::Cis::Tagging::Category::UpdateSpec.name`   provided in the  ``update_spec``  is the name of an already existing category.
+    # @raise [Com::Vmware::Vapi::Std::Errors::InvalidArgument]
+    #      if any of the information in the  ``update_spec``  is invalid.
+    # @raise [Com::Vmware::Vapi::Std::Errors::NotFound]
+    #      if the category for the given  ``category_id``  does not exist in the system.
+    # @raise [Com::Vmware::Vapi::Std::Errors::Unauthorized]
+    #      if you do not have the privilege to update the category.
+    def update(category_id, update_spec)
+      invoke_with_info(UPDATE_INFO,
+                       'category_id' => category_id,
+                       'update_spec' => update_spec)
+    end
 
+    # Deletes an existing category. To invoke this  method , you need the delete privilege on the category.
+    #
+    # @param category_id [String]
+    #      The identifier of category to be deleted.
+    # @return [Void]
+    # @raise [Com::Vmware::Vapi::Std::Errors::NotFound]
+    #      if the category for the given  ``category_id``  does not exist in the system.
+    # @raise [Com::Vmware::Vapi::Std::Errors::Unauthorized]
+    #      if you do not have the privilege to delete the category.
+    def delete(category_id)
+      invoke_with_info(DELETE_INFO,
+                       'category_id' => category_id)
+    end
 
-    # The  ``Com::Vmware::Cis::Tagging::CategoryModel``   class  defines a category that is used to group one or more tags.
-    # @!attribute [rw] id
-    #     @return [String]
-    #     The unique identifier of the category.
+    # Enumerates the categories in the system. To invoke this  method , you need the read privilege on the individual categories. The  list  will only contain those categories for which you have read privileges.
+    #
+    # @return [Array<String>]
+    #     The  list  of resource identifiers for the categories in the system.
+    def list
+      invoke_with_info(LIST_INFO)
+    end
+
+    # Enumerates all categories for which the  ``used_by_entity``  is part of the   :attr:`Com::Vmware::Cis::Tagging::CategoryModel.used_by`   subscribers  set . To invoke this  method , you need the read privilege on the individual categories.
+    #
+    # @param used_by_entity [String]
+    #      The field on which the results will be filtered.
+    # @return [Array<String>]
+    #     The  list  of resource identifiers for the categories in the system that are used by  ``used_by_entity`` .
+    def list_used_categories(used_by_entity)
+      invoke_with_info(LIST_USED_CATEGORIES_INFO,
+                       'used_by_entity' => used_by_entity)
+    end
+
+    # Adds the  ``used_by_entity``  to the   :attr:`Com::Vmware::Cis::Tagging::CategoryModel.used_by`   subscribers  set  for the specified category. If the  ``used_by_entity``  is already in the  set , then this becomes an idempotent no-op. To invoke this  method , you need the modify   :attr:`Com::Vmware::Cis::Tagging::CategoryModel.used_by`   privilege on the category.
+    #
+    # @param category_id [String]
+    #      The identifier of the input category.
+    # @param used_by_entity [String]
+    #      The name of the user to be added to the   :attr:`Com::Vmware::Cis::Tagging::CategoryModel.used_by`    set .
+    # @return [Void]
+    # @raise [Com::Vmware::Vapi::Std::Errors::NotFound]
+    #      if the category for the given  ``category_id``  does not exist in the system.
+    # @raise [Com::Vmware::Vapi::Std::Errors::Unauthorized]
+    #      if you do not have the privilege to add an entity to the   :attr:`Com::Vmware::Cis::Tagging::CategoryModel.used_by`   field.
+    def add_to_used_by(category_id, used_by_entity)
+      invoke_with_info(ADD_TO_USED_BY_INFO,
+                       'category_id' => category_id,
+                       'used_by_entity' => used_by_entity)
+    end
+
+    # Removes the  ``used_by_entity``  from the   :attr:`Com::Vmware::Cis::Tagging::CategoryModel.used_by`   subscribers  set . If the  ``used_by_entity``  is not using this category, then this becomes a no-op. To invoke this  method , you need the modify   :attr:`Com::Vmware::Cis::Tagging::CategoryModel.used_by`   privilege on the category.
+    #
+    # @param category_id [String]
+    #      The identifier of the input category.
+    # @param used_by_entity [String]
+    #      The name of the user to be removed from the   :attr:`Com::Vmware::Cis::Tagging::CategoryModel.used_by`    set .
+    # @return [Void]
+    # @raise [Com::Vmware::Vapi::Std::Errors::NotFound]
+    #      if the category for the given  ``category_id``  does not exist in the system.
+    # @raise [Com::Vmware::Vapi::Std::Errors::Unauthorized]
+    #      if you do not have the privilege to remove an entity from the   :attr:`Com::Vmware::Cis::Tagging::CategoryModel.used_by`   field.
+    def remove_from_used_by(category_id, used_by_entity)
+      invoke_with_info(REMOVE_FROM_USED_BY_INFO,
+                       'category_id' => category_id,
+                       'used_by_entity' => used_by_entity)
+    end
+
+    # Revokes all propagating permissions on the given category. You should then attach a direct permission with tagging privileges on the given category. To invoke this  method , you need category related privileges (direct or propagating) on the concerned category.
+    #
+    # @param category_id [String]
+    #      The identifier of the input category.
+    # @return [Void]
+    # @raise [Com::Vmware::Vapi::Std::Errors::NotFound]
+    #      if the category for the given  ``category_id``  does not exist in the system.
+    # @raise [Com::Vmware::Vapi::Std::Errors::Unauthorized]
+    #      if you do not have the privilege to revoke propagating permissions on the category.
+    def revoke_propagating_permissions(category_id)
+      invoke_with_info(REVOKE_PROPAGATING_PERMISSIONS_INFO,
+                       'category_id' => category_id)
+    end
+
+    # The  ``Com::Vmware::Cis::Tagging::Category::CreateSpec``   class  is used to create a category.  
+    # 
+    #  Use the   :func:`Com::Vmware::Cis::Tagging::Category.create`    method  to create a category defined by the create specification.
     # @!attribute [rw] name
     #     @return [String]
     #     The display name of the category.
@@ -1338,158 +316,1112 @@ module Com::Vmware::Cis::Tagging
     #     The associated cardinality ( ``SINGLE``, ``MULTIPLE`` ) of the category.
     # @!attribute [rw] associable_types
     #     @return [Set<String>]
-    #     The types of objects that the tags in this category can be attached to. If the  set  is empty, then tags can be attached to all types of objects. This field works only for objects that reside in Inventory Service (IS). For non IS objects, this check is not performed today and hence a tag can be attached to any non IS object.
-    # @!attribute [rw] used_by
-    #     @return [Set<String>]
-    #     The  set  of users that can use this category. To add users to this, you need to have the edit privilege on the category. Similarly, to unsubscribe from this category, you need the edit privilege on the category. You should not modify other users subscription from this  set .
-    class CategoryModel < VAPI::Bindings::VapiStruct
-
-        class << self
-            # Holds (gets or creates) the binding type metadata for this structure type.
-            # @scope class
-            # @return [VAPI::Bindings::StructType] the binding type
-            def binding_type
-                @binding_type ||= VAPI::Bindings::StructType.new(
-                    'com.vmware.cis.tagging.category_model',
-                    {
-                        'id' => VAPI::Bindings::IdType.new(resource_types='com.vmware.cis.tagging.Category'),
-                        'name' => VAPI::Bindings::StringType.instance,
-                        'description' => VAPI::Bindings::StringType.instance,
-                        'cardinality' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Cis::Tagging::CategoryModel::Cardinality'),
-                        'associable_types' => VAPI::Bindings::SetType.new(VAPI::Bindings::StringType.instance),
-                        'used_by' => VAPI::Bindings::SetType.new(VAPI::Bindings::StringType.instance),
-                    },
-                    CategoryModel,
-                    true,
-                    ["id"])
-            end
+    #     Object types to which this category's tags can be attached.
+    class CreateSpec < VAPI::Bindings::VapiStruct
+      class << self
+        # Holds (gets or creates) the binding type metadata for this structure type.
+        # @scope class
+        # @return [VAPI::Bindings::StructType] the binding type
+        def binding_type
+          @binding_type ||= VAPI::Bindings::StructType.new(
+            'com.vmware.cis.tagging.category.create_spec',
+            {
+              'name' => VAPI::Bindings::StringType.instance,
+              'description' => VAPI::Bindings::StringType.instance,
+              'cardinality' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Cis::Tagging::CategoryModel::Cardinality'),
+              'associable_types' => VAPI::Bindings::SetType.new(VAPI::Bindings::StringType.instance)
+            },
+            CreateSpec,
+            false,
+            nil
+          )
         end
+      end
 
-        attr_accessor :id,
-                      :name,
-                      :description,
-                      :cardinality,
-                      :associable_types,
-                      :used_by
+      attr_accessor :name,
+                    :description,
+                    :cardinality,
+                    :associable_types
 
-        # Constructs a new instance.
-        # @param ruby_values [Hash] a map of initial property values (optional)
-        # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
-        def initialize(ruby_values=nil, struct_value=nil)
-            super(self.class.binding_type, ruby_values, struct_value)
-        end
-
-
-        # The  ``Com::Vmware::Cis::Tagging::CategoryModel::Cardinality``   enumerated type  defines the number of tags in a category that can be assigned to an object.
-        # @!attribute [rw] single
-        #     @return [Com::Vmware::Cis::Tagging::CategoryModel::Cardinality]
-        #     An object can only be assigned one of the tags in this category. For example, if a category is "Operating System", then different tags of this category would be "Windows", "Linux", and so on. In this case a VM object can be assigned only one of these tags and hence the cardinality of the associated category here is single.
-        # @!attribute [rw] multiple
-        #     @return [Com::Vmware::Cis::Tagging::CategoryModel::Cardinality]
-        #     An object can be assigned several of the tags in this category. For example, if a category is "Server", then different tags of this category would be "AppServer", "DatabaseServer" and so on. In this case a VM object can be assigned more than one of the above tags and hence the cardinality of the associated category here is multiple.
-        class Cardinality < VAPI::Bindings::VapiEnum
-
-            class << self
-                # Holds (gets or creates) the binding type metadata for this enumeration type.
-                # @scope class
-                # @return [VAPI::Bindings::EnumType] the binding type
-                def binding_type
-                    @binding_type ||= VAPI::Bindings::EnumType.new(
-                        'com.vmware.cis.tagging.category_model.cardinality',
-                        Cardinality)
-                end
-
-                # Converts from a string value (perhaps off the wire) to an instance
-                # of this enum type.
-                # @param value [String] the actual value of the enum instance
-                # @return [Cardinality] the instance found for the value, otherwise
-                #         an unknown instance will be built for the value
-                def from_string(value)
-                    begin
-                        const_get(value)
-                    rescue NameError
-                        Cardinality.new('UNKNOWN', value)
-                    end
-                end
-            end
-
-            private
-
-            # Constructs a new instance.
-            # @param value [String] the actual value of the enum instance
-            # @param unknown [String] the unknown value when value is 'UKNOWN'
-            def initialize(value, unknown=nil)
-                super(self.class.binding_type, value, unknown)
-            end
-
-            public
-
-            # @!attribute [rw] single
-            #     @return [Com::Vmware::Cis::Tagging::CategoryModel::Cardinality]
-            #     An object can only be assigned one of the tags in this category. For example, if a category is "Operating System", then different tags of this category would be "Windows", "Linux", and so on. In this case a VM object can be assigned only one of these tags and hence the cardinality of the associated category here is single.
-            SINGLE = Cardinality.new('SINGLE')
-
-            # @!attribute [rw] multiple
-            #     @return [Com::Vmware::Cis::Tagging::CategoryModel::Cardinality]
-            #     An object can be assigned several of the tags in this category. For example, if a category is "Server", then different tags of this category would be "AppServer", "DatabaseServer" and so on. In this case a VM object can be assigned more than one of the above tags and hence the cardinality of the associated category here is multiple.
-            MULTIPLE = Cardinality.new('MULTIPLE')
-
-        end
-
-
+      # Constructs a new instance.
+      # @param ruby_values [Hash] a map of initial property values (optional)
+      # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
+      def initialize(ruby_values = nil, struct_value = nil)
+        super(self.class.binding_type, ruby_values, struct_value)
+      end
     end
 
+    # The  ``Com::Vmware::Cis::Tagging::Category::UpdateSpec``   class  describes the updates to be made to an existing category.  
+    # 
+    #  Use the   :func:`Com::Vmware::Cis::Tagging::Category.update`    method  to modify a category. When you call the  method , specify the category identifier. You obtain the category identifier when you call the   :func:`Com::Vmware::Cis::Tagging::Category.create`    method . You can also retrieve an identifier by using the   :func:`Com::Vmware::Cis::Tagging::Category.list`    method .
+    # @!attribute [rw] name
+    #     @return [String, nil]
+    #     The display name of the category.
+    #     If  nil  the name will not be modified.
+    # @!attribute [rw] description
+    #     @return [String, nil]
+    #     The description of the category.
+    #     If  nil  the description will not be modified.
+    # @!attribute [rw] cardinality
+    #     @return [Com::Vmware::Cis::Tagging::CategoryModel::Cardinality, nil]
+    #     The associated cardinality ( ``SINGLE``, ``MULTIPLE`` ) of the category.
+    #     If  nil  the cardinality will not be modified.
+    # @!attribute [rw] associable_types
+    #     @return [Set<String>, nil]
+    #     Object types to which this category's tags can be attached.  
+    #     
+    #      The  set  of associable types cannot be updated incrementally. For example, if   :attr:`Com::Vmware::Cis::Tagging::Category::UpdateSpec.associable_types`   originally contains {A,B,C} and you want to add D, then you need to pass {A,B,C,D} in your update specification. You also cannot remove any item from this  set . For example, if you have {A,B,C}, then you cannot remove say {A} from it. Similarly, if you start with an empty  set , then that implies that you can tag any object and hence you cannot later pass say {A}, because that would be restricting the type of objects you want to tag. Thus, associable types can only grow and not shrink.
+    #     If  nil  the associable types will not be modified.
+    class UpdateSpec < VAPI::Bindings::VapiStruct
+      class << self
+        # Holds (gets or creates) the binding type metadata for this structure type.
+        # @scope class
+        # @return [VAPI::Bindings::StructType] the binding type
+        def binding_type
+          @binding_type ||= VAPI::Bindings::StructType.new(
+            'com.vmware.cis.tagging.category.update_spec',
+            {
+              'name' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::StringType.instance),
+              'description' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::StringType.instance),
+              'cardinality' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Cis::Tagging::CategoryModel::Cardinality')),
+              'associable_types' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::SetType.new(VAPI::Bindings::StringType.instance))
+            },
+            UpdateSpec,
+            false,
+            nil
+          )
+        end
+      end
 
-    # The  ``Com::Vmware::Cis::Tagging::TagModel``   class  defines a tag that can be attached to vSphere objects.
-    # @!attribute [rw] id
-    #     @return [String]
-    #     The unique identifier of the tag.
-    # @!attribute [rw] category_id
-    #     @return [String]
-    #     The identifier of the parent category in which this tag will be created.
+      attr_accessor :name,
+                    :description,
+                    :cardinality,
+                    :associable_types
+
+      # Constructs a new instance.
+      # @param ruby_values [Hash] a map of initial property values (optional)
+      # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
+      def initialize(ruby_values = nil, struct_value = nil)
+        super(self.class.binding_type, ruby_values, struct_value)
+      end
+    end
+
+  end
+  # The  ``Com::Vmware::Cis::Tagging::Tag``   class  provides  methods  to create, read, update, delete, and enumerate tags.
+  class Tag < VAPI::Bindings::VapiService
+    # static metamodel definitions
+    SERVICE_ID = VAPI::Core::ServiceIdentifier.new('com.vmware.cis.tagging.tag')
+
+    CREATE_INFO = VAPI::Bindings::OperationInfo.new(
+      VAPI::Core::OperationIdentifier.new('create', SERVICE_ID),
+      VAPI::Bindings::OperationInputType.new(
+        'create_spec' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Cis::Tagging::Tag::CreateSpec')
+      ),
+      VAPI::Bindings::IdType.new('com.vmware.cis.tagging.Tag'),
+      {
+        'com.vmware.vapi.std.errors.already_exists' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::AlreadyExists'),
+        'com.vmware.vapi.std.errors.invalid_argument' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::InvalidArgument'),
+        'com.vmware.vapi.std.errors.not_found' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::NotFound'),
+        'com.vmware.vapi.std.errors.unauthorized' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Unauthorized')
+      },
+      [],
+      []
+    )
+
+    GET_INFO = VAPI::Bindings::OperationInfo.new(
+      VAPI::Core::OperationIdentifier.new('get', SERVICE_ID),
+      VAPI::Bindings::OperationInputType.new(
+        'tag_id' => VAPI::Bindings::IdType.new('com.vmware.cis.tagging.Tag')
+      ),
+      VAPI::Bindings::ReferenceType.new('Com::Vmware::Cis::Tagging::TagModel'),
+      {
+        'com.vmware.vapi.std.errors.not_found' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::NotFound'),
+        'com.vmware.vapi.std.errors.unauthorized' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Unauthorized')
+      },
+      [],
+      []
+    )
+
+    UPDATE_INFO = VAPI::Bindings::OperationInfo.new(
+      VAPI::Core::OperationIdentifier.new('update', SERVICE_ID),
+      VAPI::Bindings::OperationInputType.new(
+        'tag_id' => VAPI::Bindings::IdType.new('com.vmware.cis.tagging.Tag'),
+        'update_spec' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Cis::Tagging::Tag::UpdateSpec')
+      ),
+      VAPI::Bindings::VoidType.instance,
+      {
+        'com.vmware.vapi.std.errors.already_exists' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::AlreadyExists'),
+        'com.vmware.vapi.std.errors.invalid_argument' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::InvalidArgument'),
+        'com.vmware.vapi.std.errors.not_found' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::NotFound'),
+        'com.vmware.vapi.std.errors.unauthorized' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Unauthorized')
+      },
+      [],
+      []
+    )
+
+    DELETE_INFO = VAPI::Bindings::OperationInfo.new(
+      VAPI::Core::OperationIdentifier.new('delete', SERVICE_ID),
+      VAPI::Bindings::OperationInputType.new(
+        'tag_id' => VAPI::Bindings::IdType.new('com.vmware.cis.tagging.Tag')
+      ),
+      VAPI::Bindings::VoidType.instance,
+      {
+        'com.vmware.vapi.std.errors.not_found' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::NotFound'),
+        'com.vmware.vapi.std.errors.unauthorized' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Unauthorized')
+      },
+      [],
+      []
+    )
+
+    LIST_INFO = VAPI::Bindings::OperationInfo.new(
+      VAPI::Core::OperationIdentifier.new('list', SERVICE_ID),
+      VAPI::Bindings::OperationInputType.new,
+      VAPI::Bindings::ListType.new(VAPI::Bindings::IdType.new),
+      {},
+      [],
+      []
+    )
+
+    LIST_USED_TAGS_INFO = VAPI::Bindings::OperationInfo.new(
+      VAPI::Core::OperationIdentifier.new('list_used_tags', SERVICE_ID),
+      VAPI::Bindings::OperationInputType.new(
+        'used_by_entity' => VAPI::Bindings::StringType.instance
+      ),
+      VAPI::Bindings::ListType.new(VAPI::Bindings::IdType.new),
+      {},
+      [],
+      []
+    )
+
+    LIST_TAGS_FOR_CATEGORY_INFO = VAPI::Bindings::OperationInfo.new(
+      VAPI::Core::OperationIdentifier.new('list_tags_for_category', SERVICE_ID),
+      VAPI::Bindings::OperationInputType.new(
+        'category_id' => VAPI::Bindings::IdType.new('com.vmware.cis.tagging.Category')
+      ),
+      VAPI::Bindings::ListType.new(VAPI::Bindings::IdType.new),
+      {
+        'com.vmware.vapi.std.errors.not_found' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::NotFound'),
+        'com.vmware.vapi.std.errors.unauthorized' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Unauthorized')
+      },
+      [],
+      []
+    )
+
+    ADD_TO_USED_BY_INFO = VAPI::Bindings::OperationInfo.new(
+      VAPI::Core::OperationIdentifier.new('add_to_used_by', SERVICE_ID),
+      VAPI::Bindings::OperationInputType.new(
+        'tag_id' => VAPI::Bindings::IdType.new('com.vmware.cis.tagging.Tag'),
+        'used_by_entity' => VAPI::Bindings::StringType.instance
+      ),
+      VAPI::Bindings::VoidType.instance,
+      {
+        'com.vmware.vapi.std.errors.not_found' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::NotFound'),
+        'com.vmware.vapi.std.errors.unauthorized' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Unauthorized')
+      },
+      [],
+      []
+    )
+
+    REMOVE_FROM_USED_BY_INFO = VAPI::Bindings::OperationInfo.new(
+      VAPI::Core::OperationIdentifier.new('remove_from_used_by', SERVICE_ID),
+      VAPI::Bindings::OperationInputType.new(
+        'tag_id' => VAPI::Bindings::IdType.new('com.vmware.cis.tagging.Tag'),
+        'used_by_entity' => VAPI::Bindings::StringType.instance
+      ),
+      VAPI::Bindings::VoidType.instance,
+      {
+        'com.vmware.vapi.std.errors.not_found' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::NotFound'),
+        'com.vmware.vapi.std.errors.unauthorized' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Unauthorized')
+      },
+      [],
+      []
+    )
+
+    REVOKE_PROPAGATING_PERMISSIONS_INFO = VAPI::Bindings::OperationInfo.new(
+      VAPI::Core::OperationIdentifier.new('revoke_propagating_permissions', SERVICE_ID),
+      VAPI::Bindings::OperationInputType.new(
+        'tag_id' => VAPI::Bindings::IdType.new('com.vmware.cis.tagging.Tag')
+      ),
+      VAPI::Bindings::VoidType.instance,
+      {
+        'com.vmware.vapi.std.errors.not_found' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::NotFound'),
+        'com.vmware.vapi.std.errors.unauthorized' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Unauthorized')
+      },
+      [],
+      []
+    )
+
+    SERVICE_INFO = VAPI::Bindings::ServiceInfo.new(
+      SERVICE_ID,
+      'create' => CREATE_INFO,
+      'get' => GET_INFO,
+      'update' => UPDATE_INFO,
+      'delete' => DELETE_INFO,
+      'list' => LIST_INFO,
+      'list_used_tags' => LIST_USED_TAGS_INFO,
+      'list_tags_for_category' => LIST_TAGS_FOR_CATEGORY_INFO,
+      'add_to_used_by' => ADD_TO_USED_BY_INFO,
+      'remove_from_used_by' => REMOVE_FROM_USED_BY_INFO,
+      'revoke_propagating_permissions' => REVOKE_PROPAGATING_PERMISSIONS_INFO
+    )
+
+    # Constructs a new instance.
+    #
+    # @param config [VAPI::Bindings::StubConfig] A hash with the api provider details.
+    def initialize(config)
+      super(config, SERVICE_INFO)
+    end
+
+    # Creates a tag. To invoke this  method , you need the create tag privilege on the input category.
+    #
+    # @param create_spec [Com::Vmware::Cis::Tagging::Tag::CreateSpec]
+    #      Specification for the new tag to be created.
+    # @return [String]
+    #     The identifier of the created tag.
+    # @raise [Com::Vmware::Vapi::Std::Errors::AlreadyExists]
+    #      if the   :attr:`Com::Vmware::Cis::Tagging::Tag::CreateSpec.name`   provided in the  ``create_spec``  is the name of an already existing tag in the input category.
+    # @raise [Com::Vmware::Vapi::Std::Errors::InvalidArgument]
+    #      if any of the input information in the  ``create_spec``  is invalid.
+    # @raise [Com::Vmware::Vapi::Std::Errors::NotFound]
+    #      if the category for in the given  ``create_spec``  does not exist in the system.
+    # @raise [Com::Vmware::Vapi::Std::Errors::Unauthorized]
+    #      if you do not have the privilege to create tag.
+    def create(create_spec)
+      invoke_with_info(CREATE_INFO,
+                       'create_spec' => create_spec)
+    end
+
+    # Fetches the tag information for the given tag identifier. To invoke this  method , you need the read privilege on the tag in order to view the tag info.
+    #
+    # @param tag_id [String]
+    #      The identifier of the input tag.
+    # @return [Com::Vmware::Cis::Tagging::TagModel]
+    #     The   :class:`Com::Vmware::Cis::Tagging::TagModel`   that corresponds to  ``tag_id`` .
+    # @raise [Com::Vmware::Vapi::Std::Errors::NotFound]
+    #      if the tag for the given  ``tag_id``  does not exist in the system.
+    # @raise [Com::Vmware::Vapi::Std::Errors::Unauthorized]
+    #      if the user does not have the privilege to read the tag.
+    def get(tag_id)
+      invoke_with_info(GET_INFO,
+                       'tag_id' => tag_id)
+    end
+
+    # Updates an existing tag. To invoke this  method , you need the edit privilege on the tag.
+    #
+    # @param tag_id [String]
+    #      The identifier of the input tag.
+    # @param update_spec [Com::Vmware::Cis::Tagging::Tag::UpdateSpec]
+    #      Specification to update the tag.
+    # @return [Void]
+    # @raise [Com::Vmware::Vapi::Std::Errors::AlreadyExists]
+    #      if the   :attr:`Com::Vmware::Cis::Tagging::Tag::UpdateSpec.name`   provided in the  ``update_spec``  is the name of an already existing tag in the same category.
+    # @raise [Com::Vmware::Vapi::Std::Errors::InvalidArgument]
+    #      if any of the input information in the  ``update_spec``  is invalid.
+    # @raise [Com::Vmware::Vapi::Std::Errors::NotFound]
+    #      if the tag for the given  ``tag_id``  does not exist in the system.
+    # @raise [Com::Vmware::Vapi::Std::Errors::Unauthorized]
+    #      if you do not have the privilege to update the tag.
+    def update(tag_id, update_spec)
+      invoke_with_info(UPDATE_INFO,
+                       'tag_id' => tag_id,
+                       'update_spec' => update_spec)
+    end
+
+    # Deletes an existing tag. To invoke this  method , you need the delete privilege on the tag.
+    #
+    # @param tag_id [String]
+    #      The identifier of the input tag.
+    # @return [Void]
+    # @raise [Com::Vmware::Vapi::Std::Errors::NotFound]
+    #      if the tag for the given  ``tag_id``  does not exist in the system.
+    # @raise [Com::Vmware::Vapi::Std::Errors::Unauthorized]
+    #      if you do not have the privilege to delete the tag.
+    def delete(tag_id)
+      invoke_with_info(DELETE_INFO,
+                       'tag_id' => tag_id)
+    end
+
+    # Enumerates the tags in the system. To invoke this  method , you need read privilege on the individual tags. The  list  will only contain tags for which you have read privileges.
+    #
+    # @return [Array<String>]
+    #     The  list  of resource identifiers for the tags in the system.
+    def list
+      invoke_with_info(LIST_INFO)
+    end
+
+    # Enumerates all tags for which the  ``used_by_entity``  is part of the   :attr:`Com::Vmware::Cis::Tagging::TagModel.used_by`   subscribers  set . To invoke this  method , you need the read privilege on the individual tags.
+    #
+    # @param used_by_entity [String]
+    #      The field on which the results will be filtered.
+    # @return [Array<String>]
+    #     The  list  of resource identifiers for the tags in the system that are used by  ``used_by_entity`` .
+    def list_used_tags(used_by_entity)
+      invoke_with_info(LIST_USED_TAGS_INFO,
+                       'used_by_entity' => used_by_entity)
+    end
+
+    # Enumerates all tags for the given category. To invoke this  method , you need the read privilege on the given category and the individual tags in that category.
+    #
+    # @param category_id [String]
+    #      The identifier of the input category.
+    # @return [Array<String>]
+    #     The  list  of resource identifiers for the tags in the given input category.
+    # @raise [Com::Vmware::Vapi::Std::Errors::NotFound]
+    #      if the category for the given  ``category_id``  does not exist in the system.
+    # @raise [Com::Vmware::Vapi::Std::Errors::Unauthorized]
+    #      if you do not have the privilege to read the category.
+    def list_tags_for_category(category_id)
+      invoke_with_info(LIST_TAGS_FOR_CATEGORY_INFO,
+                       'category_id' => category_id)
+    end
+
+    # Adds the  ``used_by_entity``  to the   :attr:`Com::Vmware::Cis::Tagging::TagModel.used_by`   subscribers  set . If the  ``used_by_entity``  is already in the  set , then this becomes a no-op. To invoke this  method , you need the modify   :attr:`Com::Vmware::Cis::Tagging::TagModel.used_by`   privilege on the tag.
+    #
+    # @param tag_id [String]
+    #      The identifier of the input tag.
+    # @param used_by_entity [String]
+    #      The name of the user to be added to the   :attr:`Com::Vmware::Cis::Tagging::TagModel.used_by`    set .
+    # @return [Void]
+    # @raise [Com::Vmware::Vapi::Std::Errors::NotFound]
+    #      if the tag for the given  ``tag_id``  does not exist in the system.
+    # @raise [Com::Vmware::Vapi::Std::Errors::Unauthorized]
+    #      if you do not have the privilege to add an entity to the   :attr:`Com::Vmware::Cis::Tagging::TagModel.used_by`   field.
+    def add_to_used_by(tag_id, used_by_entity)
+      invoke_with_info(ADD_TO_USED_BY_INFO,
+                       'tag_id' => tag_id,
+                       'used_by_entity' => used_by_entity)
+    end
+
+    # Removes the  ``used_by_entity``  from the   :attr:`Com::Vmware::Cis::Tagging::TagModel.used_by`   subscribers set. If the  ``used_by_entity``  is not using this tag, then this becomes a no-op. To invoke this  method , you need modify   :attr:`Com::Vmware::Cis::Tagging::TagModel.used_by`   privilege on the tag.
+    #
+    # @param tag_id [String]
+    #      The identifier of the input tag.
+    # @param used_by_entity [String]
+    #      The name of the user to be removed from the   :attr:`Com::Vmware::Cis::Tagging::TagModel.used_by`    set .
+    # @return [Void]
+    # @raise [Com::Vmware::Vapi::Std::Errors::NotFound]
+    #      if the tag for the given  ``tag_id``  does not exist in the system.
+    # @raise [Com::Vmware::Vapi::Std::Errors::Unauthorized]
+    #      if you do not have the privilege to remove an entity from the   :attr:`Com::Vmware::Cis::Tagging::TagModel.used_by`   field.
+    def remove_from_used_by(tag_id, used_by_entity)
+      invoke_with_info(REMOVE_FROM_USED_BY_INFO,
+                       'tag_id' => tag_id,
+                       'used_by_entity' => used_by_entity)
+    end
+
+    # Revokes all propagating permissions on the given tag. You should then attach a direct permission with tagging privileges on the given tag. To invoke this  method , you need tag related privileges (direct or propagating) on the concerned tag.
+    #
+    # @param tag_id [String]
+    #      The identifier of the input tag.
+    # @return [Void]
+    # @raise [Com::Vmware::Vapi::Std::Errors::NotFound]
+    #      if the tag for the given  ``tag_id``  does not exist in the system.
+    # @raise [Com::Vmware::Vapi::Std::Errors::Unauthorized]
+    #      if you do not have the privilege to revoke propagating permissions on the tag.
+    def revoke_propagating_permissions(tag_id)
+      invoke_with_info(REVOKE_PROPAGATING_PERMISSIONS_INFO,
+                       'tag_id' => tag_id)
+    end
+
+    # The  ``Com::Vmware::Cis::Tagging::Tag::CreateSpec``   class  describes a tag.  
+    # 
+    #  Use the   :func:`Com::Vmware::Cis::Tagging::Tag.create`    method  to create a tag defined by the create specification.
     # @!attribute [rw] name
     #     @return [String]
-    #     The display name of the tag.
+    #     The display name of the tag. The name must be unique within its category.
     # @!attribute [rw] description
     #     @return [String]
     #     The description of the tag.
-    # @!attribute [rw] used_by
-    #     @return [Set<String>]
-    #     The  set  of users that can use this tag. To add users to this, you need to have the edit privilege on the tag. Similarly, to unsubscribe from this tag, you need the edit privilege on the tag. You should not modify other users subscription from this  set .
-    class TagModel < VAPI::Bindings::VapiStruct
-
-        class << self
-            # Holds (gets or creates) the binding type metadata for this structure type.
-            # @scope class
-            # @return [VAPI::Bindings::StructType] the binding type
-            def binding_type
-                @binding_type ||= VAPI::Bindings::StructType.new(
-                    'com.vmware.cis.tagging.tag_model',
-                    {
-                        'id' => VAPI::Bindings::IdType.new(resource_types='com.vmware.cis.tagging.Tag'),
-                        'category_id' => VAPI::Bindings::IdType.new(resource_types='com.vmware.cis.tagging.Category'),
-                        'name' => VAPI::Bindings::StringType.instance,
-                        'description' => VAPI::Bindings::StringType.instance,
-                        'used_by' => VAPI::Bindings::SetType.new(VAPI::Bindings::StringType.instance),
-                    },
-                    TagModel,
-                    true,
-                    ["id"])
-            end
+    # @!attribute [rw] category_id
+    #     @return [String]
+    #     The unique identifier of the parent category in which this tag will be created.
+    class CreateSpec < VAPI::Bindings::VapiStruct
+      class << self
+        # Holds (gets or creates) the binding type metadata for this structure type.
+        # @scope class
+        # @return [VAPI::Bindings::StructType] the binding type
+        def binding_type
+          @binding_type ||= VAPI::Bindings::StructType.new(
+            'com.vmware.cis.tagging.tag.create_spec',
+            {
+              'name' => VAPI::Bindings::StringType.instance,
+              'description' => VAPI::Bindings::StringType.instance,
+              'category_id' => VAPI::Bindings::IdType.new('com.vmware.cis.tagging.Category')
+            },
+            CreateSpec,
+            false,
+            nil
+          )
         end
+      end
 
-        attr_accessor :id,
-                      :category_id,
-                      :name,
-                      :description,
-                      :used_by
+      attr_accessor :name,
+                    :description,
+                    :category_id
 
-        # Constructs a new instance.
-        # @param ruby_values [Hash] a map of initial property values (optional)
-        # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
-        def initialize(ruby_values=nil, struct_value=nil)
-            super(self.class.binding_type, ruby_values, struct_value)
-        end
+      # Constructs a new instance.
+      # @param ruby_values [Hash] a map of initial property values (optional)
+      # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
+      def initialize(ruby_values = nil, struct_value = nil)
+        super(self.class.binding_type, ruby_values, struct_value)
+      end
     end
 
+    # The  ``Com::Vmware::Cis::Tagging::Tag::UpdateSpec``   class  describes the updates to be made to an existing tag.  
+    # 
+    #  Use the   :func:`Com::Vmware::Cis::Tagging::Tag.update`    method  to modify a tag. When you call the  method , you specify the tag identifier. You obtain the tag identifier when you call the   :func:`Com::Vmware::Cis::Tagging::Tag.create`    method . You can also retrieve an identifier by using the   :func:`Com::Vmware::Cis::Tagging::Tag.list`    method .
+    # @!attribute [rw] name
+    #     @return [String, nil]
+    #     The display name of the tag.
+    #     If  nil  the name will not be modified.
+    # @!attribute [rw] description
+    #     @return [String, nil]
+    #     The description of the tag.
+    #     If  nil  the description will not be modified.
+    class UpdateSpec < VAPI::Bindings::VapiStruct
+      class << self
+        # Holds (gets or creates) the binding type metadata for this structure type.
+        # @scope class
+        # @return [VAPI::Bindings::StructType] the binding type
+        def binding_type
+          @binding_type ||= VAPI::Bindings::StructType.new(
+            'com.vmware.cis.tagging.tag.update_spec',
+            {
+              'name' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::StringType.instance),
+              'description' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::StringType.instance)
+            },
+            UpdateSpec,
+            false,
+            nil
+          )
+        end
+      end
+
+      attr_accessor :name,
+                    :description
+
+      # Constructs a new instance.
+      # @param ruby_values [Hash] a map of initial property values (optional)
+      # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
+      def initialize(ruby_values = nil, struct_value = nil)
+        super(self.class.binding_type, ruby_values, struct_value)
+      end
+    end
+
+  end
+  # The  ``Com::Vmware::Cis::Tagging::TagAssociation``   class  provides  methods  to attach, detach, and query tags.
+  class TagAssociation < VAPI::Bindings::VapiService
+    # static metamodel definitions
+    SERVICE_ID = VAPI::Core::ServiceIdentifier.new('com.vmware.cis.tagging.tag_association')
+
+    ATTACH_INFO = VAPI::Bindings::OperationInfo.new(
+      VAPI::Core::OperationIdentifier.new('attach', SERVICE_ID),
+      VAPI::Bindings::OperationInputType.new(
+        'tag_id' => VAPI::Bindings::IdType.new('com.vmware.cis.tagging.Tag'),
+        'object_id' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::DynamicID')
+      ),
+      VAPI::Bindings::VoidType.instance,
+      {
+        'com.vmware.vapi.std.errors.not_found' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::NotFound'),
+        'com.vmware.vapi.std.errors.invalid_argument' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::InvalidArgument'),
+        'com.vmware.vapi.std.errors.unauthorized' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Unauthorized')
+      },
+      [],
+      []
+    )
+
+    ATTACH_MULTIPLE_TAGS_TO_OBJECT_INFO = VAPI::Bindings::OperationInfo.new(
+      VAPI::Core::OperationIdentifier.new('attach_multiple_tags_to_object', SERVICE_ID),
+      VAPI::Bindings::OperationInputType.new(
+        'object_id' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::DynamicID'),
+        'tag_ids' => VAPI::Bindings::ListType.new(VAPI::Bindings::IdType.new)
+      ),
+      VAPI::Bindings::ReferenceType.new('Com::Vmware::Cis::Tagging::TagAssociation::BatchResult'),
+      {
+        'com.vmware.vapi.std.errors.unauthorized' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Unauthorized')
+      },
+      [],
+      []
+    )
+
+    ATTACH_TAG_TO_MULTIPLE_OBJECTS_INFO = VAPI::Bindings::OperationInfo.new(
+      VAPI::Core::OperationIdentifier.new('attach_tag_to_multiple_objects', SERVICE_ID),
+      VAPI::Bindings::OperationInputType.new(
+        'tag_id' => VAPI::Bindings::IdType.new('com.vmware.cis.tagging.Tag'),
+        'object_ids' => VAPI::Bindings::ListType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::DynamicID'))
+      ),
+      VAPI::Bindings::ReferenceType.new('Com::Vmware::Cis::Tagging::TagAssociation::BatchResult'),
+      {
+        'com.vmware.vapi.std.errors.not_found' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::NotFound'),
+        'com.vmware.vapi.std.errors.unauthorized' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Unauthorized')
+      },
+      [],
+      []
+    )
+
+    DETACH_INFO = VAPI::Bindings::OperationInfo.new(
+      VAPI::Core::OperationIdentifier.new('detach', SERVICE_ID),
+      VAPI::Bindings::OperationInputType.new(
+        'tag_id' => VAPI::Bindings::IdType.new('com.vmware.cis.tagging.Tag'),
+        'object_id' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::DynamicID')
+      ),
+      VAPI::Bindings::VoidType.instance,
+      {
+        'com.vmware.vapi.std.errors.not_found' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::NotFound'),
+        'com.vmware.vapi.std.errors.unauthorized' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Unauthorized')
+      },
+      [],
+      []
+    )
+
+    DETACH_MULTIPLE_TAGS_FROM_OBJECT_INFO = VAPI::Bindings::OperationInfo.new(
+      VAPI::Core::OperationIdentifier.new('detach_multiple_tags_from_object', SERVICE_ID),
+      VAPI::Bindings::OperationInputType.new(
+        'object_id' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::DynamicID'),
+        'tag_ids' => VAPI::Bindings::ListType.new(VAPI::Bindings::IdType.new)
+      ),
+      VAPI::Bindings::ReferenceType.new('Com::Vmware::Cis::Tagging::TagAssociation::BatchResult'),
+      {
+        'com.vmware.vapi.std.errors.unauthorized' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Unauthorized')
+      },
+      [],
+      []
+    )
+
+    DETACH_TAG_FROM_MULTIPLE_OBJECTS_INFO = VAPI::Bindings::OperationInfo.new(
+      VAPI::Core::OperationIdentifier.new('detach_tag_from_multiple_objects', SERVICE_ID),
+      VAPI::Bindings::OperationInputType.new(
+        'tag_id' => VAPI::Bindings::IdType.new('com.vmware.cis.tagging.Tag'),
+        'object_ids' => VAPI::Bindings::ListType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::DynamicID'))
+      ),
+      VAPI::Bindings::ReferenceType.new('Com::Vmware::Cis::Tagging::TagAssociation::BatchResult'),
+      {
+        'com.vmware.vapi.std.errors.not_found' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::NotFound'),
+        'com.vmware.vapi.std.errors.unauthorized' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Unauthorized')
+      },
+      [],
+      []
+    )
+
+    LIST_ATTACHED_OBJECTS_INFO = VAPI::Bindings::OperationInfo.new(
+      VAPI::Core::OperationIdentifier.new('list_attached_objects', SERVICE_ID),
+      VAPI::Bindings::OperationInputType.new(
+        'tag_id' => VAPI::Bindings::IdType.new('com.vmware.cis.tagging.Tag')
+      ),
+      VAPI::Bindings::ListType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::DynamicID')),
+      {
+        'com.vmware.vapi.std.errors.not_found' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::NotFound'),
+        'com.vmware.vapi.std.errors.unauthorized' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Unauthorized')
+      },
+      [],
+      []
+    )
+
+    LIST_ATTACHED_OBJECTS_ON_TAGS_INFO = VAPI::Bindings::OperationInfo.new(
+      VAPI::Core::OperationIdentifier.new('list_attached_objects_on_tags', SERVICE_ID),
+      VAPI::Bindings::OperationInputType.new(
+        'tag_ids' => VAPI::Bindings::ListType.new(VAPI::Bindings::IdType.new)
+      ),
+      VAPI::Bindings::ListType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Cis::Tagging::TagAssociation::TagToObjects')),
+      {},
+      [],
+      []
+    )
+
+    LIST_ATTACHED_TAGS_INFO = VAPI::Bindings::OperationInfo.new(
+      VAPI::Core::OperationIdentifier.new('list_attached_tags', SERVICE_ID),
+      VAPI::Bindings::OperationInputType.new(
+        'object_id' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::DynamicID')
+      ),
+      VAPI::Bindings::ListType.new(VAPI::Bindings::IdType.new),
+      {
+        'com.vmware.vapi.std.errors.unauthorized' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Unauthorized')
+      },
+      [],
+      []
+    )
+
+    LIST_ATTACHED_TAGS_ON_OBJECTS_INFO = VAPI::Bindings::OperationInfo.new(
+      VAPI::Core::OperationIdentifier.new('list_attached_tags_on_objects', SERVICE_ID),
+      VAPI::Bindings::OperationInputType.new(
+        'object_ids' => VAPI::Bindings::ListType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::DynamicID'))
+      ),
+      VAPI::Bindings::ListType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Cis::Tagging::TagAssociation::ObjectToTags')),
+      {},
+      [],
+      []
+    )
+
+    LIST_ATTACHABLE_TAGS_INFO = VAPI::Bindings::OperationInfo.new(
+      VAPI::Core::OperationIdentifier.new('list_attachable_tags', SERVICE_ID),
+      VAPI::Bindings::OperationInputType.new(
+        'object_id' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::DynamicID')
+      ),
+      VAPI::Bindings::ListType.new(VAPI::Bindings::IdType.new),
+      {
+        'com.vmware.vapi.std.errors.unauthorized' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Unauthorized')
+      },
+      [],
+      []
+    )
+
+    SERVICE_INFO = VAPI::Bindings::ServiceInfo.new(
+      SERVICE_ID,
+      'attach' => ATTACH_INFO,
+      'attach_multiple_tags_to_object' => ATTACH_MULTIPLE_TAGS_TO_OBJECT_INFO,
+      'attach_tag_to_multiple_objects' => ATTACH_TAG_TO_MULTIPLE_OBJECTS_INFO,
+      'detach' => DETACH_INFO,
+      'detach_multiple_tags_from_object' => DETACH_MULTIPLE_TAGS_FROM_OBJECT_INFO,
+      'detach_tag_from_multiple_objects' => DETACH_TAG_FROM_MULTIPLE_OBJECTS_INFO,
+      'list_attached_objects' => LIST_ATTACHED_OBJECTS_INFO,
+      'list_attached_objects_on_tags' => LIST_ATTACHED_OBJECTS_ON_TAGS_INFO,
+      'list_attached_tags' => LIST_ATTACHED_TAGS_INFO,
+      'list_attached_tags_on_objects' => LIST_ATTACHED_TAGS_ON_OBJECTS_INFO,
+      'list_attachable_tags' => LIST_ATTACHABLE_TAGS_INFO
+    )
+
+    # Constructs a new instance.
+    #
+    # @param config [VAPI::Bindings::StubConfig] A hash with the api provider details.
+    def initialize(config)
+      super(config, SERVICE_INFO)
+    end
+
+    # Attaches the given tag to the input object. The tag needs to meet the cardinality (  :attr:`Com::Vmware::Cis::Tagging::CategoryModel.cardinality`  ) and associability (  :attr:`Com::Vmware::Cis::Tagging::CategoryModel.associable_types`  ) criteria in order to be eligible for attachment. If the tag is already attached to the object, then this  method  is a no-op and an error will not be thrown. To invoke this  method , you need the attach tag privilege on the tag and the read privilege on the object.
+    #
+    # @param tag_id [String]
+    #      The identifier of the input tag.
+    # @param object_id [Com::Vmware::Vapi::Std::DynamicID]
+    #      The identifier of the input object.
+    # @return [Void]
+    # @raise [Com::Vmware::Vapi::Std::Errors::NotFound]
+    #      if the tag for the given  ``tag_id``  does not exist in the system.
+    # @raise [Com::Vmware::Vapi::Std::Errors::InvalidArgument]
+    #      if the input tag is not eligible to be attached to this object or if the  ``object_id``  is not valid.
+    # @raise [Com::Vmware::Vapi::Std::Errors::Unauthorized]
+    #      if you do not have the privilege to attach the tag or do not have the privilege to read the object.
+    def attach(tag_id, object_id)
+      invoke_with_info(ATTACH_INFO,
+                       'tag_id' => tag_id,
+                       'object_id' => object_id)
+    end
+
+    # Attaches the given tags to the input object. If a tag is already attached to the object, then the individual  method  is a no-op and an error will not be added to   :attr:`Com::Vmware::Cis::Tagging::TagAssociation::BatchResult.error_messages`  . To invoke this  method , you need the read privilege on the object and the attach tag privilege on each tag.
+    #
+    # @param object_id [Com::Vmware::Vapi::Std::DynamicID]
+    #      The identifier of the input object.
+    # @param tag_ids [Array<String>]
+    #      The identifiers of the input tags.
+    # @return [Com::Vmware::Cis::Tagging::TagAssociation::BatchResult]
+    #     The outcome of the batch  method  and the  list  of error messages (  :attr:`Com::Vmware::Cis::Tagging::TagAssociation::BatchResult.error_messages`  ) describing attachment failures.
+    # @raise [Com::Vmware::Vapi::Std::Errors::Unauthorized]
+    #      if you do not have the privilege to read the object.
+    def attach_multiple_tags_to_object(object_id, tag_ids)
+      invoke_with_info(ATTACH_MULTIPLE_TAGS_TO_OBJECT_INFO,
+                       'object_id' => object_id,
+                       'tag_ids' => tag_ids)
+    end
+
+    # Attaches the given tag to the input objects. If a tag is already attached to the object, then the individual  method  is a no-op and an error will not be added to   :attr:`Com::Vmware::Cis::Tagging::TagAssociation::BatchResult.error_messages`  . To invoke this  method , you need the attach tag privilege on the tag and the read privilege on each object.
+    #
+    # @param tag_id [String]
+    #      The identifier of the input tag.
+    # @param object_ids [Array<Com::Vmware::Vapi::Std::DynamicID>]
+    #      The identifiers of the input objects.
+    # @return [Com::Vmware::Cis::Tagging::TagAssociation::BatchResult]
+    #     The outcome of the batch  method  and the  list  of error messages (  :attr:`Com::Vmware::Cis::Tagging::TagAssociation::BatchResult.error_messages`  ) describing attachment failures.
+    # @raise [Com::Vmware::Vapi::Std::Errors::NotFound]
+    #      if the tag for the given  ``tag_id``  does not exist in the system.
+    # @raise [Com::Vmware::Vapi::Std::Errors::Unauthorized]
+    #      if you do not have the attach tag privilege on the tag.
+    def attach_tag_to_multiple_objects(tag_id, object_ids)
+      invoke_with_info(ATTACH_TAG_TO_MULTIPLE_OBJECTS_INFO,
+                       'tag_id' => tag_id,
+                       'object_ids' => object_ids)
+    end
+
+    # Detaches the tag from the given object. If the tag is already removed from the object, then this  method  is a no-op and an error will not be thrown. To invoke this  method , you need the attach tag privilege on the tag and the read privilege on the object.
+    #
+    # @param tag_id [String]
+    #      The identifier of the input tag.
+    # @param object_id [Com::Vmware::Vapi::Std::DynamicID]
+    #      The identifier of the input object.
+    # @return [Void]
+    # @raise [Com::Vmware::Vapi::Std::Errors::NotFound]
+    #      if the tag for the given  ``tag_id``  does not exist in the system.
+    # @raise [Com::Vmware::Vapi::Std::Errors::Unauthorized]
+    #      if you do not have the privilege to detach the tag or do not have the privilege to read the given object.
+    def detach(tag_id, object_id)
+      invoke_with_info(DETACH_INFO,
+                       'tag_id' => tag_id,
+                       'object_id' => object_id)
+    end
+
+    # Detaches the given tags from the input object. If a tag is already removed from the object, then the individual  method  is a no-op and an error will not be added to   :attr:`Com::Vmware::Cis::Tagging::TagAssociation::BatchResult.error_messages`  . To invoke this  method , you need the read privilege on the object and the attach tag privilege each tag.
+    #
+    # @param object_id [Com::Vmware::Vapi::Std::DynamicID]
+    #      The identifier of the input object.
+    # @param tag_ids [Array<String>]
+    #      The identifiers of the input tags.
+    # @return [Com::Vmware::Cis::Tagging::TagAssociation::BatchResult]
+    #     The outcome of the batch  method  and the  list  of error messages (  :attr:`Com::Vmware::Cis::Tagging::TagAssociation::BatchResult.error_messages`  ) describing detachment failures.
+    # @raise [Com::Vmware::Vapi::Std::Errors::Unauthorized]
+    #      if you do not have the privilege to read the object.
+    def detach_multiple_tags_from_object(object_id, tag_ids)
+      invoke_with_info(DETACH_MULTIPLE_TAGS_FROM_OBJECT_INFO,
+                       'object_id' => object_id,
+                       'tag_ids' => tag_ids)
+    end
+
+    # Detaches the given tag from the input objects. If a tag is already removed from the object, then the individual  method  is a no-op and an error will not be added to   :attr:`Com::Vmware::Cis::Tagging::TagAssociation::BatchResult.error_messages`  . To invoke this  method , you need the attach tag privilege on the tag and the read privilege on each object.
+    #
+    # @param tag_id [String]
+    #      The identifier of the input tag.
+    # @param object_ids [Array<Com::Vmware::Vapi::Std::DynamicID>]
+    #      The identifiers of the input objects.
+    # @return [Com::Vmware::Cis::Tagging::TagAssociation::BatchResult]
+    #     The outcome of the batch  method  and the  list  of error messages (  :attr:`Com::Vmware::Cis::Tagging::TagAssociation::BatchResult.error_messages`  ) describing detachment failures.
+    # @raise [Com::Vmware::Vapi::Std::Errors::NotFound]
+    #      if the tag for the given tag does not exist in the system.
+    # @raise [Com::Vmware::Vapi::Std::Errors::Unauthorized]
+    #      if you do not have the attach tag privilege on the tag.
+    def detach_tag_from_multiple_objects(tag_id, object_ids)
+      invoke_with_info(DETACH_TAG_FROM_MULTIPLE_OBJECTS_INFO,
+                       'tag_id' => tag_id,
+                       'object_ids' => object_ids)
+    end
+
+    # Fetches the  list  of attached objects for the given tag. To invoke this  method , you need the read privilege on the input tag. Only those objects for which you have the read privilege will be returned.
+    #
+    # @param tag_id [String]
+    #      The identifier of the input tag.
+    # @return [Array<Com::Vmware::Vapi::Std::DynamicID>]
+    #     The  list  of attached object identifiers.
+    # @raise [Com::Vmware::Vapi::Std::Errors::NotFound]
+    #      if the tag for the given  ``tag_id``  does not exist in the system.
+    # @raise [Com::Vmware::Vapi::Std::Errors::Unauthorized]
+    #      if you do not have the privilege to read the tag.
+    def list_attached_objects(tag_id)
+      invoke_with_info(LIST_ATTACHED_OBJECTS_INFO,
+                       'tag_id' => tag_id)
+    end
+
+    # Fetches the  list  of   :class:`Com::Vmware::Cis::Tagging::TagAssociation::TagToObjects`   describing the input tag identifiers and the objects they are attached to. To invoke this  method , you need the read privilege on each input tag. The   :attr:`Com::Vmware::Cis::Tagging::TagAssociation::TagToObjects.object_ids`   will only contain those objects for which you have the read privilege.
+    #
+    # @param tag_ids [Array<String>]
+    #      The identifiers of the input tags.
+    # @return [Array<Com::Vmware::Cis::Tagging::TagAssociation::TagToObjects>]
+    #     The  list  of the tag identifiers to all object identifiers that each tag is attached to.
+    def list_attached_objects_on_tags(tag_ids)
+      invoke_with_info(LIST_ATTACHED_OBJECTS_ON_TAGS_INFO,
+                       'tag_ids' => tag_ids)
+    end
+
+    # Fetches the  list  of tags attached to the given object. To invoke this  method , you need the read privilege on the input object. The  list  will only contain those tags for which you have the read privileges.
+    #
+    # @param object_id [Com::Vmware::Vapi::Std::DynamicID]
+    #      The identifier of the input object.
+    # @return [Array<String>]
+    #     The  list  of all tag identifiers that correspond to the tags attached to the given object.
+    # @raise [Com::Vmware::Vapi::Std::Errors::Unauthorized]
+    #      if you do not have the privilege to read the object.
+    def list_attached_tags(object_id)
+      invoke_with_info(LIST_ATTACHED_TAGS_INFO,
+                       'object_id' => object_id)
+    end
+
+    # Fetches the  list  of   :class:`Com::Vmware::Cis::Tagging::TagAssociation::ObjectToTags`   describing the input object identifiers and the tags attached to each object. To invoke this  method , you need the read privilege on each input object. The   :attr:`Com::Vmware::Cis::Tagging::TagAssociation::ObjectToTags.tag_ids`   will only contain those tags for which you have the read privilege.
+    #
+    # @param object_ids [Array<Com::Vmware::Vapi::Std::DynamicID>]
+    #      The identifiers of the input objects.
+    # @return [Array<Com::Vmware::Cis::Tagging::TagAssociation::ObjectToTags>]
+    #     The  list  of the object identifiers to all tag identifiers that are attached to that object.
+    def list_attached_tags_on_objects(object_ids)
+      invoke_with_info(LIST_ATTACHED_TAGS_ON_OBJECTS_INFO,
+                       'object_ids' => object_ids)
+    end
+
+    # Fetches the  list  of attachable tags for the given object, omitting the tags that have already been attached. Criteria for attachability is calculated based on tagging cardinality (  :attr:`Com::Vmware::Cis::Tagging::CategoryModel.cardinality`  ) and associability (  :attr:`Com::Vmware::Cis::Tagging::CategoryModel.associable_types`  ) constructs. To invoke this  method , you need the read privilege on the input object. The  list  will only contain those tags for which you have read privileges.
+    #
+    # @param object_id [Com::Vmware::Vapi::Std::DynamicID]
+    #      The identifier of the input object.
+    # @return [Array<String>]
+    #     The  list  of tag identifiers that are eligible to be attached to the given object.
+    # @raise [Com::Vmware::Vapi::Std::Errors::Unauthorized]
+    #      if you do not have the privilege to read the object.
+    def list_attachable_tags(object_id)
+      invoke_with_info(LIST_ATTACHABLE_TAGS_INFO,
+                       'object_id' => object_id)
+    end
+
+    # The  ``Com::Vmware::Cis::Tagging::TagAssociation::BatchResult``   class  describes the result of performing the same  method  on several tags or objects in a single invocation.
+    # @!attribute [rw] success
+    #     @return [Boolean]
+    #     This is true if the batch  method  completed without any errors. Otherwise it is false and all or some  methods  have failed.
+    # @!attribute [rw] error_messages
+    #     @return [Array<Com::Vmware::Vapi::Std::LocalizableMessage>]
+    #     The  list  of error messages.
+    class BatchResult < VAPI::Bindings::VapiStruct
+      class << self
+        # Holds (gets or creates) the binding type metadata for this structure type.
+        # @scope class
+        # @return [VAPI::Bindings::StructType] the binding type
+        def binding_type
+          @binding_type ||= VAPI::Bindings::StructType.new(
+            'com.vmware.cis.tagging.tag_association.batch_result',
+            {
+              'success' => VAPI::Bindings::BooleanType.instance,
+              'error_messages' => VAPI::Bindings::ListType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::LocalizableMessage'))
+            },
+            BatchResult,
+            false,
+            nil
+          )
+        end
+      end
+
+      attr_accessor :success,
+                    :error_messages
+
+      # Constructs a new instance.
+      # @param ruby_values [Hash] a map of initial property values (optional)
+      # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
+      def initialize(ruby_values = nil, struct_value = nil)
+        super(self.class.binding_type, ruby_values, struct_value)
+      end
+    end
+
+    # The  ``Com::Vmware::Cis::Tagging::TagAssociation::TagToObjects``   class  describes a tag and its related objects. Use the   :func:`Com::Vmware::Cis::Tagging::TagAssociation.list_attached_objects_on_tags`    method  to retrieve a  list  with each element containing a tag and the objects to which it is attached.
+    # @!attribute [rw] tag_id
+    #     @return [String]
+    #     The identifier of the tag.
+    # @!attribute [rw] object_ids
+    #     @return [Array<Com::Vmware::Vapi::Std::DynamicID>]
+    #     The identifiers of the related objects.
+    class TagToObjects < VAPI::Bindings::VapiStruct
+      class << self
+        # Holds (gets or creates) the binding type metadata for this structure type.
+        # @scope class
+        # @return [VAPI::Bindings::StructType] the binding type
+        def binding_type
+          @binding_type ||= VAPI::Bindings::StructType.new(
+            'com.vmware.cis.tagging.tag_association.tag_to_objects',
+            {
+              'tag_id' => VAPI::Bindings::IdType.new('com.vmware.cis.tagging.Tag'),
+              'object_ids' => VAPI::Bindings::ListType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::DynamicID'))
+            },
+            TagToObjects,
+            false,
+            nil
+          )
+        end
+      end
+
+      attr_accessor :tag_id,
+                    :object_ids
+
+      # Constructs a new instance.
+      # @param ruby_values [Hash] a map of initial property values (optional)
+      # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
+      def initialize(ruby_values = nil, struct_value = nil)
+        super(self.class.binding_type, ruby_values, struct_value)
+      end
+    end
+
+    # The  ``Com::Vmware::Cis::Tagging::TagAssociation::ObjectToTags``   class  describes an object and its related tags. Use the   :func:`Com::Vmware::Cis::Tagging::TagAssociation.list_attached_tags_on_objects`    method  to retrieve a  list  with each element containing an object and the tags attached to it.
+    # @!attribute [rw] object_id
+    #     @return [Com::Vmware::Vapi::Std::DynamicID]
+    #     The identifier of the object.
+    # @!attribute [rw] tag_ids
+    #     @return [Array<String>]
+    #     The identifiers of the related tags.
+    class ObjectToTags < VAPI::Bindings::VapiStruct
+      class << self
+        # Holds (gets or creates) the binding type metadata for this structure type.
+        # @scope class
+        # @return [VAPI::Bindings::StructType] the binding type
+        def binding_type
+          @binding_type ||= VAPI::Bindings::StructType.new(
+            'com.vmware.cis.tagging.tag_association.object_to_tags',
+            {
+              'object_id' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::DynamicID'),
+              'tag_ids' => VAPI::Bindings::ListType.new(VAPI::Bindings::IdType.new)
+            },
+            ObjectToTags,
+            false,
+            nil
+          )
+        end
+      end
+
+      attr_accessor :object_id,
+                    :tag_ids
+
+      # Constructs a new instance.
+      # @param ruby_values [Hash] a map of initial property values (optional)
+      # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
+      def initialize(ruby_values = nil, struct_value = nil)
+        super(self.class.binding_type, ruby_values, struct_value)
+      end
+    end
+
+  end
+  # The  ``Com::Vmware::Cis::Tagging::CategoryModel``   class  defines a category that is used to group one or more tags.
+  # @!attribute [rw] id
+  #     @return [String]
+  #     The unique identifier of the category.
+  # @!attribute [rw] name
+  #     @return [String]
+  #     The display name of the category.
+  # @!attribute [rw] description
+  #     @return [String]
+  #     The description of the category.
+  # @!attribute [rw] cardinality
+  #     @return [Com::Vmware::Cis::Tagging::CategoryModel::Cardinality]
+  #     The associated cardinality ( ``SINGLE``, ``MULTIPLE`` ) of the category.
+  # @!attribute [rw] associable_types
+  #     @return [Set<String>]
+  #     The types of objects that the tags in this category can be attached to. If the  set  is empty, then tags can be attached to all types of objects. This field works only for objects that reside in Inventory Service (IS). For non IS objects, this check is not performed today and hence a tag can be attached to any non IS object.
+  # @!attribute [rw] used_by
+  #     @return [Set<String>]
+  #     The  set  of users that can use this category. To add users to this, you need to have the edit privilege on the category. Similarly, to unsubscribe from this category, you need the edit privilege on the category. You should not modify other users subscription from this  set .
+  class CategoryModel < VAPI::Bindings::VapiStruct
+    class << self
+      # Holds (gets or creates) the binding type metadata for this structure type.
+      # @scope class
+      # @return [VAPI::Bindings::StructType] the binding type
+      def binding_type
+        @binding_type ||= VAPI::Bindings::StructType.new(
+          'com.vmware.cis.tagging.category_model',
+          {
+            'id' => VAPI::Bindings::IdType.new('com.vmware.cis.tagging.Category'),
+            'name' => VAPI::Bindings::StringType.instance,
+            'description' => VAPI::Bindings::StringType.instance,
+            'cardinality' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Cis::Tagging::CategoryModel::Cardinality'),
+            'associable_types' => VAPI::Bindings::SetType.new(VAPI::Bindings::StringType.instance),
+            'used_by' => VAPI::Bindings::SetType.new(VAPI::Bindings::StringType.instance)
+          },
+          CategoryModel,
+          true,
+          ["id"]
+        )
+      end
+    end
+
+    attr_accessor :id,
+                  :name,
+                  :description,
+                  :cardinality,
+                  :associable_types,
+                  :used_by
+
+    # Constructs a new instance.
+    # @param ruby_values [Hash] a map of initial property values (optional)
+    # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
+    def initialize(ruby_values = nil, struct_value = nil)
+      super(self.class.binding_type, ruby_values, struct_value)
+    end
+
+    # The  ``Com::Vmware::Cis::Tagging::CategoryModel::Cardinality``   enumerated type  defines the number of tags in a category that can be assigned to an object.
+    # @!attribute [rw] single
+    #     @return [Com::Vmware::Cis::Tagging::CategoryModel::Cardinality]
+    #     An object can only be assigned one of the tags in this category. For example, if a category is "Operating System", then different tags of this category would be "Windows", "Linux", and so on. In this case a VM object can be assigned only one of these tags and hence the cardinality of the associated category here is single.
+    # @!attribute [rw] multiple
+    #     @return [Com::Vmware::Cis::Tagging::CategoryModel::Cardinality]
+    #     An object can be assigned several of the tags in this category. For example, if a category is "Server", then different tags of this category would be "AppServer", "DatabaseServer" and so on. In this case a VM object can be assigned more than one of the above tags and hence the cardinality of the associated category here is multiple.
+    class Cardinality < VAPI::Bindings::VapiEnum
+      class << self
+        # Holds (gets or creates) the binding type metadata for this enumeration type.
+        # @scope class
+        # @return [VAPI::Bindings::EnumType] the binding type
+        def binding_type
+          @binding_type ||= VAPI::Bindings::EnumType.new(
+            'com.vmware.cis.tagging.category_model.cardinality',
+            Cardinality
+          )
+        end
+
+        # Converts from a string value (perhaps off the wire) to an instance
+        # of this enum type.
+        # @param value [String] the actual value of the enum instance
+        # @return [Cardinality] the instance found for the value, otherwise
+        #         an unknown instance will be built for the value
+        def from_string(value)
+          const_get(value)
+        rescue NameError
+          Cardinality.send(:new, 'UNKNOWN', value)
+        end
+      end
+
+      # Constructs a new instance.
+      # @param value [String] the actual value of the enum instance
+      # @param unknown [String] the unknown value when value is 'UKNOWN'
+      def initialize(value, unknown = nil)
+        super(self.class.binding_type, value, unknown)
+      end
+
+      private_class_method :new
+
+      # @!attribute [rw] single
+      #     @return [Com::Vmware::Cis::Tagging::CategoryModel::Cardinality]
+      #     An object can only be assigned one of the tags in this category. For example, if a category is "Operating System", then different tags of this category would be "Windows", "Linux", and so on. In this case a VM object can be assigned only one of these tags and hence the cardinality of the associated category here is single.
+      SINGLE = Cardinality.send(:new, 'SINGLE')
+
+      # @!attribute [rw] multiple
+      #     @return [Com::Vmware::Cis::Tagging::CategoryModel::Cardinality]
+      #     An object can be assigned several of the tags in this category. For example, if a category is "Server", then different tags of this category would be "AppServer", "DatabaseServer" and so on. In this case a VM object can be assigned more than one of the above tags and hence the cardinality of the associated category here is multiple.
+      MULTIPLE = Cardinality.send(:new, 'MULTIPLE')
+    end
+  end
+  # The  ``Com::Vmware::Cis::Tagging::TagModel``   class  defines a tag that can be attached to vSphere objects.
+  # @!attribute [rw] id
+  #     @return [String]
+  #     The unique identifier of the tag.
+  # @!attribute [rw] category_id
+  #     @return [String]
+  #     The identifier of the parent category in which this tag will be created.
+  # @!attribute [rw] name
+  #     @return [String]
+  #     The display name of the tag.
+  # @!attribute [rw] description
+  #     @return [String]
+  #     The description of the tag.
+  # @!attribute [rw] used_by
+  #     @return [Set<String>]
+  #     The  set  of users that can use this tag. To add users to this, you need to have the edit privilege on the tag. Similarly, to unsubscribe from this tag, you need the edit privilege on the tag. You should not modify other users subscription from this  set .
+  class TagModel < VAPI::Bindings::VapiStruct
+    class << self
+      # Holds (gets or creates) the binding type metadata for this structure type.
+      # @scope class
+      # @return [VAPI::Bindings::StructType] the binding type
+      def binding_type
+        @binding_type ||= VAPI::Bindings::StructType.new(
+          'com.vmware.cis.tagging.tag_model',
+          {
+            'id' => VAPI::Bindings::IdType.new('com.vmware.cis.tagging.Tag'),
+            'category_id' => VAPI::Bindings::IdType.new('com.vmware.cis.tagging.Category'),
+            'name' => VAPI::Bindings::StringType.instance,
+            'description' => VAPI::Bindings::StringType.instance,
+            'used_by' => VAPI::Bindings::SetType.new(VAPI::Bindings::StringType.instance)
+          },
+          TagModel,
+          true,
+          ["id"]
+        )
+      end
+    end
+
+    attr_accessor :id,
+                  :category_id,
+                  :name,
+                  :description,
+                  :used_by
+
+    # Constructs a new instance.
+    # @param ruby_values [Hash] a map of initial property values (optional)
+    # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
+    def initialize(ruby_values = nil, struct_value = nil)
+      super(self.class.binding_type, ruby_values, struct_value)
+    end
+  end
 end

--- a/client/sdk/com/vmware/cis/tagging/vapi.rb
+++ b/client/sdk/com/vmware/cis/tagging/vapi.rb
@@ -1,5 +1,6 @@
 #---------------------------------------------------------------------------
-# Copyright 2016 VMware, Inc.  All rights reserved.
+# Copyright 2017 VMware, Inc.  All rights reserved.
+#
 # AUTO GENERATED FILE -- DO NOT MODIFY!
 #---------------------------------------------------------------------------
 require 'vapi'

--- a/client/sdk/com/vmware/cis/vapi.rb
+++ b/client/sdk/com/vmware/cis/vapi.rb
@@ -1,5 +1,6 @@
 #---------------------------------------------------------------------------
-# Copyright 2016 VMware, Inc.  All rights reserved.
+# Copyright 2017 VMware, Inc.  All rights reserved.
+#
 # AUTO GENERATED FILE -- DO NOT MODIFY!
 #---------------------------------------------------------------------------
 require 'vapi'

--- a/client/sdk/com/vmware/content.rb
+++ b/client/sdk/com/vmware/content.rb
@@ -1,5 +1,6 @@
 #---------------------------------------------------------------------------
-# Copyright 2016 VMware, Inc.  All rights reserved.
+# Copyright 2017 VMware, Inc.  All rights reserved.
+#
 # AUTO GENERATED FILE -- DO NOT MODIFY!
 #
 # vAPI type descriptors for package com.vmware.content.
@@ -8,1252 +9,1174 @@ require 'vapi'
 
 # declare the module hierarchy before we use the shorthand syntax below
 module Com
-    module Vmware
-        module Content
-        end
+  module Vmware
+    module Content
     end
+  end
 end
 
 # The Content  package  provides  classes  and  classs  for configuring global settings and permissions, and for managing libraries in the Content Library Service.
 module Com::Vmware::Content
+  # The  ``Com::Vmware::Content::Configuration``   class  provides  methods  to configure the global settings of the Content Library Service.  
+  # 
+  #  The configuration settings are used by the Content Library Service to control the behavior of various operations.
+  class Configuration < VAPI::Bindings::VapiService
+    # static metamodel definitions
+    SERVICE_ID = VAPI::Core::ServiceIdentifier.new('com.vmware.content.configuration')
 
-    # The  ``Com::Vmware::Content::Configuration``   class  provides  methods  to configure the global settings of the Content Library Service.  
-    # 
-    #  The configuration settings are used by the Content Library Service to control the behavior of various operations.
-    class Configuration < VAPI::Bindings::VapiService
+    UPDATE_INFO = VAPI::Bindings::OperationInfo.new(
+      VAPI::Core::OperationIdentifier.new('update', SERVICE_ID),
+      VAPI::Bindings::OperationInputType.new(
+        'model' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Content::ConfigurationModel')
+      ),
+      VAPI::Bindings::VoidType.instance,
+      {
+        'com.vmware.vapi.std.errors.invalid_argument' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::InvalidArgument')
+      },
+      [],
+      []
+    )
 
-        protected
+    GET_INFO = VAPI::Bindings::OperationInfo.new(
+      VAPI::Core::OperationIdentifier.new('get', SERVICE_ID),
+      VAPI::Bindings::OperationInputType.new,
+      VAPI::Bindings::ReferenceType.new('Com::Vmware::Content::ConfigurationModel'),
+      {},
+      [],
+      []
+    )
 
-        # static metamodel definitions
-        @@service_id = VAPI::Core::ServiceIdentifier.new('com.vmware.content.configuration')
+    SERVICE_INFO = VAPI::Bindings::ServiceInfo.new(
+      SERVICE_ID,
+      'update' => UPDATE_INFO,
+      'get' => GET_INFO
+    )
 
-        @@update_info = VAPI::Bindings::OperationInfo.new(
-            VAPI::Core::OperationIdentifier.new('update', @@service_id),
-            VAPI::Bindings::OperationInputType.new({
-                'model' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Content::ConfigurationModel'),
-            }),
-            VAPI::Bindings::VoidType.instance,
-            {
-                'com.vmware.vapi.std.errors.invalid_argument' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::InvalidArgument'),
-
-            },
-            [],
-            [])
-        @@get_info = VAPI::Bindings::OperationInfo.new(
-            VAPI::Core::OperationIdentifier.new('get', @@service_id),
-            VAPI::Bindings::OperationInputType.new,
-            VAPI::Bindings::ReferenceType.new('Com::Vmware::Content::ConfigurationModel'),
-            {},
-            [],
-            [])
-
-        @@service_info = VAPI::Bindings::ServiceInfo.new(@@service_id, {
-            'update' => @@update_info,
-            'get' => @@get_info,
-        })
-
-        public
-
-        # Constructs a new instance.
-        #
-        # @param config [VAPI::Bindings::StubConfig] A hash with the api provider details.
-        def initialize(config)
-            super(config, @@service_info)
-        end
-
-
-        # Updates the configuration. The update is incremental. Any  field  in the   :class:`Com::Vmware::Content::ConfigurationModel`    class  that is  nil  will not be modified. Note that this update  method  doesn't guarantee an atomic change of all the properties. In the case of a system crash or failure, some of the properties could be left unchanged while others may be updated.
-        #
-        # @param model [Com::Vmware::Content::ConfigurationModel]
-        #      The   :class:`Com::Vmware::Content::ConfigurationModel`   specifying the settings to update.
-        # @return [Void]
-        # @raise [Com::Vmware::Vapi::Std::Errors::InvalidArgument]
-        #      if one of the configuration properties is not within the proper range.
-        def update(model)
-            invoke_with_info(@@update_info, {
-                'model' => model,
-            })
-        end
-
-
-        # Retrieves the current configuration values.
-        #
-        # @return [Com::Vmware::Content::ConfigurationModel]
-        #     The   :class:`Com::Vmware::Content::ConfigurationModel`   instance representing the configuration of the Content Library Service.
-        def get()
-            invoke_with_info(@@get_info)
-        end
-
-
+    # Constructs a new instance.
+    #
+    # @param config [VAPI::Bindings::StubConfig] A hash with the api provider details.
+    def initialize(config)
+      super(config, SERVICE_INFO)
     end
 
-
-    # The  ``Com::Vmware::Content::Library``   class  provides  methods  to manage and find   :class:`Com::Vmware::Content::LibraryModel`   entities.  
-    # 
-    #  The  ``Com::Vmware::Content::Library``   class  provides support for generic functionality which can be applied equally to all types of libraries. The functionality provided by this  class  will not affect the properties specific to the type of library. See also   :class:`Com::Vmware::Content::LocalLibrary`   and   :class:`Com::Vmware::Content::SubscribedLibrary`  .
-    class LibraryService < VAPI::Bindings::VapiService
-
-        protected
-
-        # static metamodel definitions
-        @@service_id = VAPI::Core::ServiceIdentifier.new('com.vmware.content.library')
-
-        @@get_info = VAPI::Bindings::OperationInfo.new(
-            VAPI::Core::OperationIdentifier.new('get', @@service_id),
-            VAPI::Bindings::OperationInputType.new({
-                'library_id' => VAPI::Bindings::IdType.new(resource_types='com.vmware.content.Library'),
-            }),
-            VAPI::Bindings::ReferenceType.new('Com::Vmware::Content::LibraryModel'),
-            {
-                'com.vmware.vapi.std.errors.not_found' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::NotFound'),
-
-            },
-            [],
-            [])
-        @@list_info = VAPI::Bindings::OperationInfo.new(
-            VAPI::Core::OperationIdentifier.new('list', @@service_id),
-            VAPI::Bindings::OperationInputType.new,
-            VAPI::Bindings::ListType.new(VAPI::Bindings::IdType.new),
-            {},
-            [],
-            [])
-        @@find_info = VAPI::Bindings::OperationInfo.new(
-            VAPI::Core::OperationIdentifier.new('find', @@service_id),
-            VAPI::Bindings::OperationInputType.new({
-                'spec' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Content::Library::FindSpec'),
-            }),
-            VAPI::Bindings::ListType.new(VAPI::Bindings::IdType.new),
-            {
-                'com.vmware.vapi.std.errors.invalid_argument' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::InvalidArgument'),
-
-            },
-            [],
-            [])
-        @@update_info = VAPI::Bindings::OperationInfo.new(
-            VAPI::Core::OperationIdentifier.new('update', @@service_id),
-            VAPI::Bindings::OperationInputType.new({
-                'library_id' => VAPI::Bindings::IdType.new(resource_types='com.vmware.content.Library'),
-                'update_spec' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Content::LibraryModel'),
-            }),
-            VAPI::Bindings::VoidType.instance,
-            {
-                'com.vmware.vapi.std.errors.not_found' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::NotFound'),
-                'com.vmware.vapi.std.errors.invalid_argument' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::InvalidArgument'),
-
-            },
-            [],
-            [])
-
-        @@service_info = VAPI::Bindings::ServiceInfo.new(@@service_id, {
-            'get' => @@get_info,
-            'list' => @@list_info,
-            'find' => @@find_info,
-            'update' => @@update_info,
-        })
-
-        public
-
-        # Constructs a new instance.
-        #
-        # @param config [VAPI::Bindings::StubConfig] A hash with the api provider details.
-        def initialize(config)
-            super(config, @@service_info)
-        end
-
-        RESOURCE_TYPE = 'com.vmware.content.Library'
-
-
-        # Returns a given   :class:`Com::Vmware::Content::LibraryModel`  .
-        #
-        # @param library_id [String]
-        #      Identifier of the library to return.
-        # @return [Com::Vmware::Content::LibraryModel]
-        #     The   :class:`Com::Vmware::Content::LibraryModel`   instance with the specified  ``library_id`` .
-        # @raise [Com::Vmware::Vapi::Std::Errors::NotFound]
-        #      if the specified library does not exist.
-        def get(library_id)
-            invoke_with_info(@@get_info, {
-                'library_id' => library_id,
-            })
-        end
-
-
-        # Returns the identifiers of all libraries of any type in the Content Library.
-        #
-        # @return [Array<String>]
-        #     The  list  of all identifiers of all libraries in the Content Library.
-        def list()
-            invoke_with_info(@@list_info)
-        end
-
-
-        # Returns a list of all the visible (as determined by authorization policy) libraries matching the requested   :class:`Com::Vmware::Content::Library::FindSpec`  .
-        #
-        # @param spec [Com::Vmware::Content::Library::FindSpec]
-        #      Specification describing what properties to filter on.
-        # @return [Array<String>]
-        #     The  list  of identifiers of all the visible libraries matching the given  ``spec`` .
-        # @raise [Com::Vmware::Vapi::Std::Errors::InvalidArgument]
-        #      if no properties are specified in the  ``spec`` .
-        def find(spec)
-            invoke_with_info(@@find_info, {
-                'spec' => spec,
-            })
-        end
-
-
-        # Updates the properties of a library.  
-        # 
-        #  This is an incremental update to the library. Any  field  in the   :class:`Com::Vmware::Content::LibraryModel`    class  that is  nil  will not be modified.  
-        # 
-        #  This  method  will only update the common properties for all library types. This will not, for example, update the   :attr:`Com::Vmware::Content::LibraryModel.publish_info`   of a local library, nor the   :attr:`Com::Vmware::Content::LibraryModel.subscription_info`   of a subscribed library. Specific properties are updated in   :func:`Com::Vmware::Content::LocalLibrary.update`   and   :func:`Com::Vmware::Content::SubscribedLibrary.update`  .
-        #
-        # @param library_id [String]
-        #      Identifier of the library to update.
-        # @param update_spec [Com::Vmware::Content::LibraryModel]
-        #      Specification of the new property values to set on the library.
-        # @return [Void]
-        # @raise [Com::Vmware::Vapi::Std::Errors::NotFound]
-        #      if the library associated with  ``library_id``  does not exist.
-        # @raise [Com::Vmware::Vapi::Std::Errors::InvalidArgument]
-        #      if the  ``update_spec``  is not valid.
-        # @raise [Com::Vmware::Vapi::Std::Errors::InvalidArgument]
-        #      if the   :attr:`Com::Vmware::Content::LibraryModel.version`   of  ``update_spec``  is not equal to the current version of the library.
-        def update(library_id, update_spec)
-            invoke_with_info(@@update_info, {
-                'library_id' => library_id,
-                'update_spec' => update_spec,
-            })
-        end
-
-
-
-        # Specifies the properties that can be used as a filter to find libraries. When multiple  fields  are specified, all properties of the library must match the specification.
-        # @!attribute [rw] name
-        #     @return [String, nil]
-        #     Name of the library to search. The name is case-insensitive. See   :attr:`Com::Vmware::Content::LibraryModel.name`  .
-        #     If not specified any name will be searched.
-        # @!attribute [rw] type
-        #     @return [Com::Vmware::Content::LibraryModel::LibraryType, nil]
-        #     Library type to search. See   :attr:`Com::Vmware::Content::LibraryModel.type`  .
-        #     If not specified any library type will be searched.
-        class FindSpec < VAPI::Bindings::VapiStruct
-
-            class << self
-                # Holds (gets or creates) the binding type metadata for this structure type.
-                # @scope class
-                # @return [VAPI::Bindings::StructType] the binding type
-                def binding_type
-                    @binding_type ||= VAPI::Bindings::StructType.new(
-                        'com.vmware.content.library.find_spec',
-                        {
-                            'name' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::StringType.instance),
-                            'type' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Content::LibraryModel::LibraryType')),
-                        },
-                        FindSpec,
-                        false,
-                        nil)
-                end
-            end
-
-            attr_accessor :name,
-                          :type
-
-            # Constructs a new instance.
-            # @param ruby_values [Hash] a map of initial property values (optional)
-            # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
-            def initialize(ruby_values=nil, struct_value=nil)
-                super(self.class.binding_type, ruby_values, struct_value)
-            end
-        end
-
-
+    # Updates the configuration. The update is incremental. Any  field  in the   :class:`Com::Vmware::Content::ConfigurationModel`    class  that is  nil  will not be modified. Note that this update  method  doesn't guarantee an atomic change of all the properties. In the case of a system crash or failure, some of the properties could be left unchanged while others may be updated.
+    #
+    # @param model [Com::Vmware::Content::ConfigurationModel]
+    #      The   :class:`Com::Vmware::Content::ConfigurationModel`   specifying the settings to update.
+    # @return [Void]
+    # @raise [Com::Vmware::Vapi::Std::Errors::InvalidArgument]
+    #      if one of the configuration properties is not within the proper range.
+    def update(model)
+      invoke_with_info(UPDATE_INFO,
+                       'model' => model)
     end
 
-
-    # The  ``Com::Vmware::Content::LocalLibrary``   class  manages local libraries.  
-    # 
-    #  The  ``Com::Vmware::Content::LocalLibrary``   class  provides support for creating and maintaining local library instances. A local library may also use the   :class:`Com::Vmware::Content::Library`    class  to manage general library functionality.
-    class LocalLibrary < VAPI::Bindings::VapiService
-
-        protected
-
-        # static metamodel definitions
-        @@service_id = VAPI::Core::ServiceIdentifier.new('com.vmware.content.local_library')
-
-        @@create_info = VAPI::Bindings::OperationInfo.new(
-            VAPI::Core::OperationIdentifier.new('create', @@service_id),
-            VAPI::Bindings::OperationInputType.new({
-                'client_token' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::StringType.instance),
-                'create_spec' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Content::LibraryModel'),
-            }),
-            VAPI::Bindings::IdType.new(resource_types='com.vmware.content.Library'),
-            {
-                'com.vmware.vapi.std.errors.invalid_argument' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::InvalidArgument'),
-                'com.vmware.vapi.std.errors.unsupported' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Unsupported'),
-
-            },
-            [],
-            [])
-        @@delete_info = VAPI::Bindings::OperationInfo.new(
-            VAPI::Core::OperationIdentifier.new('delete', @@service_id),
-            VAPI::Bindings::OperationInputType.new({
-                'library_id' => VAPI::Bindings::IdType.new(resource_types='com.vmware.content.Library'),
-            }),
-            VAPI::Bindings::VoidType.instance,
-            {
-                'com.vmware.vapi.std.errors.invalid_element_type' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::InvalidElementType'),
-                'com.vmware.vapi.std.errors.not_found' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::NotFound'),
-
-            },
-            [],
-            [])
-        @@get_info = VAPI::Bindings::OperationInfo.new(
-            VAPI::Core::OperationIdentifier.new('get', @@service_id),
-            VAPI::Bindings::OperationInputType.new({
-                'library_id' => VAPI::Bindings::IdType.new(resource_types='com.vmware.content.Library'),
-            }),
-            VAPI::Bindings::ReferenceType.new('Com::Vmware::Content::LibraryModel'),
-            {
-                'com.vmware.vapi.std.errors.not_found' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::NotFound'),
-                'com.vmware.vapi.std.errors.invalid_element_type' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::InvalidElementType'),
-
-            },
-            [],
-            [])
-        @@list_info = VAPI::Bindings::OperationInfo.new(
-            VAPI::Core::OperationIdentifier.new('list', @@service_id),
-            VAPI::Bindings::OperationInputType.new,
-            VAPI::Bindings::ListType.new(VAPI::Bindings::IdType.new),
-            {},
-            [],
-            [])
-        @@update_info = VAPI::Bindings::OperationInfo.new(
-            VAPI::Core::OperationIdentifier.new('update', @@service_id),
-            VAPI::Bindings::OperationInputType.new({
-                'library_id' => VAPI::Bindings::IdType.new(resource_types='com.vmware.content.Library'),
-                'update_spec' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Content::LibraryModel'),
-            }),
-            VAPI::Bindings::VoidType.instance,
-            {
-                'com.vmware.vapi.std.errors.not_found' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::NotFound'),
-                'com.vmware.vapi.std.errors.invalid_element_type' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::InvalidElementType'),
-                'com.vmware.vapi.std.errors.invalid_argument' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::InvalidArgument'),
-
-            },
-            [],
-            [])
-
-        @@service_info = VAPI::Bindings::ServiceInfo.new(@@service_id, {
-            'create' => @@create_info,
-            'delete' => @@delete_info,
-            'get' => @@get_info,
-            'list' => @@list_info,
-            'update' => @@update_info,
-        })
-
-        public
-
-        # Constructs a new instance.
-        #
-        # @param config [VAPI::Bindings::StubConfig] A hash with the api provider details.
-        def initialize(config)
-            super(config, @@service_info)
-        end
-
-
-        # Creates a new local library.
-        #
-        # @param client_token [String, nil]
-        #      A unique token generated on the client for each creation request. The token should be a universally unique identifier (UUID), for example:  ``b8a2a2e3-2314-43cd-a871-6ede0f429751`` . This token can be used to guarantee idempotent creation.
-        #     If not specified creation is not idempotent.
-        # @param create_spec [Com::Vmware::Content::LibraryModel]
-        #      Specification for the new local library.
-        # @return [String]
-        #     Identifier of the newly created   :class:`Com::Vmware::Content::LibraryModel`  .
-        # @raise [Com::Vmware::Vapi::Std::Errors::InvalidArgument]
-        #      if the  ``create_spec``  is not valid.
-        # @raise [Com::Vmware::Vapi::Std::Errors::InvalidArgument]
-        #      if the  ``client_token``  does not conform to the UUID format.
-        # @raise [Com::Vmware::Vapi::Std::Errors::Unsupported]
-        #      if using multiple storage backings.
-        def create(create_spec, client_token=nil)
-            invoke_with_info(@@create_info, {
-                'client_token' => client_token,
-                'create_spec' => create_spec,
-            })
-        end
-
-
-        # Deletes the specified local library.  
-        # 
-        #  Deleting a local library will remove the entry immediately and begin an asynchronous task to remove all cached content for the library. If the asynchronous task fails, file content may remain on the storage backing. This content will require manual removal.
-        #
-        # @param library_id [String]
-        #      Identifier of the local library to delete.
-        # @return [Void]
-        # @raise [Com::Vmware::Vapi::Std::Errors::InvalidElementType]
-        #      if the library specified by  ``library_id``  is not a local library.
-        # @raise [Com::Vmware::Vapi::Std::Errors::NotFound]
-        #      if the library specified by  ``library_id``  does not exist.
-        def delete(library_id)
-            invoke_with_info(@@delete_info, {
-                'library_id' => library_id,
-            })
-        end
-
-
-        # Returns a given local library.
-        #
-        # @param library_id [String]
-        #      Identifier of the local library to return.
-        # @return [Com::Vmware::Content::LibraryModel]
-        #     The   :class:`Com::Vmware::Content::LibraryModel`   instance associated with  ``library_id`` .
-        # @raise [Com::Vmware::Vapi::Std::Errors::NotFound]
-        #      if the library specified by  ``library_id``  does not exist.
-        # @raise [Com::Vmware::Vapi::Std::Errors::InvalidElementType]
-        #      if the library specified by  ``library_id``  is not a local library.
-        def get(library_id)
-            invoke_with_info(@@get_info, {
-                'library_id' => library_id,
-            })
-        end
-
-
-        # Returns the identifiers of all local libraries in the Content Library.
-        #
-        # @return [Array<String>]
-        #     The  list  of identifiers of all local libraries in the Content Library.
-        def list()
-            invoke_with_info(@@list_info)
-        end
-
-
-        # Updates the properties of a local library.  
-        # 
-        #  This is an incremental update to the local library.  Fields  that are  nil  in the update specification will be left unchanged.
-        #
-        # @param library_id [String]
-        #      Identifier of the local library to update.
-        # @param update_spec [Com::Vmware::Content::LibraryModel]
-        #      Specification of the new property values to set on the local library.
-        # @return [Void]
-        # @raise [Com::Vmware::Vapi::Std::Errors::NotFound]
-        #      if the library specified by  ``library_id``  does not exist.
-        # @raise [Com::Vmware::Vapi::Std::Errors::InvalidElementType]
-        #      if the library specified by  ``library_id``  is not a local library.
-        # @raise [Com::Vmware::Vapi::Std::Errors::InvalidArgument]
-        #      if the  ``update_spec``  is not valid.
-        # @raise [Com::Vmware::Vapi::Std::Errors::InvalidArgument]
-        #      if the   :attr:`Com::Vmware::Content::LibraryModel.version`   of  ``update_spec``  is not equal to the current version of the library.
-        def update(library_id, update_spec)
-            invoke_with_info(@@update_info, {
-                'library_id' => library_id,
-                'update_spec' => update_spec,
-            })
-        end
-
-
+    # Retrieves the current configuration values.
+    #
+    # @return [Com::Vmware::Content::ConfigurationModel]
+    #     The   :class:`Com::Vmware::Content::ConfigurationModel`   instance representing the configuration of the Content Library Service.
+    def get
+      invoke_with_info(GET_INFO)
     end
 
+  end
+  # The  ``Com::Vmware::Content::Library``   class  provides  methods  to manage and find   :class:`Com::Vmware::Content::LibraryModel`   entities.  
+  # 
+  #  The  ``Com::Vmware::Content::Library``   class  provides support for generic functionality which can be applied equally to all types of libraries. The functionality provided by this  class  will not affect the properties specific to the type of library. See also   :class:`Com::Vmware::Content::LocalLibrary`   and   :class:`Com::Vmware::Content::SubscribedLibrary`  .
+  class LibraryService < VAPI::Bindings::VapiService
+    # static metamodel definitions
+    SERVICE_ID = VAPI::Core::ServiceIdentifier.new('com.vmware.content.library')
 
+    GET_INFO = VAPI::Bindings::OperationInfo.new(
+      VAPI::Core::OperationIdentifier.new('get', SERVICE_ID),
+      VAPI::Bindings::OperationInputType.new(
+        'library_id' => VAPI::Bindings::IdType.new('com.vmware.content.Library')
+      ),
+      VAPI::Bindings::ReferenceType.new('Com::Vmware::Content::LibraryModel'),
+      {
+        'com.vmware.vapi.std.errors.not_found' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::NotFound')
+      },
+      [],
+      []
+    )
 
-    class SubscribedLibrary < VAPI::Bindings::VapiService
+    LIST_INFO = VAPI::Bindings::OperationInfo.new(
+      VAPI::Core::OperationIdentifier.new('list', SERVICE_ID),
+      VAPI::Bindings::OperationInputType.new,
+      VAPI::Bindings::ListType.new(VAPI::Bindings::IdType.new),
+      {},
+      [],
+      []
+    )
 
-        protected
+    FIND_INFO = VAPI::Bindings::OperationInfo.new(
+      VAPI::Core::OperationIdentifier.new('find', SERVICE_ID),
+      VAPI::Bindings::OperationInputType.new(
+        'spec' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Content::Library::FindSpec')
+      ),
+      VAPI::Bindings::ListType.new(VAPI::Bindings::IdType.new),
+      {
+        'com.vmware.vapi.std.errors.invalid_argument' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::InvalidArgument')
+      },
+      [],
+      []
+    )
 
-        # static metamodel definitions
-        @@service_id = VAPI::Core::ServiceIdentifier.new('com.vmware.content.subscribed_library')
+    UPDATE_INFO = VAPI::Bindings::OperationInfo.new(
+      VAPI::Core::OperationIdentifier.new('update', SERVICE_ID),
+      VAPI::Bindings::OperationInputType.new(
+        'library_id' => VAPI::Bindings::IdType.new('com.vmware.content.Library'),
+        'update_spec' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Content::LibraryModel')
+      ),
+      VAPI::Bindings::VoidType.instance,
+      {
+        'com.vmware.vapi.std.errors.not_found' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::NotFound'),
+        'com.vmware.vapi.std.errors.invalid_argument' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::InvalidArgument')
+      },
+      [],
+      []
+    )
 
-        @@create_info = VAPI::Bindings::OperationInfo.new(
-            VAPI::Core::OperationIdentifier.new('create', @@service_id),
-            VAPI::Bindings::OperationInputType.new({
-                'client_token' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::StringType.instance),
-                'create_spec' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Content::LibraryModel'),
-            }),
-            VAPI::Bindings::IdType.new(resource_types='com.vmware.content.Library'),
-            {
-                'com.vmware.vapi.std.errors.invalid_argument' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::InvalidArgument'),
-                'com.vmware.vapi.std.errors.unsupported' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Unsupported'),
-                'com.vmware.vapi.std.errors.resource_inaccessible' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::ResourceInaccessible'),
+    SERVICE_INFO = VAPI::Bindings::ServiceInfo.new(
+      SERVICE_ID,
+      'get' => GET_INFO,
+      'list' => LIST_INFO,
+      'find' => FIND_INFO,
+      'update' => UPDATE_INFO
+    )
 
-            },
-            [],
-            [])
-        @@delete_info = VAPI::Bindings::OperationInfo.new(
-            VAPI::Core::OperationIdentifier.new('delete', @@service_id),
-            VAPI::Bindings::OperationInputType.new({
-                'library_id' => VAPI::Bindings::IdType.new(resource_types='com.vmware.content.Library'),
-            }),
-            VAPI::Bindings::VoidType.instance,
-            {
-                'com.vmware.vapi.std.errors.invalid_element_type' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::InvalidElementType'),
-                'com.vmware.vapi.std.errors.not_found' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::NotFound'),
-
-            },
-            [],
-            [])
-        @@evict_info = VAPI::Bindings::OperationInfo.new(
-            VAPI::Core::OperationIdentifier.new('evict', @@service_id),
-            VAPI::Bindings::OperationInputType.new({
-                'library_id' => VAPI::Bindings::IdType.new(resource_types='com.vmware.content.Library'),
-            }),
-            VAPI::Bindings::VoidType.instance,
-            {
-                'com.vmware.vapi.std.errors.not_found' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::NotFound'),
-                'com.vmware.vapi.std.errors.invalid_element_type' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::InvalidElementType'),
-                'com.vmware.vapi.std.errors.not_allowed_in_current_state' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::NotAllowedInCurrentState'),
-
-            },
-            [],
-            [])
-        @@get_info = VAPI::Bindings::OperationInfo.new(
-            VAPI::Core::OperationIdentifier.new('get', @@service_id),
-            VAPI::Bindings::OperationInputType.new({
-                'library_id' => VAPI::Bindings::IdType.new(resource_types='com.vmware.content.Library'),
-            }),
-            VAPI::Bindings::ReferenceType.new('Com::Vmware::Content::LibraryModel'),
-            {
-                'com.vmware.vapi.std.errors.not_found' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::NotFound'),
-                'com.vmware.vapi.std.errors.invalid_element_type' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::InvalidElementType'),
-
-            },
-            [],
-            [])
-        @@list_info = VAPI::Bindings::OperationInfo.new(
-            VAPI::Core::OperationIdentifier.new('list', @@service_id),
-            VAPI::Bindings::OperationInputType.new,
-            VAPI::Bindings::ListType.new(VAPI::Bindings::IdType.new),
-            {},
-            [],
-            [])
-        @@sync_info = VAPI::Bindings::OperationInfo.new(
-            VAPI::Core::OperationIdentifier.new('sync', @@service_id),
-            VAPI::Bindings::OperationInputType.new({
-                'library_id' => VAPI::Bindings::IdType.new(resource_types='com.vmware.content.Library'),
-            }),
-            VAPI::Bindings::VoidType.instance,
-            {
-                'com.vmware.vapi.std.errors.not_found' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::NotFound'),
-                'com.vmware.vapi.std.errors.invalid_element_type' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::InvalidElementType'),
-                'com.vmware.vapi.std.errors.invalid_argument' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::InvalidArgument'),
-                'com.vmware.vapi.std.errors.resource_inaccessible' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::ResourceInaccessible'),
-
-            },
-            [],
-            [])
-        @@update_info = VAPI::Bindings::OperationInfo.new(
-            VAPI::Core::OperationIdentifier.new('update', @@service_id),
-            VAPI::Bindings::OperationInputType.new({
-                'library_id' => VAPI::Bindings::IdType.new(resource_types='com.vmware.content.Library'),
-                'update_spec' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Content::LibraryModel'),
-            }),
-            VAPI::Bindings::VoidType.instance,
-            {
-                'com.vmware.vapi.std.errors.not_found' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::NotFound'),
-                'com.vmware.vapi.std.errors.invalid_element_type' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::InvalidElementType'),
-                'com.vmware.vapi.std.errors.invalid_argument' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::InvalidArgument'),
-                'com.vmware.vapi.std.errors.resource_inaccessible' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::ResourceInaccessible'),
-
-            },
-            [],
-            [])
-        @@probe_info = VAPI::Bindings::OperationInfo.new(
-            VAPI::Core::OperationIdentifier.new('probe', @@service_id),
-            VAPI::Bindings::OperationInputType.new({
-                'subscription_info' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Content::Library::SubscriptionInfo'),
-            }),
-            VAPI::Bindings::ReferenceType.new('Com::Vmware::Content::SubscribedLibrary::ProbeResult'),
-            {},
-            [],
-            [])
-
-        @@service_info = VAPI::Bindings::ServiceInfo.new(@@service_id, {
-            'create' => @@create_info,
-            'delete' => @@delete_info,
-            'evict' => @@evict_info,
-            'get' => @@get_info,
-            'list' => @@list_info,
-            'sync' => @@sync_info,
-            'update' => @@update_info,
-            'probe' => @@probe_info,
-        })
-
-        public
-
-        # Constructs a new instance.
-        #
-        # @param config [VAPI::Bindings::StubConfig] A hash with the api provider details.
-        def initialize(config)
-            super(config, @@service_info)
-        end
-
-
-        # Creates a new subscribed library.  
-        # 
-        #  Once created, the subscribed library will be empty. If the   :attr:`Com::Vmware::Content::LibraryModel.subscription_info`   property is set, the Content Library Service will attempt to synchronize to the remote source. This is an asynchronous operation so the content of the published library may not immediately appear.
-        #
-        # @param client_token [String, nil]
-        #      Unique token generated on the client for each creation request. The token should be a universally unique identifier (UUID), for example:  ``b8a2a2e3-2314-43cd-a871-6ede0f429751`` . This token can be used to guarantee idempotent creation.
-        #     If not specified creation is not idempotent.
-        # @param create_spec [Com::Vmware::Content::LibraryModel]
-        #      Specification for the new subscribed library.
-        # @return [String]
-        #     Identifier of the newly created subscribed library.
-        # @raise [Com::Vmware::Vapi::Std::Errors::InvalidArgument]
-        #      if the  ``create_spec``  is not valid.
-        # @raise [Com::Vmware::Vapi::Std::Errors::InvalidArgument]
-        #      if the  ``client_token``  does not conform to the UUID format.
-        # @raise [Com::Vmware::Vapi::Std::Errors::Unsupported]
-        #      if using multiple storage backings.
-        # @raise [Com::Vmware::Vapi::Std::Errors::ResourceInaccessible]
-        #      if subscribing to a published library which cannot be accessed.
-        def create(create_spec, client_token=nil)
-            invoke_with_info(@@create_info, {
-                'client_token' => client_token,
-                'create_spec' => create_spec,
-            })
-        end
-
-
-        # Deletes the specified subscribed library.  
-        # 
-        #  Deleting a subscribed library will remove the entry immediately and begin an asynchronous task to remove all cached content for the library. If the asynchronous task fails, file content may remain on the storage backing. This content will require manual removal.
-        #
-        # @param library_id [String]
-        #      Identifier of the subscribed library to delete.
-        # @return [Void]
-        # @raise [Com::Vmware::Vapi::Std::Errors::InvalidElementType]
-        #      if the library referenced by  ``library_id``  is not a subscribed library.
-        # @raise [Com::Vmware::Vapi::Std::Errors::NotFound]
-        #      if the library referenced by  ``library_id``  does not exist.
-        def delete(library_id)
-            invoke_with_info(@@delete_info, {
-                'library_id' => library_id,
-            })
-        end
-
-
-        # Evicts the cached content of an on-demand subscribed library.  
-        # 
-        #  This  method  allows the cached content of a subscribed library to be removed to free up storage capacity. This  method  will only work when a subscribed library is synchronized on-demand.
-        #
-        # @param library_id [String]
-        #      Identifier of the subscribed library whose content should be evicted.
-        # @return [Void]
-        # @raise [Com::Vmware::Vapi::Std::Errors::NotFound]
-        #      if the library specified by  ``library_id``  does not exist.
-        # @raise [Com::Vmware::Vapi::Std::Errors::InvalidElementType]
-        #      if the library specified by  ``library_id``  is not a subscribed library.
-        # @raise [Com::Vmware::Vapi::Std::Errors::NotAllowedInCurrentState]
-        #      if the library specified by  ``library_id``  does not synchronize on-demand.
-        def evict(library_id)
-            invoke_with_info(@@evict_info, {
-                'library_id' => library_id,
-            })
-        end
-
-
-        # Returns a given subscribed library.
-        #
-        # @param library_id [String]
-        #      Identifier of the subscribed library to return.
-        # @return [Com::Vmware::Content::LibraryModel]
-        #     The   :class:`Com::Vmware::Content::LibraryModel`   instance that corresponds to  ``library_id`` .
-        # @raise [Com::Vmware::Vapi::Std::Errors::NotFound]
-        #      if the library associated with  ``library_id``  does not exist.
-        # @raise [Com::Vmware::Vapi::Std::Errors::InvalidElementType]
-        #      if the library associated with  ``library_id``  is not a subscribed library.
-        def get(library_id)
-            invoke_with_info(@@get_info, {
-                'library_id' => library_id,
-            })
-        end
-
-
-        # Returns the identifiers of all subscribed libraries in the Content Library.
-        #
-        # @return [Array<String>]
-        #     The  list  of identifiers of all subscribed libraries in the Content Library.
-        def list()
-            invoke_with_info(@@list_info)
-        end
-
-
-        # Forces the synchronization of the subscribed library.  
-        # 
-        #  Synchronizing a subscribed library forcefully with this  method  will perform the same synchronization behavior as would run periodically for the library. The   :attr:`Com::Vmware::Content::Library::SubscriptionInfo.on_demand`   setting is respected. Calling this  method  on a library that is already in the process of synchronizing will have no effect.
-        #
-        # @param library_id [String]
-        #      Identifier of the subscribed library to synchronize.
-        # @return [Void]
-        # @raise [Com::Vmware::Vapi::Std::Errors::NotFound]
-        #      if the library specified by  ``library_id``  does not exist.
-        # @raise [Com::Vmware::Vapi::Std::Errors::InvalidElementType]
-        #      if the library specified by  ``library_id``  is not a subscribed library.
-        # @raise [Com::Vmware::Vapi::Std::Errors::InvalidArgument]
-        #      if some parameter in the subscribed library subscription info is invalid.
-        # @raise [Com::Vmware::Vapi::Std::Errors::ResourceInaccessible]
-        #      if the published library cannot be contacted or found.
-        def sync(library_id)
-            invoke_with_info(@@sync_info, {
-                'library_id' => library_id,
-            })
-        end
-
-
-        # Updates the properties of a subscribed library.  
-        # 
-        #  This is an incremental update to the subscribed library.  Fields  that are  nil  in the update specification will be left unchanged.
-        #
-        # @param library_id [String]
-        #      Identifier of the subscribed library to update.
-        # @param update_spec [Com::Vmware::Content::LibraryModel]
-        #      Specification of the new property values to set on the subscribed library.
-        # @return [Void]
-        # @raise [Com::Vmware::Vapi::Std::Errors::NotFound]
-        #      if the library specified by  ``library_id``  does not exist.
-        # @raise [Com::Vmware::Vapi::Std::Errors::InvalidElementType]
-        #      if the library specified by  ``library_id``  is not a subscribed library.
-        # @raise [Com::Vmware::Vapi::Std::Errors::InvalidArgument]
-        #      if the  ``update_spec``  is not valid.
-        # @raise [Com::Vmware::Vapi::Std::Errors::InvalidArgument]
-        #      if the   :attr:`Com::Vmware::Content::LibraryModel.version`   of  ``update_spec``  is not equal to the current version of the library.
-        # @raise [Com::Vmware::Vapi::Std::Errors::ResourceInaccessible]
-        #      if the subscription info is being updated but the published library cannot be contacted or found.
-        def update(library_id, update_spec)
-            invoke_with_info(@@update_info, {
-                'library_id' => library_id,
-                'update_spec' => update_spec,
-            })
-        end
-
-
-        # Probes remote library subscription information, including URL, SSL certificate and password. The resulting   :class:`Com::Vmware::Content::SubscribedLibrary::ProbeResult`    class  describes whether or not the subscription configuration is successful.
-        #
-        # @param subscription_info [Com::Vmware::Content::Library::SubscriptionInfo]
-        #      The subscription info to be probed.
-        # @return [Com::Vmware::Content::SubscribedLibrary::ProbeResult]
-        #     The subscription info probe result.
-        def probe(subscription_info)
-            invoke_with_info(@@probe_info, {
-                'subscription_info' => subscription_info,
-            })
-        end
-
-
-
-        # The  ``Com::Vmware::Content::SubscribedLibrary::ProbeResult``   class  defines the subscription information probe result. This describes whether using a given subscription URL is successful or if there are access problems, such as SSL errors.
-        # @!attribute [rw] status
-        #     @return [Com::Vmware::Content::SubscribedLibrary::ProbeResult::Status]
-        #     The status of probe result. This will be one of  ``SUCCESS``, ``INVALID_URL``, ``TIMED_OUT``, ``HOST_NOT_FOUND``, ``RESOURCE_NOT_FOUND``, ``INVALID_CREDENTIALS``, ``CERTIFICATE_ERROR``, ``UNKNOWN_ERROR`` .
-        # @!attribute [rw] ssl_thumbprint
-        #     @return [String, nil]
-        #     The SSL thumbprint for the remote endpoint.
-        #     An SSL thumbprint is only returned if the host is secured with SSL/TLS.
-        # @!attribute [rw] error_messages
-        #     @return [Array<Com::Vmware::Vapi::Std::LocalizableMessage>]
-        #     If the probe result is in an error status, this  field  will contain the detailed error messages.
-        class ProbeResult < VAPI::Bindings::VapiStruct
-
-            class << self
-                # Holds (gets or creates) the binding type metadata for this structure type.
-                # @scope class
-                # @return [VAPI::Bindings::StructType] the binding type
-                def binding_type
-                    @binding_type ||= VAPI::Bindings::StructType.new(
-                        'com.vmware.content.subscribed_library.probe_result',
-                        {
-                            'status' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Content::SubscribedLibrary::ProbeResult::Status'),
-                            'ssl_thumbprint' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::StringType.instance),
-                            'error_messages' => VAPI::Bindings::ListType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::LocalizableMessage')),
-                        },
-                        ProbeResult,
-                        false,
-                        nil)
-                end
-            end
-
-            attr_accessor :status,
-                          :ssl_thumbprint,
-                          :error_messages
-
-            # Constructs a new instance.
-            # @param ruby_values [Hash] a map of initial property values (optional)
-            # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
-            def initialize(ruby_values=nil, struct_value=nil)
-                super(self.class.binding_type, ruby_values, struct_value)
-            end
-
-
-            # The  ``Com::Vmware::Content::SubscribedLibrary::ProbeResult::Status``   enumerated type  defines the error status constants for the probe result.
-            # @!attribute [rw] success
-            #     @return [Com::Vmware::Content::SubscribedLibrary::ProbeResult::Status]
-            #     Indicates that the probe was successful.
-            # @!attribute [rw] invalid_url
-            #     @return [Com::Vmware::Content::SubscribedLibrary::ProbeResult::Status]
-            #     Indicates that the supplied URL was not valid.
-            # @!attribute [rw] timed_out
-            #     @return [Com::Vmware::Content::SubscribedLibrary::ProbeResult::Status]
-            #     Indicates that the probe timed out while attempting to connect to the URL.
-            # @!attribute [rw] host_not_found
-            #     @return [Com::Vmware::Content::SubscribedLibrary::ProbeResult::Status]
-            #     Indicates that the host in the URL could not be found.
-            # @!attribute [rw] resource_not_found
-            #     @return [Com::Vmware::Content::SubscribedLibrary::ProbeResult::Status]
-            #     Indicates that the given resource at the URL was not found.
-            # @!attribute [rw] invalid_credentials
-            #     @return [Com::Vmware::Content::SubscribedLibrary::ProbeResult::Status]
-            #     Indicates that the connection was rejected due to invalid credentials.
-            # @!attribute [rw] certificate_error
-            #     @return [Com::Vmware::Content::SubscribedLibrary::ProbeResult::Status]
-            #     Indicates that the provided server certificate thumbprint in   :attr:`Com::Vmware::Content::Library::SubscriptionInfo.ssl_thumbprint`   is invalid. In this case, the returned  null  should be set in   :attr:`Com::Vmware::Content::Library::SubscriptionInfo.ssl_thumbprint`  .
-            # @!attribute [rw] unknown_error
-            #     @return [Com::Vmware::Content::SubscribedLibrary::ProbeResult::Status]
-            #     Indicates an unspecified error different from the other error cases defined in   :class:`Com::Vmware::Content::SubscribedLibrary::ProbeResult::Status`  .
-            class Status < VAPI::Bindings::VapiEnum
-
-                class << self
-                    # Holds (gets or creates) the binding type metadata for this enumeration type.
-                    # @scope class
-                    # @return [VAPI::Bindings::EnumType] the binding type
-                    def binding_type
-                        @binding_type ||= VAPI::Bindings::EnumType.new(
-                            'com.vmware.content.subscribed_library.probe_result.status',
-                            Status)
-                    end
-
-                    # Converts from a string value (perhaps off the wire) to an instance
-                    # of this enum type.
-                    # @param value [String] the actual value of the enum instance
-                    # @return [Status] the instance found for the value, otherwise
-                    #         an unknown instance will be built for the value
-                    def from_string(value)
-                        begin
-                            const_get(value)
-                        rescue NameError
-                            Status.new('UNKNOWN', value)
-                        end
-                    end
-                end
-
-                private
-
-                # Constructs a new instance.
-                # @param value [String] the actual value of the enum instance
-                # @param unknown [String] the unknown value when value is 'UKNOWN'
-                def initialize(value, unknown=nil)
-                    super(self.class.binding_type, value, unknown)
-                end
-
-                public
-
-                # @!attribute [rw] success
-                #     @return [Com::Vmware::Content::SubscribedLibrary::ProbeResult::Status]
-                #     Indicates that the probe was successful.
-                SUCCESS = Status.new('SUCCESS')
-
-                # @!attribute [rw] invalid_url
-                #     @return [Com::Vmware::Content::SubscribedLibrary::ProbeResult::Status]
-                #     Indicates that the supplied URL was not valid.
-                INVALID_URL = Status.new('INVALID_URL')
-
-                # @!attribute [rw] timed_out
-                #     @return [Com::Vmware::Content::SubscribedLibrary::ProbeResult::Status]
-                #     Indicates that the probe timed out while attempting to connect to the URL.
-                TIMED_OUT = Status.new('TIMED_OUT')
-
-                # @!attribute [rw] host_not_found
-                #     @return [Com::Vmware::Content::SubscribedLibrary::ProbeResult::Status]
-                #     Indicates that the host in the URL could not be found.
-                HOST_NOT_FOUND = Status.new('HOST_NOT_FOUND')
-
-                # @!attribute [rw] resource_not_found
-                #     @return [Com::Vmware::Content::SubscribedLibrary::ProbeResult::Status]
-                #     Indicates that the given resource at the URL was not found.
-                RESOURCE_NOT_FOUND = Status.new('RESOURCE_NOT_FOUND')
-
-                # @!attribute [rw] invalid_credentials
-                #     @return [Com::Vmware::Content::SubscribedLibrary::ProbeResult::Status]
-                #     Indicates that the connection was rejected due to invalid credentials.
-                INVALID_CREDENTIALS = Status.new('INVALID_CREDENTIALS')
-
-                # @!attribute [rw] certificate_error
-                #     @return [Com::Vmware::Content::SubscribedLibrary::ProbeResult::Status]
-                #     Indicates that the provided server certificate thumbprint in   :attr:`Com::Vmware::Content::Library::SubscriptionInfo.ssl_thumbprint`   is invalid. In this case, the returned  null  should be set in   :attr:`Com::Vmware::Content::Library::SubscriptionInfo.ssl_thumbprint`  .
-                CERTIFICATE_ERROR = Status.new('CERTIFICATE_ERROR')
-
-                # @!attribute [rw] unknown_error
-                #     @return [Com::Vmware::Content::SubscribedLibrary::ProbeResult::Status]
-                #     Indicates an unspecified error different from the other error cases defined in   :class:`Com::Vmware::Content::SubscribedLibrary::ProbeResult::Status`  .
-                UNKNOWN_ERROR = Status.new('UNKNOWN_ERROR')
-
-            end
-
-
-        end
-
-
+    # Constructs a new instance.
+    #
+    # @param config [VAPI::Bindings::StubConfig] A hash with the api provider details.
+    def initialize(config)
+      super(config, SERVICE_INFO)
     end
 
-
-    # The  ``Com::Vmware::Content::Type``   class  exposes the   :class:`Com::Vmware::Content::Library::ItemModel`   types that this Content Library Service supports.  
-    # 
-    #  A library item has an optional type which can be specified with the   :attr:`Com::Vmware::Content::Library::ItemModel.type`    field . For items with a type that is supported by a plugin, the Content Library Service may understand the files which are part of the library item and can produce metadata for the item.  
-    # 
-    #  In other cases, uploads may require a process in which one upload implies subsequent uploads. For example, an Open Virtualization Format (OVF) package is composed of an OVF descriptor file and the associated virtual disk files. Uploading an OVF descriptor can enable the Content Library Service to understand that the complete OVF package requires additional disk files, and it can set up the transfers for the disks automatically by adding the file entries for the disks when the OVF descriptor is uploaded.  
-    # 
-    #  When a type is not supported by a plugin, or the type is not specified, the Content Library Service can handle a library item in a default way, without adding metadata to the item or guiding the upload process.
-    class Type < VAPI::Bindings::VapiService
-
-        protected
-
-        # static metamodel definitions
-        @@service_id = VAPI::Core::ServiceIdentifier.new('com.vmware.content.type')
-
-        @@list_info = VAPI::Bindings::OperationInfo.new(
-            VAPI::Core::OperationIdentifier.new('list', @@service_id),
-            VAPI::Bindings::OperationInputType.new,
-            VAPI::Bindings::ListType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Content::Type::Info')),
-            {},
-            [],
-            [])
-
-        @@service_info = VAPI::Bindings::ServiceInfo.new(@@service_id, {
-            'list' => @@list_info,
-        })
-
-        public
-
-        # Constructs a new instance.
-        #
-        # @param config [VAPI::Bindings::StubConfig] A hash with the api provider details.
-        def initialize(config)
-            super(config, @@service_info)
-        end
-
-
-        # Returns a  list  of   :class:`Com::Vmware::Content::Type::Info`   instances which describe the type support plugins in this Content Library.
-        #
-        # @return [Array<Com::Vmware::Content::Type::Info>]
-        #     The  list  of   :class:`Com::Vmware::Content::Type::Info`   instances which describe the type support plugins in this Content Library.
-        def list()
-            invoke_with_info(@@list_info)
-        end
-
-
-
-        # The  ``Com::Vmware::Content::Type::Info``   class  describes support for a specific type of data in an   :class:`Com::Vmware::Content::Library::ItemModel`  . The  ``Com::Vmware::Content::Type::Info``  can be queried through the   :class:`Com::Vmware::Content::Type`    class . Type support describes plugins in the Content Library which can provide metadata on library items and help manage the transfer process by adding dependent files when a current file is added.
-        # @!attribute [rw] description
-        #     @return [String]
-        #     A description of the type support offered by the plugin.
-        # @!attribute [rw] name
-        #     @return [String]
-        #     The name of the plugin which provides the type support.
-        # @!attribute [rw] type
-        #     @return [String]
-        #     The type which the plugin supports.  
-        #     
-        #      To upload a library item of the type supported by the plugin, the   :attr:`Com::Vmware::Content::Library::ItemModel.type`    field  of the item should be set to this value.
-        # @!attribute [rw] vendor
-        #     @return [String]
-        #     The name of the vendor who created the type support plugin.
-        # @!attribute [rw] version
-        #     @return [String]
-        #     The version number of the type support plugin.
-        class Info < VAPI::Bindings::VapiStruct
-
-            class << self
-                # Holds (gets or creates) the binding type metadata for this structure type.
-                # @scope class
-                # @return [VAPI::Bindings::StructType] the binding type
-                def binding_type
-                    @binding_type ||= VAPI::Bindings::StructType.new(
-                        'com.vmware.content.type.info',
-                        {
-                            'description' => VAPI::Bindings::StringType.instance,
-                            'name' => VAPI::Bindings::StringType.instance,
-                            'type' => VAPI::Bindings::StringType.instance,
-                            'vendor' => VAPI::Bindings::StringType.instance,
-                            'version' => VAPI::Bindings::StringType.instance,
-                        },
-                        Info,
-                        false,
-                        nil)
-                end
-            end
-
-            attr_accessor :description,
-                          :name,
-                          :type,
-                          :vendor,
-                          :version
-
-            # Constructs a new instance.
-            # @param ruby_values [Hash] a map of initial property values (optional)
-            # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
-            def initialize(ruby_values=nil, struct_value=nil)
-                super(self.class.binding_type, ruby_values, struct_value)
-            end
-        end
-
-
+    RESOURCE_TYPE = 'com.vmware.content.Library'
+    # Returns a given   :class:`Com::Vmware::Content::LibraryModel`  .
+    #
+    # @param library_id [String]
+    #      Identifier of the library to return.
+    # @return [Com::Vmware::Content::LibraryModel]
+    #     The   :class:`Com::Vmware::Content::LibraryModel`   instance with the specified  ``library_id`` .
+    # @raise [Com::Vmware::Vapi::Std::Errors::NotFound]
+    #      if the specified library does not exist.
+    def get(library_id)
+      invoke_with_info(GET_INFO,
+                       'library_id' => library_id)
     end
 
+    # Returns the identifiers of all libraries of any type in the Content Library.
+    #
+    # @return [Array<String>]
+    #     The  list  of all identifiers of all libraries in the Content Library.
+    def list
+      invoke_with_info(LIST_INFO)
+    end
 
+    # Returns a list of all the visible (as determined by authorization policy) libraries matching the requested   :class:`Com::Vmware::Content::Library::FindSpec`  .
+    #
+    # @param spec [Com::Vmware::Content::Library::FindSpec]
+    #      Specification describing what properties to filter on.
+    # @return [Array<String>]
+    #     The  list  of identifiers of all the visible libraries matching the given  ``spec`` .
+    # @raise [Com::Vmware::Vapi::Std::Errors::InvalidArgument]
+    #      if no properties are specified in the  ``spec`` .
+    def find(spec)
+      invoke_with_info(FIND_INFO,
+                       'spec' => spec)
+    end
 
-    # The  ``Com::Vmware::Content::ConfigurationModel``   class  defines the global settings of the Content Library Service.
-    # @!attribute [rw] automatic_sync_enabled
-    #     @return [Boolean]
-    #     Whether automatic synchronization is enabled.  
-    #     
-    #      When automatic synchronization is enabled, the Content Library Service will automatically synchronize all subscribed libraries on a daily basis. Subscribed libraries with the   :attr:`Com::Vmware::Content::Library::SubscriptionInfo.automatic_sync_enabled`   flag turned on will be synchronized every hour between   :attr:`Com::Vmware::Content::ConfigurationModel.automatic_sync_start_hour`   and   :attr:`Com::Vmware::Content::ConfigurationModel.automatic_sync_stop_hour`  .
-    #     This  field  is not used for the  ``create``   method . It will always be present in the  result  of the  ``get``  or  ``list``   methods . It is optional for the  ``update``   method .
-    # @!attribute [rw] automatic_sync_start_hour
-    #     @return [Fixnum]
-    #     The hour at which the automatic synchronization will start. This value is between 0 (midnight) and 23 inclusive.
-    #     This  field  is not used for the  ``create``   method . It will always be present in the  result  of the  ``get``  or  ``list``   methods . It is optional for the  ``update``   method .
-    # @!attribute [rw] automatic_sync_stop_hour
-    #     @return [Fixnum]
-    #     The hour at which the automatic synchronization will stop. Any active synchronization operation will continue to run, however no new synchronization operations will be triggered after the stop hour. This value is between 0 (midnight) and 23 inclusive.
-    #     This  field  is not used for the  ``create``   method . It will always be present in the  result  of the  ``get``  or  ``list``   methods . It is optional for the  ``update``   method .
-    # @!attribute [rw] maximum_concurrent_item_syncs
-    #     @return [Fixnum]
-    #     The maximum allowed number of library items to synchronize concurrently from remote libraries. This must be a positive number. The service may not be able to guarantee the requested concurrency if there is no available capacity.  
-    #     
-    #      This setting is global across all subscribed libraries.
-    #     This  field  is not used for the  ``create``   method . It will always be present in the  result  of the  ``get``  or  ``list``   methods . It is optional for the  ``update``   method .
-    class ConfigurationModel < VAPI::Bindings::VapiStruct
+    # Updates the properties of a library.  
+    # 
+    #  This is an incremental update to the library. Any  field  in the   :class:`Com::Vmware::Content::LibraryModel`    class  that is  nil  will not be modified.  
+    # 
+    #  This  method  will only update the common properties for all library types. This will not, for example, update the   :attr:`Com::Vmware::Content::LibraryModel.publish_info`   of a local library, nor the   :attr:`Com::Vmware::Content::LibraryModel.subscription_info`   of a subscribed library. Specific properties are updated in   :func:`Com::Vmware::Content::LocalLibrary.update`   and   :func:`Com::Vmware::Content::SubscribedLibrary.update`  .
+    #
+    # @param library_id [String]
+    #      Identifier of the library to update.
+    # @param update_spec [Com::Vmware::Content::LibraryModel]
+    #      Specification of the new property values to set on the library.
+    # @return [Void]
+    # @raise [Com::Vmware::Vapi::Std::Errors::NotFound]
+    #      if the library associated with  ``library_id``  does not exist.
+    # @raise [Com::Vmware::Vapi::Std::Errors::InvalidArgument]
+    #      if the  ``update_spec``  is not valid.
+    # @raise [Com::Vmware::Vapi::Std::Errors::InvalidArgument]
+    #      if the   :attr:`Com::Vmware::Content::LibraryModel.version`   of  ``update_spec``  is not equal to the current version of the library.
+    def update(library_id, update_spec)
+      invoke_with_info(UPDATE_INFO,
+                       'library_id' => library_id,
+                       'update_spec' => update_spec)
+    end
 
+    # Specifies the properties that can be used as a filter to find libraries. When multiple  fields  are specified, all properties of the library must match the specification.
+    # @!attribute [rw] name
+    #     @return [String, nil]
+    #     Name of the library to search. The name is case-insensitive. See   :attr:`Com::Vmware::Content::LibraryModel.name`  .
+    #     If not specified any name will be searched.
+    # @!attribute [rw] type
+    #     @return [Com::Vmware::Content::LibraryModel::LibraryType, nil]
+    #     Library type to search. See   :attr:`Com::Vmware::Content::LibraryModel.type`  .
+    #     If not specified any library type will be searched.
+    class FindSpec < VAPI::Bindings::VapiStruct
+      class << self
+        # Holds (gets or creates) the binding type metadata for this structure type.
+        # @scope class
+        # @return [VAPI::Bindings::StructType] the binding type
+        def binding_type
+          @binding_type ||= VAPI::Bindings::StructType.new(
+            'com.vmware.content.library.find_spec',
+            {
+              'name' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::StringType.instance),
+              'type' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Content::LibraryModel::LibraryType'))
+            },
+            FindSpec,
+            false,
+            nil
+          )
+        end
+      end
+
+      attr_accessor :name,
+                    :type
+
+      # Constructs a new instance.
+      # @param ruby_values [Hash] a map of initial property values (optional)
+      # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
+      def initialize(ruby_values = nil, struct_value = nil)
+        super(self.class.binding_type, ruby_values, struct_value)
+      end
+    end
+
+  end
+  # The  ``Com::Vmware::Content::LocalLibrary``   class  manages local libraries.  
+  # 
+  #  The  ``Com::Vmware::Content::LocalLibrary``   class  provides support for creating and maintaining local library instances. A local library may also use the   :class:`Com::Vmware::Content::Library`    class  to manage general library functionality.
+  class LocalLibrary < VAPI::Bindings::VapiService
+    # static metamodel definitions
+    SERVICE_ID = VAPI::Core::ServiceIdentifier.new('com.vmware.content.local_library')
+
+    CREATE_INFO = VAPI::Bindings::OperationInfo.new(
+      VAPI::Core::OperationIdentifier.new('create', SERVICE_ID),
+      VAPI::Bindings::OperationInputType.new(
+        'client_token' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::StringType.instance),
+        'create_spec' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Content::LibraryModel')
+      ),
+      VAPI::Bindings::IdType.new('com.vmware.content.Library'),
+      {
+        'com.vmware.vapi.std.errors.invalid_argument' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::InvalidArgument'),
+        'com.vmware.vapi.std.errors.unsupported' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Unsupported')
+      },
+      [],
+      []
+    )
+
+    DELETE_INFO = VAPI::Bindings::OperationInfo.new(
+      VAPI::Core::OperationIdentifier.new('delete', SERVICE_ID),
+      VAPI::Bindings::OperationInputType.new(
+        'library_id' => VAPI::Bindings::IdType.new('com.vmware.content.Library')
+      ),
+      VAPI::Bindings::VoidType.instance,
+      {
+        'com.vmware.vapi.std.errors.invalid_element_type' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::InvalidElementType'),
+        'com.vmware.vapi.std.errors.not_found' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::NotFound')
+      },
+      [],
+      []
+    )
+
+    GET_INFO = VAPI::Bindings::OperationInfo.new(
+      VAPI::Core::OperationIdentifier.new('get', SERVICE_ID),
+      VAPI::Bindings::OperationInputType.new(
+        'library_id' => VAPI::Bindings::IdType.new('com.vmware.content.Library')
+      ),
+      VAPI::Bindings::ReferenceType.new('Com::Vmware::Content::LibraryModel'),
+      {
+        'com.vmware.vapi.std.errors.not_found' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::NotFound'),
+        'com.vmware.vapi.std.errors.invalid_element_type' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::InvalidElementType')
+      },
+      [],
+      []
+    )
+
+    LIST_INFO = VAPI::Bindings::OperationInfo.new(
+      VAPI::Core::OperationIdentifier.new('list', SERVICE_ID),
+      VAPI::Bindings::OperationInputType.new,
+      VAPI::Bindings::ListType.new(VAPI::Bindings::IdType.new),
+      {},
+      [],
+      []
+    )
+
+    UPDATE_INFO = VAPI::Bindings::OperationInfo.new(
+      VAPI::Core::OperationIdentifier.new('update', SERVICE_ID),
+      VAPI::Bindings::OperationInputType.new(
+        'library_id' => VAPI::Bindings::IdType.new('com.vmware.content.Library'),
+        'update_spec' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Content::LibraryModel')
+      ),
+      VAPI::Bindings::VoidType.instance,
+      {
+        'com.vmware.vapi.std.errors.not_found' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::NotFound'),
+        'com.vmware.vapi.std.errors.invalid_element_type' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::InvalidElementType'),
+        'com.vmware.vapi.std.errors.invalid_argument' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::InvalidArgument')
+      },
+      [],
+      []
+    )
+
+    SERVICE_INFO = VAPI::Bindings::ServiceInfo.new(
+      SERVICE_ID,
+      'create' => CREATE_INFO,
+      'delete' => DELETE_INFO,
+      'get' => GET_INFO,
+      'list' => LIST_INFO,
+      'update' => UPDATE_INFO
+    )
+
+    # Constructs a new instance.
+    #
+    # @param config [VAPI::Bindings::StubConfig] A hash with the api provider details.
+    def initialize(config)
+      super(config, SERVICE_INFO)
+    end
+
+    # Creates a new local library.
+    #
+    # @param client_token [String, nil]
+    #      A unique token generated on the client for each creation request. The token should be a universally unique identifier (UUID), for example:  ``b8a2a2e3-2314-43cd-a871-6ede0f429751`` . This token can be used to guarantee idempotent creation.
+    #     If not specified creation is not idempotent.
+    # @param create_spec [Com::Vmware::Content::LibraryModel]
+    #      Specification for the new local library.
+    # @return [String]
+    #     Identifier of the newly created   :class:`Com::Vmware::Content::LibraryModel`  .
+    # @raise [Com::Vmware::Vapi::Std::Errors::InvalidArgument]
+    #      if the  ``create_spec``  is not valid.
+    # @raise [Com::Vmware::Vapi::Std::Errors::InvalidArgument]
+    #      if the  ``client_token``  does not conform to the UUID format.
+    # @raise [Com::Vmware::Vapi::Std::Errors::Unsupported]
+    #      if using multiple storage backings.
+    def create(create_spec, client_token = nil)
+      invoke_with_info(CREATE_INFO,
+                       'client_token' => client_token,
+                       'create_spec' => create_spec)
+    end
+
+    # Deletes the specified local library.  
+    # 
+    #  Deleting a local library will remove the entry immediately and begin an asynchronous task to remove all cached content for the library. If the asynchronous task fails, file content may remain on the storage backing. This content will require manual removal.
+    #
+    # @param library_id [String]
+    #      Identifier of the local library to delete.
+    # @return [Void]
+    # @raise [Com::Vmware::Vapi::Std::Errors::InvalidElementType]
+    #      if the library specified by  ``library_id``  is not a local library.
+    # @raise [Com::Vmware::Vapi::Std::Errors::NotFound]
+    #      if the library specified by  ``library_id``  does not exist.
+    def delete(library_id)
+      invoke_with_info(DELETE_INFO,
+                       'library_id' => library_id)
+    end
+
+    # Returns a given local library.
+    #
+    # @param library_id [String]
+    #      Identifier of the local library to return.
+    # @return [Com::Vmware::Content::LibraryModel]
+    #     The   :class:`Com::Vmware::Content::LibraryModel`   instance associated with  ``library_id`` .
+    # @raise [Com::Vmware::Vapi::Std::Errors::NotFound]
+    #      if the library specified by  ``library_id``  does not exist.
+    # @raise [Com::Vmware::Vapi::Std::Errors::InvalidElementType]
+    #      if the library specified by  ``library_id``  is not a local library.
+    def get(library_id)
+      invoke_with_info(GET_INFO,
+                       'library_id' => library_id)
+    end
+
+    # Returns the identifiers of all local libraries in the Content Library.
+    #
+    # @return [Array<String>]
+    #     The  list  of identifiers of all local libraries in the Content Library.
+    def list
+      invoke_with_info(LIST_INFO)
+    end
+
+    # Updates the properties of a local library.  
+    # 
+    #  This is an incremental update to the local library.  Fields  that are  nil  in the update specification will be left unchanged.
+    #
+    # @param library_id [String]
+    #      Identifier of the local library to update.
+    # @param update_spec [Com::Vmware::Content::LibraryModel]
+    #      Specification of the new property values to set on the local library.
+    # @return [Void]
+    # @raise [Com::Vmware::Vapi::Std::Errors::NotFound]
+    #      if the library specified by  ``library_id``  does not exist.
+    # @raise [Com::Vmware::Vapi::Std::Errors::InvalidElementType]
+    #      if the library specified by  ``library_id``  is not a local library.
+    # @raise [Com::Vmware::Vapi::Std::Errors::InvalidArgument]
+    #      if the  ``update_spec``  is not valid.
+    # @raise [Com::Vmware::Vapi::Std::Errors::InvalidArgument]
+    #      if the   :attr:`Com::Vmware::Content::LibraryModel.version`   of  ``update_spec``  is not equal to the current version of the library.
+    def update(library_id, update_spec)
+      invoke_with_info(UPDATE_INFO,
+                       'library_id' => library_id,
+                       'update_spec' => update_spec)
+    end
+
+  end
+  class SubscribedLibrary < VAPI::Bindings::VapiService
+    # static metamodel definitions
+    SERVICE_ID = VAPI::Core::ServiceIdentifier.new('com.vmware.content.subscribed_library')
+
+    CREATE_INFO = VAPI::Bindings::OperationInfo.new(
+      VAPI::Core::OperationIdentifier.new('create', SERVICE_ID),
+      VAPI::Bindings::OperationInputType.new(
+        'client_token' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::StringType.instance),
+        'create_spec' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Content::LibraryModel')
+      ),
+      VAPI::Bindings::IdType.new('com.vmware.content.Library'),
+      {
+        'com.vmware.vapi.std.errors.invalid_argument' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::InvalidArgument'),
+        'com.vmware.vapi.std.errors.unsupported' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Unsupported'),
+        'com.vmware.vapi.std.errors.resource_inaccessible' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::ResourceInaccessible')
+      },
+      [],
+      []
+    )
+
+    DELETE_INFO = VAPI::Bindings::OperationInfo.new(
+      VAPI::Core::OperationIdentifier.new('delete', SERVICE_ID),
+      VAPI::Bindings::OperationInputType.new(
+        'library_id' => VAPI::Bindings::IdType.new('com.vmware.content.Library')
+      ),
+      VAPI::Bindings::VoidType.instance,
+      {
+        'com.vmware.vapi.std.errors.invalid_element_type' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::InvalidElementType'),
+        'com.vmware.vapi.std.errors.not_found' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::NotFound')
+      },
+      [],
+      []
+    )
+
+    EVICT_INFO = VAPI::Bindings::OperationInfo.new(
+      VAPI::Core::OperationIdentifier.new('evict', SERVICE_ID),
+      VAPI::Bindings::OperationInputType.new(
+        'library_id' => VAPI::Bindings::IdType.new('com.vmware.content.Library')
+      ),
+      VAPI::Bindings::VoidType.instance,
+      {
+        'com.vmware.vapi.std.errors.not_found' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::NotFound'),
+        'com.vmware.vapi.std.errors.invalid_element_type' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::InvalidElementType'),
+        'com.vmware.vapi.std.errors.not_allowed_in_current_state' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::NotAllowedInCurrentState')
+      },
+      [],
+      []
+    )
+
+    GET_INFO = VAPI::Bindings::OperationInfo.new(
+      VAPI::Core::OperationIdentifier.new('get', SERVICE_ID),
+      VAPI::Bindings::OperationInputType.new(
+        'library_id' => VAPI::Bindings::IdType.new('com.vmware.content.Library')
+      ),
+      VAPI::Bindings::ReferenceType.new('Com::Vmware::Content::LibraryModel'),
+      {
+        'com.vmware.vapi.std.errors.not_found' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::NotFound'),
+        'com.vmware.vapi.std.errors.invalid_element_type' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::InvalidElementType')
+      },
+      [],
+      []
+    )
+
+    LIST_INFO = VAPI::Bindings::OperationInfo.new(
+      VAPI::Core::OperationIdentifier.new('list', SERVICE_ID),
+      VAPI::Bindings::OperationInputType.new,
+      VAPI::Bindings::ListType.new(VAPI::Bindings::IdType.new),
+      {},
+      [],
+      []
+    )
+
+    SYNC_INFO = VAPI::Bindings::OperationInfo.new(
+      VAPI::Core::OperationIdentifier.new('sync', SERVICE_ID),
+      VAPI::Bindings::OperationInputType.new(
+        'library_id' => VAPI::Bindings::IdType.new('com.vmware.content.Library')
+      ),
+      VAPI::Bindings::VoidType.instance,
+      {
+        'com.vmware.vapi.std.errors.not_found' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::NotFound'),
+        'com.vmware.vapi.std.errors.invalid_element_type' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::InvalidElementType'),
+        'com.vmware.vapi.std.errors.invalid_argument' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::InvalidArgument'),
+        'com.vmware.vapi.std.errors.resource_inaccessible' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::ResourceInaccessible')
+      },
+      [],
+      []
+    )
+
+    UPDATE_INFO = VAPI::Bindings::OperationInfo.new(
+      VAPI::Core::OperationIdentifier.new('update', SERVICE_ID),
+      VAPI::Bindings::OperationInputType.new(
+        'library_id' => VAPI::Bindings::IdType.new('com.vmware.content.Library'),
+        'update_spec' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Content::LibraryModel')
+      ),
+      VAPI::Bindings::VoidType.instance,
+      {
+        'com.vmware.vapi.std.errors.not_found' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::NotFound'),
+        'com.vmware.vapi.std.errors.invalid_element_type' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::InvalidElementType'),
+        'com.vmware.vapi.std.errors.invalid_argument' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::InvalidArgument'),
+        'com.vmware.vapi.std.errors.resource_inaccessible' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::ResourceInaccessible')
+      },
+      [],
+      []
+    )
+
+    PROBE_INFO = VAPI::Bindings::OperationInfo.new(
+      VAPI::Core::OperationIdentifier.new('probe', SERVICE_ID),
+      VAPI::Bindings::OperationInputType.new(
+        'subscription_info' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Content::Library::SubscriptionInfo')
+      ),
+      VAPI::Bindings::ReferenceType.new('Com::Vmware::Content::SubscribedLibrary::ProbeResult'),
+      {},
+      [],
+      []
+    )
+
+    SERVICE_INFO = VAPI::Bindings::ServiceInfo.new(
+      SERVICE_ID,
+      'create' => CREATE_INFO,
+      'delete' => DELETE_INFO,
+      'evict' => EVICT_INFO,
+      'get' => GET_INFO,
+      'list' => LIST_INFO,
+      'sync' => SYNC_INFO,
+      'update' => UPDATE_INFO,
+      'probe' => PROBE_INFO
+    )
+
+    # Constructs a new instance.
+    #
+    # @param config [VAPI::Bindings::StubConfig] A hash with the api provider details.
+    def initialize(config)
+      super(config, SERVICE_INFO)
+    end
+
+    # Creates a new subscribed library.  
+    # 
+    #  Once created, the subscribed library will be empty. If the   :attr:`Com::Vmware::Content::LibraryModel.subscription_info`   property is set, the Content Library Service will attempt to synchronize to the remote source. This is an asynchronous operation so the content of the published library may not immediately appear.
+    #
+    # @param client_token [String, nil]
+    #      Unique token generated on the client for each creation request. The token should be a universally unique identifier (UUID), for example:  ``b8a2a2e3-2314-43cd-a871-6ede0f429751`` . This token can be used to guarantee idempotent creation.
+    #     If not specified creation is not idempotent.
+    # @param create_spec [Com::Vmware::Content::LibraryModel]
+    #      Specification for the new subscribed library.
+    # @return [String]
+    #     Identifier of the newly created subscribed library.
+    # @raise [Com::Vmware::Vapi::Std::Errors::InvalidArgument]
+    #      if the  ``create_spec``  is not valid.
+    # @raise [Com::Vmware::Vapi::Std::Errors::InvalidArgument]
+    #      if the  ``client_token``  does not conform to the UUID format.
+    # @raise [Com::Vmware::Vapi::Std::Errors::Unsupported]
+    #      if using multiple storage backings.
+    # @raise [Com::Vmware::Vapi::Std::Errors::ResourceInaccessible]
+    #      if subscribing to a published library which cannot be accessed.
+    def create(create_spec, client_token = nil)
+      invoke_with_info(CREATE_INFO,
+                       'client_token' => client_token,
+                       'create_spec' => create_spec)
+    end
+
+    # Deletes the specified subscribed library.  
+    # 
+    #  Deleting a subscribed library will remove the entry immediately and begin an asynchronous task to remove all cached content for the library. If the asynchronous task fails, file content may remain on the storage backing. This content will require manual removal.
+    #
+    # @param library_id [String]
+    #      Identifier of the subscribed library to delete.
+    # @return [Void]
+    # @raise [Com::Vmware::Vapi::Std::Errors::InvalidElementType]
+    #      if the library referenced by  ``library_id``  is not a subscribed library.
+    # @raise [Com::Vmware::Vapi::Std::Errors::NotFound]
+    #      if the library referenced by  ``library_id``  does not exist.
+    def delete(library_id)
+      invoke_with_info(DELETE_INFO,
+                       'library_id' => library_id)
+    end
+
+    # Evicts the cached content of an on-demand subscribed library.  
+    # 
+    #  This  method  allows the cached content of a subscribed library to be removed to free up storage capacity. This  method  will only work when a subscribed library is synchronized on-demand.
+    #
+    # @param library_id [String]
+    #      Identifier of the subscribed library whose content should be evicted.
+    # @return [Void]
+    # @raise [Com::Vmware::Vapi::Std::Errors::NotFound]
+    #      if the library specified by  ``library_id``  does not exist.
+    # @raise [Com::Vmware::Vapi::Std::Errors::InvalidElementType]
+    #      if the library specified by  ``library_id``  is not a subscribed library.
+    # @raise [Com::Vmware::Vapi::Std::Errors::NotAllowedInCurrentState]
+    #      if the library specified by  ``library_id``  does not synchronize on-demand.
+    def evict(library_id)
+      invoke_with_info(EVICT_INFO,
+                       'library_id' => library_id)
+    end
+
+    # Returns a given subscribed library.
+    #
+    # @param library_id [String]
+    #      Identifier of the subscribed library to return.
+    # @return [Com::Vmware::Content::LibraryModel]
+    #     The   :class:`Com::Vmware::Content::LibraryModel`   instance that corresponds to  ``library_id`` .
+    # @raise [Com::Vmware::Vapi::Std::Errors::NotFound]
+    #      if the library associated with  ``library_id``  does not exist.
+    # @raise [Com::Vmware::Vapi::Std::Errors::InvalidElementType]
+    #      if the library associated with  ``library_id``  is not a subscribed library.
+    def get(library_id)
+      invoke_with_info(GET_INFO,
+                       'library_id' => library_id)
+    end
+
+    # Returns the identifiers of all subscribed libraries in the Content Library.
+    #
+    # @return [Array<String>]
+    #     The  list  of identifiers of all subscribed libraries in the Content Library.
+    def list
+      invoke_with_info(LIST_INFO)
+    end
+
+    # Forces the synchronization of the subscribed library.  
+    # 
+    #  Synchronizing a subscribed library forcefully with this  method  will perform the same synchronization behavior as would run periodically for the library. The   :attr:`Com::Vmware::Content::Library::SubscriptionInfo.on_demand`   setting is respected. Calling this  method  on a library that is already in the process of synchronizing will have no effect.
+    #
+    # @param library_id [String]
+    #      Identifier of the subscribed library to synchronize.
+    # @return [Void]
+    # @raise [Com::Vmware::Vapi::Std::Errors::NotFound]
+    #      if the library specified by  ``library_id``  does not exist.
+    # @raise [Com::Vmware::Vapi::Std::Errors::InvalidElementType]
+    #      if the library specified by  ``library_id``  is not a subscribed library.
+    # @raise [Com::Vmware::Vapi::Std::Errors::InvalidArgument]
+    #      if some parameter in the subscribed library subscription info is invalid.
+    # @raise [Com::Vmware::Vapi::Std::Errors::ResourceInaccessible]
+    #      if the published library cannot be contacted or found.
+    def sync(library_id)
+      invoke_with_info(SYNC_INFO,
+                       'library_id' => library_id)
+    end
+
+    # Updates the properties of a subscribed library.  
+    # 
+    #  This is an incremental update to the subscribed library.  Fields  that are  nil  in the update specification will be left unchanged.
+    #
+    # @param library_id [String]
+    #      Identifier of the subscribed library to update.
+    # @param update_spec [Com::Vmware::Content::LibraryModel]
+    #      Specification of the new property values to set on the subscribed library.
+    # @return [Void]
+    # @raise [Com::Vmware::Vapi::Std::Errors::NotFound]
+    #      if the library specified by  ``library_id``  does not exist.
+    # @raise [Com::Vmware::Vapi::Std::Errors::InvalidElementType]
+    #      if the library specified by  ``library_id``  is not a subscribed library.
+    # @raise [Com::Vmware::Vapi::Std::Errors::InvalidArgument]
+    #      if the  ``update_spec``  is not valid.
+    # @raise [Com::Vmware::Vapi::Std::Errors::InvalidArgument]
+    #      if the   :attr:`Com::Vmware::Content::LibraryModel.version`   of  ``update_spec``  is not equal to the current version of the library.
+    # @raise [Com::Vmware::Vapi::Std::Errors::ResourceInaccessible]
+    #      if the subscription info is being updated but the published library cannot be contacted or found.
+    def update(library_id, update_spec)
+      invoke_with_info(UPDATE_INFO,
+                       'library_id' => library_id,
+                       'update_spec' => update_spec)
+    end
+
+    # Probes remote library subscription information, including URL, SSL certificate and password. The resulting   :class:`Com::Vmware::Content::SubscribedLibrary::ProbeResult`    class  describes whether or not the subscription configuration is successful.
+    #
+    # @param subscription_info [Com::Vmware::Content::Library::SubscriptionInfo]
+    #      The subscription info to be probed.
+    # @return [Com::Vmware::Content::SubscribedLibrary::ProbeResult]
+    #     The subscription info probe result.
+    def probe(subscription_info)
+      invoke_with_info(PROBE_INFO,
+                       'subscription_info' => subscription_info)
+    end
+
+    # The  ``Com::Vmware::Content::SubscribedLibrary::ProbeResult``   class  defines the subscription information probe result. This describes whether using a given subscription URL is successful or if there are access problems, such as SSL errors.
+    # @!attribute [rw] status
+    #     @return [Com::Vmware::Content::SubscribedLibrary::ProbeResult::Status]
+    #     The status of probe result. This will be one of  ``SUCCESS``, ``INVALID_URL``, ``TIMED_OUT``, ``HOST_NOT_FOUND``, ``RESOURCE_NOT_FOUND``, ``INVALID_CREDENTIALS``, ``CERTIFICATE_ERROR``, ``UNKNOWN_ERROR`` .
+    # @!attribute [rw] ssl_thumbprint
+    #     @return [String, nil]
+    #     The SSL thumbprint for the remote endpoint.
+    #     An SSL thumbprint is only returned if the host is secured with SSL/TLS.
+    # @!attribute [rw] error_messages
+    #     @return [Array<Com::Vmware::Vapi::Std::LocalizableMessage>]
+    #     If the probe result is in an error status, this  field  will contain the detailed error messages.
+    class ProbeResult < VAPI::Bindings::VapiStruct
+      class << self
+        # Holds (gets or creates) the binding type metadata for this structure type.
+        # @scope class
+        # @return [VAPI::Bindings::StructType] the binding type
+        def binding_type
+          @binding_type ||= VAPI::Bindings::StructType.new(
+            'com.vmware.content.subscribed_library.probe_result',
+            {
+              'status' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Content::SubscribedLibrary::ProbeResult::Status'),
+              'ssl_thumbprint' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::StringType.instance),
+              'error_messages' => VAPI::Bindings::ListType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::LocalizableMessage'))
+            },
+            ProbeResult,
+            false,
+            nil
+          )
+        end
+      end
+
+      attr_accessor :status,
+                    :ssl_thumbprint,
+                    :error_messages
+
+      # Constructs a new instance.
+      # @param ruby_values [Hash] a map of initial property values (optional)
+      # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
+      def initialize(ruby_values = nil, struct_value = nil)
+        super(self.class.binding_type, ruby_values, struct_value)
+      end
+
+      # The  ``Com::Vmware::Content::SubscribedLibrary::ProbeResult::Status``   enumerated type  defines the error status constants for the probe result.
+      # @!attribute [rw] success
+      #     @return [Com::Vmware::Content::SubscribedLibrary::ProbeResult::Status]
+      #     Indicates that the probe was successful.
+      # @!attribute [rw] invalid_url
+      #     @return [Com::Vmware::Content::SubscribedLibrary::ProbeResult::Status]
+      #     Indicates that the supplied URL was not valid.
+      # @!attribute [rw] timed_out
+      #     @return [Com::Vmware::Content::SubscribedLibrary::ProbeResult::Status]
+      #     Indicates that the probe timed out while attempting to connect to the URL.
+      # @!attribute [rw] host_not_found
+      #     @return [Com::Vmware::Content::SubscribedLibrary::ProbeResult::Status]
+      #     Indicates that the host in the URL could not be found.
+      # @!attribute [rw] resource_not_found
+      #     @return [Com::Vmware::Content::SubscribedLibrary::ProbeResult::Status]
+      #     Indicates that the given resource at the URL was not found.
+      # @!attribute [rw] invalid_credentials
+      #     @return [Com::Vmware::Content::SubscribedLibrary::ProbeResult::Status]
+      #     Indicates that the connection was rejected due to invalid credentials.
+      # @!attribute [rw] certificate_error
+      #     @return [Com::Vmware::Content::SubscribedLibrary::ProbeResult::Status]
+      #     Indicates that the provided server certificate thumbprint in   :attr:`Com::Vmware::Content::Library::SubscriptionInfo.ssl_thumbprint`   is invalid. In this case, the returned  null  should be set in   :attr:`Com::Vmware::Content::Library::SubscriptionInfo.ssl_thumbprint`  .
+      # @!attribute [rw] unknown_error
+      #     @return [Com::Vmware::Content::SubscribedLibrary::ProbeResult::Status]
+      #     Indicates an unspecified error different from the other error cases defined in   :class:`Com::Vmware::Content::SubscribedLibrary::ProbeResult::Status`  .
+      class Status < VAPI::Bindings::VapiEnum
         class << self
-            # Holds (gets or creates) the binding type metadata for this structure type.
-            # @scope class
-            # @return [VAPI::Bindings::StructType] the binding type
-            def binding_type
-                @binding_type ||= VAPI::Bindings::StructType.new(
-                    'com.vmware.content.configuration_model',
-                    {
-                        'automatic_sync_enabled' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::BooleanType.instance),
-                        'automatic_sync_start_hour' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::IntegerType.instance),
-                        'automatic_sync_stop_hour' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::IntegerType.instance),
-                        'maximum_concurrent_item_syncs' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::IntegerType.instance),
-                    },
-                    ConfigurationModel,
-                    false,
-                    nil)
-            end
-        end
+          # Holds (gets or creates) the binding type metadata for this enumeration type.
+          # @scope class
+          # @return [VAPI::Bindings::EnumType] the binding type
+          def binding_type
+            @binding_type ||= VAPI::Bindings::EnumType.new(
+              'com.vmware.content.subscribed_library.probe_result.status',
+              Status
+            )
+          end
 
-        attr_accessor :automatic_sync_enabled,
-                      :automatic_sync_start_hour,
-                      :automatic_sync_stop_hour,
-                      :maximum_concurrent_item_syncs
+          # Converts from a string value (perhaps off the wire) to an instance
+          # of this enum type.
+          # @param value [String] the actual value of the enum instance
+          # @return [Status] the instance found for the value, otherwise
+          #         an unknown instance will be built for the value
+          def from_string(value)
+            const_get(value)
+          rescue NameError
+            Status.send(:new, 'UNKNOWN', value)
+          end
+        end
 
         # Constructs a new instance.
-        # @param ruby_values [Hash] a map of initial property values (optional)
-        # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
-        def initialize(ruby_values=nil, struct_value=nil)
-            super(self.class.binding_type, ruby_values, struct_value)
+        # @param value [String] the actual value of the enum instance
+        # @param unknown [String] the unknown value when value is 'UKNOWN'
+        def initialize(value, unknown = nil)
+          super(self.class.binding_type, value, unknown)
         end
+
+        private_class_method :new
+
+        # @!attribute [rw] success
+        #     @return [Com::Vmware::Content::SubscribedLibrary::ProbeResult::Status]
+        #     Indicates that the probe was successful.
+        SUCCESS = Status.send(:new, 'SUCCESS')
+
+        # @!attribute [rw] invalid_url
+        #     @return [Com::Vmware::Content::SubscribedLibrary::ProbeResult::Status]
+        #     Indicates that the supplied URL was not valid.
+        INVALID_URL = Status.send(:new, 'INVALID_URL')
+
+        # @!attribute [rw] timed_out
+        #     @return [Com::Vmware::Content::SubscribedLibrary::ProbeResult::Status]
+        #     Indicates that the probe timed out while attempting to connect to the URL.
+        TIMED_OUT = Status.send(:new, 'TIMED_OUT')
+
+        # @!attribute [rw] host_not_found
+        #     @return [Com::Vmware::Content::SubscribedLibrary::ProbeResult::Status]
+        #     Indicates that the host in the URL could not be found.
+        HOST_NOT_FOUND = Status.send(:new, 'HOST_NOT_FOUND')
+
+        # @!attribute [rw] resource_not_found
+        #     @return [Com::Vmware::Content::SubscribedLibrary::ProbeResult::Status]
+        #     Indicates that the given resource at the URL was not found.
+        RESOURCE_NOT_FOUND = Status.send(:new, 'RESOURCE_NOT_FOUND')
+
+        # @!attribute [rw] invalid_credentials
+        #     @return [Com::Vmware::Content::SubscribedLibrary::ProbeResult::Status]
+        #     Indicates that the connection was rejected due to invalid credentials.
+        INVALID_CREDENTIALS = Status.send(:new, 'INVALID_CREDENTIALS')
+
+        # @!attribute [rw] certificate_error
+        #     @return [Com::Vmware::Content::SubscribedLibrary::ProbeResult::Status]
+        #     Indicates that the provided server certificate thumbprint in   :attr:`Com::Vmware::Content::Library::SubscriptionInfo.ssl_thumbprint`   is invalid. In this case, the returned  null  should be set in   :attr:`Com::Vmware::Content::Library::SubscriptionInfo.ssl_thumbprint`  .
+        CERTIFICATE_ERROR = Status.send(:new, 'CERTIFICATE_ERROR')
+
+        # @!attribute [rw] unknown_error
+        #     @return [Com::Vmware::Content::SubscribedLibrary::ProbeResult::Status]
+        #     Indicates an unspecified error different from the other error cases defined in   :class:`Com::Vmware::Content::SubscribedLibrary::ProbeResult::Status`  .
+        UNKNOWN_ERROR = Status.send(:new, 'UNKNOWN_ERROR')
+      end
     end
 
+  end
+  # The  ``Com::Vmware::Content::Type``   class  exposes the   :class:`Com::Vmware::Content::Library::ItemModel`   types that this Content Library Service supports.  
+  # 
+  #  A library item has an optional type which can be specified with the   :attr:`Com::Vmware::Content::Library::ItemModel.type`    field . For items with a type that is supported by a plugin, the Content Library Service may understand the files which are part of the library item and can produce metadata for the item.  
+  # 
+  #  In other cases, uploads may require a process in which one upload implies subsequent uploads. For example, an Open Virtualization Format (OVF) package is composed of an OVF descriptor file and the associated virtual disk files. Uploading an OVF descriptor can enable the Content Library Service to understand that the complete OVF package requires additional disk files, and it can set up the transfers for the disks automatically by adding the file entries for the disks when the OVF descriptor is uploaded.  
+  # 
+  #  When a type is not supported by a plugin, or the type is not specified, the Content Library Service can handle a library item in a default way, without adding metadata to the item or guiding the upload process.
+  class Type < VAPI::Bindings::VapiService
+    # static metamodel definitions
+    SERVICE_ID = VAPI::Core::ServiceIdentifier.new('com.vmware.content.type')
 
-    # The   :class:`Com::Vmware::Content::LibraryModel`    class  represents a Content Library resource model.  
-    # 
-    #  A  ``Com::Vmware::Content::LibraryModel``  is a container for a set of items which represent a usable set of files. The Content Library Service allows for multiple libraries to be created with separate authorization and sharing policies.  
-    # 
-    #  Each  ``Com::Vmware::Content::LibraryModel``  is a container for a set of   :class:`Com::Vmware::Content::Library::ItemModel`   instances. Each item is a logical object in a library, which may have multiple files.  
-    # 
-    #  A  ``Com::Vmware::Content::LibraryModel``  may be local or subscribed. A local library has its source of truth about items within this Content Library Service. Items may be added to or removed from the library. A local library may also be private or published. When published, the library is exposed by a network endpoint and can be used by another Content Library Service for synchronization. A private local library cannot be used for synchronization.  
-    # 
-    #  A subscribed library is a library which gets its source of truth from another library that may be across a network in another Content Library Service. A subscribed library may have a different name and metadata from the library to which it subscribes, but the set of library items is always the same as those in the source library. Library items cannot be manually added to a subscribed library -- they can only be added by adding new items to the source library.
-    # @!attribute [rw] id
-    #     @return [String]
-    #     An identifier which uniquely identifies this  ``Com::Vmware::Content::LibraryModel`` .
-    #     This  field  is not used for the  ``create``   method . It will not be present in the  result  of the  ``get``  or  ``list``   methods . It is not used for the  ``update``   method .
-    # @!attribute [rw] creation_time
-    #     @return [DateTime]
-    #     The date and time when this library was created.
-    #     This  field  is not used for the  ``create``   method . It will always be present in the  result  of the  ``get``  or  ``list``   methods . It is not used for the  ``update``   method .
+    LIST_INFO = VAPI::Bindings::OperationInfo.new(
+      VAPI::Core::OperationIdentifier.new('list', SERVICE_ID),
+      VAPI::Bindings::OperationInputType.new,
+      VAPI::Bindings::ListType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Content::Type::Info')),
+      {},
+      [],
+      []
+    )
+
+    SERVICE_INFO = VAPI::Bindings::ServiceInfo.new(
+      SERVICE_ID,
+      'list' => LIST_INFO
+    )
+
+    # Constructs a new instance.
+    #
+    # @param config [VAPI::Bindings::StubConfig] A hash with the api provider details.
+    def initialize(config)
+      super(config, SERVICE_INFO)
+    end
+
+    # Returns a  list  of   :class:`Com::Vmware::Content::Type::Info`   instances which describe the type support plugins in this Content Library.
+    #
+    # @return [Array<Com::Vmware::Content::Type::Info>]
+    #     The  list  of   :class:`Com::Vmware::Content::Type::Info`   instances which describe the type support plugins in this Content Library.
+    def list
+      invoke_with_info(LIST_INFO)
+    end
+
+    # The  ``Com::Vmware::Content::Type::Info``   class  describes support for a specific type of data in an   :class:`Com::Vmware::Content::Library::ItemModel`  . The  ``Com::Vmware::Content::Type::Info``  can be queried through the   :class:`Com::Vmware::Content::Type`    class . Type support describes plugins in the Content Library which can provide metadata on library items and help manage the transfer process by adding dependent files when a current file is added.
     # @!attribute [rw] description
     #     @return [String]
-    #     A human-readable description for this library.
-    #     This  field  is optional for the  ``create``   method . Leaving it  nil  during creation will result in an empty string value. It will always be present in the result of a  ``get``  or  ``list``   method . It is optional for the  ``update``   method . Leaving it  nil  during update indicates that the description should be left unchanged.
-    # @!attribute [rw] last_modified_time
-    #     @return [DateTime]
-    #     The date and time when this library was last updated.  
-    #     
-    #      This  field  is updated automatically when the library properties are changed. This  field  is not affected by adding, removing, or modifying a library item or its content within the library. Tagging the library or syncing the subscribed library does not alter this  field .
-    #     This  field  is not used for the  ``create``   method . It will always be present in the  result  of the  ``get``  or  ``list``   methods . It is not used for the  ``update``   method .
-    # @!attribute [rw] last_sync_time
-    #     @return [DateTime]
-    #     The date and time when this library was last synchronized.  
-    #     
-    #      This  field  applies only to subscribed libraries. It is updated every time a synchronization is triggered on the library. The value is  nil  for a local library.
-    #     This  field  is not used for the  ``create``   method . It is optional in the  result  of the  ``get``  or  ``list``   methods . It is not used for the  ``update``   method .
+    #     A description of the type support offered by the plugin.
     # @!attribute [rw] name
     #     @return [String]
-    #     The name of the library.  
-    #     
-    #      A Library is identified by a human-readable name. Library names cannot be undefined or an empty string. Names do not have to be unique.
-    #     This  field  must be provided for the  ``create``   method . It will always be present in the  result  of the  ``get``  or  ``list``   methods . It is optional for the  ``update``   method .
-    # @!attribute [rw] storage_backings
-    #     @return [Array<Com::Vmware::Content::Library::StorageBacking>]
-    #     The list of storage backings which are available for this library.  
-    #     
-    #      A   :class:`Com::Vmware::Content::Library::StorageBacking`   defines a storage location which can be used to store files for the library items in this library. Multiple storage locations are not currently supported but may become supported in future releases.
-    #     This  field  must be provided for the  ``create``   method . It will always be present in the  result  of the  ``get``  or  ``list``   methods . It is not used for the  ``update``   method .
+    #     The name of the plugin which provides the type support.
     # @!attribute [rw] type
-    #     @return [Com::Vmware::Content::LibraryModel::LibraryType]
-    #     The type ( ``LOCAL``, ``SUBSCRIBED`` ) of this library.  
+    #     @return [String]
+    #     The type which the plugin supports.  
     #     
-    #      This value can be used to determine what additional services and information can be available for this library.
-    #     This  field  must be provided for the  ``create``   method . It will always be present in the  result  of the  ``get``  or  ``list``   methods . It is not used for the  ``update``   method .
-    # @!attribute [rw] optimization_info
-    #     @return [Com::Vmware::Content::Library::OptimizationInfo]
-    #     Defines various optimizations and optimization parameters applied to this library.
-    #     This  field  is optional for the  ``create``   method . It is optional in the  result  of the  ``get``  or  ``list``   methods . It is optional for the  ``update``   method .
+    #      To upload a library item of the type supported by the plugin, the   :attr:`Com::Vmware::Content::Library::ItemModel.type`    field  of the item should be set to this value.
+    # @!attribute [rw] vendor
+    #     @return [String]
+    #     The name of the vendor who created the type support plugin.
     # @!attribute [rw] version
     #     @return [String]
-    #     A version number which is updated on metadata changes. This value allows clients to detect concurrent updates and prevent accidental clobbering of data.  
-    #     
-    #      This value represents a number which is incremented every time library properties, such as name or description, are changed. It is not incremented by changes to a library item within the library, including adding or removing items. It is also not affected by tagging the library.
-    #     This  field  is not used for the  ``create``   method . It will always be present in the result of a  ``get``  or  ``list``   method . It is optional for the  ``update``   method . Leaving it  nil  during update indicates that you do not need to detect concurrent updates.
-    # @!attribute [rw] publish_info
-    #     @return [Com::Vmware::Content::Library::PublishInfo]
-    #     Defines how this library is published so that it can be subscribed to by a remote subscribed library.  
-    #     
-    #      The   :class:`Com::Vmware::Content::Library::PublishInfo`   defines where and how the metadata for this local library is accessible. A local library is only published publically if   :attr:`Com::Vmware::Content::Library::PublishInfo.published`   is  ``true`` .
-    #     This  field  is optional for the  ``create``  and  ``update``   methods . If not specified during creation, the default is for the library to not be published. If not specified during update, the  field  is left unchanged.
-    # @!attribute [rw] subscription_info
-    #     @return [Com::Vmware::Content::Library::SubscriptionInfo]
-    #     Defines the subscription behavior for this Library.  
-    #     
-    #      The   :class:`Com::Vmware::Content::Library::SubscriptionInfo`   defines how this subscribed library synchronizes to a remote source. Setting the value will determine the remote source to which the library synchronizes, and how. Changing the subscription will result in synchronizing to a new source. If the new source differs from the old one, the old library items and data will be lost. Setting   :attr:`Com::Vmware::Content::Library::SubscriptionInfo.automatic_sync_enabled`   to false will halt subscription but will not remove existing cached data.
-    #     This  field  is optional for the  ``create``  and  ``update``   methods . If not specified during creation, a default will be created without an active subscription. If not specified during update, the  field  is left unchanged.
-    # @!attribute [rw] server_guid
-    #     @return [String]
-    #     The unique identifier of the vCenter server where the library exists.
-    #     This  field  is optional for the  ``create``   method . It will always be present in the  result  of the  ``get``  or  ``list``   methods . It is not used for the  ``update``   method .
-    class LibraryModel < VAPI::Bindings::VapiStruct
-
-        class << self
-            # Holds (gets or creates) the binding type metadata for this structure type.
-            # @scope class
-            # @return [VAPI::Bindings::StructType] the binding type
-            def binding_type
-                @binding_type ||= VAPI::Bindings::StructType.new(
-                    'com.vmware.content.library_model',
-                    {
-                        'id' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::IdType.new),
-                        'creation_time' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::DateTimeType.instance),
-                        'description' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::StringType.instance),
-                        'last_modified_time' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::DateTimeType.instance),
-                        'last_sync_time' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::DateTimeType.instance),
-                        'name' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::StringType.instance),
-                        'storage_backings' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::ListType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Content::Library::StorageBacking'))),
-                        'type' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Content::LibraryModel::LibraryType')),
-                        'optimization_info' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Content::Library::OptimizationInfo')),
-                        'version' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::StringType.instance),
-                        'publish_info' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Content::Library::PublishInfo')),
-                        'subscription_info' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Content::Library::SubscriptionInfo')),
-                        'server_guid' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::IdType.new),
-                    },
-                    LibraryModel,
-                    true,
-                    ["id"])
-            end
+    #     The version number of the type support plugin.
+    class Info < VAPI::Bindings::VapiStruct
+      class << self
+        # Holds (gets or creates) the binding type metadata for this structure type.
+        # @scope class
+        # @return [VAPI::Bindings::StructType] the binding type
+        def binding_type
+          @binding_type ||= VAPI::Bindings::StructType.new(
+            'com.vmware.content.type.info',
+            {
+              'description' => VAPI::Bindings::StringType.instance,
+              'name' => VAPI::Bindings::StringType.instance,
+              'type' => VAPI::Bindings::StringType.instance,
+              'vendor' => VAPI::Bindings::StringType.instance,
+              'version' => VAPI::Bindings::StringType.instance
+            },
+            Info,
+            false,
+            nil
+          )
         end
+      end
 
-        attr_accessor :id,
-                      :creation_time,
-                      :description,
-                      :last_modified_time,
-                      :last_sync_time,
-                      :name,
-                      :storage_backings,
-                      :type,
-                      :optimization_info,
-                      :version,
-                      :publish_info,
-                      :subscription_info,
-                      :server_guid
+      attr_accessor :description,
+                    :name,
+                    :type,
+                    :vendor,
+                    :version
 
-        # Constructs a new instance.
-        # @param ruby_values [Hash] a map of initial property values (optional)
-        # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
-        def initialize(ruby_values=nil, struct_value=nil)
-            super(self.class.binding_type, ruby_values, struct_value)
-        end
-
-
-        # The  ``Com::Vmware::Content::LibraryModel::LibraryType``   enumerated type  defines the type of a   :class:`Com::Vmware::Content::LibraryModel`  .  
-        # 
-        #  The type of a library can be used to determine which additional services can be performed with a library.
-        # @!attribute [rw] local
-        #     @return [Com::Vmware::Content::LibraryModel::LibraryType]
-        #     The library contents are defined and stored by the local Content Library Service installation.  
-        #     
-        #      A local library can be retrieved and managed via the   :class:`Com::Vmware::Content::LocalLibrary`  .
-        # @!attribute [rw] subscribed
-        #     @return [Com::Vmware::Content::LibraryModel::LibraryType]
-        #     The library synchronizes its items and content from another published library.  
-        #     
-        #      A subscribed library can be retrieved and managed via the   :class:`Com::Vmware::Content::SubscribedLibrary`  .
-        class LibraryType < VAPI::Bindings::VapiEnum
-
-            class << self
-                # Holds (gets or creates) the binding type metadata for this enumeration type.
-                # @scope class
-                # @return [VAPI::Bindings::EnumType] the binding type
-                def binding_type
-                    @binding_type ||= VAPI::Bindings::EnumType.new(
-                        'com.vmware.content.library_model.library_type',
-                        LibraryType)
-                end
-
-                # Converts from a string value (perhaps off the wire) to an instance
-                # of this enum type.
-                # @param value [String] the actual value of the enum instance
-                # @return [LibraryType] the instance found for the value, otherwise
-                #         an unknown instance will be built for the value
-                def from_string(value)
-                    begin
-                        const_get(value)
-                    rescue NameError
-                        LibraryType.new('UNKNOWN', value)
-                    end
-                end
-            end
-
-            private
-
-            # Constructs a new instance.
-            # @param value [String] the actual value of the enum instance
-            # @param unknown [String] the unknown value when value is 'UKNOWN'
-            def initialize(value, unknown=nil)
-                super(self.class.binding_type, value, unknown)
-            end
-
-            public
-
-            # @!attribute [rw] local
-            #     @return [Com::Vmware::Content::LibraryModel::LibraryType]
-            #     The library contents are defined and stored by the local Content Library Service installation.  
-            #     
-            #      A local library can be retrieved and managed via the   :class:`Com::Vmware::Content::LocalLibrary`  .
-            LOCAL = LibraryType.new('LOCAL')
-
-            # @!attribute [rw] subscribed
-            #     @return [Com::Vmware::Content::LibraryModel::LibraryType]
-            #     The library synchronizes its items and content from another published library.  
-            #     
-            #      A subscribed library can be retrieved and managed via the   :class:`Com::Vmware::Content::SubscribedLibrary`  .
-            SUBSCRIBED = LibraryType.new('SUBSCRIBED')
-
-        end
-
-
+      # Constructs a new instance.
+      # @param ruby_values [Hash] a map of initial property values (optional)
+      # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
+      def initialize(ruby_values = nil, struct_value = nil)
+        super(self.class.binding_type, ruby_values, struct_value)
+      end
     end
 
+  end
+  # The  ``Com::Vmware::Content::ConfigurationModel``   class  defines the global settings of the Content Library Service.
+  # @!attribute [rw] automatic_sync_enabled
+  #     @return [Boolean]
+  #     Whether automatic synchronization is enabled.  
+  #     
+  #      When automatic synchronization is enabled, the Content Library Service will automatically synchronize all subscribed libraries on a daily basis. Subscribed libraries with the   :attr:`Com::Vmware::Content::Library::SubscriptionInfo.automatic_sync_enabled`   flag turned on will be synchronized every hour between   :attr:`Com::Vmware::Content::ConfigurationModel.automatic_sync_start_hour`   and   :attr:`Com::Vmware::Content::ConfigurationModel.automatic_sync_stop_hour`  .
+  #     This  field  is not used for the  ``create``   method . It will always be present in the  result  of the  ``get``  or  ``list``   methods . It is optional for the  ``update``   method .
+  # @!attribute [rw] automatic_sync_start_hour
+  #     @return [Fixnum]
+  #     The hour at which the automatic synchronization will start. This value is between 0 (midnight) and 23 inclusive.
+  #     This  field  is not used for the  ``create``   method . It will always be present in the  result  of the  ``get``  or  ``list``   methods . It is optional for the  ``update``   method .
+  # @!attribute [rw] automatic_sync_stop_hour
+  #     @return [Fixnum]
+  #     The hour at which the automatic synchronization will stop. Any active synchronization operation will continue to run, however no new synchronization operations will be triggered after the stop hour. This value is between 0 (midnight) and 23 inclusive.
+  #     This  field  is not used for the  ``create``   method . It will always be present in the  result  of the  ``get``  or  ``list``   methods . It is optional for the  ``update``   method .
+  # @!attribute [rw] maximum_concurrent_item_syncs
+  #     @return [Fixnum]
+  #     The maximum allowed number of library items to synchronize concurrently from remote libraries. This must be a positive number. The service may not be able to guarantee the requested concurrency if there is no available capacity.  
+  #     
+  #      This setting is global across all subscribed libraries.
+  #     This  field  is not used for the  ``create``   method . It will always be present in the  result  of the  ``get``  or  ``list``   methods . It is optional for the  ``update``   method .
+  class ConfigurationModel < VAPI::Bindings::VapiStruct
+    class << self
+      # Holds (gets or creates) the binding type metadata for this structure type.
+      # @scope class
+      # @return [VAPI::Bindings::StructType] the binding type
+      def binding_type
+        @binding_type ||= VAPI::Bindings::StructType.new(
+          'com.vmware.content.configuration_model',
+          {
+            'automatic_sync_enabled' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::BooleanType.instance),
+            'automatic_sync_start_hour' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::IntegerType.instance),
+            'automatic_sync_stop_hour' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::IntegerType.instance),
+            'maximum_concurrent_item_syncs' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::IntegerType.instance)
+          },
+          ConfigurationModel,
+          false,
+          nil
+        )
+      end
+    end
+
+    attr_accessor :automatic_sync_enabled,
+                  :automatic_sync_start_hour,
+                  :automatic_sync_stop_hour,
+                  :maximum_concurrent_item_syncs
+
+    # Constructs a new instance.
+    # @param ruby_values [Hash] a map of initial property values (optional)
+    # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
+    def initialize(ruby_values = nil, struct_value = nil)
+      super(self.class.binding_type, ruby_values, struct_value)
+    end
+  end
+  # The   :class:`Com::Vmware::Content::LibraryModel`    class  represents a Content Library resource model.  
+  # 
+  #  A  ``Com::Vmware::Content::LibraryModel``  is a container for a set of items which represent a usable set of files. The Content Library Service allows for multiple libraries to be created with separate authorization and sharing policies.  
+  # 
+  #  Each  ``Com::Vmware::Content::LibraryModel``  is a container for a set of   :class:`Com::Vmware::Content::Library::ItemModel`   instances. Each item is a logical object in a library, which may have multiple files.  
+  # 
+  #  A  ``Com::Vmware::Content::LibraryModel``  may be local or subscribed. A local library has its source of truth about items within this Content Library Service. Items may be added to or removed from the library. A local library may also be private or published. When published, the library is exposed by a network endpoint and can be used by another Content Library Service for synchronization. A private local library cannot be used for synchronization.  
+  # 
+  #  A subscribed library is a library which gets its source of truth from another library that may be across a network in another Content Library Service. A subscribed library may have a different name and metadata from the library to which it subscribes, but the set of library items is always the same as those in the source library. Library items cannot be manually added to a subscribed library -- they can only be added by adding new items to the source library.
+  # @!attribute [rw] id
+  #     @return [String]
+  #     An identifier which uniquely identifies this  ``Com::Vmware::Content::LibraryModel`` .
+  #     This  field  is not used for the  ``create``   method . It will not be present in the  result  of the  ``get``  or  ``list``   methods . It is not used for the  ``update``   method .
+  # @!attribute [rw] creation_time
+  #     @return [DateTime]
+  #     The date and time when this library was created.
+  #     This  field  is not used for the  ``create``   method . It will always be present in the  result  of the  ``get``  or  ``list``   methods . It is not used for the  ``update``   method .
+  # @!attribute [rw] description
+  #     @return [String]
+  #     A human-readable description for this library.
+  #     This  field  is optional for the  ``create``   method . Leaving it  nil  during creation will result in an empty string value. It will always be present in the result of a  ``get``  or  ``list``   method . It is optional for the  ``update``   method . Leaving it  nil  during update indicates that the description should be left unchanged.
+  # @!attribute [rw] last_modified_time
+  #     @return [DateTime]
+  #     The date and time when this library was last updated.  
+  #     
+  #      This  field  is updated automatically when the library properties are changed. This  field  is not affected by adding, removing, or modifying a library item or its content within the library. Tagging the library or syncing the subscribed library does not alter this  field .
+  #     This  field  is not used for the  ``create``   method . It will always be present in the  result  of the  ``get``  or  ``list``   methods . It is not used for the  ``update``   method .
+  # @!attribute [rw] last_sync_time
+  #     @return [DateTime]
+  #     The date and time when this library was last synchronized.  
+  #     
+  #      This  field  applies only to subscribed libraries. It is updated every time a synchronization is triggered on the library. The value is  nil  for a local library.
+  #     This  field  is not used for the  ``create``   method . It is optional in the  result  of the  ``get``  or  ``list``   methods . It is not used for the  ``update``   method .
+  # @!attribute [rw] name
+  #     @return [String]
+  #     The name of the library.  
+  #     
+  #      A Library is identified by a human-readable name. Library names cannot be undefined or an empty string. Names do not have to be unique.
+  #     This  field  must be provided for the  ``create``   method . It will always be present in the  result  of the  ``get``  or  ``list``   methods . It is optional for the  ``update``   method .
+  # @!attribute [rw] storage_backings
+  #     @return [Array<Com::Vmware::Content::Library::StorageBacking>]
+  #     The list of storage backings which are available for this library.  
+  #     
+  #      A   :class:`Com::Vmware::Content::Library::StorageBacking`   defines a storage location which can be used to store files for the library items in this library. Multiple storage locations are not currently supported but may become supported in future releases.
+  #     This  field  must be provided for the  ``create``   method . It will always be present in the  result  of the  ``get``  or  ``list``   methods . It is not used for the  ``update``   method .
+  # @!attribute [rw] type
+  #     @return [Com::Vmware::Content::LibraryModel::LibraryType]
+  #     The type ( ``LOCAL``, ``SUBSCRIBED`` ) of this library.  
+  #     
+  #      This value can be used to determine what additional services and information can be available for this library.
+  #     This  field  must be provided for the  ``create``   method . It will always be present in the  result  of the  ``get``  or  ``list``   methods . It is not used for the  ``update``   method .
+  # @!attribute [rw] optimization_info
+  #     @return [Com::Vmware::Content::Library::OptimizationInfo]
+  #     Defines various optimizations and optimization parameters applied to this library.
+  #     This  field  is optional for the  ``create``   method . It is optional in the  result  of the  ``get``  or  ``list``   methods . It is optional for the  ``update``   method .
+  # @!attribute [rw] version
+  #     @return [String]
+  #     A version number which is updated on metadata changes. This value allows clients to detect concurrent updates and prevent accidental clobbering of data.  
+  #     
+  #      This value represents a number which is incremented every time library properties, such as name or description, are changed. It is not incremented by changes to a library item within the library, including adding or removing items. It is also not affected by tagging the library.
+  #     This  field  is not used for the  ``create``   method . It will always be present in the result of a  ``get``  or  ``list``   method . It is optional for the  ``update``   method . Leaving it  nil  during update indicates that you do not need to detect concurrent updates.
+  # @!attribute [rw] publish_info
+  #     @return [Com::Vmware::Content::Library::PublishInfo]
+  #     Defines how this library is published so that it can be subscribed to by a remote subscribed library.  
+  #     
+  #      The   :class:`Com::Vmware::Content::Library::PublishInfo`   defines where and how the metadata for this local library is accessible. A local library is only published publically if   :attr:`Com::Vmware::Content::Library::PublishInfo.published`   is  ``true`` .
+  #     This  field  is optional for the  ``create``  and  ``update``   methods . If not specified during creation, the default is for the library to not be published. If not specified during update, the  field  is left unchanged.
+  # @!attribute [rw] subscription_info
+  #     @return [Com::Vmware::Content::Library::SubscriptionInfo]
+  #     Defines the subscription behavior for this Library.  
+  #     
+  #      The   :class:`Com::Vmware::Content::Library::SubscriptionInfo`   defines how this subscribed library synchronizes to a remote source. Setting the value will determine the remote source to which the library synchronizes, and how. Changing the subscription will result in synchronizing to a new source. If the new source differs from the old one, the old library items and data will be lost. Setting   :attr:`Com::Vmware::Content::Library::SubscriptionInfo.automatic_sync_enabled`   to false will halt subscription but will not remove existing cached data.
+  #     This  field  is optional for the  ``create``  and  ``update``   methods . If not specified during creation, a default will be created without an active subscription. If not specified during update, the  field  is left unchanged.
+  # @!attribute [rw] server_guid
+  #     @return [String]
+  #     The unique identifier of the vCenter server where the library exists.
+  #     This  field  is optional for the  ``create``   method . It will always be present in the  result  of the  ``get``  or  ``list``   methods . It is not used for the  ``update``   method .
+  class LibraryModel < VAPI::Bindings::VapiStruct
+    class << self
+      # Holds (gets or creates) the binding type metadata for this structure type.
+      # @scope class
+      # @return [VAPI::Bindings::StructType] the binding type
+      def binding_type
+        @binding_type ||= VAPI::Bindings::StructType.new(
+          'com.vmware.content.library_model',
+          {
+            'id' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::IdType.new),
+            'creation_time' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::DateTimeType.instance),
+            'description' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::StringType.instance),
+            'last_modified_time' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::DateTimeType.instance),
+            'last_sync_time' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::DateTimeType.instance),
+            'name' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::StringType.instance),
+            'storage_backings' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::ListType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Content::Library::StorageBacking'))),
+            'type' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Content::LibraryModel::LibraryType')),
+            'optimization_info' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Content::Library::OptimizationInfo')),
+            'version' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::StringType.instance),
+            'publish_info' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Content::Library::PublishInfo')),
+            'subscription_info' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Content::Library::SubscriptionInfo')),
+            'server_guid' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::IdType.new)
+          },
+          LibraryModel,
+          true,
+          ["id"]
+        )
+      end
+    end
+
+    attr_accessor :id,
+                  :creation_time,
+                  :description,
+                  :last_modified_time,
+                  :last_sync_time,
+                  :name,
+                  :storage_backings,
+                  :type,
+                  :optimization_info,
+                  :version,
+                  :publish_info,
+                  :subscription_info,
+                  :server_guid
+
+    # Constructs a new instance.
+    # @param ruby_values [Hash] a map of initial property values (optional)
+    # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
+    def initialize(ruby_values = nil, struct_value = nil)
+      super(self.class.binding_type, ruby_values, struct_value)
+    end
+
+    # The  ``Com::Vmware::Content::LibraryModel::LibraryType``   enumerated type  defines the type of a   :class:`Com::Vmware::Content::LibraryModel`  .  
+    # 
+    #  The type of a library can be used to determine which additional services can be performed with a library.
+    # @!attribute [rw] local
+    #     @return [Com::Vmware::Content::LibraryModel::LibraryType]
+    #     The library contents are defined and stored by the local Content Library Service installation.  
+    #     
+    #      A local library can be retrieved and managed via the   :class:`Com::Vmware::Content::LocalLibrary`  .
+    # @!attribute [rw] subscribed
+    #     @return [Com::Vmware::Content::LibraryModel::LibraryType]
+    #     The library synchronizes its items and content from another published library.  
+    #     
+    #      A subscribed library can be retrieved and managed via the   :class:`Com::Vmware::Content::SubscribedLibrary`  .
+    class LibraryType < VAPI::Bindings::VapiEnum
+      class << self
+        # Holds (gets or creates) the binding type metadata for this enumeration type.
+        # @scope class
+        # @return [VAPI::Bindings::EnumType] the binding type
+        def binding_type
+          @binding_type ||= VAPI::Bindings::EnumType.new(
+            'com.vmware.content.library_model.library_type',
+            LibraryType
+          )
+        end
+
+        # Converts from a string value (perhaps off the wire) to an instance
+        # of this enum type.
+        # @param value [String] the actual value of the enum instance
+        # @return [LibraryType] the instance found for the value, otherwise
+        #         an unknown instance will be built for the value
+        def from_string(value)
+          const_get(value)
+        rescue NameError
+          LibraryType.send(:new, 'UNKNOWN', value)
+        end
+      end
+
+      # Constructs a new instance.
+      # @param value [String] the actual value of the enum instance
+      # @param unknown [String] the unknown value when value is 'UKNOWN'
+      def initialize(value, unknown = nil)
+        super(self.class.binding_type, value, unknown)
+      end
+
+      private_class_method :new
+
+      # @!attribute [rw] local
+      #     @return [Com::Vmware::Content::LibraryModel::LibraryType]
+      #     The library contents are defined and stored by the local Content Library Service installation.  
+      #     
+      #      A local library can be retrieved and managed via the   :class:`Com::Vmware::Content::LocalLibrary`  .
+      LOCAL = LibraryType.send(:new, 'LOCAL')
+
+      # @!attribute [rw] subscribed
+      #     @return [Com::Vmware::Content::LibraryModel::LibraryType]
+      #     The library synchronizes its items and content from another published library.  
+      #     
+      #      A subscribed library can be retrieved and managed via the   :class:`Com::Vmware::Content::SubscribedLibrary`  .
+      SUBSCRIBED = LibraryType.send(:new, 'SUBSCRIBED')
+    end
+  end
 end

--- a/client/sdk/com/vmware/content/library.rb
+++ b/client/sdk/com/vmware/content/library.rb
@@ -1,5 +1,6 @@
 #---------------------------------------------------------------------------
-# Copyright 2016 VMware, Inc.  All rights reserved.
+# Copyright 2017 VMware, Inc.  All rights reserved.
+#
 # AUTO GENERATED FILE -- DO NOT MODIFY!
 #
 # vAPI type descriptors for package com.vmware.content.library.
@@ -8,1104 +9,1041 @@ require 'vapi'
 
 # declare the module hierarchy before we use the shorthand syntax below
 module Com
-    module Vmware
-        module Content
-            module Library
-            end
-        end
+  module Vmware
+    module Content
+      module Library
+      end
     end
+  end
 end
 
 # The Content Library  package  provides  classes  and  classs  for defining and managing the library's items, subscription, publication, and storage.
 module Com::Vmware::Content::Library
+  # The  ``Com::Vmware::Content::Library::Item``   class  provides  methods  for managing library items.
+  class ItemService < VAPI::Bindings::VapiService
+    # static metamodel definitions
+    SERVICE_ID = VAPI::Core::ServiceIdentifier.new('com.vmware.content.library.item')
 
-    # The  ``Com::Vmware::Content::Library::Item``   class  provides  methods  for managing library items.
-    class ItemService < VAPI::Bindings::VapiService
+    COPY_INFO = VAPI::Bindings::OperationInfo.new(
+      VAPI::Core::OperationIdentifier.new('copy', SERVICE_ID),
+      VAPI::Bindings::OperationInputType.new(
+        'client_token' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::StringType.instance),
+        'source_library_item_id' => VAPI::Bindings::IdType.new('com.vmware.content.library.Item'),
+        'destination_create_spec' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Content::Library::ItemModel')
+      ),
+      VAPI::Bindings::IdType.new('com.vmware.content.library.Item'),
+      {
+        'com.vmware.vapi.std.errors.not_found' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::NotFound'),
+        'com.vmware.vapi.std.errors.invalid_argument' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::InvalidArgument'),
+        'com.vmware.vapi.std.errors.invalid_element_type' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::InvalidElementType'),
+        'com.vmware.vapi.std.errors.resource_inaccessible' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::ResourceInaccessible')
+      },
+      [],
+      []
+    )
 
-        protected
+    CREATE_INFO = VAPI::Bindings::OperationInfo.new(
+      VAPI::Core::OperationIdentifier.new('create', SERVICE_ID),
+      VAPI::Bindings::OperationInputType.new(
+        'client_token' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::StringType.instance),
+        'create_spec' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Content::Library::ItemModel')
+      ),
+      VAPI::Bindings::IdType.new('com.vmware.content.library.Item'),
+      {
+        'com.vmware.vapi.std.errors.not_found' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::NotFound'),
+        'com.vmware.vapi.std.errors.invalid_argument' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::InvalidArgument'),
+        'com.vmware.vapi.std.errors.invalid_element_type' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::InvalidElementType')
+      },
+      [],
+      []
+    )
 
-        # static metamodel definitions
-        @@service_id = VAPI::Core::ServiceIdentifier.new('com.vmware.content.library.item')
+    DELETE_INFO = VAPI::Bindings::OperationInfo.new(
+      VAPI::Core::OperationIdentifier.new('delete', SERVICE_ID),
+      VAPI::Bindings::OperationInputType.new(
+        'library_item_id' => VAPI::Bindings::IdType.new('com.vmware.content.library.Item')
+      ),
+      VAPI::Bindings::VoidType.instance,
+      {
+        'com.vmware.vapi.std.errors.invalid_element_type' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::InvalidElementType'),
+        'com.vmware.vapi.std.errors.not_found' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::NotFound')
+      },
+      [],
+      []
+    )
 
-        @@copy_info = VAPI::Bindings::OperationInfo.new(
-            VAPI::Core::OperationIdentifier.new('copy', @@service_id),
-            VAPI::Bindings::OperationInputType.new({
-                'client_token' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::StringType.instance),
-                'source_library_item_id' => VAPI::Bindings::IdType.new(resource_types='com.vmware.content.library.Item'),
-                'destination_create_spec' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Content::Library::ItemModel'),
-            }),
-            VAPI::Bindings::IdType.new(resource_types='com.vmware.content.library.Item'),
-            {
-                'com.vmware.vapi.std.errors.not_found' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::NotFound'),
-                'com.vmware.vapi.std.errors.invalid_argument' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::InvalidArgument'),
-                'com.vmware.vapi.std.errors.invalid_element_type' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::InvalidElementType'),
-                'com.vmware.vapi.std.errors.resource_inaccessible' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::ResourceInaccessible'),
+    GET_INFO = VAPI::Bindings::OperationInfo.new(
+      VAPI::Core::OperationIdentifier.new('get', SERVICE_ID),
+      VAPI::Bindings::OperationInputType.new(
+        'library_item_id' => VAPI::Bindings::IdType.new('com.vmware.content.library.Item')
+      ),
+      VAPI::Bindings::ReferenceType.new('Com::Vmware::Content::Library::ItemModel'),
+      {
+        'com.vmware.vapi.std.errors.not_found' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::NotFound')
+      },
+      [],
+      []
+    )
 
-            },
-            [],
-            [])
-        @@create_info = VAPI::Bindings::OperationInfo.new(
-            VAPI::Core::OperationIdentifier.new('create', @@service_id),
-            VAPI::Bindings::OperationInputType.new({
-                'client_token' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::StringType.instance),
-                'create_spec' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Content::Library::ItemModel'),
-            }),
-            VAPI::Bindings::IdType.new(resource_types='com.vmware.content.library.Item'),
-            {
-                'com.vmware.vapi.std.errors.not_found' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::NotFound'),
-                'com.vmware.vapi.std.errors.invalid_argument' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::InvalidArgument'),
-                'com.vmware.vapi.std.errors.invalid_element_type' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::InvalidElementType'),
+    LIST_INFO = VAPI::Bindings::OperationInfo.new(
+      VAPI::Core::OperationIdentifier.new('list', SERVICE_ID),
+      VAPI::Bindings::OperationInputType.new(
+        'library_id' => VAPI::Bindings::IdType.new('com.vmware.content.Library')
+      ),
+      VAPI::Bindings::ListType.new(VAPI::Bindings::IdType.new),
+      {
+        'com.vmware.vapi.std.errors.not_found' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::NotFound')
+      },
+      [],
+      []
+    )
 
-            },
-            [],
-            [])
-        @@delete_info = VAPI::Bindings::OperationInfo.new(
-            VAPI::Core::OperationIdentifier.new('delete', @@service_id),
-            VAPI::Bindings::OperationInputType.new({
-                'library_item_id' => VAPI::Bindings::IdType.new(resource_types='com.vmware.content.library.Item'),
-            }),
-            VAPI::Bindings::VoidType.instance,
-            {
-                'com.vmware.vapi.std.errors.invalid_element_type' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::InvalidElementType'),
-                'com.vmware.vapi.std.errors.not_found' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::NotFound'),
+    FIND_INFO = VAPI::Bindings::OperationInfo.new(
+      VAPI::Core::OperationIdentifier.new('find', SERVICE_ID),
+      VAPI::Bindings::OperationInputType.new(
+        'spec' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Content::Library::Item::FindSpec')
+      ),
+      VAPI::Bindings::ListType.new(VAPI::Bindings::IdType.new),
+      {
+        'com.vmware.vapi.std.errors.invalid_argument' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::InvalidArgument')
+      },
+      [],
+      []
+    )
 
-            },
-            [],
-            [])
-        @@get_info = VAPI::Bindings::OperationInfo.new(
-            VAPI::Core::OperationIdentifier.new('get', @@service_id),
-            VAPI::Bindings::OperationInputType.new({
-                'library_item_id' => VAPI::Bindings::IdType.new(resource_types='com.vmware.content.library.Item'),
-            }),
-            VAPI::Bindings::ReferenceType.new('Com::Vmware::Content::Library::ItemModel'),
-            {
-                'com.vmware.vapi.std.errors.not_found' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::NotFound'),
+    UPDATE_INFO = VAPI::Bindings::OperationInfo.new(
+      VAPI::Core::OperationIdentifier.new('update', SERVICE_ID),
+      VAPI::Bindings::OperationInputType.new(
+        'library_item_id' => VAPI::Bindings::IdType.new('com.vmware.content.library.Item'),
+        'update_spec' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Content::Library::ItemModel')
+      ),
+      VAPI::Bindings::VoidType.instance,
+      {
+        'com.vmware.vapi.std.errors.not_found' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::NotFound'),
+        'com.vmware.vapi.std.errors.invalid_element_type' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::InvalidElementType'),
+        'com.vmware.vapi.std.errors.invalid_argument' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::InvalidArgument')
+      },
+      [],
+      []
+    )
 
-            },
-            [],
-            [])
-        @@list_info = VAPI::Bindings::OperationInfo.new(
-            VAPI::Core::OperationIdentifier.new('list', @@service_id),
-            VAPI::Bindings::OperationInputType.new({
-                'library_id' => VAPI::Bindings::IdType.new(resource_types='com.vmware.content.Library'),
-            }),
-            VAPI::Bindings::ListType.new(VAPI::Bindings::IdType.new),
-            {
-                'com.vmware.vapi.std.errors.not_found' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::NotFound'),
+    SERVICE_INFO = VAPI::Bindings::ServiceInfo.new(
+      SERVICE_ID,
+      'copy' => COPY_INFO,
+      'create' => CREATE_INFO,
+      'delete' => DELETE_INFO,
+      'get' => GET_INFO,
+      'list' => LIST_INFO,
+      'find' => FIND_INFO,
+      'update' => UPDATE_INFO
+    )
 
-            },
-            [],
-            [])
-        @@find_info = VAPI::Bindings::OperationInfo.new(
-            VAPI::Core::OperationIdentifier.new('find', @@service_id),
-            VAPI::Bindings::OperationInputType.new({
-                'spec' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Content::Library::Item::FindSpec'),
-            }),
-            VAPI::Bindings::ListType.new(VAPI::Bindings::IdType.new),
-            {
-                'com.vmware.vapi.std.errors.invalid_argument' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::InvalidArgument'),
-
-            },
-            [],
-            [])
-        @@update_info = VAPI::Bindings::OperationInfo.new(
-            VAPI::Core::OperationIdentifier.new('update', @@service_id),
-            VAPI::Bindings::OperationInputType.new({
-                'library_item_id' => VAPI::Bindings::IdType.new(resource_types='com.vmware.content.library.Item'),
-                'update_spec' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Content::Library::ItemModel'),
-            }),
-            VAPI::Bindings::VoidType.instance,
-            {
-                'com.vmware.vapi.std.errors.not_found' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::NotFound'),
-                'com.vmware.vapi.std.errors.invalid_element_type' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::InvalidElementType'),
-                'com.vmware.vapi.std.errors.invalid_argument' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::InvalidArgument'),
-
-            },
-            [],
-            [])
-
-        @@service_info = VAPI::Bindings::ServiceInfo.new(@@service_id, {
-            'copy' => @@copy_info,
-            'create' => @@create_info,
-            'delete' => @@delete_info,
-            'get' => @@get_info,
-            'list' => @@list_info,
-            'find' => @@find_info,
-            'update' => @@update_info,
-        })
-
-        public
-
-        # Constructs a new instance.
-        #
-        # @param config [VAPI::Bindings::StubConfig] A hash with the api provider details.
-        def initialize(config)
-            super(config, @@service_info)
-        end
-
-        RESOURCE_TYPE = 'com.vmware.content.library.Item'
-
-
-        # Copies a library item.  
-        # 
-        #  Copying a library item allows a duplicate to be made within the same or different library. The copy occurs by first creating a new library item, whose identifier is returned. The content of the library item is then copied asynchronously. This copy can be tracked as a task.  
-        # 
-        #  If the copy fails, Content Library Service will roll back the copy by deleting any content that was already copied, and removing the new library item. A failure during rollback may require manual cleanup by an administrator.  
-        # 
-        #  A library item cannot be copied into a subscribed library.
-        #
-        # @param client_token [String, nil]
-        #      A unique token generated on the client for each copy request. The token should be a universally unique identifier (UUID), for example:  ``b8a2a2e3-2314-43cd-a871-6ede0f429751`` . This token can be used to guarantee idempotent copy.
-        #     If not specified copy is not idempotent.
-        # @param source_library_item_id [String]
-        #      Identifier of the existing library item from which the content will be copied.
-        # @param destination_create_spec [Com::Vmware::Content::Library::ItemModel]
-        #      Specification for the new library item to be created.
-        # @return [String]
-        #     The identifier of the new library item into which the content is being copied.
-        # @raise [Com::Vmware::Vapi::Std::Errors::NotFound]
-        #      if the library item with  ``source_library_item_id``  does not exist, or if the library referenced by the   :attr:`Com::Vmware::Content::Library::ItemModel.library_id`   property of  ``destination_create_spec``  does not exist.
-        # @raise [Com::Vmware::Vapi::Std::Errors::InvalidArgument]
-        #      if one of the following is true for the new library item:  
-        #     
-        #       * name is empty
-        #        * name exceeds 80 characters
-        #        * description exceeds 1024 characters
-        #       
-        # @raise [Com::Vmware::Vapi::Std::Errors::InvalidArgument]
-        #      if the  ``client_token``  does not conform to the UUID format.
-        # @raise [Com::Vmware::Vapi::Std::Errors::InvalidElementType]
-        #      if the   :attr:`Com::Vmware::Content::Library::ItemModel.library_id`   property of  ``destination_create_spec``  refers to a subscribed library.
-        # @raise [Com::Vmware::Vapi::Std::Errors::ResourceInaccessible]
-        #      if the copy operation failed because the source or destination library item is not accessible.
-        def copy(source_library_item_id, destination_create_spec, client_token=nil)
-            invoke_with_info(@@copy_info, {
-                'client_token' => client_token,
-                'source_library_item_id' => source_library_item_id,
-                'destination_create_spec' => destination_create_spec,
-            })
-        end
-
-
-        # Creates a new library item.  
-        # 
-        #  A new library item is created without any content. After creation, content can be added through the   :class:`Com::Vmware::Content::Library::Item::UpdateSession`   and   :class:`Com::Vmware::Content::Library::Item::Updatesession::File`    classs .  
-        # 
-        #  A library item cannot be created in a subscribed library.
-        #
-        # @param client_token [String, nil]
-        #      A unique token generated on the client for each creation request. The token should be a universally unique identifier (UUID), for example:  ``b8a2a2e3-2314-43cd-a871-6ede0f429751`` . This token can be used to guarantee idempotent creation.
-        #     If not specified creation is not idempotent.
-        # @param create_spec [Com::Vmware::Content::Library::ItemModel]
-        #      Specification that defines the properties of the new library item.
-        # @return [String]
-        #     Identifier of the new library item.
-        # @raise [Com::Vmware::Vapi::Std::Errors::NotFound]
-        #      if the   :attr:`Com::Vmware::Content::Library::ItemModel.library_id`   property of  ``create_spec``  refers to a library that does not exist.
-        # @raise [Com::Vmware::Vapi::Std::Errors::InvalidArgument]
-        #      if one of the following is true for the new library item:  
-        #     
-        #       * name is empty
-        #        * name exceeds 80 characters
-        #        * description exceeds 1024 characters
-        #       
-        # @raise [Com::Vmware::Vapi::Std::Errors::InvalidArgument]
-        #      if the  ``client_token``  does not conform to the UUID format.
-        # @raise [Com::Vmware::Vapi::Std::Errors::InvalidElementType]
-        #      if the   :attr:`Com::Vmware::Content::Library::ItemModel.library_id`   property of  ``destinationCreateSpec``  refers to a subscribed library.
-        def create(create_spec, client_token=nil)
-            invoke_with_info(@@create_info, {
-                'client_token' => client_token,
-                'create_spec' => create_spec,
-            })
-        end
-
-
-        # Deletes a library item.  
-        # 
-        #  This  method  will immediately remove the item from the library that owns it. The content of the item will be asynchronously removed from the storage backings. The content deletion can be tracked with a task. In the event that the task fails, an administrator may need to manually remove the files from the storage backing.  
-        # 
-        #  This  method  cannot be used to delete a library item that is a member of a subscribed library. Removing an item from a subscribed library requires deleting the item from the original published local library and syncing the subscribed library.
-        #
-        # @param library_item_id [String]
-        #      Identifier of the library item to delete.
-        # @return [Void]
-        # @raise [Com::Vmware::Vapi::Std::Errors::InvalidElementType]
-        #      if the library item with the given  ``library_item_id``  is a member of a subscribed library.
-        # @raise [Com::Vmware::Vapi::Std::Errors::NotFound]
-        #      if the library item with the specified  ``library_item_id``  does not exist.
-        def delete(library_item_id)
-            invoke_with_info(@@delete_info, {
-                'library_item_id' => library_item_id,
-            })
-        end
-
-
-        # Returns the   :class:`Com::Vmware::Content::Library::ItemModel`   with the given identifier.
-        #
-        # @param library_item_id [String]
-        #      Identifier of the library item to return.
-        # @return [Com::Vmware::Content::Library::ItemModel]
-        #     The   :class:`Com::Vmware::Content::Library::ItemModel`   instance with the given  ``library_item_id`` .
-        # @raise [Com::Vmware::Vapi::Std::Errors::NotFound]
-        #      if no item with the given  ``library_item_id``  exists.
-        def get(library_item_id)
-            invoke_with_info(@@get_info, {
-                'library_item_id' => library_item_id,
-            })
-        end
-
-
-        # Returns the identifiers of all items in the given library.
-        #
-        # @param library_id [String]
-        #      Identifier of the library whose items should be returned.
-        # @return [Array<String>]
-        #     The  list  of identifiers of the items in the library specified by  ``library_id`` .
-        # @raise [Com::Vmware::Vapi::Std::Errors::NotFound]
-        #      if the library associated with  ``library_id``  does not exist.
-        def list(library_id)
-            invoke_with_info(@@list_info, {
-                'library_id' => library_id,
-            })
-        end
-
-
-        # Returns identifiers of all the visible (as determined by authorization policy) library items matching the requested   :class:`Com::Vmware::Content::Library::Item::FindSpec`  .
-        #
-        # @param spec [Com::Vmware::Content::Library::Item::FindSpec]
-        #      Specification describing what properties to filter on.
-        # @return [Array<String>]
-        #     The  list  of identifiers of all the visible library items matching the given  ``spec`` .
-        # @raise [Com::Vmware::Vapi::Std::Errors::InvalidArgument]
-        #      if no properties are specified in the  ``spec`` .
-        def find(spec)
-            invoke_with_info(@@find_info, {
-                'spec' => spec,
-            })
-        end
-
-
-        # Updates the specified properties of a library item.  
-        # 
-        #  This is an incremental update to the library item.  Fields  that are  nil  in the update specification are left unchanged.  
-        # 
-        #  This  method  cannot update a library item that is a member of a subscribed library. Those items must be updated in the source published library and synchronized to the subscribed library.
-        #
-        # @param library_item_id [String]
-        #      Identifier of the library item to update.
-        # @param update_spec [Com::Vmware::Content::Library::ItemModel]
-        #      Specification of the properties to set.
-        # @return [Void]
-        # @raise [Com::Vmware::Vapi::Std::Errors::NotFound]
-        #      if the library item specified by  ``library_item_id``  does not exist.
-        # @raise [Com::Vmware::Vapi::Std::Errors::InvalidElementType]
-        #      if the library item corresponding to  ``library_item_id``  is a member of a subscribed library.
-        # @raise [Com::Vmware::Vapi::Std::Errors::InvalidArgument]
-        #      if one of the following is true for the  ``update_spec`` :  
-        #     
-        #       * name is empty
-        #        * name exceeds 80 characters
-        #        * description exceeds 1024 characters
-        #        * version is not equal to the current version of the library item
-        #       
-        def update(library_item_id, update_spec)
-            invoke_with_info(@@update_info, {
-                'library_item_id' => library_item_id,
-                'update_spec' => update_spec,
-            })
-        end
-
-
-
-        # The  ``Com::Vmware::Content::Library::Item::FindSpec``   class  specifies the properties that can be used as a filter to find library items. When multiple  fields  are specified, all properties of the item must match the specification.
-        # @!attribute [rw] name
-        #     @return [String, nil]
-        #     The name of the library item. The name is case-insensitive. See   :attr:`Com::Vmware::Content::Library::ItemModel.name`  .
-        #     If not specified all library item names are searched.
-        # @!attribute [rw] library_id
-        #     @return [String, nil]
-        #     The identifier of the library containing the item. See   :attr:`Com::Vmware::Content::Library::ItemModel.library_id`  .
-        #     If not specified all libraries are searched.
-        # @!attribute [rw] source_id
-        #     @return [String, nil]
-        #     The identifier of the library item as reported by the publisher. See   :attr:`Com::Vmware::Content::Library::ItemModel.source_id`  .
-        #     If not specified all library items are searched.
-        # @!attribute [rw] type
-        #     @return [String, nil]
-        #     The type of the library item. The type is case-insensitive. See   :attr:`Com::Vmware::Content::Library::ItemModel.type`  .
-        #     If not specified all types are searched.
-        # @!attribute [rw] cached
-        #     @return [Boolean, nil]
-        #     Whether the item is cached. Possible values are 'true' or 'false'. See   :attr:`Com::Vmware::Content::Library::ItemModel.cached`  .
-        #     If not specified all library items are searched.
-        class FindSpec < VAPI::Bindings::VapiStruct
-
-            class << self
-                # Holds (gets or creates) the binding type metadata for this structure type.
-                # @scope class
-                # @return [VAPI::Bindings::StructType] the binding type
-                def binding_type
-                    @binding_type ||= VAPI::Bindings::StructType.new(
-                        'com.vmware.content.library.item.find_spec',
-                        {
-                            'name' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::StringType.instance),
-                            'library_id' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::IdType.new),
-                            'source_id' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::IdType.new),
-                            'type' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::StringType.instance),
-                            'cached' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::BooleanType.instance),
-                        },
-                        FindSpec,
-                        false,
-                        nil)
-                end
-            end
-
-            attr_accessor :name,
-                          :library_id,
-                          :source_id,
-                          :type,
-                          :cached
-
-            # Constructs a new instance.
-            # @param ruby_values [Hash] a map of initial property values (optional)
-            # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
-            def initialize(ruby_values=nil, struct_value=nil)
-                super(self.class.binding_type, ruby_values, struct_value)
-            end
-        end
-
-
+    # Constructs a new instance.
+    #
+    # @param config [VAPI::Bindings::StubConfig] A hash with the api provider details.
+    def initialize(config)
+      super(config, SERVICE_INFO)
     end
 
-
-    # The  ``Com::Vmware::Content::Library::SubscribedItem``   class  manages the unique features of library items that are members of a subscribed library.
-    class SubscribedItem < VAPI::Bindings::VapiService
-
-        protected
-
-        # static metamodel definitions
-        @@service_id = VAPI::Core::ServiceIdentifier.new('com.vmware.content.library.subscribed_item')
-
-        @@evict_info = VAPI::Bindings::OperationInfo.new(
-            VAPI::Core::OperationIdentifier.new('evict', @@service_id),
-            VAPI::Bindings::OperationInputType.new({
-                'library_item_id' => VAPI::Bindings::IdType.new(resource_types='com.vmware.content.library.Item'),
-            }),
-            VAPI::Bindings::VoidType.instance,
-            {
-                'com.vmware.vapi.std.errors.not_found' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::NotFound'),
-                'com.vmware.vapi.std.errors.invalid_element_type' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::InvalidElementType'),
-                'com.vmware.vapi.std.errors.invalid_element_configuration' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::InvalidElementConfiguration'),
-
-            },
-            [],
-            [])
-        @@sync_info = VAPI::Bindings::OperationInfo.new(
-            VAPI::Core::OperationIdentifier.new('sync', @@service_id),
-            VAPI::Bindings::OperationInputType.new({
-                'library_item_id' => VAPI::Bindings::IdType.new(resource_types='com.vmware.content.library.Item'),
-                'force_sync_content' => VAPI::Bindings::BooleanType.instance,
-            }),
-            VAPI::Bindings::VoidType.instance,
-            {
-                'com.vmware.vapi.std.errors.not_found' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::NotFound'),
-                'com.vmware.vapi.std.errors.invalid_element_type' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::InvalidElementType'),
-
-            },
-            [],
-            [])
-
-        @@service_info = VAPI::Bindings::ServiceInfo.new(@@service_id, {
-            'evict' => @@evict_info,
-            'sync' => @@sync_info,
-        })
-
-        public
-
-        # Constructs a new instance.
-        #
-        # @param config [VAPI::Bindings::StubConfig] A hash with the api provider details.
-        def initialize(config)
-            super(config, @@service_info)
-        end
-
-
-        # Evicts the cached content of a library item in a subscribed library.  
-        # 
-        #  This  method  allows the cached content of a library item to be removed to free up storage capacity. This  method  will only work when a library item is synchronized on-demand. When a library is not synchronized on-demand, it always attempts to keep its cache up-to-date with the published source. Evicting the library item will set   :attr:`Com::Vmware::Content::Library::ItemModel.cached`   to false.
-        #
-        # @param library_item_id [String]
-        #      Identifier of the library item whose content should be evicted.
-        # @return [Void]
-        # @raise [Com::Vmware::Vapi::Std::Errors::NotFound]
-        #      if the library item specified by  ``library_item_id``  does not exist.
-        # @raise [Com::Vmware::Vapi::Std::Errors::InvalidElementType]
-        #      if the library item specified by  ``library_item_id``  is not a member of a subscribed library.
-        # @raise [Com::Vmware::Vapi::Std::Errors::InvalidElementConfiguration]
-        #      if the library item specified by  ``library_item_id``  is a member of a subscribed library that does not synchronize on-demand.
-        def evict(library_item_id)
-            invoke_with_info(@@evict_info, {
-                'library_item_id' => library_item_id,
-            })
-        end
-
-
-        # Forces the synchronization of an individual library item in a subscribed library.  
-        # 
-        #  Synchronizing an individual item will update that item's metadata from the remote source. If the source library item on the remote library has been deleted, this  method  will delete the library item from the subscribed library as well.  
-        # 
-        #  The default behavior of the synchronization is determined by the   :class:`Com::Vmware::Content::Library::SubscriptionInfo`   of the library which owns the library item.  
-        # 
-        #   * If   :attr:`Com::Vmware::Content::Library::SubscriptionInfo.on_demand`   is true, then the file content is not synchronized by default. In this case, only the library item metadata is synchronized. The file content may still be forcefully synchronized by passing true for the  ``force_sync_content``   parameter .
-        #    * If   :attr:`Com::Vmware::Content::Library::SubscriptionInfo.on_demand`   is false, then this call will always synchronize the file content. The  ``force_sync_content``   parameter  is ignored when the subscription is not on-demand.
-        #   
-        #   When the file content has been synchronized, the   :attr:`Com::Vmware::Content::Library::ItemModel.cached`    field  will be true.  
-        # 
-        #  This  method  will return immediately and create an asynchronous task to perform the synchronization.
-        #
-        # @param library_item_id [String]
-        #      Identifier of the library item to synchronize.
-        # @param force_sync_content [Boolean]
-        #      Whether to synchronize file content as well as metadata. This  parameter  applies only if the subscription is on-demand.
-        # @return [Void]
-        # @raise [Com::Vmware::Vapi::Std::Errors::NotFound]
-        #      if the library item specified by  ``library_item_id``  could not be found.
-        # @raise [Com::Vmware::Vapi::Std::Errors::InvalidElementType]
-        #      if the library item specified by  ``library_item_id``  is not a member of a subscribed library.
-        def sync(library_item_id, force_sync_content)
-            invoke_with_info(@@sync_info, {
-                'library_item_id' => library_item_id,
-                'force_sync_content' => force_sync_content,
-            })
-        end
-
-
+    RESOURCE_TYPE = 'com.vmware.content.library.Item'
+    # Copies a library item.  
+    # 
+    #  Copying a library item allows a duplicate to be made within the same or different library. The copy occurs by first creating a new library item, whose identifier is returned. The content of the library item is then copied asynchronously. This copy can be tracked as a task.  
+    # 
+    #  If the copy fails, Content Library Service will roll back the copy by deleting any content that was already copied, and removing the new library item. A failure during rollback may require manual cleanup by an administrator.  
+    # 
+    #  A library item cannot be copied into a subscribed library.
+    #
+    # @param client_token [String, nil]
+    #      A unique token generated on the client for each copy request. The token should be a universally unique identifier (UUID), for example:  ``b8a2a2e3-2314-43cd-a871-6ede0f429751`` . This token can be used to guarantee idempotent copy.
+    #     If not specified copy is not idempotent.
+    # @param source_library_item_id [String]
+    #      Identifier of the existing library item from which the content will be copied.
+    # @param destination_create_spec [Com::Vmware::Content::Library::ItemModel]
+    #      Specification for the new library item to be created.
+    # @return [String]
+    #     The identifier of the new library item into which the content is being copied.
+    # @raise [Com::Vmware::Vapi::Std::Errors::NotFound]
+    #      if the library item with  ``source_library_item_id``  does not exist, or if the library referenced by the   :attr:`Com::Vmware::Content::Library::ItemModel.library_id`   property of  ``destination_create_spec``  does not exist.
+    # @raise [Com::Vmware::Vapi::Std::Errors::InvalidArgument]
+    #      if one of the following is true for the new library item:  
+    #     
+    #       * name is empty
+    #        * name exceeds 80 characters
+    #        * description exceeds 1024 characters
+    #       
+    # @raise [Com::Vmware::Vapi::Std::Errors::InvalidArgument]
+    #      if the  ``client_token``  does not conform to the UUID format.
+    # @raise [Com::Vmware::Vapi::Std::Errors::InvalidElementType]
+    #      if the   :attr:`Com::Vmware::Content::Library::ItemModel.library_id`   property of  ``destination_create_spec``  refers to a subscribed library.
+    # @raise [Com::Vmware::Vapi::Std::Errors::ResourceInaccessible]
+    #      if the copy operation failed because the source or destination library item is not accessible.
+    def copy(source_library_item_id, destination_create_spec, client_token = nil)
+      invoke_with_info(COPY_INFO,
+                       'client_token' => client_token,
+                       'source_library_item_id' => source_library_item_id,
+                       'destination_create_spec' => destination_create_spec)
     end
 
+    # Creates a new library item.  
+    # 
+    #  A new library item is created without any content. After creation, content can be added through the   :class:`Com::Vmware::Content::Library::Item::UpdateSession`   and   :class:`Com::Vmware::Content::Library::Item::Updatesession::File`    classs .  
+    # 
+    #  A library item cannot be created in a subscribed library.
+    #
+    # @param client_token [String, nil]
+    #      A unique token generated on the client for each creation request. The token should be a universally unique identifier (UUID), for example:  ``b8a2a2e3-2314-43cd-a871-6ede0f429751`` . This token can be used to guarantee idempotent creation.
+    #     If not specified creation is not idempotent.
+    # @param create_spec [Com::Vmware::Content::Library::ItemModel]
+    #      Specification that defines the properties of the new library item.
+    # @return [String]
+    #     Identifier of the new library item.
+    # @raise [Com::Vmware::Vapi::Std::Errors::NotFound]
+    #      if the   :attr:`Com::Vmware::Content::Library::ItemModel.library_id`   property of  ``create_spec``  refers to a library that does not exist.
+    # @raise [Com::Vmware::Vapi::Std::Errors::InvalidArgument]
+    #      if one of the following is true for the new library item:  
+    #     
+    #       * name is empty
+    #        * name exceeds 80 characters
+    #        * description exceeds 1024 characters
+    #       
+    # @raise [Com::Vmware::Vapi::Std::Errors::InvalidArgument]
+    #      if the  ``client_token``  does not conform to the UUID format.
+    # @raise [Com::Vmware::Vapi::Std::Errors::InvalidElementType]
+    #      if the   :attr:`Com::Vmware::Content::Library::ItemModel.library_id`   property of  ``destinationCreateSpec``  refers to a subscribed library.
+    def create(create_spec, client_token = nil)
+      invoke_with_info(CREATE_INFO,
+                       'client_token' => client_token,
+                       'create_spec' => create_spec)
+    end
 
+    # Deletes a library item.  
+    # 
+    #  This  method  will immediately remove the item from the library that owns it. The content of the item will be asynchronously removed from the storage backings. The content deletion can be tracked with a task. In the event that the task fails, an administrator may need to manually remove the files from the storage backing.  
+    # 
+    #  This  method  cannot be used to delete a library item that is a member of a subscribed library. Removing an item from a subscribed library requires deleting the item from the original published local library and syncing the subscribed library.
+    #
+    # @param library_item_id [String]
+    #      Identifier of the library item to delete.
+    # @return [Void]
+    # @raise [Com::Vmware::Vapi::Std::Errors::InvalidElementType]
+    #      if the library item with the given  ``library_item_id``  is a member of a subscribed library.
+    # @raise [Com::Vmware::Vapi::Std::Errors::NotFound]
+    #      if the library item with the specified  ``library_item_id``  does not exist.
+    def delete(library_item_id)
+      invoke_with_info(DELETE_INFO,
+                       'library_item_id' => library_item_id)
+    end
 
-    # The  ``Com::Vmware::Content::Library::ItemModel``   class  represents a library item that has been stored in a library.  
+    # Returns the   :class:`Com::Vmware::Content::Library::ItemModel`   with the given identifier.
+    #
+    # @param library_item_id [String]
+    #      Identifier of the library item to return.
+    # @return [Com::Vmware::Content::Library::ItemModel]
+    #     The   :class:`Com::Vmware::Content::Library::ItemModel`   instance with the given  ``library_item_id`` .
+    # @raise [Com::Vmware::Vapi::Std::Errors::NotFound]
+    #      if no item with the given  ``library_item_id``  exists.
+    def get(library_item_id)
+      invoke_with_info(GET_INFO,
+                       'library_item_id' => library_item_id)
+    end
+
+    # Returns the identifiers of all items in the given library.
+    #
+    # @param library_id [String]
+    #      Identifier of the library whose items should be returned.
+    # @return [Array<String>]
+    #     The  list  of identifiers of the items in the library specified by  ``library_id`` .
+    # @raise [Com::Vmware::Vapi::Std::Errors::NotFound]
+    #      if the library associated with  ``library_id``  does not exist.
+    def list(library_id)
+      invoke_with_info(LIST_INFO,
+                       'library_id' => library_id)
+    end
+
+    # Returns identifiers of all the visible (as determined by authorization policy) library items matching the requested   :class:`Com::Vmware::Content::Library::Item::FindSpec`  .
+    #
+    # @param spec [Com::Vmware::Content::Library::Item::FindSpec]
+    #      Specification describing what properties to filter on.
+    # @return [Array<String>]
+    #     The  list  of identifiers of all the visible library items matching the given  ``spec`` .
+    # @raise [Com::Vmware::Vapi::Std::Errors::InvalidArgument]
+    #      if no properties are specified in the  ``spec`` .
+    def find(spec)
+      invoke_with_info(FIND_INFO,
+                       'spec' => spec)
+    end
+
+    # Updates the specified properties of a library item.  
     # 
-    #  A  ``Com::Vmware::Content::Library::ItemModel``  represents a single logical unit to be managed within a   :class:`Com::Vmware::Content::LibraryModel`  . Items contain the actual content of a library, and their placement within a library determines policies that affect that content such as publishing.  
+    #  This is an incremental update to the library item.  Fields  that are  nil  in the update specification are left unchanged.  
     # 
-    #  A library item can have a specified type, indicated with the   :attr:`Com::Vmware::Content::Library::ItemModel.type`    field . This property is associated with a Content Library Service plugin that supports specific types and provides additional services. The types available in a specific Content Library Service can be queried using the   :class:`Com::Vmware::Content::Type`    class . Items of an unknown or unspecified type are treated generically. Because subscribed library catalogs are synchronized as is, subscribing to a remote Content Library Service effectively gives you a library with the functionality of the remote service's type adapter plugins, even if they are not installed locally.  
-    # 
-    #  Items can be managed using the   :class:`Com::Vmware::Content::Library::Item`    class  and, for items in subscribed libraries, the   :class:`Com::Vmware::Content::Library::SubscribedItem`    class .
-    # @!attribute [rw] id
-    #     @return [String]
-    #     A unique identifier for this library item.
-    #     This  field  is not used for the  ``create``   method . It will not be present in the  result  of the  ``get``  or  ``list``   methods . It is not used for the  ``update``   method .
-    # @!attribute [rw] library_id
-    #     @return [String]
-    #     The identifier of the   :class:`Com::Vmware::Content::LibraryModel`   to which this item belongs.
-    #     This  field  must be provided for the  ``create``   method . It will always be present in the  result  of the  ``get``  or  ``list``   methods . It is not used for the  ``update``   method .
-    # @!attribute [rw] content_version
-    #     @return [String]
-    #     The version of the file content list of this library item.
-    #     This  field  is not used for the  ``create``   method . It will always be present in the  result  of the  ``get``  or  ``list``   methods . It is not used for the  ``update``   method .
-    # @!attribute [rw] creation_time
-    #     @return [DateTime]
-    #     The date and time when this library item was created.
-    #     This  field  is not used for the  ``create``   method . It will always be present in the  result  of the  ``get``  or  ``list``   methods . It is not used for the  ``update``   method .
-    # @!attribute [rw] description
-    #     @return [String]
-    #     A human-readable description for this library item.
-    #     This  field  is optional for the  ``create``   method . Leaving it  nil  during creation will result in an empty string value. It will always be present in the result of a  ``get``  or  ``list``   method . It is optional for the  ``update``   method . Leaving it  nil  during update indicates that the description remains unchanged.
-    # @!attribute [rw] last_modified_time
-    #     @return [DateTime]
-    #     The date and time when the metadata for this library item was last changed.  
+    #  This  method  cannot update a library item that is a member of a subscribed library. Those items must be updated in the source published library and synchronized to the subscribed library.
+    #
+    # @param library_item_id [String]
+    #      Identifier of the library item to update.
+    # @param update_spec [Com::Vmware::Content::Library::ItemModel]
+    #      Specification of the properties to set.
+    # @return [Void]
+    # @raise [Com::Vmware::Vapi::Std::Errors::NotFound]
+    #      if the library item specified by  ``library_item_id``  does not exist.
+    # @raise [Com::Vmware::Vapi::Std::Errors::InvalidElementType]
+    #      if the library item corresponding to  ``library_item_id``  is a member of a subscribed library.
+    # @raise [Com::Vmware::Vapi::Std::Errors::InvalidArgument]
+    #      if one of the following is true for the  ``update_spec`` :  
     #     
-    #      This  field  is affected by changes to the properties or file content of this item. It is not modified by changes to the tags of the item, or by changes to the library which owns this item.
-    #     This  field  is not used for the  ``create``   method . It will always be present in the  result  of the  ``get``  or  ``list``   methods . It is not used for the  ``update``   method .
-    # @!attribute [rw] last_sync_time
-    #     @return [DateTime]
-    #     The date and time when this library item was last synchronized.  
-    #     
-    #      This  field  is updated every time a synchronization is triggered on the library item, including when a synchronization is triggered on the library to which this item belongs. The value is  nil  for a library item that belongs to a local library.
-    #     This  field  is not used for the  ``create``   method . It is optional in the  result  of the  ``get``  or  ``list``   methods . It is not used for the  ``update``   method .
-    # @!attribute [rw] metadata_version
-    #     @return [String]
-    #     A version number for the metadata of this library item.  
-    #     
-    #      This value is incremented with each change to the metadata of this item. Changes to name, description, and so on will increment this value. The value is not incremented by changes to the content or tags of the item or the library which owns it.
-    #     This  field  is not used for the  ``create``   method . It will always be present in the  result  of the  ``get``  or  ``list``   methods . It is not used for the  ``update``   method .
+    #       * name is empty
+    #        * name exceeds 80 characters
+    #        * description exceeds 1024 characters
+    #        * version is not equal to the current version of the library item
+    #       
+    def update(library_item_id, update_spec)
+      invoke_with_info(UPDATE_INFO,
+                       'library_item_id' => library_item_id,
+                       'update_spec' => update_spec)
+    end
+
+    # The  ``Com::Vmware::Content::Library::Item::FindSpec``   class  specifies the properties that can be used as a filter to find library items. When multiple  fields  are specified, all properties of the item must match the specification.
     # @!attribute [rw] name
-    #     @return [String]
-    #     A human-readable name for this library item.  
-    #     
-    #      The name may not be  nil  or an empty string. The name does not have to be unique, even within the same library.
-    #     This  field  must be provided for the  ``create``   method . It will always be present in the  result  of the  ``get``  or  ``list``   methods . It is optional for the  ``update``   method .
-    # @!attribute [rw] cached
-    #     @return [Boolean]
-    #     The status that indicates whether the library item is on disk or not. The library item is cached when all its files are on disk.
-    #     This  field  is not used for the  ``create``   method . It will always be present in the  result  of the  ``get``  or  ``list``   methods . It is not used for the  ``update``   method .
-    # @!attribute [rw] size
-    #     @return [Fixnum]
-    #     The library item size, in bytes. The size is the sum of the size used on the storage backing for all the files in the item. When the library item is not cached, the size is 0.
-    #     This  field  is not used for the  ``create``   method . It is optional in the  result  of the  ``get``  or  ``list``   methods . It is not used for the  ``update``   method .
-    # @!attribute [rw] type
-    #     @return [String]
-    #     An optional type identifier which indicates the type adapter plugin to use.  
-    #     
-    #      This  field  may be set to a non-empty string value that corresponds to an identifier supported by a type adapter plugin present in the Content Library Service. A type adapter plugin, if present for the specified type, can provide additional information and services around the item content. A type adapter can guide the upload process by creating file entries that are in need of being uploaded to complete an item.  
-    #     
-    #      The types and plugins supported by the Content Library Service can be queried using the   :class:`Com::Vmware::Content::Type`    class .
-    #     This  field  is optional for the  ``create``  and  ``update``   methods . During creation, if the type is left unspecified, or if the type is specified but does not have a corresponding type support plugin, then the type of the library item is considered to be generic and all data is treated as generic files. During update, if the type is not specified, then it is not updated.
-    # @!attribute [rw] version
-    #     @return [String]
-    #     A version number that is updated on metadata changes. This value is used to validate update requests to provide optimistic concurrency of changes.  
-    #     
-    #      This value represents a number that is incremented every time library item properties, such as name or description, are changed. It is not incremented by changes to the file content of the library item, including adding or removing files. It is also not affected by tagging the library item.
-    #     This  field  is not used for the  ``create``   method . It will always be present in the result of a  ``get``  or  ``list``   method . It is optional for the  ``update``   method . Leaving it  nil  during update indicates that you do not need to detect concurrent updates.
+    #     @return [String, nil]
+    #     The name of the library item. The name is case-insensitive. See   :attr:`Com::Vmware::Content::Library::ItemModel.name`  .
+    #     If not specified all library item names are searched.
+    # @!attribute [rw] library_id
+    #     @return [String, nil]
+    #     The identifier of the library containing the item. See   :attr:`Com::Vmware::Content::Library::ItemModel.library_id`  .
+    #     If not specified all libraries are searched.
     # @!attribute [rw] source_id
-    #     @return [String]
-    #     The identifier of the   :class:`Com::Vmware::Content::Library::ItemModel`   to which this item is synchronized to if the item belongs to a subscribed library. The value is  nil  for a library item that belongs to a local library.
-    #     This  field  is not used for the  ``create``   method . It is optional in the  result  of the  ``get``  or  ``list``   methods . It is not used for the  ``update``   method .
-    class ItemModel < VAPI::Bindings::VapiStruct
-
-        class << self
-            # Holds (gets or creates) the binding type metadata for this structure type.
-            # @scope class
-            # @return [VAPI::Bindings::StructType] the binding type
-            def binding_type
-                @binding_type ||= VAPI::Bindings::StructType.new(
-                    'com.vmware.content.library.item_model',
-                    {
-                        'id' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::IdType.new),
-                        'library_id' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::IdType.new),
-                        'content_version' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::StringType.instance),
-                        'creation_time' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::DateTimeType.instance),
-                        'description' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::StringType.instance),
-                        'last_modified_time' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::DateTimeType.instance),
-                        'last_sync_time' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::DateTimeType.instance),
-                        'metadata_version' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::StringType.instance),
-                        'name' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::StringType.instance),
-                        'cached' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::BooleanType.instance),
-                        'size' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::IntegerType.instance),
-                        'type' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::StringType.instance),
-                        'version' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::StringType.instance),
-                        'source_id' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::IdType.new),
-                    },
-                    ItemModel,
-                    true,
-                    ["id"])
-            end
-        end
-
-        attr_accessor :id,
-                      :library_id,
-                      :content_version,
-                      :creation_time,
-                      :description,
-                      :last_modified_time,
-                      :last_sync_time,
-                      :metadata_version,
-                      :name,
-                      :cached,
-                      :size,
-                      :type,
-                      :version,
-                      :source_id
-
-        # Constructs a new instance.
-        # @param ruby_values [Hash] a map of initial property values (optional)
-        # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
-        def initialize(ruby_values=nil, struct_value=nil)
-            super(self.class.binding_type, ruby_values, struct_value)
-        end
-    end
-
-
-    # The  ``Com::Vmware::Content::Library::OptimizationInfo``   class  defines different optimizations and optimization parameters applied to particular library.
-    # @!attribute [rw] optimize_remote_publishing
-    #     @return [Boolean]
-    #     If set to  ``true``  then library would be optimized for remote publishing.  
-    #     
-    #      Turn it on if remote publishing is dominant use case for this library. Remote publishing means here that publisher and subscribers are not the part of the same  ``Vcenter``  SSO domain.  
-    #     
-    #      Any optimizations could be done as result of turning on this optimization during library creation. For example, library content could be stored in different format but optimizations are not limited to just storage format.  
-    #     
-    #      Note, that value of this toggle could be set only during creation of the library and you would need to migrate your library in case you need to change this value (optimize the library for different use case).
-    #     This  field  is optional for the  ``create``   method . If not specified for the  ``create`` , the default is for the library to not be optmized for specific use case. It is not used for the  ``update``   method .
-    class OptimizationInfo < VAPI::Bindings::VapiStruct
-
-        class << self
-            # Holds (gets or creates) the binding type metadata for this structure type.
-            # @scope class
-            # @return [VAPI::Bindings::StructType] the binding type
-            def binding_type
-                @binding_type ||= VAPI::Bindings::StructType.new(
-                    'com.vmware.content.library.optimization_info',
-                    {
-                        'optimize_remote_publishing' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::BooleanType.instance),
-                    },
-                    OptimizationInfo,
-                    false,
-                    nil)
-            end
-        end
-
-        attr_accessor :optimize_remote_publishing
-
-        # Constructs a new instance.
-        # @param ruby_values [Hash] a map of initial property values (optional)
-        # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
-        def initialize(ruby_values=nil, struct_value=nil)
-            super(self.class.binding_type, ruby_values, struct_value)
-        end
-    end
-
-
-    # The  ``Com::Vmware::Content::Library::PublishInfo``   class  defines how a local library is published publicly for synchronization to other libraries.
-    # @!attribute [rw] authentication_method
-    #     @return [Com::Vmware::Content::Library::PublishInfo::AuthenticationMethod]
-    #     Indicates how a subscribed library should authenticate ( ``BASIC``, ``NONE`` ) to the published library endpoint.
-    #     This  field  must be provided for the  ``create``   method . It will always be present in the  result  of the  ``get``  or  ``list``   methods . It is optional for the  ``update``   method .
-    # @!attribute [rw] published
-    #     @return [Boolean]
-    #     Whether the local library is published.
-    #     This  field  must be provided for the  ``create``   method . It will always be present in the  result  of the  ``get``  or  ``list``   methods . It is optional for the  ``update``   method .
-    # @!attribute [rw] publish_url
-    #     @return [URI]
-    #     The URL to which the library metadata is published by the Content Library Service.  
-    #     
-    #      This value can be used to set the   :attr:`Com::Vmware::Content::Library::SubscriptionInfo.subscription_url`   property when creating a subscribed library.
-    #     This  field  is not used for the  ``create``   method . It will always be present in the  result  of the  ``get``  or  ``list``   methods . It is not used for the  ``update``   method .
-    # @!attribute [rw] user_name
-    #     @return [String]
-    #     The username to require for authentication.
-    #     This  field  is optional for the  ``create``  and  ``update``   method . When the authentication is not required, the username can be left  nil . When the authentication method is basic, the username is ignored in the current release. It defaults to "vcsp". It is preferable to leave this unset. If specified, it must be set to "vcsp".
-    # @!attribute [rw] password
-    #     @return [String]
-    #     The password to require for authentication.
-    #     This  field  is optional for the  ``create``   method . When the authentication method is   :attr:`Com::Vmware::Content::Library::PublishInfo::AuthenticationMethod.NONE`  , the password can be left  nil . When the authentication method is   :attr:`Com::Vmware::Content::Library::PublishInfo::AuthenticationMethod.BASIC`  , the password should be a non-empty string. This  field  is optional for the  ``update``   method . Leaving it  nil  during update indicates that the password is not changed. This  field  is not used for the  ``get``  or  ``list``   method .
-    # @!attribute [rw] persist_json_enabled
-    #     @return [Boolean]
-    #     Whether library and library item metadata are persisted in the storage backing as JSON files. This flag only applies if the local library is published.  
-    #     
-    #      Enabling JSON persistence allows you to synchronize a subscribed library manually instead of over HTTP. You copy the local library content and metadata to another storage backing manually and then create a subscribed library referencing the location of the library JSON file in the   :attr:`Com::Vmware::Content::Library::SubscriptionInfo.subscription_url`  . When the subscribed library's storage backing matches the subscription URL, files do not need to be copied to the subscribed library.  
-    #     
-    #      For a library backed by a datastore, the library JSON file will be stored at the path contentlib-{library_id}/lib.json on the datastore.  
-    #     
-    #      For a library backed by a remote file system, the library JSON file will be stored at {library_id}/lib.json in the remote file system path.
-    #     This  field  is optional for the  ``create``   method . It will always be present in the  result  of the  ``get``  or  ``list``   methods . It is optional for the  ``update``   method .
-    class PublishInfo < VAPI::Bindings::VapiStruct
-
-        class << self
-            # Holds (gets or creates) the binding type metadata for this structure type.
-            # @scope class
-            # @return [VAPI::Bindings::StructType] the binding type
-            def binding_type
-                @binding_type ||= VAPI::Bindings::StructType.new(
-                    'com.vmware.content.library.publish_info',
-                    {
-                        'authentication_method' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Content::Library::PublishInfo::AuthenticationMethod')),
-                        'published' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::BooleanType.instance),
-                        'publish_url' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::URIType.instance),
-                        'user_name' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::StringType.instance),
-                        'password' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::SecretType.instance),
-                        'persist_json_enabled' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::BooleanType.instance),
-                    },
-                    PublishInfo,
-                    false,
-                    nil)
-            end
-        end
-
-        attr_accessor :authentication_method,
-                      :published,
-                      :publish_url,
-                      :user_name,
-                      :password,
-                      :persist_json_enabled
-
-        # Constructs a new instance.
-        # @param ruby_values [Hash] a map of initial property values (optional)
-        # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
-        def initialize(ruby_values=nil, struct_value=nil)
-            super(self.class.binding_type, ruby_values, struct_value)
-        end
-
-
-        # The  ``Com::Vmware::Content::Library::PublishInfo::AuthenticationMethod``   enumerated type  indicates how a subscribed library should authenticate to the published library endpoint.
-        # @!attribute [rw] basic
-        #     @return [Com::Vmware::Content::Library::PublishInfo::AuthenticationMethod]
-        #     Require HTTP Basic authentication matching a specified username and password.
-        # @!attribute [rw] none
-        #     @return [Com::Vmware::Content::Library::PublishInfo::AuthenticationMethod]
-        #     Require no authentication.
-        class AuthenticationMethod < VAPI::Bindings::VapiEnum
-
-            class << self
-                # Holds (gets or creates) the binding type metadata for this enumeration type.
-                # @scope class
-                # @return [VAPI::Bindings::EnumType] the binding type
-                def binding_type
-                    @binding_type ||= VAPI::Bindings::EnumType.new(
-                        'com.vmware.content.library.publish_info.authentication_method',
-                        AuthenticationMethod)
-                end
-
-                # Converts from a string value (perhaps off the wire) to an instance
-                # of this enum type.
-                # @param value [String] the actual value of the enum instance
-                # @return [AuthenticationMethod] the instance found for the value, otherwise
-                #         an unknown instance will be built for the value
-                def from_string(value)
-                    begin
-                        const_get(value)
-                    rescue NameError
-                        AuthenticationMethod.new('UNKNOWN', value)
-                    end
-                end
-            end
-
-            private
-
-            # Constructs a new instance.
-            # @param value [String] the actual value of the enum instance
-            # @param unknown [String] the unknown value when value is 'UKNOWN'
-            def initialize(value, unknown=nil)
-                super(self.class.binding_type, value, unknown)
-            end
-
-            public
-
-            # @!attribute [rw] basic
-            #     @return [Com::Vmware::Content::Library::PublishInfo::AuthenticationMethod]
-            #     Require HTTP Basic authentication matching a specified username and password.
-            BASIC = AuthenticationMethod.new('BASIC')
-
-            # @!attribute [rw] none
-            #     @return [Com::Vmware::Content::Library::PublishInfo::AuthenticationMethod]
-            #     Require no authentication.
-            NONE = AuthenticationMethod.new('NONE')
-
-        end
-
-
-    end
-
-
-    # The  ``Com::Vmware::Content::Library::StorageBacking``   class  defines a storage location where content in a library will be stored. The storage location can either be a Datastore or Other type.
+    #     @return [String, nil]
+    #     The identifier of the library item as reported by the publisher. See   :attr:`Com::Vmware::Content::Library::ItemModel.source_id`  .
+    #     If not specified all library items are searched.
     # @!attribute [rw] type
+    #     @return [String, nil]
+    #     The type of the library item. The type is case-insensitive. See   :attr:`Com::Vmware::Content::Library::ItemModel.type`  .
+    #     If not specified all types are searched.
+    # @!attribute [rw] cached
+    #     @return [Boolean, nil]
+    #     Whether the item is cached. Possible values are 'true' or 'false'. See   :attr:`Com::Vmware::Content::Library::ItemModel.cached`  .
+    #     If not specified all library items are searched.
+    class FindSpec < VAPI::Bindings::VapiStruct
+      class << self
+        # Holds (gets or creates) the binding type metadata for this structure type.
+        # @scope class
+        # @return [VAPI::Bindings::StructType] the binding type
+        def binding_type
+          @binding_type ||= VAPI::Bindings::StructType.new(
+            'com.vmware.content.library.item.find_spec',
+            {
+              'name' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::StringType.instance),
+              'library_id' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::IdType.new),
+              'source_id' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::IdType.new),
+              'type' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::StringType.instance),
+              'cached' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::BooleanType.instance)
+            },
+            FindSpec,
+            false,
+            nil
+          )
+        end
+      end
+
+      attr_accessor :name,
+                    :library_id,
+                    :source_id,
+                    :type,
+                    :cached
+
+      # Constructs a new instance.
+      # @param ruby_values [Hash] a map of initial property values (optional)
+      # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
+      def initialize(ruby_values = nil, struct_value = nil)
+        super(self.class.binding_type, ruby_values, struct_value)
+      end
+    end
+
+  end
+  # The  ``Com::Vmware::Content::Library::SubscribedItem``   class  manages the unique features of library items that are members of a subscribed library.
+  class SubscribedItem < VAPI::Bindings::VapiService
+    # static metamodel definitions
+    SERVICE_ID = VAPI::Core::ServiceIdentifier.new('com.vmware.content.library.subscribed_item')
+
+    EVICT_INFO = VAPI::Bindings::OperationInfo.new(
+      VAPI::Core::OperationIdentifier.new('evict', SERVICE_ID),
+      VAPI::Bindings::OperationInputType.new(
+        'library_item_id' => VAPI::Bindings::IdType.new('com.vmware.content.library.Item')
+      ),
+      VAPI::Bindings::VoidType.instance,
+      {
+        'com.vmware.vapi.std.errors.not_found' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::NotFound'),
+        'com.vmware.vapi.std.errors.invalid_element_type' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::InvalidElementType'),
+        'com.vmware.vapi.std.errors.invalid_element_configuration' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::InvalidElementConfiguration')
+      },
+      [],
+      []
+    )
+
+    SYNC_INFO = VAPI::Bindings::OperationInfo.new(
+      VAPI::Core::OperationIdentifier.new('sync', SERVICE_ID),
+      VAPI::Bindings::OperationInputType.new(
+        'library_item_id' => VAPI::Bindings::IdType.new('com.vmware.content.library.Item'),
+        'force_sync_content' => VAPI::Bindings::BooleanType.instance
+      ),
+      VAPI::Bindings::VoidType.instance,
+      {
+        'com.vmware.vapi.std.errors.not_found' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::NotFound'),
+        'com.vmware.vapi.std.errors.invalid_element_type' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::InvalidElementType')
+      },
+      [],
+      []
+    )
+
+    SERVICE_INFO = VAPI::Bindings::ServiceInfo.new(
+      SERVICE_ID,
+      'evict' => EVICT_INFO,
+      'sync' => SYNC_INFO
+    )
+
+    # Constructs a new instance.
+    #
+    # @param config [VAPI::Bindings::StubConfig] A hash with the api provider details.
+    def initialize(config)
+      super(config, SERVICE_INFO)
+    end
+
+    # Evicts the cached content of a library item in a subscribed library.  
+    # 
+    #  This  method  allows the cached content of a library item to be removed to free up storage capacity. This  method  will only work when a library item is synchronized on-demand. When a library is not synchronized on-demand, it always attempts to keep its cache up-to-date with the published source. Evicting the library item will set   :attr:`Com::Vmware::Content::Library::ItemModel.cached`   to false.
+    #
+    # @param library_item_id [String]
+    #      Identifier of the library item whose content should be evicted.
+    # @return [Void]
+    # @raise [Com::Vmware::Vapi::Std::Errors::NotFound]
+    #      if the library item specified by  ``library_item_id``  does not exist.
+    # @raise [Com::Vmware::Vapi::Std::Errors::InvalidElementType]
+    #      if the library item specified by  ``library_item_id``  is not a member of a subscribed library.
+    # @raise [Com::Vmware::Vapi::Std::Errors::InvalidElementConfiguration]
+    #      if the library item specified by  ``library_item_id``  is a member of a subscribed library that does not synchronize on-demand.
+    def evict(library_item_id)
+      invoke_with_info(EVICT_INFO,
+                       'library_item_id' => library_item_id)
+    end
+
+    # Forces the synchronization of an individual library item in a subscribed library.  
+    # 
+    #  Synchronizing an individual item will update that item's metadata from the remote source. If the source library item on the remote library has been deleted, this  method  will delete the library item from the subscribed library as well.  
+    # 
+    #  The default behavior of the synchronization is determined by the   :class:`Com::Vmware::Content::Library::SubscriptionInfo`   of the library which owns the library item.  
+    # 
+    #   * If   :attr:`Com::Vmware::Content::Library::SubscriptionInfo.on_demand`   is true, then the file content is not synchronized by default. In this case, only the library item metadata is synchronized. The file content may still be forcefully synchronized by passing true for the  ``force_sync_content``   parameter .
+    #    * If   :attr:`Com::Vmware::Content::Library::SubscriptionInfo.on_demand`   is false, then this call will always synchronize the file content. The  ``force_sync_content``   parameter  is ignored when the subscription is not on-demand.
+    #   
+    #   When the file content has been synchronized, the   :attr:`Com::Vmware::Content::Library::ItemModel.cached`    field  will be true.  
+    # 
+    #  This  method  will return immediately and create an asynchronous task to perform the synchronization.
+    #
+    # @param library_item_id [String]
+    #      Identifier of the library item to synchronize.
+    # @param force_sync_content [Boolean]
+    #      Whether to synchronize file content as well as metadata. This  parameter  applies only if the subscription is on-demand.
+    # @return [Void]
+    # @raise [Com::Vmware::Vapi::Std::Errors::NotFound]
+    #      if the library item specified by  ``library_item_id``  could not be found.
+    # @raise [Com::Vmware::Vapi::Std::Errors::InvalidElementType]
+    #      if the library item specified by  ``library_item_id``  is not a member of a subscribed library.
+    def sync(library_item_id, force_sync_content)
+      invoke_with_info(SYNC_INFO,
+                       'library_item_id' => library_item_id,
+                       'force_sync_content' => force_sync_content)
+    end
+
+  end
+  # The  ``Com::Vmware::Content::Library::ItemModel``   class  represents a library item that has been stored in a library.  
+  # 
+  #  A  ``Com::Vmware::Content::Library::ItemModel``  represents a single logical unit to be managed within a   :class:`Com::Vmware::Content::LibraryModel`  . Items contain the actual content of a library, and their placement within a library determines policies that affect that content such as publishing.  
+  # 
+  #  A library item can have a specified type, indicated with the   :attr:`Com::Vmware::Content::Library::ItemModel.type`    field . This property is associated with a Content Library Service plugin that supports specific types and provides additional services. The types available in a specific Content Library Service can be queried using the   :class:`Com::Vmware::Content::Type`    class . Items of an unknown or unspecified type are treated generically. Because subscribed library catalogs are synchronized as is, subscribing to a remote Content Library Service effectively gives you a library with the functionality of the remote service's type adapter plugins, even if they are not installed locally.  
+  # 
+  #  Items can be managed using the   :class:`Com::Vmware::Content::Library::Item`    class  and, for items in subscribed libraries, the   :class:`Com::Vmware::Content::Library::SubscribedItem`    class .
+  # @!attribute [rw] id
+  #     @return [String]
+  #     A unique identifier for this library item.
+  #     This  field  is not used for the  ``create``   method . It will not be present in the  result  of the  ``get``  or  ``list``   methods . It is not used for the  ``update``   method .
+  # @!attribute [rw] library_id
+  #     @return [String]
+  #     The identifier of the   :class:`Com::Vmware::Content::LibraryModel`   to which this item belongs.
+  #     This  field  must be provided for the  ``create``   method . It will always be present in the  result  of the  ``get``  or  ``list``   methods . It is not used for the  ``update``   method .
+  # @!attribute [rw] content_version
+  #     @return [String]
+  #     The version of the file content list of this library item.
+  #     This  field  is not used for the  ``create``   method . It will always be present in the  result  of the  ``get``  or  ``list``   methods . It is not used for the  ``update``   method .
+  # @!attribute [rw] creation_time
+  #     @return [DateTime]
+  #     The date and time when this library item was created.
+  #     This  field  is not used for the  ``create``   method . It will always be present in the  result  of the  ``get``  or  ``list``   methods . It is not used for the  ``update``   method .
+  # @!attribute [rw] description
+  #     @return [String]
+  #     A human-readable description for this library item.
+  #     This  field  is optional for the  ``create``   method . Leaving it  nil  during creation will result in an empty string value. It will always be present in the result of a  ``get``  or  ``list``   method . It is optional for the  ``update``   method . Leaving it  nil  during update indicates that the description remains unchanged.
+  # @!attribute [rw] last_modified_time
+  #     @return [DateTime]
+  #     The date and time when the metadata for this library item was last changed.  
+  #     
+  #      This  field  is affected by changes to the properties or file content of this item. It is not modified by changes to the tags of the item, or by changes to the library which owns this item.
+  #     This  field  is not used for the  ``create``   method . It will always be present in the  result  of the  ``get``  or  ``list``   methods . It is not used for the  ``update``   method .
+  # @!attribute [rw] last_sync_time
+  #     @return [DateTime]
+  #     The date and time when this library item was last synchronized.  
+  #     
+  #      This  field  is updated every time a synchronization is triggered on the library item, including when a synchronization is triggered on the library to which this item belongs. The value is  nil  for a library item that belongs to a local library.
+  #     This  field  is not used for the  ``create``   method . It is optional in the  result  of the  ``get``  or  ``list``   methods . It is not used for the  ``update``   method .
+  # @!attribute [rw] metadata_version
+  #     @return [String]
+  #     A version number for the metadata of this library item.  
+  #     
+  #      This value is incremented with each change to the metadata of this item. Changes to name, description, and so on will increment this value. The value is not incremented by changes to the content or tags of the item or the library which owns it.
+  #     This  field  is not used for the  ``create``   method . It will always be present in the  result  of the  ``get``  or  ``list``   methods . It is not used for the  ``update``   method .
+  # @!attribute [rw] name
+  #     @return [String]
+  #     A human-readable name for this library item.  
+  #     
+  #      The name may not be  nil  or an empty string. The name does not have to be unique, even within the same library.
+  #     This  field  must be provided for the  ``create``   method . It will always be present in the  result  of the  ``get``  or  ``list``   methods . It is optional for the  ``update``   method .
+  # @!attribute [rw] cached
+  #     @return [Boolean]
+  #     The status that indicates whether the library item is on disk or not. The library item is cached when all its files are on disk.
+  #     This  field  is not used for the  ``create``   method . It will always be present in the  result  of the  ``get``  or  ``list``   methods . It is not used for the  ``update``   method .
+  # @!attribute [rw] size
+  #     @return [Fixnum]
+  #     The library item size, in bytes. The size is the sum of the size used on the storage backing for all the files in the item. When the library item is not cached, the size is 0.
+  #     This  field  is not used for the  ``create``   method . It is optional in the  result  of the  ``get``  or  ``list``   methods . It is not used for the  ``update``   method .
+  # @!attribute [rw] type
+  #     @return [String]
+  #     An optional type identifier which indicates the type adapter plugin to use.  
+  #     
+  #      This  field  may be set to a non-empty string value that corresponds to an identifier supported by a type adapter plugin present in the Content Library Service. A type adapter plugin, if present for the specified type, can provide additional information and services around the item content. A type adapter can guide the upload process by creating file entries that are in need of being uploaded to complete an item.  
+  #     
+  #      The types and plugins supported by the Content Library Service can be queried using the   :class:`Com::Vmware::Content::Type`    class .
+  #     This  field  is optional for the  ``create``  and  ``update``   methods . During creation, if the type is left unspecified, or if the type is specified but does not have a corresponding type support plugin, then the type of the library item is considered to be generic and all data is treated as generic files. During update, if the type is not specified, then it is not updated.
+  # @!attribute [rw] version
+  #     @return [String]
+  #     A version number that is updated on metadata changes. This value is used to validate update requests to provide optimistic concurrency of changes.  
+  #     
+  #      This value represents a number that is incremented every time library item properties, such as name or description, are changed. It is not incremented by changes to the file content of the library item, including adding or removing files. It is also not affected by tagging the library item.
+  #     This  field  is not used for the  ``create``   method . It will always be present in the result of a  ``get``  or  ``list``   method . It is optional for the  ``update``   method . Leaving it  nil  during update indicates that you do not need to detect concurrent updates.
+  # @!attribute [rw] source_id
+  #     @return [String]
+  #     The identifier of the   :class:`Com::Vmware::Content::Library::ItemModel`   to which this item is synchronized to if the item belongs to a subscribed library. The value is  nil  for a library item that belongs to a local library.
+  #     This  field  is not used for the  ``create``   method . It is optional in the  result  of the  ``get``  or  ``list``   methods . It is not used for the  ``update``   method .
+  class ItemModel < VAPI::Bindings::VapiStruct
+    class << self
+      # Holds (gets or creates) the binding type metadata for this structure type.
+      # @scope class
+      # @return [VAPI::Bindings::StructType] the binding type
+      def binding_type
+        @binding_type ||= VAPI::Bindings::StructType.new(
+          'com.vmware.content.library.item_model',
+          {
+            'id' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::IdType.new),
+            'library_id' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::IdType.new),
+            'content_version' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::StringType.instance),
+            'creation_time' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::DateTimeType.instance),
+            'description' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::StringType.instance),
+            'last_modified_time' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::DateTimeType.instance),
+            'last_sync_time' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::DateTimeType.instance),
+            'metadata_version' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::StringType.instance),
+            'name' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::StringType.instance),
+            'cached' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::BooleanType.instance),
+            'size' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::IntegerType.instance),
+            'type' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::StringType.instance),
+            'version' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::StringType.instance),
+            'source_id' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::IdType.new)
+          },
+          ItemModel,
+          true,
+          ["id"]
+        )
+      end
+    end
+
+    attr_accessor :id,
+                  :library_id,
+                  :content_version,
+                  :creation_time,
+                  :description,
+                  :last_modified_time,
+                  :last_sync_time,
+                  :metadata_version,
+                  :name,
+                  :cached,
+                  :size,
+                  :type,
+                  :version,
+                  :source_id
+
+    # Constructs a new instance.
+    # @param ruby_values [Hash] a map of initial property values (optional)
+    # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
+    def initialize(ruby_values = nil, struct_value = nil)
+      super(self.class.binding_type, ruby_values, struct_value)
+    end
+  end
+  # The  ``Com::Vmware::Content::Library::OptimizationInfo``   class  defines different optimizations and optimization parameters applied to particular library.
+  # @!attribute [rw] optimize_remote_publishing
+  #     @return [Boolean]
+  #     If set to  ``true``  then library would be optimized for remote publishing.  
+  #     
+  #      Turn it on if remote publishing is dominant use case for this library. Remote publishing means here that publisher and subscribers are not the part of the same  ``Vcenter``  SSO domain.  
+  #     
+  #      Any optimizations could be done as result of turning on this optimization during library creation. For example, library content could be stored in different format but optimizations are not limited to just storage format.  
+  #     
+  #      Note, that value of this toggle could be set only during creation of the library and you would need to migrate your library in case you need to change this value (optimize the library for different use case).
+  #     This  field  is optional for the  ``create``   method . If not specified for the  ``create`` , the default is for the library to not be optmized for specific use case. It is not used for the  ``update``   method .
+  class OptimizationInfo < VAPI::Bindings::VapiStruct
+    class << self
+      # Holds (gets or creates) the binding type metadata for this structure type.
+      # @scope class
+      # @return [VAPI::Bindings::StructType] the binding type
+      def binding_type
+        @binding_type ||= VAPI::Bindings::StructType.new(
+          'com.vmware.content.library.optimization_info',
+          {
+            'optimize_remote_publishing' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::BooleanType.instance)
+          },
+          OptimizationInfo,
+          false,
+          nil
+        )
+      end
+    end
+
+    attr_accessor :optimize_remote_publishing
+
+    # Constructs a new instance.
+    # @param ruby_values [Hash] a map of initial property values (optional)
+    # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
+    def initialize(ruby_values = nil, struct_value = nil)
+      super(self.class.binding_type, ruby_values, struct_value)
+    end
+  end
+  # The  ``Com::Vmware::Content::Library::PublishInfo``   class  defines how a local library is published publicly for synchronization to other libraries.
+  # @!attribute [rw] authentication_method
+  #     @return [Com::Vmware::Content::Library::PublishInfo::AuthenticationMethod]
+  #     Indicates how a subscribed library should authenticate ( ``BASIC``, ``NONE`` ) to the published library endpoint.
+  #     This  field  must be provided for the  ``create``   method . It will always be present in the  result  of the  ``get``  or  ``list``   methods . It is optional for the  ``update``   method .
+  # @!attribute [rw] published
+  #     @return [Boolean]
+  #     Whether the local library is published.
+  #     This  field  must be provided for the  ``create``   method . It will always be present in the  result  of the  ``get``  or  ``list``   methods . It is optional for the  ``update``   method .
+  # @!attribute [rw] publish_url
+  #     @return [URI]
+  #     The URL to which the library metadata is published by the Content Library Service.  
+  #     
+  #      This value can be used to set the   :attr:`Com::Vmware::Content::Library::SubscriptionInfo.subscription_url`   property when creating a subscribed library.
+  #     This  field  is not used for the  ``create``   method . It will always be present in the  result  of the  ``get``  or  ``list``   methods . It is not used for the  ``update``   method .
+  # @!attribute [rw] user_name
+  #     @return [String]
+  #     The username to require for authentication.
+  #     This  field  is optional for the  ``create``  and  ``update``   method . When the authentication is not required, the username can be left  nil . When the authentication method is basic, the username is ignored in the current release. It defaults to "vcsp". It is preferable to leave this unset. If specified, it must be set to "vcsp".
+  # @!attribute [rw] password
+  #     @return [String]
+  #     The password to require for authentication.
+  #     This  field  is optional for the  ``create``   method . When the authentication method is   :attr:`Com::Vmware::Content::Library::PublishInfo::AuthenticationMethod.NONE`  , the password can be left  nil . When the authentication method is   :attr:`Com::Vmware::Content::Library::PublishInfo::AuthenticationMethod.BASIC`  , the password should be a non-empty string. This  field  is optional for the  ``update``   method . Leaving it  nil  during update indicates that the password is not changed. This  field  is not used for the  ``get``  or  ``list``   method .
+  # @!attribute [rw] persist_json_enabled
+  #     @return [Boolean]
+  #     Whether library and library item metadata are persisted in the storage backing as JSON files. This flag only applies if the local library is published.  
+  #     
+  #      Enabling JSON persistence allows you to synchronize a subscribed library manually instead of over HTTP. You copy the local library content and metadata to another storage backing manually and then create a subscribed library referencing the location of the library JSON file in the   :attr:`Com::Vmware::Content::Library::SubscriptionInfo.subscription_url`  . When the subscribed library's storage backing matches the subscription URL, files do not need to be copied to the subscribed library.  
+  #     
+  #      For a library backed by a datastore, the library JSON file will be stored at the path contentlib-{library_id}/lib.json on the datastore.  
+  #     
+  #      For a library backed by a remote file system, the library JSON file will be stored at {library_id}/lib.json in the remote file system path.
+  #     This  field  is optional for the  ``create``   method . It will always be present in the  result  of the  ``get``  or  ``list``   methods . It is optional for the  ``update``   method .
+  class PublishInfo < VAPI::Bindings::VapiStruct
+    class << self
+      # Holds (gets or creates) the binding type metadata for this structure type.
+      # @scope class
+      # @return [VAPI::Bindings::StructType] the binding type
+      def binding_type
+        @binding_type ||= VAPI::Bindings::StructType.new(
+          'com.vmware.content.library.publish_info',
+          {
+            'authentication_method' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Content::Library::PublishInfo::AuthenticationMethod')),
+            'published' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::BooleanType.instance),
+            'publish_url' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::URIType.instance),
+            'user_name' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::StringType.instance),
+            'password' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::SecretType.instance),
+            'persist_json_enabled' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::BooleanType.instance)
+          },
+          PublishInfo,
+          false,
+          nil
+        )
+      end
+    end
+
+    attr_accessor :authentication_method,
+                  :published,
+                  :publish_url,
+                  :user_name,
+                  :password,
+                  :persist_json_enabled
+
+    # Constructs a new instance.
+    # @param ruby_values [Hash] a map of initial property values (optional)
+    # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
+    def initialize(ruby_values = nil, struct_value = nil)
+      super(self.class.binding_type, ruby_values, struct_value)
+    end
+
+    # The  ``Com::Vmware::Content::Library::PublishInfo::AuthenticationMethod``   enumerated type  indicates how a subscribed library should authenticate to the published library endpoint.
+    # @!attribute [rw] basic
+    #     @return [Com::Vmware::Content::Library::PublishInfo::AuthenticationMethod]
+    #     Require HTTP Basic authentication matching a specified username and password.
+    # @!attribute [rw] none
+    #     @return [Com::Vmware::Content::Library::PublishInfo::AuthenticationMethod]
+    #     Require no authentication.
+    class AuthenticationMethod < VAPI::Bindings::VapiEnum
+      class << self
+        # Holds (gets or creates) the binding type metadata for this enumeration type.
+        # @scope class
+        # @return [VAPI::Bindings::EnumType] the binding type
+        def binding_type
+          @binding_type ||= VAPI::Bindings::EnumType.new(
+            'com.vmware.content.library.publish_info.authentication_method',
+            AuthenticationMethod
+          )
+        end
+
+        # Converts from a string value (perhaps off the wire) to an instance
+        # of this enum type.
+        # @param value [String] the actual value of the enum instance
+        # @return [AuthenticationMethod] the instance found for the value, otherwise
+        #         an unknown instance will be built for the value
+        def from_string(value)
+          const_get(value)
+        rescue NameError
+          AuthenticationMethod.send(:new, 'UNKNOWN', value)
+        end
+      end
+
+      # Constructs a new instance.
+      # @param value [String] the actual value of the enum instance
+      # @param unknown [String] the unknown value when value is 'UKNOWN'
+      def initialize(value, unknown = nil)
+        super(self.class.binding_type, value, unknown)
+      end
+
+      private_class_method :new
+
+      # @!attribute [rw] basic
+      #     @return [Com::Vmware::Content::Library::PublishInfo::AuthenticationMethod]
+      #     Require HTTP Basic authentication matching a specified username and password.
+      BASIC = AuthenticationMethod.send(:new, 'BASIC')
+
+      # @!attribute [rw] none
+      #     @return [Com::Vmware::Content::Library::PublishInfo::AuthenticationMethod]
+      #     Require no authentication.
+      NONE = AuthenticationMethod.send(:new, 'NONE')
+    end
+  end
+  # The  ``Com::Vmware::Content::Library::StorageBacking``   class  defines a storage location where content in a library will be stored. The storage location can either be a Datastore or Other type.
+  # @!attribute [rw] type
+  #     @return [Com::Vmware::Content::Library::StorageBacking::Type]
+  #     Type ( ``DATASTORE``, ``OTHER`` ) of   :class:`Com::Vmware::Content::Library::StorageBacking`  .
+  #     This  field  must be provided for the  ``create``   method . It will always be present in the  result  of the  ``get``  or  ``list``   methods . It is not used for the  ``update``   method .
+  # @!attribute [rw] datastore_id
+  #     @return [String]
+  #     Identifier of the datastore used to store the content in the library.
+  #     This  field  is optional and it is only relevant when the value of  ``type``  is   :attr:`Com::Vmware::Content::Library::StorageBacking::Type.DATASTORE`  .
+  # @!attribute [rw] storage_uri
+  #     @return [URI]
+  #     URI identifying the location used to store the content in the library.  
+  #     
+  #      The following URI formats are supported:  
+  #     
+  #      vSphere 6.5  
+  #     
+  #       * nfs://server/path?version=4 (for vCenter Server Appliance only) - Specifies an NFS Version 4 server.
+  #        * nfs://server/path (for vCenter Server Appliance only) - Specifies an NFS Version 3 server. The nfs://server:/path format is also supported.
+  #        * smb://server/path - Specifies an SMB server or Windows share.
+  #       
+  #        
+  #     
+  #      vSphere 6.0 Update 1  
+  #     
+  #       * nfs://server:/path (for vCenter Server Appliance only)
+  #        * file://unc-server/path (for vCenter Server for Windows only)
+  #        * file:///mount/point (for vCenter Server Appliance only) - Local file URIs are supported only when the path is a local mount point for an NFS file system. Use of file URIs is strongly discouraged. Instead, use an NFS URI to specify the remote file system.
+  #       
+  #        
+  #     
+  #      vSphere 6.0  
+  #     
+  #       * nfs://server:/path (for vCenter Server Appliance only)
+  #        * file://unc-server/path (for vCenter Server for Windows only)
+  #        * file:///path - Local file URIs are supported but strongly discouraged because it may interfere with the performance of vCenter Server.
+  #       
+  #     This  field  is optional and it is only relevant when the value of  ``type``  is   :attr:`Com::Vmware::Content::Library::StorageBacking::Type.OTHER`  .
+  class StorageBacking < VAPI::Bindings::VapiStruct
+    class << self
+      # Holds (gets or creates) the binding type metadata for this structure type.
+      # @scope class
+      # @return [VAPI::Bindings::StructType] the binding type
+      def binding_type
+        @binding_type ||= VAPI::Bindings::StructType.new(
+          'com.vmware.content.library.storage_backing',
+          {
+            'type' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Content::Library::StorageBacking::Type')),
+            'datastore_id' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::IdType.new),
+            'storage_uri' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::URIType.instance)
+          },
+          StorageBacking,
+          false,
+          nil
+        )
+      end
+    end
+
+    attr_accessor :type,
+                  :datastore_id,
+                  :storage_uri
+
+    # Constructs a new instance.
+    # @param ruby_values [Hash] a map of initial property values (optional)
+    # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
+    def initialize(ruby_values = nil, struct_value = nil)
+      super(self.class.binding_type, ruby_values, struct_value)
+    end
+
+    # The  ``Com::Vmware::Content::Library::StorageBacking::Type``   enumerated type  specifies the type of the   :class:`Com::Vmware::Content::Library::StorageBacking`  .
+    # @!attribute [rw] datastore
     #     @return [Com::Vmware::Content::Library::StorageBacking::Type]
-    #     Type ( ``DATASTORE``, ``OTHER`` ) of   :class:`Com::Vmware::Content::Library::StorageBacking`  .
-    #     This  field  must be provided for the  ``create``   method . It will always be present in the  result  of the  ``get``  or  ``list``   methods . It is not used for the  ``update``   method .
-    # @!attribute [rw] datastore_id
-    #     @return [String]
-    #     Identifier of the datastore used to store the content in the library.
-    #     This  field  is optional and it is only relevant when the value of  ``type``  is   :attr:`Com::Vmware::Content::Library::StorageBacking::Type.DATASTORE`  .
-    # @!attribute [rw] storage_uri
-    #     @return [URI]
-    #     URI identifying the location used to store the content in the library.  
+    #     The content of the library will be stored on a datastore.  
     #     
-    #      The following URI formats are supported:  
+    #      These are vCenter Server managed datastores, and are logical containers that hide specifics of each storage device. Depending on the type of storage you use, datastores can be backed by the following file system formats:  
     #     
-    #      vSphere 6.5  
-    #     
-    #       * nfs://server/path?version=4 (for vCenter Server Appliance only) - Specifies an NFS Version 4 server.
-    #        * nfs://server/path (for vCenter Server Appliance only) - Specifies an NFS Version 3 server. The nfs://server:/path format is also supported.
-    #        * smb://server/path - Specifies an SMB server or Windows share.
+    #       *  Virtual Machine File System (VMFS) 
+    #        *  Network File System (NFS) 
     #       
     #        
+    # @!attribute [rw] other
+    #     @return [Com::Vmware::Content::Library::StorageBacking::Type]
+    #     The content of the library will be stored on a remote file system.  
     #     
-    #      vSphere 6.0 Update 1  
+    #      Supports the following remote file systems:  
     #     
-    #       * nfs://server:/path (for vCenter Server Appliance only)
-    #        * file://unc-server/path (for vCenter Server for Windows only)
-    #        * file:///mount/point (for vCenter Server Appliance only) - Local file URIs are supported only when the path is a local mount point for an NFS file system. Use of file URIs is strongly discouraged. Instead, use an NFS URI to specify the remote file system.
+    #       *  NFS (on vCenter Server Appliance) 
+    #        *  SMB (on vCenter Server Appliance and vCenter Server for Windows) 
     #       
     #        
-    #     
-    #      vSphere 6.0  
-    #     
-    #       * nfs://server:/path (for vCenter Server Appliance only)
-    #        * file://unc-server/path (for vCenter Server for Windows only)
-    #        * file:///path - Local file URIs are supported but strongly discouraged because it may interfere with the performance of vCenter Server.
-    #       
-    #     This  field  is optional and it is only relevant when the value of  ``type``  is   :attr:`Com::Vmware::Content::Library::StorageBacking::Type.OTHER`  .
-    class StorageBacking < VAPI::Bindings::VapiStruct
-
-        class << self
-            # Holds (gets or creates) the binding type metadata for this structure type.
-            # @scope class
-            # @return [VAPI::Bindings::StructType] the binding type
-            def binding_type
-                @binding_type ||= VAPI::Bindings::StructType.new(
-                    'com.vmware.content.library.storage_backing',
-                    {
-                        'type' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Content::Library::StorageBacking::Type')),
-                        'datastore_id' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::IdType.new),
-                        'storage_uri' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::URIType.instance),
-                    },
-                    StorageBacking,
-                    false,
-                    nil)
-            end
+    class Type < VAPI::Bindings::VapiEnum
+      class << self
+        # Holds (gets or creates) the binding type metadata for this enumeration type.
+        # @scope class
+        # @return [VAPI::Bindings::EnumType] the binding type
+        def binding_type
+          @binding_type ||= VAPI::Bindings::EnumType.new(
+            'com.vmware.content.library.storage_backing.type',
+            Type
+          )
         end
 
-        attr_accessor :type,
-                      :datastore_id,
-                      :storage_uri
-
-        # Constructs a new instance.
-        # @param ruby_values [Hash] a map of initial property values (optional)
-        # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
-        def initialize(ruby_values=nil, struct_value=nil)
-            super(self.class.binding_type, ruby_values, struct_value)
+        # Converts from a string value (perhaps off the wire) to an instance
+        # of this enum type.
+        # @param value [String] the actual value of the enum instance
+        # @return [Type] the instance found for the value, otherwise
+        #         an unknown instance will be built for the value
+        def from_string(value)
+          const_get(value)
+        rescue NameError
+          Type.send(:new, 'UNKNOWN', value)
         end
+      end
 
+      # Constructs a new instance.
+      # @param value [String] the actual value of the enum instance
+      # @param unknown [String] the unknown value when value is 'UKNOWN'
+      def initialize(value, unknown = nil)
+        super(self.class.binding_type, value, unknown)
+      end
 
-        # The  ``Com::Vmware::Content::Library::StorageBacking::Type``   enumerated type  specifies the type of the   :class:`Com::Vmware::Content::Library::StorageBacking`  .
-        # @!attribute [rw] datastore
-        #     @return [Com::Vmware::Content::Library::StorageBacking::Type]
-        #     The content of the library will be stored on a datastore.  
-        #     
-        #      These are vCenter Server managed datastores, and are logical containers that hide specifics of each storage device. Depending on the type of storage you use, datastores can be backed by the following file system formats:  
-        #     
-        #       *  Virtual Machine File System (VMFS) 
-        #        *  Network File System (NFS) 
-        #       
-        #        
-        # @!attribute [rw] other
-        #     @return [Com::Vmware::Content::Library::StorageBacking::Type]
-        #     The content of the library will be stored on a remote file system.  
-        #     
-        #      Supports the following remote file systems:  
-        #     
-        #       *  NFS (on vCenter Server Appliance) 
-        #        *  SMB (on vCenter Server Appliance and vCenter Server for Windows) 
-        #       
-        #        
-        class Type < VAPI::Bindings::VapiEnum
+      private_class_method :new
 
-            class << self
-                # Holds (gets or creates) the binding type metadata for this enumeration type.
-                # @scope class
-                # @return [VAPI::Bindings::EnumType] the binding type
-                def binding_type
-                    @binding_type ||= VAPI::Bindings::EnumType.new(
-                        'com.vmware.content.library.storage_backing.type',
-                        Type)
-                end
+      # @!attribute [rw] datastore
+      #     @return [Com::Vmware::Content::Library::StorageBacking::Type]
+      #     The content of the library will be stored on a datastore.  
+      #     
+      #      These are vCenter Server managed datastores, and are logical containers that hide specifics of each storage device. Depending on the type of storage you use, datastores can be backed by the following file system formats:  
+      #     
+      #       *  Virtual Machine File System (VMFS) 
+      #        *  Network File System (NFS) 
+      #       
+      #        
+      DATASTORE = Type.send(:new, 'DATASTORE')
 
-                # Converts from a string value (perhaps off the wire) to an instance
-                # of this enum type.
-                # @param value [String] the actual value of the enum instance
-                # @return [Type] the instance found for the value, otherwise
-                #         an unknown instance will be built for the value
-                def from_string(value)
-                    begin
-                        const_get(value)
-                    rescue NameError
-                        Type.new('UNKNOWN', value)
-                    end
-                end
-            end
-
-            private
-
-            # Constructs a new instance.
-            # @param value [String] the actual value of the enum instance
-            # @param unknown [String] the unknown value when value is 'UKNOWN'
-            def initialize(value, unknown=nil)
-                super(self.class.binding_type, value, unknown)
-            end
-
-            public
-
-            # @!attribute [rw] datastore
-            #     @return [Com::Vmware::Content::Library::StorageBacking::Type]
-            #     The content of the library will be stored on a datastore.  
-            #     
-            #      These are vCenter Server managed datastores, and are logical containers that hide specifics of each storage device. Depending on the type of storage you use, datastores can be backed by the following file system formats:  
-            #     
-            #       *  Virtual Machine File System (VMFS) 
-            #        *  Network File System (NFS) 
-            #       
-            #        
-            DATASTORE = Type.new('DATASTORE')
-
-            # @!attribute [rw] other
-            #     @return [Com::Vmware::Content::Library::StorageBacking::Type]
-            #     The content of the library will be stored on a remote file system.  
-            #     
-            #      Supports the following remote file systems:  
-            #     
-            #       *  NFS (on vCenter Server Appliance) 
-            #        *  SMB (on vCenter Server Appliance and vCenter Server for Windows) 
-            #       
-            #        
-            OTHER = Type.new('OTHER')
-
-        end
-
-
+      # @!attribute [rw] other
+      #     @return [Com::Vmware::Content::Library::StorageBacking::Type]
+      #     The content of the library will be stored on a remote file system.  
+      #     
+      #      Supports the following remote file systems:  
+      #     
+      #       *  NFS (on vCenter Server Appliance) 
+      #        *  SMB (on vCenter Server Appliance and vCenter Server for Windows) 
+      #       
+      #        
+      OTHER = Type.send(:new, 'OTHER')
+    end
+  end
+  # The  ``Com::Vmware::Content::Library::SubscriptionInfo``   class  defines the subscription behavior for a subscribed library.
+  # @!attribute [rw] authentication_method
+  #     @return [Com::Vmware::Content::Library::SubscriptionInfo::AuthenticationMethod]
+  #     Indicate how the subscribed library should authenticate ( ``BASIC``, ``NONE`` ) with the published library endpoint.
+  #     This  field  must be provided for the  ``create``   method . It will always be present in the  result  of the  ``get``  or  ``list``   methods . It is optional for the  ``update``   method .
+  # @!attribute [rw] automatic_sync_enabled
+  #     @return [Boolean]
+  #     Whether the library should participate in automatic library synchronization. In order for automatic synchronization to happen, the global   :attr:`Com::Vmware::Content::ConfigurationModel.automatic_sync_enabled`   option must also be true. The subscription is still active even when automatic synchronization is turned off, but synchronization is only activated with an explicit call to   :func:`Com::Vmware::Content::SubscribedLibrary.sync`   or   :func:`Com::Vmware::Content::Library::SubscribedItem.sync`  . In other words, manual synchronization is still available even when automatic synchronization is disabled.
+  #     This  field  must be provided for the  ``create``   method . It will always be present in the  result  of the  ``get``  or  ``list``   methods . It is optional for the  ``update``   method .
+  # @!attribute [rw] on_demand
+  #     @return [Boolean]
+  #     Indicates whether a library item's content will be synchronized only on demand.  
+  #     
+  #      If this is set to  ``true`` , then the library item's metadata will be synchronized but the item's content (its files) will not be synchronized. The Content Library Service will synchronize the content upon request only. This can cause the first use of the content to have a noticeable delay.  
+  #     
+  #      Items without synchronized content can be forcefully synchronized in advance using the   :func:`Com::Vmware::Content::Library::SubscribedItem.sync`   call with  ``forceSyncContent``  set to true. Once content has been synchronized, the content can removed with the   :func:`Com::Vmware::Content::Library::SubscribedItem.evict`   call.  
+  #     
+  #      If this value is set to  ``false`` , all content will be synchronized in advance.
+  #     This  field  must be provided for the  ``create``   method . It will always be present in the  result  of the  ``get``  or  ``list``   methods . It is optional for the  ``update``   method .
+  # @!attribute [rw] password
+  #     @return [String]
+  #     The password to use when authenticating.  
+  #     
+  #      The password must be set when using a password-based authentication method; empty strings are not allowed.
+  #     This  field  is optional for the  ``create``   method . It will not be present in the  result  of the  ``get``  or  ``list``   methods . It is optional for the  ``update``   method .
+  # @!attribute [rw] ssl_thumbprint
+  #     @return [String]
+  #     An optional SHA-1 hash of the SSL certificate for the remote endpoint.  
+  #     
+  #      If this value is defined the SSL certificate will be verified by comparing it to the SSL thumbprint. The SSL certificate must verify against the thumbprint. When specified, the standard certificate chain validation behavior is not used. The certificate chain is validated normally if this value is  nil .
+  #     This  field  is optional for the  ``create``   method . It will not be present in the  result  of the  ``get``  or  ``list``   methods . It is optional for the  ``update``   method .
+  # @!attribute [rw] subscription_url
+  #     @return [URI]
+  #     The URL of the endpoint where the metadata for the remotely published library is being served.  
+  #     
+  #      This URL can be the   :attr:`Com::Vmware::Content::Library::PublishInfo.publish_url`   of the published library (for example, https://server/path/lib.json).  
+  #     
+  #      If the source content comes from a published library with   :attr:`Com::Vmware::Content::Library::PublishInfo.persist_json_enabled`  , the subscription URL can be a URL pointing to the library JSON file on a datastore or remote file system. The supported formats are:  
+  #     
+  #      vSphere 6.5  
+  #     
+  #       * ds:///vmfs/volumes/{uuid}/mylibrary/lib.json (for datastore)
+  #        * nfs://server/path/mylibrary/lib.json (for NFSv3 server on vCenter Server Appliance)
+  #        * nfs://server/path/mylibrary/lib.json?version=4 (for NFSv4 server on vCenter Server Appliance) 
+  #        * smb://server/path/mylibrary/lib.json (for SMB server)
+  #       
+  #        
+  #     
+  #      vSphere 6.0  
+  #     
+  #       * file://server/mylibrary/lib.json (for UNC server on vCenter Server for Windows)
+  #        * file:///path/mylibrary/lib.json (for local file system)
+  #       
+  #        
+  #     
+  #      When you specify a DS subscription URL, the datastore must be on the same vCenter Server as the subscribed library. When you specify an NFS or SMB subscription URL, the   :attr:`Com::Vmware::Content::Library::StorageBacking.storage_uri`   of the subscribed library must be on the same remote file server and should share a common parent path with the subscription URL.
+  #     This  field  must be provided for the  ``create``   method . It will always be present in the  result  of the  ``get``  or  ``list``   methods . It is optional for the  ``update``   method .
+  # @!attribute [rw] user_name
+  #     @return [String]
+  #     The username to use when authenticating.  
+  #     
+  #      The username must be set when using a password-based authentication method. Empty strings are allowed for usernames.
+  #     This  field  is optional for the  ``create``   method . It is optional in the  result  of the  ``get``  or  ``list``   methods . It is optional for the  ``update``   method .
+  class SubscriptionInfo < VAPI::Bindings::VapiStruct
+    class << self
+      # Holds (gets or creates) the binding type metadata for this structure type.
+      # @scope class
+      # @return [VAPI::Bindings::StructType] the binding type
+      def binding_type
+        @binding_type ||= VAPI::Bindings::StructType.new(
+          'com.vmware.content.library.subscription_info',
+          {
+            'authentication_method' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Content::Library::SubscriptionInfo::AuthenticationMethod')),
+            'automatic_sync_enabled' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::BooleanType.instance),
+            'on_demand' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::BooleanType.instance),
+            'password' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::SecretType.instance),
+            'ssl_thumbprint' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::StringType.instance),
+            'subscription_url' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::URIType.instance),
+            'user_name' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::StringType.instance)
+          },
+          SubscriptionInfo,
+          false,
+          nil
+        )
+      end
     end
 
+    attr_accessor :authentication_method,
+                  :automatic_sync_enabled,
+                  :on_demand,
+                  :password,
+                  :ssl_thumbprint,
+                  :subscription_url,
+                  :user_name
 
-    # The  ``Com::Vmware::Content::Library::SubscriptionInfo``   class  defines the subscription behavior for a subscribed library.
-    # @!attribute [rw] authentication_method
+    # Constructs a new instance.
+    # @param ruby_values [Hash] a map of initial property values (optional)
+    # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
+    def initialize(ruby_values = nil, struct_value = nil)
+      super(self.class.binding_type, ruby_values, struct_value)
+    end
+
+    # Indicate how the subscribed library should authenticate with the published library endpoint.
+    # @!attribute [rw] basic
     #     @return [Com::Vmware::Content::Library::SubscriptionInfo::AuthenticationMethod]
-    #     Indicate how the subscribed library should authenticate ( ``BASIC``, ``NONE`` ) with the published library endpoint.
-    #     This  field  must be provided for the  ``create``   method . It will always be present in the  result  of the  ``get``  or  ``list``   methods . It is optional for the  ``update``   method .
-    # @!attribute [rw] automatic_sync_enabled
-    #     @return [Boolean]
-    #     Whether the library should participate in automatic library synchronization. In order for automatic synchronization to happen, the global   :attr:`Com::Vmware::Content::ConfigurationModel.automatic_sync_enabled`   option must also be true. The subscription is still active even when automatic synchronization is turned off, but synchronization is only activated with an explicit call to   :func:`Com::Vmware::Content::SubscribedLibrary.sync`   or   :func:`Com::Vmware::Content::Library::SubscribedItem.sync`  . In other words, manual synchronization is still available even when automatic synchronization is disabled.
-    #     This  field  must be provided for the  ``create``   method . It will always be present in the  result  of the  ``get``  or  ``list``   methods . It is optional for the  ``update``   method .
-    # @!attribute [rw] on_demand
-    #     @return [Boolean]
-    #     Indicates whether a library item's content will be synchronized only on demand.  
-    #     
-    #      If this is set to  ``true`` , then the library item's metadata will be synchronized but the item's content (its files) will not be synchronized. The Content Library Service will synchronize the content upon request only. This can cause the first use of the content to have a noticeable delay.  
-    #     
-    #      Items without synchronized content can be forcefully synchronized in advance using the   :func:`Com::Vmware::Content::Library::SubscribedItem.sync`   call with  ``forceSyncContent``  set to true. Once content has been synchronized, the content can removed with the   :func:`Com::Vmware::Content::Library::SubscribedItem.evict`   call.  
-    #     
-    #      If this value is set to  ``false`` , all content will be synchronized in advance.
-    #     This  field  must be provided for the  ``create``   method . It will always be present in the  result  of the  ``get``  or  ``list``   methods . It is optional for the  ``update``   method .
-    # @!attribute [rw] password
-    #     @return [String]
-    #     The password to use when authenticating.  
-    #     
-    #      The password must be set when using a password-based authentication method; empty strings are not allowed.
-    #     This  field  is optional for the  ``create``   method . It will not be present in the  result  of the  ``get``  or  ``list``   methods . It is optional for the  ``update``   method .
-    # @!attribute [rw] ssl_thumbprint
-    #     @return [String]
-    #     An optional SHA-1 hash of the SSL certificate for the remote endpoint.  
-    #     
-    #      If this value is defined the SSL certificate will be verified by comparing it to the SSL thumbprint. The SSL certificate must verify against the thumbprint. When specified, the standard certificate chain validation behavior is not used. The certificate chain is validated normally if this value is  nil .
-    #     This  field  is optional for the  ``create``   method . It will not be present in the  result  of the  ``get``  or  ``list``   methods . It is optional for the  ``update``   method .
-    # @!attribute [rw] subscription_url
-    #     @return [URI]
-    #     The URL of the endpoint where the metadata for the remotely published library is being served.  
-    #     
-    #      This URL can be the   :attr:`Com::Vmware::Content::Library::PublishInfo.publish_url`   of the published library (for example, https://server/path/lib.json).  
-    #     
-    #      If the source content comes from a published library with   :attr:`Com::Vmware::Content::Library::PublishInfo.persist_json_enabled`  , the subscription URL can be a URL pointing to the library JSON file on a datastore or remote file system. The supported formats are:  
-    #     
-    #      vSphere 6.5  
-    #     
-    #       * ds:///vmfs/volumes/{uuid}/mylibrary/lib.json (for datastore)
-    #        * nfs://server/path/mylibrary/lib.json (for NFSv3 server on vCenter Server Appliance)
-    #        * nfs://server/path/mylibrary/lib.json?version=4 (for NFSv4 server on vCenter Server Appliance) 
-    #        * smb://server/path/mylibrary/lib.json (for SMB server)
-    #       
-    #        
-    #     
-    #      vSphere 6.0  
-    #     
-    #       * file://server/mylibrary/lib.json (for UNC server on vCenter Server for Windows)
-    #        * file:///path/mylibrary/lib.json (for local file system)
-    #       
-    #        
-    #     
-    #      When you specify a DS subscription URL, the datastore must be on the same vCenter Server as the subscribed library. When you specify an NFS or SMB subscription URL, the   :attr:`Com::Vmware::Content::Library::StorageBacking.storage_uri`   of the subscribed library must be on the same remote file server and should share a common parent path with the subscription URL.
-    #     This  field  must be provided for the  ``create``   method . It will always be present in the  result  of the  ``get``  or  ``list``   methods . It is optional for the  ``update``   method .
-    # @!attribute [rw] user_name
-    #     @return [String]
-    #     The username to use when authenticating.  
-    #     
-    #      The username must be set when using a password-based authentication method. Empty strings are allowed for usernames.
-    #     This  field  is optional for the  ``create``   method . It is optional in the  result  of the  ``get``  or  ``list``   methods . It is optional for the  ``update``   method .
-    class SubscriptionInfo < VAPI::Bindings::VapiStruct
-
-        class << self
-            # Holds (gets or creates) the binding type metadata for this structure type.
-            # @scope class
-            # @return [VAPI::Bindings::StructType] the binding type
-            def binding_type
-                @binding_type ||= VAPI::Bindings::StructType.new(
-                    'com.vmware.content.library.subscription_info',
-                    {
-                        'authentication_method' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Content::Library::SubscriptionInfo::AuthenticationMethod')),
-                        'automatic_sync_enabled' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::BooleanType.instance),
-                        'on_demand' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::BooleanType.instance),
-                        'password' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::SecretType.instance),
-                        'ssl_thumbprint' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::StringType.instance),
-                        'subscription_url' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::URIType.instance),
-                        'user_name' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::StringType.instance),
-                    },
-                    SubscriptionInfo,
-                    false,
-                    nil)
-            end
+    #     Require HTTP Basic authentication matching a specified username and password.
+    # @!attribute [rw] none
+    #     @return [Com::Vmware::Content::Library::SubscriptionInfo::AuthenticationMethod]
+    #     Require no authentication.
+    class AuthenticationMethod < VAPI::Bindings::VapiEnum
+      class << self
+        # Holds (gets or creates) the binding type metadata for this enumeration type.
+        # @scope class
+        # @return [VAPI::Bindings::EnumType] the binding type
+        def binding_type
+          @binding_type ||= VAPI::Bindings::EnumType.new(
+            'com.vmware.content.library.subscription_info.authentication_method',
+            AuthenticationMethod
+          )
         end
 
-        attr_accessor :authentication_method,
-                      :automatic_sync_enabled,
-                      :on_demand,
-                      :password,
-                      :ssl_thumbprint,
-                      :subscription_url,
-                      :user_name
-
-        # Constructs a new instance.
-        # @param ruby_values [Hash] a map of initial property values (optional)
-        # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
-        def initialize(ruby_values=nil, struct_value=nil)
-            super(self.class.binding_type, ruby_values, struct_value)
+        # Converts from a string value (perhaps off the wire) to an instance
+        # of this enum type.
+        # @param value [String] the actual value of the enum instance
+        # @return [AuthenticationMethod] the instance found for the value, otherwise
+        #         an unknown instance will be built for the value
+        def from_string(value)
+          const_get(value)
+        rescue NameError
+          AuthenticationMethod.send(:new, 'UNKNOWN', value)
         end
+      end
 
+      # Constructs a new instance.
+      # @param value [String] the actual value of the enum instance
+      # @param unknown [String] the unknown value when value is 'UKNOWN'
+      def initialize(value, unknown = nil)
+        super(self.class.binding_type, value, unknown)
+      end
 
-        # Indicate how the subscribed library should authenticate with the published library endpoint.
-        # @!attribute [rw] basic
-        #     @return [Com::Vmware::Content::Library::SubscriptionInfo::AuthenticationMethod]
-        #     Require HTTP Basic authentication matching a specified username and password.
-        # @!attribute [rw] none
-        #     @return [Com::Vmware::Content::Library::SubscriptionInfo::AuthenticationMethod]
-        #     Require no authentication.
-        class AuthenticationMethod < VAPI::Bindings::VapiEnum
+      private_class_method :new
 
-            class << self
-                # Holds (gets or creates) the binding type metadata for this enumeration type.
-                # @scope class
-                # @return [VAPI::Bindings::EnumType] the binding type
-                def binding_type
-                    @binding_type ||= VAPI::Bindings::EnumType.new(
-                        'com.vmware.content.library.subscription_info.authentication_method',
-                        AuthenticationMethod)
-                end
+      # @!attribute [rw] basic
+      #     @return [Com::Vmware::Content::Library::SubscriptionInfo::AuthenticationMethod]
+      #     Require HTTP Basic authentication matching a specified username and password.
+      BASIC = AuthenticationMethod.send(:new, 'BASIC')
 
-                # Converts from a string value (perhaps off the wire) to an instance
-                # of this enum type.
-                # @param value [String] the actual value of the enum instance
-                # @return [AuthenticationMethod] the instance found for the value, otherwise
-                #         an unknown instance will be built for the value
-                def from_string(value)
-                    begin
-                        const_get(value)
-                    rescue NameError
-                        AuthenticationMethod.new('UNKNOWN', value)
-                    end
-                end
-            end
-
-            private
-
-            # Constructs a new instance.
-            # @param value [String] the actual value of the enum instance
-            # @param unknown [String] the unknown value when value is 'UKNOWN'
-            def initialize(value, unknown=nil)
-                super(self.class.binding_type, value, unknown)
-            end
-
-            public
-
-            # @!attribute [rw] basic
-            #     @return [Com::Vmware::Content::Library::SubscriptionInfo::AuthenticationMethod]
-            #     Require HTTP Basic authentication matching a specified username and password.
-            BASIC = AuthenticationMethod.new('BASIC')
-
-            # @!attribute [rw] none
-            #     @return [Com::Vmware::Content::Library::SubscriptionInfo::AuthenticationMethod]
-            #     Require no authentication.
-            NONE = AuthenticationMethod.new('NONE')
-
-        end
-
-
+      # @!attribute [rw] none
+      #     @return [Com::Vmware::Content::Library::SubscriptionInfo::AuthenticationMethod]
+      #     Require no authentication.
+      NONE = AuthenticationMethod.send(:new, 'NONE')
     end
-
+  end
 end

--- a/client/sdk/com/vmware/content/library/item.rb
+++ b/client/sdk/com/vmware/content/library/item.rb
@@ -1,5 +1,6 @@
 #---------------------------------------------------------------------------
-# Copyright 2016 VMware, Inc.  All rights reserved.
+# Copyright 2017 VMware, Inc.  All rights reserved.
+#
 # AUTO GENERATED FILE -- DO NOT MODIFY!
 #
 # vAPI type descriptors for package com.vmware.content.library.item.
@@ -8,1392 +9,1295 @@ require 'vapi'
 
 # declare the module hierarchy before we use the shorthand syntax below
 module Com
-    module Vmware
-        module Content
-            module Library
-                module Item
-                end
-            end
+  module Vmware
+    module Content
+      module Library
+        module Item
         end
+      end
     end
+  end
 end
 
 # The Content Library Item  package  provides  classes  and  classs  for managing files in a library item.
 module Com::Vmware::Content::Library::Item
+  # The  ``Com::Vmware::Content::Library::Item::DownloadSession``   class  manipulates download sessions, which are used to download content from the Content Library Service.  
+  # 
+  #  A download session is an object that tracks the download of content (that is, downloading content from the Content Library Service) and acts as a lease to keep the download links available.  
+  # 
+  #  The   :class:`Com::Vmware::Content::Library::Item::Downloadsession::File`    class  provides access to the download links.
+  class DownloadSession < VAPI::Bindings::VapiService
+    # static metamodel definitions
+    SERVICE_ID = VAPI::Core::ServiceIdentifier.new('com.vmware.content.library.item.download_session')
 
-    # The  ``Com::Vmware::Content::Library::Item::DownloadSession``   class  manipulates download sessions, which are used to download content from the Content Library Service.  
-    # 
-    #  A download session is an object that tracks the download of content (that is, downloading content from the Content Library Service) and acts as a lease to keep the download links available.  
-    # 
-    #  The   :class:`Com::Vmware::Content::Library::Item::Downloadsession::File`    class  provides access to the download links.
-    class DownloadSession < VAPI::Bindings::VapiService
+    CREATE_INFO = VAPI::Bindings::OperationInfo.new(
+      VAPI::Core::OperationIdentifier.new('create', SERVICE_ID),
+      VAPI::Bindings::OperationInputType.new(
+        'client_token' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::StringType.instance),
+        'create_spec' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Content::Library::Item::DownloadSessionModel')
+      ),
+      VAPI::Bindings::IdType.new('com.vmware.content.library.item.DownloadSession'),
+      {
+        'com.vmware.vapi.std.errors.invalid_argument' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::InvalidArgument'),
+        'com.vmware.vapi.std.errors.not_found' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::NotFound')
+      },
+      [],
+      []
+    )
 
-        protected
+    GET_INFO = VAPI::Bindings::OperationInfo.new(
+      VAPI::Core::OperationIdentifier.new('get', SERVICE_ID),
+      VAPI::Bindings::OperationInputType.new(
+        'download_session_id' => VAPI::Bindings::IdType.new('com.vmware.content.library.item.DownloadSession')
+      ),
+      VAPI::Bindings::ReferenceType.new('Com::Vmware::Content::Library::Item::DownloadSessionModel'),
+      {
+        'com.vmware.vapi.std.errors.not_found' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::NotFound')
+      },
+      [],
+      []
+    )
 
-        # static metamodel definitions
-        @@service_id = VAPI::Core::ServiceIdentifier.new('com.vmware.content.library.item.download_session')
+    LIST_INFO = VAPI::Bindings::OperationInfo.new(
+      VAPI::Core::OperationIdentifier.new('list', SERVICE_ID),
+      VAPI::Bindings::OperationInputType.new(
+        'library_item_id' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::IdType.new)
+      ),
+      VAPI::Bindings::ListType.new(VAPI::Bindings::IdType.new),
+      {
+        'com.vmware.vapi.std.errors.not_found' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::NotFound')
+      },
+      [],
+      []
+    )
 
-        @@create_info = VAPI::Bindings::OperationInfo.new(
-            VAPI::Core::OperationIdentifier.new('create', @@service_id),
-            VAPI::Bindings::OperationInputType.new({
-                'client_token' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::StringType.instance),
-                'create_spec' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Content::Library::Item::DownloadSessionModel'),
-            }),
-            VAPI::Bindings::IdType.new(resource_types='com.vmware.content.library.item.DownloadSession'),
-            {
-                'com.vmware.vapi.std.errors.invalid_argument' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::InvalidArgument'),
-                'com.vmware.vapi.std.errors.not_found' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::NotFound'),
+    KEEP_ALIVE_INFO = VAPI::Bindings::OperationInfo.new(
+      VAPI::Core::OperationIdentifier.new('keep_alive', SERVICE_ID),
+      VAPI::Bindings::OperationInputType.new(
+        'download_session_id' => VAPI::Bindings::IdType.new('com.vmware.content.library.item.DownloadSession'),
+        'progress' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::IntegerType.instance)
+      ),
+      VAPI::Bindings::VoidType.instance,
+      {
+        'com.vmware.vapi.std.errors.not_found' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::NotFound'),
+        'com.vmware.vapi.std.errors.not_allowed_in_current_state' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::NotAllowedInCurrentState')
+      },
+      [],
+      []
+    )
 
-            },
-            [],
-            [])
-        @@get_info = VAPI::Bindings::OperationInfo.new(
-            VAPI::Core::OperationIdentifier.new('get', @@service_id),
-            VAPI::Bindings::OperationInputType.new({
-                'download_session_id' => VAPI::Bindings::IdType.new(resource_types='com.vmware.content.library.item.DownloadSession'),
-            }),
-            VAPI::Bindings::ReferenceType.new('Com::Vmware::Content::Library::Item::DownloadSessionModel'),
-            {
-                'com.vmware.vapi.std.errors.not_found' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::NotFound'),
+    CANCEL_INFO = VAPI::Bindings::OperationInfo.new(
+      VAPI::Core::OperationIdentifier.new('cancel', SERVICE_ID),
+      VAPI::Bindings::OperationInputType.new(
+        'download_session_id' => VAPI::Bindings::IdType.new('com.vmware.content.library.item.DownloadSession')
+      ),
+      VAPI::Bindings::VoidType.instance,
+      {
+        'com.vmware.vapi.std.errors.not_found' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::NotFound'),
+        'com.vmware.vapi.std.errors.not_allowed_in_current_state' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::NotAllowedInCurrentState')
+      },
+      [],
+      []
+    )
 
-            },
-            [],
-            [])
-        @@list_info = VAPI::Bindings::OperationInfo.new(
-            VAPI::Core::OperationIdentifier.new('list', @@service_id),
-            VAPI::Bindings::OperationInputType.new({
-                'library_item_id' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::IdType.new),
-            }),
-            VAPI::Bindings::ListType.new(VAPI::Bindings::IdType.new),
-            {
-                'com.vmware.vapi.std.errors.not_found' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::NotFound'),
+    DELETE_INFO = VAPI::Bindings::OperationInfo.new(
+      VAPI::Core::OperationIdentifier.new('delete', SERVICE_ID),
+      VAPI::Bindings::OperationInputType.new(
+        'download_session_id' => VAPI::Bindings::IdType.new('com.vmware.content.library.item.DownloadSession')
+      ),
+      VAPI::Bindings::VoidType.instance,
+      {
+        'com.vmware.vapi.std.errors.not_found' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::NotFound')
+      },
+      [],
+      []
+    )
 
-            },
-            [],
-            [])
-        @@keep_alive_info = VAPI::Bindings::OperationInfo.new(
-            VAPI::Core::OperationIdentifier.new('keep_alive', @@service_id),
-            VAPI::Bindings::OperationInputType.new({
-                'download_session_id' => VAPI::Bindings::IdType.new(resource_types='com.vmware.content.library.item.DownloadSession'),
-                'progress' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::IntegerType.instance),
-            }),
-            VAPI::Bindings::VoidType.instance,
-            {
-                'com.vmware.vapi.std.errors.not_found' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::NotFound'),
-                'com.vmware.vapi.std.errors.not_allowed_in_current_state' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::NotAllowedInCurrentState'),
+    FAIL_INFO = VAPI::Bindings::OperationInfo.new(
+      VAPI::Core::OperationIdentifier.new('fail', SERVICE_ID),
+      VAPI::Bindings::OperationInputType.new(
+        'download_session_id' => VAPI::Bindings::IdType.new('com.vmware.content.library.item.DownloadSession'),
+        'client_error_message' => VAPI::Bindings::StringType.instance
+      ),
+      VAPI::Bindings::VoidType.instance,
+      {
+        'com.vmware.vapi.std.errors.not_found' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::NotFound'),
+        'com.vmware.vapi.std.errors.not_allowed_in_current_state' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::NotAllowedInCurrentState')
+      },
+      [],
+      []
+    )
 
-            },
-            [],
-            [])
-        @@cancel_info = VAPI::Bindings::OperationInfo.new(
-            VAPI::Core::OperationIdentifier.new('cancel', @@service_id),
-            VAPI::Bindings::OperationInputType.new({
-                'download_session_id' => VAPI::Bindings::IdType.new(resource_types='com.vmware.content.library.item.DownloadSession'),
-            }),
-            VAPI::Bindings::VoidType.instance,
-            {
-                'com.vmware.vapi.std.errors.not_found' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::NotFound'),
-                'com.vmware.vapi.std.errors.not_allowed_in_current_state' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::NotAllowedInCurrentState'),
+    SERVICE_INFO = VAPI::Bindings::ServiceInfo.new(
+      SERVICE_ID,
+      'create' => CREATE_INFO,
+      'get' => GET_INFO,
+      'list' => LIST_INFO,
+      'keep_alive' => KEEP_ALIVE_INFO,
+      'cancel' => CANCEL_INFO,
+      'delete' => DELETE_INFO,
+      'fail' => FAIL_INFO
+    )
 
-            },
-            [],
-            [])
-        @@delete_info = VAPI::Bindings::OperationInfo.new(
-            VAPI::Core::OperationIdentifier.new('delete', @@service_id),
-            VAPI::Bindings::OperationInputType.new({
-                'download_session_id' => VAPI::Bindings::IdType.new(resource_types='com.vmware.content.library.item.DownloadSession'),
-            }),
-            VAPI::Bindings::VoidType.instance,
-            {
-                'com.vmware.vapi.std.errors.not_found' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::NotFound'),
-
-            },
-            [],
-            [])
-        @@fail_info = VAPI::Bindings::OperationInfo.new(
-            VAPI::Core::OperationIdentifier.new('fail', @@service_id),
-            VAPI::Bindings::OperationInputType.new({
-                'download_session_id' => VAPI::Bindings::IdType.new(resource_types='com.vmware.content.library.item.DownloadSession'),
-                'client_error_message' => VAPI::Bindings::StringType.instance,
-            }),
-            VAPI::Bindings::VoidType.instance,
-            {
-                'com.vmware.vapi.std.errors.not_found' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::NotFound'),
-                'com.vmware.vapi.std.errors.not_allowed_in_current_state' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::NotAllowedInCurrentState'),
-
-            },
-            [],
-            [])
-
-        @@service_info = VAPI::Bindings::ServiceInfo.new(@@service_id, {
-            'create' => @@create_info,
-            'get' => @@get_info,
-            'list' => @@list_info,
-            'keep_alive' => @@keep_alive_info,
-            'cancel' => @@cancel_info,
-            'delete' => @@delete_info,
-            'fail' => @@fail_info,
-        })
-
-        public
-
-        # Constructs a new instance.
-        #
-        # @param config [VAPI::Bindings::StubConfig] A hash with the api provider details.
-        def initialize(config)
-            super(config, @@service_info)
-        end
-
-        RESOURCE_TYPE = 'com.vmware.content.library.item.DownloadSession'
-
-
-        # Creates a new download session.
-        #
-        # @param client_token [String, nil]
-        #      A unique token generated by the client for each creation request. The token should be a universally unique identifier (UUID), for example:  ``b8a2a2e3-2314-43cd-a871-6ede0f429751`` . This token can be used to guarantee idempotent creation.
-        #     If not specified creation is not idempotent.
-        # @param create_spec [Com::Vmware::Content::Library::Item::DownloadSessionModel]
-        #      Specification for the new download session to be created.
-        # @return [String]
-        #     Identifier of the new download session being created.
-        # @raise [Com::Vmware::Vapi::Std::Errors::InvalidArgument]
-        #      if the session specification is not valid.
-        # @raise [Com::Vmware::Vapi::Std::Errors::InvalidArgument]
-        #      format.
-        # @raise [Com::Vmware::Vapi::Std::Errors::NotFound]
-        #      if the library item targeted by the download does not exist.
-        def create(create_spec, client_token=nil)
-            invoke_with_info(@@create_info, {
-                'client_token' => client_token,
-                'create_spec' => create_spec,
-            })
-        end
-
-
-        # Gets the download session with the specified identifier, including the most up-to-date status information for the session.
-        #
-        # @param download_session_id [String]
-        #      Identifier of the download session to retrieve.
-        # @return [Com::Vmware::Content::Library::Item::DownloadSessionModel]
-        #     The   :class:`Com::Vmware::Content::Library::Item::DownloadSessionModel`   instance with the given  ``download_session_id`` .
-        # @raise [Com::Vmware::Vapi::Std::Errors::NotFound]
-        #      if no download session with the given  ``download_session_id``  exists.
-        def get(download_session_id)
-            invoke_with_info(@@get_info, {
-                'download_session_id' => download_session_id,
-            })
-        end
-
-
-        # Lists the identifiers of the download sessions created by the calling user. Optionally may filter by library item.
-        #
-        # @param library_item_id [String, nil]
-        #      Library item identifier on which to filter results.
-        #     If not specified all download session identifiers are listed.
-        # @return [Array<String>]
-        #     The  list  of identifiers of all download sessions created by the calling user.
-        # @raise [Com::Vmware::Vapi::Std::Errors::NotFound]
-        #      if a library item identifier is given for an item which does not exist.
-        def list(library_item_id=nil)
-            invoke_with_info(@@list_info, {
-                'library_item_id' => library_item_id,
-            })
-        end
-
-
-        # Keeps a download session alive. This operation is allowed only if the session is in the   :attr:`Com::Vmware::Content::Library::Item::DownloadSessionModel::State.ACTIVE`   state.  
-        # 
-        #  If there is no activity for a download session for a certain period of time, the download session will expire. The download session expiration timeout is configurable in the Content Library Service system configuration. The default is five minutes. Invoking this  method  enables a client to specifically extend the lifetime of an active download session.
-        #
-        # @param download_session_id [String]
-        #      Identifier of the download session whose lifetime should be extended.
-        # @param progress [Fixnum, nil]
-        #      Optional update to the progress property of the session. If specified, the new progress should be greater then the current progress. See   :attr:`Com::Vmware::Content::Library::Item::DownloadSessionModel.client_progress`  .
-        #     If not specified the progress is not updated.
-        # @return [Void]
-        # @raise [Com::Vmware::Vapi::Std::Errors::NotFound]
-        #      if no download session with the given identifier exists.
-        # @raise [Com::Vmware::Vapi::Std::Errors::NotAllowedInCurrentState]
-        #      if the download session is not in the   :attr:`Com::Vmware::Content::Library::Item::DownloadSessionModel::State.ACTIVE`   state.
-        def keep_alive(download_session_id, progress=nil)
-            invoke_with_info(@@keep_alive_info, {
-                'download_session_id' => download_session_id,
-                'progress' => progress,
-            })
-        end
-
-
-        # Cancels the download session. This  method  will abort any ongoing transfers and invalidate transfer urls that the client may be downloading from.
-        #
-        # @param download_session_id [String]
-        #      Identifer of the download session that should be canceled.
-        # @return [Void]
-        # @raise [Com::Vmware::Vapi::Std::Errors::NotFound]
-        #      if no download session with the given identifier exists.
-        # @raise [Com::Vmware::Vapi::Std::Errors::NotAllowedInCurrentState]
-        #      if the download session is not in the   :attr:`Com::Vmware::Content::Library::Item::DownloadSessionModel::State.ACTIVE`   state.
-        def cancel(download_session_id)
-            invoke_with_info(@@cancel_info, {
-                'download_session_id' => download_session_id,
-            })
-        end
-
-
-        # Deletes a download session. This removes the session and all information associated with it.  
-        # 
-        #  Removing a download session leaves any current transfers for that session in an indeterminate state (there is no guarantee that the transfers will be able to complete). However there will no longer be a means of inspecting the status of those downloads except by seeing the effect on the library item.  
-        # 
-        #  Download sessions for which there is no download activity or which are complete will automatically be expired and then deleted after a period of time.
-        #
-        # @param download_session_id [String]
-        #      Identifier of the download session to be deleted.
-        # @return [Void]
-        # @raise [Com::Vmware::Vapi::Std::Errors::NotFound]
-        #      if the download session does not exist.
-        def delete(download_session_id)
-            invoke_with_info(@@delete_info, {
-                'download_session_id' => download_session_id,
-            })
-        end
-
-
-        # Terminates the download session with a client specified error message.  
-        # 
-        #  This is useful in transmitting client side failures (for example, not being able to download a file) to the server side.
-        #
-        # @param download_session_id [String]
-        #      Identifier of the download session to fail.
-        # @param client_error_message [String]
-        #      Client side error message. This can be useful in providing some extra details about the client side failure. Note that the message won't be translated to the user's locale.
-        # @return [Void]
-        # @raise [Com::Vmware::Vapi::Std::Errors::NotFound]
-        #      if the download session does not exist.
-        # @raise [Com::Vmware::Vapi::Std::Errors::NotAllowedInCurrentState]
-        #      if the download session is not in the   :attr:`Com::Vmware::Content::Library::Item::DownloadSessionModel::State.ACTIVE`   state.
-        def fail(download_session_id, client_error_message)
-            invoke_with_info(@@fail_info, {
-                'download_session_id' => download_session_id,
-                'client_error_message' => client_error_message,
-            })
-        end
-
-
+    # Constructs a new instance.
+    #
+    # @param config [VAPI::Bindings::StubConfig] A hash with the api provider details.
+    def initialize(config)
+      super(config, SERVICE_INFO)
     end
 
-
-    # The  ``Com::Vmware::Content::Library::Item::File``   class  can be used to query for information on the files within a library item. Files are objects which are added to a library item through the   :class:`Com::Vmware::Content::Library::Item::UpdateSession`   and   :class:`Com::Vmware::Content::Library::Item::Updatesession::File`    classs .
-    class File < VAPI::Bindings::VapiService
-
-        protected
-
-        # static metamodel definitions
-        @@service_id = VAPI::Core::ServiceIdentifier.new('com.vmware.content.library.item.file')
-
-        @@get_info = VAPI::Bindings::OperationInfo.new(
-            VAPI::Core::OperationIdentifier.new('get', @@service_id),
-            VAPI::Bindings::OperationInputType.new({
-                'library_item_id' => VAPI::Bindings::IdType.new(resource_types='com.vmware.content.library.Item'),
-                'name' => VAPI::Bindings::StringType.instance,
-            }),
-            VAPI::Bindings::ReferenceType.new('Com::Vmware::Content::Library::Item::File::Info'),
-            {
-                'com.vmware.vapi.std.errors.not_found' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::NotFound'),
-
-            },
-            [],
-            [])
-        @@list_info = VAPI::Bindings::OperationInfo.new(
-            VAPI::Core::OperationIdentifier.new('list', @@service_id),
-            VAPI::Bindings::OperationInputType.new({
-                'library_item_id' => VAPI::Bindings::IdType.new(resource_types='com.vmware.content.library.Item'),
-            }),
-            VAPI::Bindings::ListType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Content::Library::Item::File::Info')),
-            {
-                'com.vmware.vapi.std.errors.not_found' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::NotFound'),
-
-            },
-            [],
-            [])
-
-        @@service_info = VAPI::Bindings::ServiceInfo.new(@@service_id, {
-            'get' => @@get_info,
-            'list' => @@list_info,
-        })
-
-        public
-
-        # Constructs a new instance.
-        #
-        # @param config [VAPI::Bindings::StubConfig] A hash with the api provider details.
-        def initialize(config)
-            super(config, @@service_info)
-        end
-
-
-        # Retrieves the information for a single file in a library item by its name.
-        #
-        # @param library_item_id [String]
-        #      Identifier of the library item whose file information should be returned.
-        # @param name [String]
-        #      Name of the file in the library item whose information should be returned.
-        # @return [Com::Vmware::Content::Library::Item::File::Info]
-        #     The   :class:`Com::Vmware::Content::Library::Item::File::Info`   object with information on the specified file.
-        # @raise [Com::Vmware::Vapi::Std::Errors::NotFound]
-        #      if  ``library_item_id``  refers to a library item that does not exist.
-        # @raise [Com::Vmware::Vapi::Std::Errors::NotFound]
-        #      if  ``name``  refers to a file that does not exist in the library item.
-        def get(library_item_id, name)
-            invoke_with_info(@@get_info, {
-                'library_item_id' => library_item_id,
-                'name' => name,
-            })
-        end
-
-
-        # Lists all of the files that are stored within a given library item.
-        #
-        # @param library_item_id [String]
-        #      Identifier of the library item whose files should be listed.
-        # @return [Array<Com::Vmware::Content::Library::Item::File::Info>]
-        #     The  list  of all of the files that are stored within the given library item.
-        # @raise [Com::Vmware::Vapi::Std::Errors::NotFound]
-        #      if  ``library_item_id``  refers to a library item that does not exist.
-        def list(library_item_id)
-            invoke_with_info(@@list_info, {
-                'library_item_id' => library_item_id,
-            })
-        end
-
-
-
-        # Provides checksums for a   :class:`Com::Vmware::Content::Library::Item::File::Info`   object.
-        # @!attribute [rw] algorithm
-        #     @return [Com::Vmware::Content::Library::Item::File::ChecksumAlgorithm, nil]
-        #     The checksum algorithm ( ``SHA1``, ``MD5`` ) used to calculate the checksum.
-        #     If not specified the default checksum algorithm is   :attr:`Com::Vmware::Content::Library::Item::File::ChecksumAlgorithm.SHA1`  .
-        # @!attribute [rw] checksum
-        #     @return [String]
-        #     The checksum value calculated with   :attr:`Com::Vmware::Content::Library::Item::File::ChecksumInfo.algorithm`  .
-        class ChecksumInfo < VAPI::Bindings::VapiStruct
-
-            class << self
-                # Holds (gets or creates) the binding type metadata for this structure type.
-                # @scope class
-                # @return [VAPI::Bindings::StructType] the binding type
-                def binding_type
-                    @binding_type ||= VAPI::Bindings::StructType.new(
-                        'com.vmware.content.library.item.file.checksum_info',
-                        {
-                            'algorithm' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Content::Library::Item::File::ChecksumAlgorithm')),
-                            'checksum' => VAPI::Bindings::StringType.instance,
-                        },
-                        ChecksumInfo,
-                        false,
-                        nil)
-                end
-            end
-
-            attr_accessor :algorithm,
-                          :checksum
-
-            # Constructs a new instance.
-            # @param ruby_values [Hash] a map of initial property values (optional)
-            # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
-            def initialize(ruby_values=nil, struct_value=nil)
-                super(self.class.binding_type, ruby_values, struct_value)
-            end
-        end
-
-
-        # The  ``Com::Vmware::Content::Library::Item::File::Info``   class  provides information about a file in Content Library Service storage.  
-        # 
-        #  A file is an actual stored object for a library item. An item will have zero files initially, but one or more can be uploaded to the item.
-        # @!attribute [rw] checksum_info
-        #     @return [Com::Vmware::Content::Library::Item::File::ChecksumInfo, nil]
-        #     A checksum for validating the content of the file.  
-        #     
-        #      This value can be used to verify that a transfer was completed without errors.
-        #     A checksum cannot always be calculated, and the value will be  nil  if the file does not have content.
-        # @!attribute [rw] name
-        #     @return [String]
-        #     The name of the file.  
-        #     
-        #      This value will be unique within the library item for each file. It cannot be an empty string.
-        # @!attribute [rw] size
-        #     @return [Fixnum]
-        #     The file size, in bytes. The file size is the storage used and not the uploaded or provisioned size. For example, when uploading a disk to a datastore, the amount of storage that the disk consumes may be different from the disk file size. When the file is not cached, the size is 0.
-        # @!attribute [rw] cached
-        #     @return [Boolean]
-        #     Indicates whether the file is on disk or not.
-        # @!attribute [rw] version
-        #     @return [String]
-        #     The version of this file; incremented when a new copy of the file is uploaded.
-        class Info < VAPI::Bindings::VapiStruct
-
-            class << self
-                # Holds (gets or creates) the binding type metadata for this structure type.
-                # @scope class
-                # @return [VAPI::Bindings::StructType] the binding type
-                def binding_type
-                    @binding_type ||= VAPI::Bindings::StructType.new(
-                        'com.vmware.content.library.item.file.info',
-                        {
-                            'checksum_info' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Content::Library::Item::File::ChecksumInfo')),
-                            'name' => VAPI::Bindings::StringType.instance,
-                            'size' => VAPI::Bindings::IntegerType.instance,
-                            'cached' => VAPI::Bindings::BooleanType.instance,
-                            'version' => VAPI::Bindings::StringType.instance,
-                        },
-                        Info,
-                        false,
-                        nil)
-                end
-            end
-
-            attr_accessor :checksum_info,
-                          :name,
-                          :size,
-                          :cached,
-                          :version
-
-            # Constructs a new instance.
-            # @param ruby_values [Hash] a map of initial property values (optional)
-            # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
-            def initialize(ruby_values=nil, struct_value=nil)
-                super(self.class.binding_type, ruby_values, struct_value)
-            end
-        end
-
-
-
-        # The  ``Com::Vmware::Content::Library::Item::File::ChecksumAlgorithm``   enumerated type  defines the valid checksum algorithms.
-        # @!attribute [rw] sh_a1
-        #     @return [Com::Vmware::Content::Library::Item::File::ChecksumAlgorithm]
-        #     Checksum algorithm: SHA-1
-        # @!attribute [rw] m_d5
-        #     @return [Com::Vmware::Content::Library::Item::File::ChecksumAlgorithm]
-        #     Checksum algorithm: MD5
-        class ChecksumAlgorithm < VAPI::Bindings::VapiEnum
-
-            class << self
-                # Holds (gets or creates) the binding type metadata for this enumeration type.
-                # @scope class
-                # @return [VAPI::Bindings::EnumType] the binding type
-                def binding_type
-                    @binding_type ||= VAPI::Bindings::EnumType.new(
-                        'com.vmware.content.library.item.file.checksum_algorithm',
-                        ChecksumAlgorithm)
-                end
-
-                # Converts from a string value (perhaps off the wire) to an instance
-                # of this enum type.
-                # @param value [String] the actual value of the enum instance
-                # @return [ChecksumAlgorithm] the instance found for the value, otherwise
-                #         an unknown instance will be built for the value
-                def from_string(value)
-                    begin
-                        const_get(value)
-                    rescue NameError
-                        ChecksumAlgorithm.new('UNKNOWN', value)
-                    end
-                end
-            end
-
-            private
-
-            # Constructs a new instance.
-            # @param value [String] the actual value of the enum instance
-            # @param unknown [String] the unknown value when value is 'UKNOWN'
-            def initialize(value, unknown=nil)
-                super(self.class.binding_type, value, unknown)
-            end
-
-            public
-
-            # @!attribute [rw] sh_a1
-            #     @return [Com::Vmware::Content::Library::Item::File::ChecksumAlgorithm]
-            #     Checksum algorithm: SHA-1
-            SH_A1 = ChecksumAlgorithm.new('SH_A1')
-
-            # @!attribute [rw] m_d5
-            #     @return [Com::Vmware::Content::Library::Item::File::ChecksumAlgorithm]
-            #     Checksum algorithm: MD5
-            M_D5 = ChecksumAlgorithm.new('M_D5')
-
-        end
-
-
+    RESOURCE_TYPE = 'com.vmware.content.library.item.DownloadSession'
+    # Creates a new download session.
+    #
+    # @param client_token [String, nil]
+    #      A unique token generated by the client for each creation request. The token should be a universally unique identifier (UUID), for example:  ``b8a2a2e3-2314-43cd-a871-6ede0f429751`` . This token can be used to guarantee idempotent creation.
+    #     If not specified creation is not idempotent.
+    # @param create_spec [Com::Vmware::Content::Library::Item::DownloadSessionModel]
+    #      Specification for the new download session to be created.
+    # @return [String]
+    #     Identifier of the new download session being created.
+    # @raise [Com::Vmware::Vapi::Std::Errors::InvalidArgument]
+    #      if the session specification is not valid.
+    # @raise [Com::Vmware::Vapi::Std::Errors::InvalidArgument]
+    #      format.
+    # @raise [Com::Vmware::Vapi::Std::Errors::NotFound]
+    #      if the library item targeted by the download does not exist.
+    def create(create_spec, client_token = nil)
+      invoke_with_info(CREATE_INFO,
+                       'client_token' => client_token,
+                       'create_spec' => create_spec)
     end
 
-
-    # ``Com::Vmware::Content::Library::Item::Storage``  is a resource that represents a specific instance of a file stored on a storage backing. Unlike   :class:`Com::Vmware::Content::Library::Item::File`  , which is abstract, storage represents concrete files on the various storage backings. A file is only represented once in   :class:`Com::Vmware::Content::Library::Item::File`  , but will be represented multiple times (once for each storage backing) in  ``Com::Vmware::Content::Library::Item::Storage`` . The  ``Com::Vmware::Content::Library::Item::Storage``   class  provides information on the storage backing and the specific location of the file in that backing to privileged users who want direct access to the file on the storage medium.
-    class Storage < VAPI::Bindings::VapiService
-
-        protected
-
-        # static metamodel definitions
-        @@service_id = VAPI::Core::ServiceIdentifier.new('com.vmware.content.library.item.storage')
-
-        @@get_info = VAPI::Bindings::OperationInfo.new(
-            VAPI::Core::OperationIdentifier.new('get', @@service_id),
-            VAPI::Bindings::OperationInputType.new({
-                'library_item_id' => VAPI::Bindings::IdType.new(resource_types='com.vmware.content.library.Item'),
-                'file_name' => VAPI::Bindings::StringType.instance,
-            }),
-            VAPI::Bindings::ListType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Content::Library::Item::Storage::Info')),
-            {
-                'com.vmware.vapi.std.errors.not_found' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::NotFound'),
-
-            },
-            [],
-            [])
-        @@list_info = VAPI::Bindings::OperationInfo.new(
-            VAPI::Core::OperationIdentifier.new('list', @@service_id),
-            VAPI::Bindings::OperationInputType.new({
-                'library_item_id' => VAPI::Bindings::IdType.new(resource_types='com.vmware.content.library.Item'),
-            }),
-            VAPI::Bindings::ListType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Content::Library::Item::Storage::Info')),
-            {
-                'com.vmware.vapi.std.errors.not_found' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::NotFound'),
-
-            },
-            [],
-            [])
-
-        @@service_info = VAPI::Bindings::ServiceInfo.new(@@service_id, {
-            'get' => @@get_info,
-            'list' => @@list_info,
-        })
-
-        public
-
-        # Constructs a new instance.
-        #
-        # @param config [VAPI::Bindings::StubConfig] A hash with the api provider details.
-        def initialize(config)
-            super(config, @@service_info)
-        end
-
-
-        # Retrieves the storage information for a specific file in a library item.
-        #
-        # @param library_item_id [String]
-        #      Identifier of the library item whose storage information should be retrieved.
-        # @param file_name [String]
-        #      Name of the file for which the storage information should be listed.
-        # @return [Array<Com::Vmware::Content::Library::Item::Storage::Info>]
-        #     The  list  of all the storage items for the given file within the given library item.
-        # @raise [Com::Vmware::Vapi::Std::Errors::NotFound]
-        #      if the specified library item does not exist.
-        # @raise [Com::Vmware::Vapi::Std::Errors::NotFound]
-        #      if the specified file does not exist in the given library item.
-        def get(library_item_id, file_name)
-            invoke_with_info(@@get_info, {
-                'library_item_id' => library_item_id,
-                'file_name' => file_name,
-            })
-        end
-
-
-        # Lists all storage items for a given library item.
-        #
-        # @param library_item_id [String]
-        #      Identifier of the library item whose storage information should be listed.
-        # @return [Array<Com::Vmware::Content::Library::Item::Storage::Info>]
-        #     The  list  of all storage items for a given library item.
-        # @raise [Com::Vmware::Vapi::Std::Errors::NotFound]
-        #      if the specified library item does not exist.
-        def list(library_item_id)
-            invoke_with_info(@@list_info, {
-                'library_item_id' => library_item_id,
-            })
-        end
-
-
-
-        # The  ``Com::Vmware::Content::Library::Item::Storage::Info``   class  is the expanded form of   :class:`Com::Vmware::Content::Library::Item::File::Info`   that includes details about the storage backing for a file in a library item.
-        # @!attribute [rw] storage_backing
-        #     @return [Com::Vmware::Content::Library::StorageBacking]
-        #     The storage backing on which this object resides.
-        # @!attribute [rw] storage_uris
-        #     @return [Array<URI>]
-        #     URIs that identify the file on the storage backing.  
-        #     
-        #      These URIs may be specific to the backing and may need interpretation by the client. A client that understands a URI scheme in this list may use that URI to directly access the file on the storage backing. This can provide high-performance support for file manipulation.
-        class Info < VAPI::Bindings::VapiStruct
-
-            class << self
-                # Holds (gets or creates) the binding type metadata for this structure type.
-                # @scope class
-                # @return [VAPI::Bindings::StructType] the binding type
-                def binding_type
-                    @binding_type ||= VAPI::Bindings::StructType.new(
-                        'com.vmware.content.library.item.storage.info',
-                        {
-                            'storage_backing' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Content::Library::StorageBacking'),
-                            'storage_uris' => VAPI::Bindings::ListType.new(VAPI::Bindings::URIType.instance),
-                            'checksum_info' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Content::Library::Item::File::ChecksumInfo')),
-                            'name' => VAPI::Bindings::StringType.instance,
-                            'size' => VAPI::Bindings::IntegerType.instance,
-                            'cached' => VAPI::Bindings::BooleanType.instance,
-                            'version' => VAPI::Bindings::StringType.instance,
-                        },
-                        Info,
-                        false,
-                        nil)
-                end
-            end
-
-            attr_accessor :storage_backing,
-                          :storage_uris,
-                          :checksum_info,
-                          :name,
-                          :size,
-                          :cached,
-                          :version
-
-            # Constructs a new instance.
-            # @param ruby_values [Hash] a map of initial property values (optional)
-            # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
-            def initialize(ruby_values=nil, struct_value=nil)
-                super(self.class.binding_type, ruby_values, struct_value)
-            end
-        end
-
-
+    # Gets the download session with the specified identifier, including the most up-to-date status information for the session.
+    #
+    # @param download_session_id [String]
+    #      Identifier of the download session to retrieve.
+    # @return [Com::Vmware::Content::Library::Item::DownloadSessionModel]
+    #     The   :class:`Com::Vmware::Content::Library::Item::DownloadSessionModel`   instance with the given  ``download_session_id`` .
+    # @raise [Com::Vmware::Vapi::Std::Errors::NotFound]
+    #      if no download session with the given  ``download_session_id``  exists.
+    def get(download_session_id)
+      invoke_with_info(GET_INFO,
+                       'download_session_id' => download_session_id)
     end
 
-
-    # The  ``Com::Vmware::Content::Library::Item::UpdateSession``   class  manipulates sessions that are used to upload content into the Content Library Service, and/or to remove files from a library item.  
-    # 
-    #  An update session is a resource which tracks changes to content. An update session is created with a set of files that are intended to be uploaded to a specific   :class:`Com::Vmware::Content::Library::ItemModel`  , or removed from an item. The session object can be used to track the uploads and inspect the changes that are being made to the item by that upload. It can also serve as a channel to check on the result of the upload, and status messages such as errors and warnings for the upload.  
-    # 
-    #  Modifications are not visible to other clients unless the session is completed and all necessary files have been received.  
-    # 
-    #  The management of the files within the session is done through the   :class:`Com::Vmware::Content::Library::Item::Updatesession::File`    class .
-    class UpdateSession < VAPI::Bindings::VapiService
-
-        protected
-
-        # static metamodel definitions
-        @@service_id = VAPI::Core::ServiceIdentifier.new('com.vmware.content.library.item.update_session')
-
-        @@create_info = VAPI::Bindings::OperationInfo.new(
-            VAPI::Core::OperationIdentifier.new('create', @@service_id),
-            VAPI::Bindings::OperationInputType.new({
-                'client_token' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::StringType.instance),
-                'create_spec' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Content::Library::Item::UpdateSessionModel'),
-            }),
-            VAPI::Bindings::IdType.new(resource_types='com.vmware.content.library.item.UpdateSession'),
-            {
-                'com.vmware.vapi.std.errors.invalid_argument' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::InvalidArgument'),
-                'com.vmware.vapi.std.errors.invalid_element_type' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::InvalidElementType'),
-                'com.vmware.vapi.std.errors.not_found' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::NotFound'),
-                'com.vmware.vapi.std.errors.resource_busy' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::ResourceBusy'),
-
-            },
-            [],
-            [])
-        @@get_info = VAPI::Bindings::OperationInfo.new(
-            VAPI::Core::OperationIdentifier.new('get', @@service_id),
-            VAPI::Bindings::OperationInputType.new({
-                'update_session_id' => VAPI::Bindings::IdType.new(resource_types='com.vmware.content.library.item.UpdateSession'),
-            }),
-            VAPI::Bindings::ReferenceType.new('Com::Vmware::Content::Library::Item::UpdateSessionModel'),
-            {
-                'com.vmware.vapi.std.errors.not_found' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::NotFound'),
-
-            },
-            [],
-            [])
-        @@list_info = VAPI::Bindings::OperationInfo.new(
-            VAPI::Core::OperationIdentifier.new('list', @@service_id),
-            VAPI::Bindings::OperationInputType.new({
-                'library_item_id' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::IdType.new),
-            }),
-            VAPI::Bindings::ListType.new(VAPI::Bindings::IdType.new),
-            {
-                'com.vmware.vapi.std.errors.not_found' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::NotFound'),
-
-            },
-            [],
-            [])
-        @@complete_info = VAPI::Bindings::OperationInfo.new(
-            VAPI::Core::OperationIdentifier.new('complete', @@service_id),
-            VAPI::Bindings::OperationInputType.new({
-                'update_session_id' => VAPI::Bindings::IdType.new(resource_types='com.vmware.content.library.item.UpdateSession'),
-            }),
-            VAPI::Bindings::VoidType.instance,
-            {
-                'com.vmware.vapi.std.errors.not_found' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::NotFound'),
-                'com.vmware.vapi.std.errors.not_allowed_in_current_state' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::NotAllowedInCurrentState'),
-
-            },
-            [],
-            [])
-        @@keep_alive_info = VAPI::Bindings::OperationInfo.new(
-            VAPI::Core::OperationIdentifier.new('keep_alive', @@service_id),
-            VAPI::Bindings::OperationInputType.new({
-                'update_session_id' => VAPI::Bindings::IdType.new(resource_types='com.vmware.content.library.item.UpdateSession'),
-                'client_progress' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::IntegerType.instance),
-            }),
-            VAPI::Bindings::VoidType.instance,
-            {
-                'com.vmware.vapi.std.errors.not_found' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::NotFound'),
-                'com.vmware.vapi.std.errors.not_allowed_in_current_state' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::NotAllowedInCurrentState'),
-
-            },
-            [],
-            [])
-        @@cancel_info = VAPI::Bindings::OperationInfo.new(
-            VAPI::Core::OperationIdentifier.new('cancel', @@service_id),
-            VAPI::Bindings::OperationInputType.new({
-                'update_session_id' => VAPI::Bindings::IdType.new(resource_types='com.vmware.content.library.item.UpdateSession'),
-            }),
-            VAPI::Bindings::VoidType.instance,
-            {
-                'com.vmware.vapi.std.errors.not_found' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::NotFound'),
-                'com.vmware.vapi.std.errors.not_allowed_in_current_state' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::NotAllowedInCurrentState'),
-
-            },
-            [],
-            [])
-        @@fail_info = VAPI::Bindings::OperationInfo.new(
-            VAPI::Core::OperationIdentifier.new('fail', @@service_id),
-            VAPI::Bindings::OperationInputType.new({
-                'update_session_id' => VAPI::Bindings::IdType.new(resource_types='com.vmware.content.library.item.UpdateSession'),
-                'client_error_message' => VAPI::Bindings::StringType.instance,
-            }),
-            VAPI::Bindings::VoidType.instance,
-            {
-                'com.vmware.vapi.std.errors.not_found' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::NotFound'),
-                'com.vmware.vapi.std.errors.not_allowed_in_current_state' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::NotAllowedInCurrentState'),
-
-            },
-            [],
-            [])
-        @@delete_info = VAPI::Bindings::OperationInfo.new(
-            VAPI::Core::OperationIdentifier.new('delete', @@service_id),
-            VAPI::Bindings::OperationInputType.new({
-                'update_session_id' => VAPI::Bindings::IdType.new(resource_types='com.vmware.content.library.item.UpdateSession'),
-            }),
-            VAPI::Bindings::VoidType.instance,
-            {
-                'com.vmware.vapi.std.errors.not_found' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::NotFound'),
-                'com.vmware.vapi.std.errors.not_allowed_in_current_state' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::NotAllowedInCurrentState'),
-
-            },
-            [],
-            [])
-
-        @@service_info = VAPI::Bindings::ServiceInfo.new(@@service_id, {
-            'create' => @@create_info,
-            'get' => @@get_info,
-            'list' => @@list_info,
-            'complete' => @@complete_info,
-            'keep_alive' => @@keep_alive_info,
-            'cancel' => @@cancel_info,
-            'fail' => @@fail_info,
-            'delete' => @@delete_info,
-        })
-
-        public
-
-        # Constructs a new instance.
-        #
-        # @param config [VAPI::Bindings::StubConfig] A hash with the api provider details.
-        def initialize(config)
-            super(config, @@service_info)
-        end
-
-        RESOURCE_TYPE = 'com.vmware.content.library.item.UpdateSession'
-
-
-        # Creates a new update session. An update session is used to make modifications to a library item. Modifications are not visible to other clients unless the session is completed and all necessary files have been received.  
-        # 
-        #  Content Library Service allows only one single update session to be active for a specific library item.
-        #
-        # @param client_token [String, nil]
-        #      Unique token generated by the client for each creation request. The token should be a universally unique identifier (UUID), for example:  ``b8a2a2e3-2314-43cd-a871-6ede0f429751`` . This token can be used to guarantee idempotent creation.
-        #     If not specified creation is not idempotent.
-        # @param create_spec [Com::Vmware::Content::Library::Item::UpdateSessionModel]
-        #      Specification for the new update session to be created.
-        # @return [String]
-        #     Identifier of the new update session being created.
-        # @raise [Com::Vmware::Vapi::Std::Errors::InvalidArgument]
-        #      if the session specification is not valid.
-        # @raise [Com::Vmware::Vapi::Std::Errors::InvalidArgument]
-        #      if the  ``client_token``  does not conform to the UUID format.
-        # @raise [Com::Vmware::Vapi::Std::Errors::InvalidElementType]
-        #      if the update session is being created on a subscribed library item.
-        # @raise [Com::Vmware::Vapi::Std::Errors::NotFound]
-        #      if the item targeted for update does not exist.
-        # @raise [Com::Vmware::Vapi::Std::Errors::ResourceBusy]
-        #      if there is another update session on the same library item.
-        def create(create_spec, client_token=nil)
-            invoke_with_info(@@create_info, {
-                'client_token' => client_token,
-                'create_spec' => create_spec,
-            })
-        end
-
-
-        # Gets the update session with the specified identifier, including the most up-to-date status information for the session.
-        #
-        # @param update_session_id [String]
-        #      Identifier of the update session to retrieve.
-        # @return [Com::Vmware::Content::Library::Item::UpdateSessionModel]
-        #     The   :class:`Com::Vmware::Content::Library::Item::UpdateSessionModel`   instance with the given  ``update_session_id`` .
-        # @raise [Com::Vmware::Vapi::Std::Errors::NotFound]
-        #      if no update session with the given identifier exists.
-        def get(update_session_id)
-            invoke_with_info(@@get_info, {
-                'update_session_id' => update_session_id,
-            })
-        end
-
-
-        # Lists the identifiers of the update session created by the calling user. Optionally may filter by library item.
-        #
-        # @param library_item_id [String, nil]
-        #      Optional library item identifier on which to filter results.
-        #     If not specified the results are not filtered.
-        # @return [Array<String>]
-        #     The  list  of identifiers of all update sessions created by the calling user.
-        # @raise [Com::Vmware::Vapi::Std::Errors::NotFound]
-        #      if a library item identifier is given for an item which does not exist.
-        def list(library_item_id=nil)
-            invoke_with_info(@@list_info, {
-                'library_item_id' => library_item_id,
-            })
-        end
-
-
-        # Completes the update session. This indicates that the client has finished making all the changes required to the underlying library item. If the client is pushing the content to the server, the library item will be updated once this call returns. If the server is pulling the content, the call may return before the changes become visible. In that case, the client can track the session to know when the server is done.  
-        # 
-        #  This  method  requires the session to be in the   :attr:`Com::Vmware::Content::Library::Item::UpdateSessionModel::State.ACTIVE`   state.  
-        # 
-        #  Depending on the type of the library item associated with this session, a type adapter may be invoked to verify the validity of the files uploaded. The user can explicitly validate the session before completing the session by using the   :func:`Com::Vmware::Content::Library::Item::Updatesession::File.validate`    method .  
-        # 
-        #  Modifications are not visible to other clients unless the session is completed and all necessary files have been received.
-        #
-        # @param update_session_id [String]
-        #      Identifier of the update session that should be completed.
-        # @return [Void]
-        # @raise [Com::Vmware::Vapi::Std::Errors::NotFound]
-        #      if no update session with the given identifier exists.
-        # @raise [Com::Vmware::Vapi::Std::Errors::NotAllowedInCurrentState]
-        #      if the update session is not in the   :attr:`Com::Vmware::Content::Library::Item::UpdateSessionModel::State.ACTIVE`   state, or if some of the files that will be uploaded by the client aren't received correctly.
-        def complete(update_session_id)
-            invoke_with_info(@@complete_info, {
-                'update_session_id' => update_session_id,
-            })
-        end
-
-
-        # Keeps an update session alive.  
-        # 
-        #  If there is no activity for an update session after a period of time, the update session will expire, then be deleted. The update session expiration timeout is configurable in the Content Library Service system configuration. The default is five minutes. Invoking this  method  enables a client to specifically extend the lifetime of the update session.
-        #
-        # @param update_session_id [String]
-        #      Identifier of the update session whose lifetime should be extended.
-        # @param client_progress [Fixnum, nil]
-        #      Optional update to the progress property of the session. If specified, the new progress should be greater then the current progress. See   :attr:`Com::Vmware::Content::Library::Item::UpdateSessionModel.client_progress`  .
-        #     If not specified the progress is not updated.
-        # @return [Void]
-        # @raise [Com::Vmware::Vapi::Std::Errors::NotFound]
-        #      if no update session with the given identifier exists.
-        # @raise [Com::Vmware::Vapi::Std::Errors::NotAllowedInCurrentState]
-        #      if the update session is not in the   :attr:`Com::Vmware::Content::Library::Item::UpdateSessionModel::State.ACTIVE`   state.
-        def keep_alive(update_session_id, client_progress=nil)
-            invoke_with_info(@@keep_alive_info, {
-                'update_session_id' => update_session_id,
-                'client_progress' => client_progress,
-            })
-        end
-
-
-        # Cancels the update session and deletes it. This  method  will free up any temporary resources currently associated with the session.  
-        # 
-        #  This  method  is not allowed if the session has been already completed.  
-        # 
-        #  Cancelling an update session will cancel any in progress transfers (either uploaded by the client or pulled by the server). Any content that has been already received will be scheduled for deletion.
-        #
-        # @param update_session_id [String]
-        #      Identifier of the update session that should be canceled.
-        # @return [Void]
-        # @raise [Com::Vmware::Vapi::Std::Errors::NotFound]
-        #      if no update session with the given identifier exists.
-        # @raise [Com::Vmware::Vapi::Std::Errors::NotAllowedInCurrentState]
-        #      if the update session is not in the   :attr:`Com::Vmware::Content::Library::Item::UpdateSessionModel::State.ACTIVE`   state.
-        def cancel(update_session_id)
-            invoke_with_info(@@cancel_info, {
-                'update_session_id' => update_session_id,
-            })
-        end
-
-
-        # Terminates the update session with a client specified error message.  
-        # 
-        #  This is useful in transmitting client side failures (for example, not being able to access a file) to the server side.
-        #
-        # @param update_session_id [String]
-        #      Identifier of the update session to fail.
-        # @param client_error_message [String]
-        #      Client side error message. This can be useful in providing some extra details about the client side failure. Note that the message won't be translated to the user's locale.
-        # @return [Void]
-        # @raise [Com::Vmware::Vapi::Std::Errors::NotFound]
-        #      if the update session does not exist.
-        # @raise [Com::Vmware::Vapi::Std::Errors::NotAllowedInCurrentState]
-        #      if the update session is not in the   :attr:`Com::Vmware::Content::Library::Item::UpdateSessionModel::State.ACTIVE`   state.
-        def fail(update_session_id, client_error_message)
-            invoke_with_info(@@fail_info, {
-                'update_session_id' => update_session_id,
-                'client_error_message' => client_error_message,
-            })
-        end
-
-
-        # Deletes an update session. This removes the session and all information associated with it.  
-        # 
-        #  Removing an update session leaves any current transfers for that session in an indeterminate state (there is no guarantee that the server will terminate the transfers, or that the transfers can be completed). However there will no longer be a means of inspecting the status of those uploads except by seeing the effect on the library item.  
-        # 
-        #  Update sessions for which there is no upload activity or which are complete will automatically be deleted after a period of time.
-        #
-        # @param update_session_id [String]
-        #      Identifer of the update session to delete.
-        # @return [Void]
-        # @raise [Com::Vmware::Vapi::Std::Errors::NotFound]
-        #      if the update session does not exist.
-        # @raise [Com::Vmware::Vapi::Std::Errors::NotAllowedInCurrentState]
-        #      if the update session is in the   :attr:`Com::Vmware::Content::Library::Item::UpdateSessionModel::State.ACTIVE`   state.
-        def delete(update_session_id)
-            invoke_with_info(@@delete_info, {
-                'update_session_id' => update_session_id,
-            })
-        end
-
-
+    # Lists the identifiers of the download sessions created by the calling user. Optionally may filter by library item.
+    #
+    # @param library_item_id [String, nil]
+    #      Library item identifier on which to filter results.
+    #     If not specified all download session identifiers are listed.
+    # @return [Array<String>]
+    #     The  list  of identifiers of all download sessions created by the calling user.
+    # @raise [Com::Vmware::Vapi::Std::Errors::NotFound]
+    #      if a library item identifier is given for an item which does not exist.
+    def list(library_item_id = nil)
+      invoke_with_info(LIST_INFO,
+                       'library_item_id' => library_item_id)
     end
 
+    # Keeps a download session alive. This operation is allowed only if the session is in the   :attr:`Com::Vmware::Content::Library::Item::DownloadSessionModel::State.ACTIVE`   state.  
+    # 
+    #  If there is no activity for a download session for a certain period of time, the download session will expire. The download session expiration timeout is configurable in the Content Library Service system configuration. The default is five minutes. Invoking this  method  enables a client to specifically extend the lifetime of an active download session.
+    #
+    # @param download_session_id [String]
+    #      Identifier of the download session whose lifetime should be extended.
+    # @param progress [Fixnum, nil]
+    #      Optional update to the progress property of the session. If specified, the new progress should be greater then the current progress. See   :attr:`Com::Vmware::Content::Library::Item::DownloadSessionModel.client_progress`  .
+    #     If not specified the progress is not updated.
+    # @return [Void]
+    # @raise [Com::Vmware::Vapi::Std::Errors::NotFound]
+    #      if no download session with the given identifier exists.
+    # @raise [Com::Vmware::Vapi::Std::Errors::NotAllowedInCurrentState]
+    #      if the download session is not in the   :attr:`Com::Vmware::Content::Library::Item::DownloadSessionModel::State.ACTIVE`   state.
+    def keep_alive(download_session_id, progress = nil)
+      invoke_with_info(KEEP_ALIVE_INFO,
+                       'download_session_id' => download_session_id,
+                       'progress' => progress)
+    end
 
+    # Cancels the download session. This  method  will abort any ongoing transfers and invalidate transfer urls that the client may be downloading from.
+    #
+    # @param download_session_id [String]
+    #      Identifer of the download session that should be canceled.
+    # @return [Void]
+    # @raise [Com::Vmware::Vapi::Std::Errors::NotFound]
+    #      if no download session with the given identifier exists.
+    # @raise [Com::Vmware::Vapi::Std::Errors::NotAllowedInCurrentState]
+    #      if the download session is not in the   :attr:`Com::Vmware::Content::Library::Item::DownloadSessionModel::State.ACTIVE`   state.
+    def cancel(download_session_id)
+      invoke_with_info(CANCEL_INFO,
+                       'download_session_id' => download_session_id)
+    end
 
-    # The  ``Com::Vmware::Content::Library::Item::DownloadSessionModel``   class  provides information on an active   :class:`Com::Vmware::Content::Library::Item::DownloadSession`   resource.
-    # @!attribute [rw] id
+    # Deletes a download session. This removes the session and all information associated with it.  
+    # 
+    #  Removing a download session leaves any current transfers for that session in an indeterminate state (there is no guarantee that the transfers will be able to complete). However there will no longer be a means of inspecting the status of those downloads except by seeing the effect on the library item.  
+    # 
+    #  Download sessions for which there is no download activity or which are complete will automatically be expired and then deleted after a period of time.
+    #
+    # @param download_session_id [String]
+    #      Identifier of the download session to be deleted.
+    # @return [Void]
+    # @raise [Com::Vmware::Vapi::Std::Errors::NotFound]
+    #      if the download session does not exist.
+    def delete(download_session_id)
+      invoke_with_info(DELETE_INFO,
+                       'download_session_id' => download_session_id)
+    end
+
+    # Terminates the download session with a client specified error message.  
+    # 
+    #  This is useful in transmitting client side failures (for example, not being able to download a file) to the server side.
+    #
+    # @param download_session_id [String]
+    #      Identifier of the download session to fail.
+    # @param client_error_message [String]
+    #      Client side error message. This can be useful in providing some extra details about the client side failure. Note that the message won't be translated to the user's locale.
+    # @return [Void]
+    # @raise [Com::Vmware::Vapi::Std::Errors::NotFound]
+    #      if the download session does not exist.
+    # @raise [Com::Vmware::Vapi::Std::Errors::NotAllowedInCurrentState]
+    #      if the download session is not in the   :attr:`Com::Vmware::Content::Library::Item::DownloadSessionModel::State.ACTIVE`   state.
+    def fail(download_session_id, client_error_message)
+      invoke_with_info(FAIL_INFO,
+                       'download_session_id' => download_session_id,
+                       'client_error_message' => client_error_message)
+    end
+
+  end
+  # The  ``Com::Vmware::Content::Library::Item::File``   class  can be used to query for information on the files within a library item. Files are objects which are added to a library item through the   :class:`Com::Vmware::Content::Library::Item::UpdateSession`   and   :class:`Com::Vmware::Content::Library::Item::Updatesession::File`    classs .
+  class File < VAPI::Bindings::VapiService
+    # static metamodel definitions
+    SERVICE_ID = VAPI::Core::ServiceIdentifier.new('com.vmware.content.library.item.file')
+
+    GET_INFO = VAPI::Bindings::OperationInfo.new(
+      VAPI::Core::OperationIdentifier.new('get', SERVICE_ID),
+      VAPI::Bindings::OperationInputType.new(
+        'library_item_id' => VAPI::Bindings::IdType.new('com.vmware.content.library.Item'),
+        'name' => VAPI::Bindings::StringType.instance
+      ),
+      VAPI::Bindings::ReferenceType.new('Com::Vmware::Content::Library::Item::File::Info'),
+      {
+        'com.vmware.vapi.std.errors.not_found' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::NotFound')
+      },
+      [],
+      []
+    )
+
+    LIST_INFO = VAPI::Bindings::OperationInfo.new(
+      VAPI::Core::OperationIdentifier.new('list', SERVICE_ID),
+      VAPI::Bindings::OperationInputType.new(
+        'library_item_id' => VAPI::Bindings::IdType.new('com.vmware.content.library.Item')
+      ),
+      VAPI::Bindings::ListType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Content::Library::Item::File::Info')),
+      {
+        'com.vmware.vapi.std.errors.not_found' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::NotFound')
+      },
+      [],
+      []
+    )
+
+    SERVICE_INFO = VAPI::Bindings::ServiceInfo.new(
+      SERVICE_ID,
+      'get' => GET_INFO,
+      'list' => LIST_INFO
+    )
+
+    # Constructs a new instance.
+    #
+    # @param config [VAPI::Bindings::StubConfig] A hash with the api provider details.
+    def initialize(config)
+      super(config, SERVICE_INFO)
+    end
+
+    # Retrieves the information for a single file in a library item by its name.
+    #
+    # @param library_item_id [String]
+    #      Identifier of the library item whose file information should be returned.
+    # @param name [String]
+    #      Name of the file in the library item whose information should be returned.
+    # @return [Com::Vmware::Content::Library::Item::File::Info]
+    #     The   :class:`Com::Vmware::Content::Library::Item::File::Info`   object with information on the specified file.
+    # @raise [Com::Vmware::Vapi::Std::Errors::NotFound]
+    #      if  ``library_item_id``  refers to a library item that does not exist.
+    # @raise [Com::Vmware::Vapi::Std::Errors::NotFound]
+    #      if  ``name``  refers to a file that does not exist in the library item.
+    def get(library_item_id, name)
+      invoke_with_info(GET_INFO,
+                       'library_item_id' => library_item_id,
+                       'name' => name)
+    end
+
+    # Lists all of the files that are stored within a given library item.
+    #
+    # @param library_item_id [String]
+    #      Identifier of the library item whose files should be listed.
+    # @return [Array<Com::Vmware::Content::Library::Item::File::Info>]
+    #     The  list  of all of the files that are stored within the given library item.
+    # @raise [Com::Vmware::Vapi::Std::Errors::NotFound]
+    #      if  ``library_item_id``  refers to a library item that does not exist.
+    def list(library_item_id)
+      invoke_with_info(LIST_INFO,
+                       'library_item_id' => library_item_id)
+    end
+
+    # Provides checksums for a   :class:`Com::Vmware::Content::Library::Item::File::Info`   object.
+    # @!attribute [rw] algorithm
+    #     @return [Com::Vmware::Content::Library::Item::File::ChecksumAlgorithm, nil]
+    #     The checksum algorithm ( ``SHA1``, ``MD5`` ) used to calculate the checksum.
+    #     If not specified the default checksum algorithm is   :attr:`Com::Vmware::Content::Library::Item::File::ChecksumAlgorithm.SHA1`  .
+    # @!attribute [rw] checksum
     #     @return [String]
-    #     The identifier of this download session.
-    #     This  field  is not used for the  ``create``   method . It will not be present in the  result  of the  ``get``  or  ``list``   methods . It is not used for the  ``update``   method .
-    # @!attribute [rw] library_item_id
+    #     The checksum value calculated with   :attr:`Com::Vmware::Content::Library::Item::File::ChecksumInfo.algorithm`  .
+    class ChecksumInfo < VAPI::Bindings::VapiStruct
+      class << self
+        # Holds (gets or creates) the binding type metadata for this structure type.
+        # @scope class
+        # @return [VAPI::Bindings::StructType] the binding type
+        def binding_type
+          @binding_type ||= VAPI::Bindings::StructType.new(
+            'com.vmware.content.library.item.file.checksum_info',
+            {
+              'algorithm' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Content::Library::Item::File::ChecksumAlgorithm')),
+              'checksum' => VAPI::Bindings::StringType.instance
+            },
+            ChecksumInfo,
+            false,
+            nil
+          )
+        end
+      end
+
+      attr_accessor :algorithm,
+                    :checksum
+
+      # Constructs a new instance.
+      # @param ruby_values [Hash] a map of initial property values (optional)
+      # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
+      def initialize(ruby_values = nil, struct_value = nil)
+        super(self.class.binding_type, ruby_values, struct_value)
+      end
+    end
+
+    # The  ``Com::Vmware::Content::Library::Item::File::Info``   class  provides information about a file in Content Library Service storage.  
+    # 
+    #  A file is an actual stored object for a library item. An item will have zero files initially, but one or more can be uploaded to the item.
+    # @!attribute [rw] checksum_info
+    #     @return [Com::Vmware::Content::Library::Item::File::ChecksumInfo, nil]
+    #     A checksum for validating the content of the file.  
+    #     
+    #      This value can be used to verify that a transfer was completed without errors.
+    #     A checksum cannot always be calculated, and the value will be  nil  if the file does not have content.
+    # @!attribute [rw] name
     #     @return [String]
-    #     The identifier of the library item whose content is being downloaded.
-    #     This  field  must be provided for the  ``create``   method . It will always be present in the  result  of the  ``get``  or  ``list``   methods . It is not used for the  ``update``   method .
-    # @!attribute [rw] library_item_content_version
-    #     @return [String]
-    #     The content version of the library item whose content is being downloaded. This value is the   :attr:`Com::Vmware::Content::Library::ItemModel.content_version`   at the time when the session is created for the library item.
-    #     This  field  is not used for the  ``create``   method . It will always be present in the  result  of the  ``get``  or  ``list``   methods . It is not used for the  ``update``   method .
-    # @!attribute [rw] error_message
-    #     @return [Com::Vmware::Vapi::Std::LocalizableMessage]
-    #     If the session is in the   :attr:`Com::Vmware::Content::Library::Item::DownloadSessionModel::State.ERROR`   status this property will have more details about the error.
-    #     This  field  is not used for the  ``create``   method . It is optional in the  result  of the  ``get``  or  ``list``   methods . It is not used for the  ``update``   method .
-    # @!attribute [rw] client_progress
+    #     The name of the file.  
+    #     
+    #      This value will be unique within the library item for each file. It cannot be an empty string.
+    # @!attribute [rw] size
     #     @return [Fixnum]
-    #     The progress that has been made with the download. This property is to be updated by the client during the download process to indicate the progress of its work in completing the download. The initial progress is 0 until updated by the client. The maximum value is 100, which indicates that the download is complete.
-    #     This  field  is not used for the  ``create``   method . It will always be present in the  result  of the  ``get``  or  ``list``   methods . It is optional for the  ``update``   method .
-    # @!attribute [rw] state
+    #     The file size, in bytes. The file size is the storage used and not the uploaded or provisioned size. For example, when uploading a disk to a datastore, the amount of storage that the disk consumes may be different from the disk file size. When the file is not cached, the size is 0.
+    # @!attribute [rw] cached
+    #     @return [Boolean]
+    #     Indicates whether the file is on disk or not.
+    # @!attribute [rw] version
+    #     @return [String]
+    #     The version of this file; incremented when a new copy of the file is uploaded.
+    class Info < VAPI::Bindings::VapiStruct
+      class << self
+        # Holds (gets or creates) the binding type metadata for this structure type.
+        # @scope class
+        # @return [VAPI::Bindings::StructType] the binding type
+        def binding_type
+          @binding_type ||= VAPI::Bindings::StructType.new(
+            'com.vmware.content.library.item.file.info',
+            {
+              'checksum_info' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Content::Library::Item::File::ChecksumInfo')),
+              'name' => VAPI::Bindings::StringType.instance,
+              'size' => VAPI::Bindings::IntegerType.instance,
+              'cached' => VAPI::Bindings::BooleanType.instance,
+              'version' => VAPI::Bindings::StringType.instance
+            },
+            Info,
+            false,
+            nil
+          )
+        end
+      end
+
+      attr_accessor :checksum_info,
+                    :name,
+                    :size,
+                    :cached,
+                    :version
+
+      # Constructs a new instance.
+      # @param ruby_values [Hash] a map of initial property values (optional)
+      # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
+      def initialize(ruby_values = nil, struct_value = nil)
+        super(self.class.binding_type, ruby_values, struct_value)
+      end
+    end
+
+    # The  ``Com::Vmware::Content::Library::Item::File::ChecksumAlgorithm``   enumerated type  defines the valid checksum algorithms.
+    # @!attribute [rw] sh_a1
+    #     @return [Com::Vmware::Content::Library::Item::File::ChecksumAlgorithm]
+    #     Checksum algorithm: SHA-1
+    # @!attribute [rw] m_d5
+    #     @return [Com::Vmware::Content::Library::Item::File::ChecksumAlgorithm]
+    #     Checksum algorithm: MD5
+    class ChecksumAlgorithm < VAPI::Bindings::VapiEnum
+      class << self
+        # Holds (gets or creates) the binding type metadata for this enumeration type.
+        # @scope class
+        # @return [VAPI::Bindings::EnumType] the binding type
+        def binding_type
+          @binding_type ||= VAPI::Bindings::EnumType.new(
+            'com.vmware.content.library.item.file.checksum_algorithm',
+            ChecksumAlgorithm
+          )
+        end
+
+        # Converts from a string value (perhaps off the wire) to an instance
+        # of this enum type.
+        # @param value [String] the actual value of the enum instance
+        # @return [ChecksumAlgorithm] the instance found for the value, otherwise
+        #         an unknown instance will be built for the value
+        def from_string(value)
+          const_get(value)
+        rescue NameError
+          ChecksumAlgorithm.send(:new, 'UNKNOWN', value)
+        end
+      end
+
+      # Constructs a new instance.
+      # @param value [String] the actual value of the enum instance
+      # @param unknown [String] the unknown value when value is 'UKNOWN'
+      def initialize(value, unknown = nil)
+        super(self.class.binding_type, value, unknown)
+      end
+
+      private_class_method :new
+
+      # @!attribute [rw] sh_a1
+      #     @return [Com::Vmware::Content::Library::Item::File::ChecksumAlgorithm]
+      #     Checksum algorithm: SHA-1
+      SH_A1 = ChecksumAlgorithm.send(:new, 'SH_A1')
+
+      # @!attribute [rw] m_d5
+      #     @return [Com::Vmware::Content::Library::Item::File::ChecksumAlgorithm]
+      #     Checksum algorithm: MD5
+      M_D5 = ChecksumAlgorithm.send(:new, 'M_D5')
+    end
+  end
+  # ``Com::Vmware::Content::Library::Item::Storage``  is a resource that represents a specific instance of a file stored on a storage backing. Unlike   :class:`Com::Vmware::Content::Library::Item::File`  , which is abstract, storage represents concrete files on the various storage backings. A file is only represented once in   :class:`Com::Vmware::Content::Library::Item::File`  , but will be represented multiple times (once for each storage backing) in  ``Com::Vmware::Content::Library::Item::Storage`` . The  ``Com::Vmware::Content::Library::Item::Storage``   class  provides information on the storage backing and the specific location of the file in that backing to privileged users who want direct access to the file on the storage medium.
+  class Storage < VAPI::Bindings::VapiService
+    # static metamodel definitions
+    SERVICE_ID = VAPI::Core::ServiceIdentifier.new('com.vmware.content.library.item.storage')
+
+    GET_INFO = VAPI::Bindings::OperationInfo.new(
+      VAPI::Core::OperationIdentifier.new('get', SERVICE_ID),
+      VAPI::Bindings::OperationInputType.new(
+        'library_item_id' => VAPI::Bindings::IdType.new('com.vmware.content.library.Item'),
+        'file_name' => VAPI::Bindings::StringType.instance
+      ),
+      VAPI::Bindings::ListType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Content::Library::Item::Storage::Info')),
+      {
+        'com.vmware.vapi.std.errors.not_found' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::NotFound')
+      },
+      [],
+      []
+    )
+
+    LIST_INFO = VAPI::Bindings::OperationInfo.new(
+      VAPI::Core::OperationIdentifier.new('list', SERVICE_ID),
+      VAPI::Bindings::OperationInputType.new(
+        'library_item_id' => VAPI::Bindings::IdType.new('com.vmware.content.library.Item')
+      ),
+      VAPI::Bindings::ListType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Content::Library::Item::Storage::Info')),
+      {
+        'com.vmware.vapi.std.errors.not_found' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::NotFound')
+      },
+      [],
+      []
+    )
+
+    SERVICE_INFO = VAPI::Bindings::ServiceInfo.new(
+      SERVICE_ID,
+      'get' => GET_INFO,
+      'list' => LIST_INFO
+    )
+
+    # Constructs a new instance.
+    #
+    # @param config [VAPI::Bindings::StubConfig] A hash with the api provider details.
+    def initialize(config)
+      super(config, SERVICE_INFO)
+    end
+
+    # Retrieves the storage information for a specific file in a library item.
+    #
+    # @param library_item_id [String]
+    #      Identifier of the library item whose storage information should be retrieved.
+    # @param file_name [String]
+    #      Name of the file for which the storage information should be listed.
+    # @return [Array<Com::Vmware::Content::Library::Item::Storage::Info>]
+    #     The  list  of all the storage items for the given file within the given library item.
+    # @raise [Com::Vmware::Vapi::Std::Errors::NotFound]
+    #      if the specified library item does not exist.
+    # @raise [Com::Vmware::Vapi::Std::Errors::NotFound]
+    #      if the specified file does not exist in the given library item.
+    def get(library_item_id, file_name)
+      invoke_with_info(GET_INFO,
+                       'library_item_id' => library_item_id,
+                       'file_name' => file_name)
+    end
+
+    # Lists all storage items for a given library item.
+    #
+    # @param library_item_id [String]
+    #      Identifier of the library item whose storage information should be listed.
+    # @return [Array<Com::Vmware::Content::Library::Item::Storage::Info>]
+    #     The  list  of all storage items for a given library item.
+    # @raise [Com::Vmware::Vapi::Std::Errors::NotFound]
+    #      if the specified library item does not exist.
+    def list(library_item_id)
+      invoke_with_info(LIST_INFO,
+                       'library_item_id' => library_item_id)
+    end
+
+    # The  ``Com::Vmware::Content::Library::Item::Storage::Info``   class  is the expanded form of   :class:`Com::Vmware::Content::Library::Item::File::Info`   that includes details about the storage backing for a file in a library item.
+    # @!attribute [rw] storage_backing
+    #     @return [Com::Vmware::Content::Library::StorageBacking]
+    #     The storage backing on which this object resides.
+    # @!attribute [rw] storage_uris
+    #     @return [Array<URI>]
+    #     URIs that identify the file on the storage backing.  
+    #     
+    #      These URIs may be specific to the backing and may need interpretation by the client. A client that understands a URI scheme in this list may use that URI to directly access the file on the storage backing. This can provide high-performance support for file manipulation.
+    class Info < VAPI::Bindings::VapiStruct
+      class << self
+        # Holds (gets or creates) the binding type metadata for this structure type.
+        # @scope class
+        # @return [VAPI::Bindings::StructType] the binding type
+        def binding_type
+          @binding_type ||= VAPI::Bindings::StructType.new(
+            'com.vmware.content.library.item.storage.info',
+            {
+              'storage_backing' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Content::Library::StorageBacking'),
+              'storage_uris' => VAPI::Bindings::ListType.new(VAPI::Bindings::URIType.instance),
+              'checksum_info' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Content::Library::Item::File::ChecksumInfo')),
+              'name' => VAPI::Bindings::StringType.instance,
+              'size' => VAPI::Bindings::IntegerType.instance,
+              'cached' => VAPI::Bindings::BooleanType.instance,
+              'version' => VAPI::Bindings::StringType.instance
+            },
+            Info,
+            false,
+            nil
+          )
+        end
+      end
+
+      attr_accessor :storage_backing,
+                    :storage_uris,
+                    :checksum_info,
+                    :name,
+                    :size,
+                    :cached,
+                    :version
+
+      # Constructs a new instance.
+      # @param ruby_values [Hash] a map of initial property values (optional)
+      # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
+      def initialize(ruby_values = nil, struct_value = nil)
+        super(self.class.binding_type, ruby_values, struct_value)
+      end
+    end
+
+  end
+  # The  ``Com::Vmware::Content::Library::Item::UpdateSession``   class  manipulates sessions that are used to upload content into the Content Library Service, and/or to remove files from a library item.  
+  # 
+  #  An update session is a resource which tracks changes to content. An update session is created with a set of files that are intended to be uploaded to a specific   :class:`Com::Vmware::Content::Library::ItemModel`  , or removed from an item. The session object can be used to track the uploads and inspect the changes that are being made to the item by that upload. It can also serve as a channel to check on the result of the upload, and status messages such as errors and warnings for the upload.  
+  # 
+  #  Modifications are not visible to other clients unless the session is completed and all necessary files have been received.  
+  # 
+  #  The management of the files within the session is done through the   :class:`Com::Vmware::Content::Library::Item::Updatesession::File`    class .
+  class UpdateSession < VAPI::Bindings::VapiService
+    # static metamodel definitions
+    SERVICE_ID = VAPI::Core::ServiceIdentifier.new('com.vmware.content.library.item.update_session')
+
+    CREATE_INFO = VAPI::Bindings::OperationInfo.new(
+      VAPI::Core::OperationIdentifier.new('create', SERVICE_ID),
+      VAPI::Bindings::OperationInputType.new(
+        'client_token' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::StringType.instance),
+        'create_spec' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Content::Library::Item::UpdateSessionModel')
+      ),
+      VAPI::Bindings::IdType.new('com.vmware.content.library.item.UpdateSession'),
+      {
+        'com.vmware.vapi.std.errors.invalid_argument' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::InvalidArgument'),
+        'com.vmware.vapi.std.errors.invalid_element_type' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::InvalidElementType'),
+        'com.vmware.vapi.std.errors.not_found' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::NotFound'),
+        'com.vmware.vapi.std.errors.resource_busy' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::ResourceBusy')
+      },
+      [],
+      []
+    )
+
+    GET_INFO = VAPI::Bindings::OperationInfo.new(
+      VAPI::Core::OperationIdentifier.new('get', SERVICE_ID),
+      VAPI::Bindings::OperationInputType.new(
+        'update_session_id' => VAPI::Bindings::IdType.new('com.vmware.content.library.item.UpdateSession')
+      ),
+      VAPI::Bindings::ReferenceType.new('Com::Vmware::Content::Library::Item::UpdateSessionModel'),
+      {
+        'com.vmware.vapi.std.errors.not_found' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::NotFound')
+      },
+      [],
+      []
+    )
+
+    LIST_INFO = VAPI::Bindings::OperationInfo.new(
+      VAPI::Core::OperationIdentifier.new('list', SERVICE_ID),
+      VAPI::Bindings::OperationInputType.new(
+        'library_item_id' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::IdType.new)
+      ),
+      VAPI::Bindings::ListType.new(VAPI::Bindings::IdType.new),
+      {
+        'com.vmware.vapi.std.errors.not_found' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::NotFound')
+      },
+      [],
+      []
+    )
+
+    COMPLETE_INFO = VAPI::Bindings::OperationInfo.new(
+      VAPI::Core::OperationIdentifier.new('complete', SERVICE_ID),
+      VAPI::Bindings::OperationInputType.new(
+        'update_session_id' => VAPI::Bindings::IdType.new('com.vmware.content.library.item.UpdateSession')
+      ),
+      VAPI::Bindings::VoidType.instance,
+      {
+        'com.vmware.vapi.std.errors.not_found' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::NotFound'),
+        'com.vmware.vapi.std.errors.not_allowed_in_current_state' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::NotAllowedInCurrentState')
+      },
+      [],
+      []
+    )
+
+    KEEP_ALIVE_INFO = VAPI::Bindings::OperationInfo.new(
+      VAPI::Core::OperationIdentifier.new('keep_alive', SERVICE_ID),
+      VAPI::Bindings::OperationInputType.new(
+        'update_session_id' => VAPI::Bindings::IdType.new('com.vmware.content.library.item.UpdateSession'),
+        'client_progress' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::IntegerType.instance)
+      ),
+      VAPI::Bindings::VoidType.instance,
+      {
+        'com.vmware.vapi.std.errors.not_found' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::NotFound'),
+        'com.vmware.vapi.std.errors.not_allowed_in_current_state' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::NotAllowedInCurrentState')
+      },
+      [],
+      []
+    )
+
+    CANCEL_INFO = VAPI::Bindings::OperationInfo.new(
+      VAPI::Core::OperationIdentifier.new('cancel', SERVICE_ID),
+      VAPI::Bindings::OperationInputType.new(
+        'update_session_id' => VAPI::Bindings::IdType.new('com.vmware.content.library.item.UpdateSession')
+      ),
+      VAPI::Bindings::VoidType.instance,
+      {
+        'com.vmware.vapi.std.errors.not_found' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::NotFound'),
+        'com.vmware.vapi.std.errors.not_allowed_in_current_state' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::NotAllowedInCurrentState')
+      },
+      [],
+      []
+    )
+
+    FAIL_INFO = VAPI::Bindings::OperationInfo.new(
+      VAPI::Core::OperationIdentifier.new('fail', SERVICE_ID),
+      VAPI::Bindings::OperationInputType.new(
+        'update_session_id' => VAPI::Bindings::IdType.new('com.vmware.content.library.item.UpdateSession'),
+        'client_error_message' => VAPI::Bindings::StringType.instance
+      ),
+      VAPI::Bindings::VoidType.instance,
+      {
+        'com.vmware.vapi.std.errors.not_found' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::NotFound'),
+        'com.vmware.vapi.std.errors.not_allowed_in_current_state' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::NotAllowedInCurrentState')
+      },
+      [],
+      []
+    )
+
+    DELETE_INFO = VAPI::Bindings::OperationInfo.new(
+      VAPI::Core::OperationIdentifier.new('delete', SERVICE_ID),
+      VAPI::Bindings::OperationInputType.new(
+        'update_session_id' => VAPI::Bindings::IdType.new('com.vmware.content.library.item.UpdateSession')
+      ),
+      VAPI::Bindings::VoidType.instance,
+      {
+        'com.vmware.vapi.std.errors.not_found' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::NotFound'),
+        'com.vmware.vapi.std.errors.not_allowed_in_current_state' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::NotAllowedInCurrentState')
+      },
+      [],
+      []
+    )
+
+    SERVICE_INFO = VAPI::Bindings::ServiceInfo.new(
+      SERVICE_ID,
+      'create' => CREATE_INFO,
+      'get' => GET_INFO,
+      'list' => LIST_INFO,
+      'complete' => COMPLETE_INFO,
+      'keep_alive' => KEEP_ALIVE_INFO,
+      'cancel' => CANCEL_INFO,
+      'fail' => FAIL_INFO,
+      'delete' => DELETE_INFO
+    )
+
+    # Constructs a new instance.
+    #
+    # @param config [VAPI::Bindings::StubConfig] A hash with the api provider details.
+    def initialize(config)
+      super(config, SERVICE_INFO)
+    end
+
+    RESOURCE_TYPE = 'com.vmware.content.library.item.UpdateSession'
+    # Creates a new update session. An update session is used to make modifications to a library item. Modifications are not visible to other clients unless the session is completed and all necessary files have been received.  
+    # 
+    #  Content Library Service allows only one single update session to be active for a specific library item.
+    #
+    # @param client_token [String, nil]
+    #      Unique token generated by the client for each creation request. The token should be a universally unique identifier (UUID), for example:  ``b8a2a2e3-2314-43cd-a871-6ede0f429751`` . This token can be used to guarantee idempotent creation.
+    #     If not specified creation is not idempotent.
+    # @param create_spec [Com::Vmware::Content::Library::Item::UpdateSessionModel]
+    #      Specification for the new update session to be created.
+    # @return [String]
+    #     Identifier of the new update session being created.
+    # @raise [Com::Vmware::Vapi::Std::Errors::InvalidArgument]
+    #      if the session specification is not valid.
+    # @raise [Com::Vmware::Vapi::Std::Errors::InvalidArgument]
+    #      if the  ``client_token``  does not conform to the UUID format.
+    # @raise [Com::Vmware::Vapi::Std::Errors::InvalidElementType]
+    #      if the update session is being created on a subscribed library item.
+    # @raise [Com::Vmware::Vapi::Std::Errors::NotFound]
+    #      if the item targeted for update does not exist.
+    # @raise [Com::Vmware::Vapi::Std::Errors::ResourceBusy]
+    #      if there is another update session on the same library item.
+    def create(create_spec, client_token = nil)
+      invoke_with_info(CREATE_INFO,
+                       'client_token' => client_token,
+                       'create_spec' => create_spec)
+    end
+
+    # Gets the update session with the specified identifier, including the most up-to-date status information for the session.
+    #
+    # @param update_session_id [String]
+    #      Identifier of the update session to retrieve.
+    # @return [Com::Vmware::Content::Library::Item::UpdateSessionModel]
+    #     The   :class:`Com::Vmware::Content::Library::Item::UpdateSessionModel`   instance with the given  ``update_session_id`` .
+    # @raise [Com::Vmware::Vapi::Std::Errors::NotFound]
+    #      if no update session with the given identifier exists.
+    def get(update_session_id)
+      invoke_with_info(GET_INFO,
+                       'update_session_id' => update_session_id)
+    end
+
+    # Lists the identifiers of the update session created by the calling user. Optionally may filter by library item.
+    #
+    # @param library_item_id [String, nil]
+    #      Optional library item identifier on which to filter results.
+    #     If not specified the results are not filtered.
+    # @return [Array<String>]
+    #     The  list  of identifiers of all update sessions created by the calling user.
+    # @raise [Com::Vmware::Vapi::Std::Errors::NotFound]
+    #      if a library item identifier is given for an item which does not exist.
+    def list(library_item_id = nil)
+      invoke_with_info(LIST_INFO,
+                       'library_item_id' => library_item_id)
+    end
+
+    # Completes the update session. This indicates that the client has finished making all the changes required to the underlying library item. If the client is pushing the content to the server, the library item will be updated once this call returns. If the server is pulling the content, the call may return before the changes become visible. In that case, the client can track the session to know when the server is done.  
+    # 
+    #  This  method  requires the session to be in the   :attr:`Com::Vmware::Content::Library::Item::UpdateSessionModel::State.ACTIVE`   state.  
+    # 
+    #  Depending on the type of the library item associated with this session, a type adapter may be invoked to verify the validity of the files uploaded. The user can explicitly validate the session before completing the session by using the   :func:`Com::Vmware::Content::Library::Item::Updatesession::File.validate`    method .  
+    # 
+    #  Modifications are not visible to other clients unless the session is completed and all necessary files have been received.
+    #
+    # @param update_session_id [String]
+    #      Identifier of the update session that should be completed.
+    # @return [Void]
+    # @raise [Com::Vmware::Vapi::Std::Errors::NotFound]
+    #      if no update session with the given identifier exists.
+    # @raise [Com::Vmware::Vapi::Std::Errors::NotAllowedInCurrentState]
+    #      if the update session is not in the   :attr:`Com::Vmware::Content::Library::Item::UpdateSessionModel::State.ACTIVE`   state, or if some of the files that will be uploaded by the client aren't received correctly.
+    def complete(update_session_id)
+      invoke_with_info(COMPLETE_INFO,
+                       'update_session_id' => update_session_id)
+    end
+
+    # Keeps an update session alive.  
+    # 
+    #  If there is no activity for an update session after a period of time, the update session will expire, then be deleted. The update session expiration timeout is configurable in the Content Library Service system configuration. The default is five minutes. Invoking this  method  enables a client to specifically extend the lifetime of the update session.
+    #
+    # @param update_session_id [String]
+    #      Identifier of the update session whose lifetime should be extended.
+    # @param client_progress [Fixnum, nil]
+    #      Optional update to the progress property of the session. If specified, the new progress should be greater then the current progress. See   :attr:`Com::Vmware::Content::Library::Item::UpdateSessionModel.client_progress`  .
+    #     If not specified the progress is not updated.
+    # @return [Void]
+    # @raise [Com::Vmware::Vapi::Std::Errors::NotFound]
+    #      if no update session with the given identifier exists.
+    # @raise [Com::Vmware::Vapi::Std::Errors::NotAllowedInCurrentState]
+    #      if the update session is not in the   :attr:`Com::Vmware::Content::Library::Item::UpdateSessionModel::State.ACTIVE`   state.
+    def keep_alive(update_session_id, client_progress = nil)
+      invoke_with_info(KEEP_ALIVE_INFO,
+                       'update_session_id' => update_session_id,
+                       'client_progress' => client_progress)
+    end
+
+    # Cancels the update session and deletes it. This  method  will free up any temporary resources currently associated with the session.  
+    # 
+    #  This  method  is not allowed if the session has been already completed.  
+    # 
+    #  Cancelling an update session will cancel any in progress transfers (either uploaded by the client or pulled by the server). Any content that has been already received will be scheduled for deletion.
+    #
+    # @param update_session_id [String]
+    #      Identifier of the update session that should be canceled.
+    # @return [Void]
+    # @raise [Com::Vmware::Vapi::Std::Errors::NotFound]
+    #      if no update session with the given identifier exists.
+    # @raise [Com::Vmware::Vapi::Std::Errors::NotAllowedInCurrentState]
+    #      if the update session is not in the   :attr:`Com::Vmware::Content::Library::Item::UpdateSessionModel::State.ACTIVE`   state.
+    def cancel(update_session_id)
+      invoke_with_info(CANCEL_INFO,
+                       'update_session_id' => update_session_id)
+    end
+
+    # Terminates the update session with a client specified error message.  
+    # 
+    #  This is useful in transmitting client side failures (for example, not being able to access a file) to the server side.
+    #
+    # @param update_session_id [String]
+    #      Identifier of the update session to fail.
+    # @param client_error_message [String]
+    #      Client side error message. This can be useful in providing some extra details about the client side failure. Note that the message won't be translated to the user's locale.
+    # @return [Void]
+    # @raise [Com::Vmware::Vapi::Std::Errors::NotFound]
+    #      if the update session does not exist.
+    # @raise [Com::Vmware::Vapi::Std::Errors::NotAllowedInCurrentState]
+    #      if the update session is not in the   :attr:`Com::Vmware::Content::Library::Item::UpdateSessionModel::State.ACTIVE`   state.
+    def fail(update_session_id, client_error_message)
+      invoke_with_info(FAIL_INFO,
+                       'update_session_id' => update_session_id,
+                       'client_error_message' => client_error_message)
+    end
+
+    # Deletes an update session. This removes the session and all information associated with it.  
+    # 
+    #  Removing an update session leaves any current transfers for that session in an indeterminate state (there is no guarantee that the server will terminate the transfers, or that the transfers can be completed). However there will no longer be a means of inspecting the status of those uploads except by seeing the effect on the library item.  
+    # 
+    #  Update sessions for which there is no upload activity or which are complete will automatically be deleted after a period of time.
+    #
+    # @param update_session_id [String]
+    #      Identifer of the update session to delete.
+    # @return [Void]
+    # @raise [Com::Vmware::Vapi::Std::Errors::NotFound]
+    #      if the update session does not exist.
+    # @raise [Com::Vmware::Vapi::Std::Errors::NotAllowedInCurrentState]
+    #      if the update session is in the   :attr:`Com::Vmware::Content::Library::Item::UpdateSessionModel::State.ACTIVE`   state.
+    def delete(update_session_id)
+      invoke_with_info(DELETE_INFO,
+                       'update_session_id' => update_session_id)
+    end
+
+  end
+  # The  ``Com::Vmware::Content::Library::Item::DownloadSessionModel``   class  provides information on an active   :class:`Com::Vmware::Content::Library::Item::DownloadSession`   resource.
+  # @!attribute [rw] id
+  #     @return [String]
+  #     The identifier of this download session.
+  #     This  field  is not used for the  ``create``   method . It will not be present in the  result  of the  ``get``  or  ``list``   methods . It is not used for the  ``update``   method .
+  # @!attribute [rw] library_item_id
+  #     @return [String]
+  #     The identifier of the library item whose content is being downloaded.
+  #     This  field  must be provided for the  ``create``   method . It will always be present in the  result  of the  ``get``  or  ``list``   methods . It is not used for the  ``update``   method .
+  # @!attribute [rw] library_item_content_version
+  #     @return [String]
+  #     The content version of the library item whose content is being downloaded. This value is the   :attr:`Com::Vmware::Content::Library::ItemModel.content_version`   at the time when the session is created for the library item.
+  #     This  field  is not used for the  ``create``   method . It will always be present in the  result  of the  ``get``  or  ``list``   methods . It is not used for the  ``update``   method .
+  # @!attribute [rw] error_message
+  #     @return [Com::Vmware::Vapi::Std::LocalizableMessage]
+  #     If the session is in the   :attr:`Com::Vmware::Content::Library::Item::DownloadSessionModel::State.ERROR`   status this property will have more details about the error.
+  #     This  field  is not used for the  ``create``   method . It is optional in the  result  of the  ``get``  or  ``list``   methods . It is not used for the  ``update``   method .
+  # @!attribute [rw] client_progress
+  #     @return [Fixnum]
+  #     The progress that has been made with the download. This property is to be updated by the client during the download process to indicate the progress of its work in completing the download. The initial progress is 0 until updated by the client. The maximum value is 100, which indicates that the download is complete.
+  #     This  field  is not used for the  ``create``   method . It will always be present in the  result  of the  ``get``  or  ``list``   methods . It is optional for the  ``update``   method .
+  # @!attribute [rw] state
+  #     @return [Com::Vmware::Content::Library::Item::DownloadSessionModel::State]
+  #     The current state ( ``ACTIVE``, ``CANCELED``, ``ERROR`` ) of the download session.
+  #     This  field  is not used for the  ``create``   method . It will always be present in the  result  of the  ``get``  or  ``list``   methods . It is not used for the  ``update``   method .
+  # @!attribute [rw] expiration_time
+  #     @return [DateTime]
+  #     Indicates the time after which the session will expire. The session is guaranteed not to expire before this time.
+  #     This  field  is not used for the  ``create``   method . It will always be present in the  result  of the  ``get``  or  ``list``   methods . It is not used for the  ``update``   method .
+  class DownloadSessionModel < VAPI::Bindings::VapiStruct
+    class << self
+      # Holds (gets or creates) the binding type metadata for this structure type.
+      # @scope class
+      # @return [VAPI::Bindings::StructType] the binding type
+      def binding_type
+        @binding_type ||= VAPI::Bindings::StructType.new(
+          'com.vmware.content.library.item.download_session_model',
+          {
+            'id' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::IdType.new),
+            'library_item_id' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::IdType.new),
+            'library_item_content_version' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::StringType.instance),
+            'error_message' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::LocalizableMessage')),
+            'client_progress' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::IntegerType.instance),
+            'state' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Content::Library::Item::DownloadSessionModel::State')),
+            'expiration_time' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::DateTimeType.instance)
+          },
+          DownloadSessionModel,
+          true,
+          ["id"]
+        )
+      end
+    end
+
+    attr_accessor :id,
+                  :library_item_id,
+                  :library_item_content_version,
+                  :error_message,
+                  :client_progress,
+                  :state,
+                  :expiration_time
+
+    # Constructs a new instance.
+    # @param ruby_values [Hash] a map of initial property values (optional)
+    # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
+    def initialize(ruby_values = nil, struct_value = nil)
+      super(self.class.binding_type, ruby_values, struct_value)
+    end
+
+    # The state of the download session.
+    # @!attribute [rw] active
     #     @return [Com::Vmware::Content::Library::Item::DownloadSessionModel::State]
-    #     The current state ( ``ACTIVE``, ``CANCELED``, ``ERROR`` ) of the download session.
-    #     This  field  is not used for the  ``create``   method . It will always be present in the  result  of the  ``get``  or  ``list``   methods . It is not used for the  ``update``   method .
-    # @!attribute [rw] expiration_time
-    #     @return [DateTime]
-    #     Indicates the time after which the session will expire. The session is guaranteed not to expire before this time.
-    #     This  field  is not used for the  ``create``   method . It will always be present in the  result  of the  ``get``  or  ``list``   methods . It is not used for the  ``update``   method .
-    class DownloadSessionModel < VAPI::Bindings::VapiStruct
-
-        class << self
-            # Holds (gets or creates) the binding type metadata for this structure type.
-            # @scope class
-            # @return [VAPI::Bindings::StructType] the binding type
-            def binding_type
-                @binding_type ||= VAPI::Bindings::StructType.new(
-                    'com.vmware.content.library.item.download_session_model',
-                    {
-                        'id' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::IdType.new),
-                        'library_item_id' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::IdType.new),
-                        'library_item_content_version' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::StringType.instance),
-                        'error_message' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::LocalizableMessage')),
-                        'client_progress' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::IntegerType.instance),
-                        'state' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Content::Library::Item::DownloadSessionModel::State')),
-                        'expiration_time' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::DateTimeType.instance),
-                    },
-                    DownloadSessionModel,
-                    true,
-                    ["id"])
-            end
+    #     The session is active. Individual files may be in the process of being transferred and may become ready for download at different times.
+    # @!attribute [rw] canceled
+    #     @return [Com::Vmware::Content::Library::Item::DownloadSessionModel::State]
+    #     The session has been canceled. On-going downloads may fail. The session will stay in this state until it is either deleted by the user or automatically cleaned up by the Content Library Service.
+    # @!attribute [rw] error
+    #     @return [Com::Vmware::Content::Library::Item::DownloadSessionModel::State]
+    #     Indicates there was an error during the session lifecycle.
+    class State < VAPI::Bindings::VapiEnum
+      class << self
+        # Holds (gets or creates) the binding type metadata for this enumeration type.
+        # @scope class
+        # @return [VAPI::Bindings::EnumType] the binding type
+        def binding_type
+          @binding_type ||= VAPI::Bindings::EnumType.new(
+            'com.vmware.content.library.item.download_session_model.state',
+            State
+          )
         end
 
-        attr_accessor :id,
-                      :library_item_id,
-                      :library_item_content_version,
-                      :error_message,
-                      :client_progress,
-                      :state,
-                      :expiration_time
-
-        # Constructs a new instance.
-        # @param ruby_values [Hash] a map of initial property values (optional)
-        # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
-        def initialize(ruby_values=nil, struct_value=nil)
-            super(self.class.binding_type, ruby_values, struct_value)
+        # Converts from a string value (perhaps off the wire) to an instance
+        # of this enum type.
+        # @param value [String] the actual value of the enum instance
+        # @return [State] the instance found for the value, otherwise
+        #         an unknown instance will be built for the value
+        def from_string(value)
+          const_get(value)
+        rescue NameError
+          State.send(:new, 'UNKNOWN', value)
         end
+      end
 
+      # Constructs a new instance.
+      # @param value [String] the actual value of the enum instance
+      # @param unknown [String] the unknown value when value is 'UKNOWN'
+      def initialize(value, unknown = nil)
+        super(self.class.binding_type, value, unknown)
+      end
 
-        # The state of the download session.
-        # @!attribute [rw] active
-        #     @return [Com::Vmware::Content::Library::Item::DownloadSessionModel::State]
-        #     The session is active. Individual files may be in the process of being transferred and may become ready for download at different times.
-        # @!attribute [rw] canceled
-        #     @return [Com::Vmware::Content::Library::Item::DownloadSessionModel::State]
-        #     The session has been canceled. On-going downloads may fail. The session will stay in this state until it is either deleted by the user or automatically cleaned up by the Content Library Service.
-        # @!attribute [rw] error
-        #     @return [Com::Vmware::Content::Library::Item::DownloadSessionModel::State]
-        #     Indicates there was an error during the session lifecycle.
-        class State < VAPI::Bindings::VapiEnum
+      private_class_method :new
 
-            class << self
-                # Holds (gets or creates) the binding type metadata for this enumeration type.
-                # @scope class
-                # @return [VAPI::Bindings::EnumType] the binding type
-                def binding_type
-                    @binding_type ||= VAPI::Bindings::EnumType.new(
-                        'com.vmware.content.library.item.download_session_model.state',
-                        State)
-                end
+      # @!attribute [rw] active
+      #     @return [Com::Vmware::Content::Library::Item::DownloadSessionModel::State]
+      #     The session is active. Individual files may be in the process of being transferred and may become ready for download at different times.
+      ACTIVE = State.send(:new, 'ACTIVE')
 
-                # Converts from a string value (perhaps off the wire) to an instance
-                # of this enum type.
-                # @param value [String] the actual value of the enum instance
-                # @return [State] the instance found for the value, otherwise
-                #         an unknown instance will be built for the value
-                def from_string(value)
-                    begin
-                        const_get(value)
-                    rescue NameError
-                        State.new('UNKNOWN', value)
-                    end
-                end
-            end
+      # @!attribute [rw] canceled
+      #     @return [Com::Vmware::Content::Library::Item::DownloadSessionModel::State]
+      #     The session has been canceled. On-going downloads may fail. The session will stay in this state until it is either deleted by the user or automatically cleaned up by the Content Library Service.
+      CANCELED = State.send(:new, 'CANCELED')
 
-            private
-
-            # Constructs a new instance.
-            # @param value [String] the actual value of the enum instance
-            # @param unknown [String] the unknown value when value is 'UKNOWN'
-            def initialize(value, unknown=nil)
-                super(self.class.binding_type, value, unknown)
-            end
-
-            public
-
-            # @!attribute [rw] active
-            #     @return [Com::Vmware::Content::Library::Item::DownloadSessionModel::State]
-            #     The session is active. Individual files may be in the process of being transferred and may become ready for download at different times.
-            ACTIVE = State.new('ACTIVE')
-
-            # @!attribute [rw] canceled
-            #     @return [Com::Vmware::Content::Library::Item::DownloadSessionModel::State]
-            #     The session has been canceled. On-going downloads may fail. The session will stay in this state until it is either deleted by the user or automatically cleaned up by the Content Library Service.
-            CANCELED = State.new('CANCELED')
-
-            # @!attribute [rw] error
-            #     @return [Com::Vmware::Content::Library::Item::DownloadSessionModel::State]
-            #     Indicates there was an error during the session lifecycle.
-            ERROR = State.new('ERROR')
-
-        end
-
-
+      # @!attribute [rw] error
+      #     @return [Com::Vmware::Content::Library::Item::DownloadSessionModel::State]
+      #     Indicates there was an error during the session lifecycle.
+      ERROR = State.send(:new, 'ERROR')
+    end
+  end
+  # The  ``Com::Vmware::Content::Library::Item::TransferEndpoint``   class  encapsulates a URI along with extra information about it.
+  # @!attribute [rw] uri
+  #     @return [URI]
+  #     Transfer endpoint URI. The supported URI schemes are:  ``http`` ,  ``https`` ,  ``file`` , and  ``ds`` .  
+  #     
+  #      An endpoint URI with the  ``ds``  scheme specifies the location of the file on the datastore. The format of the datastore URI is:  
+  #     
+  #       * ds:///vmfs/volumes/uuid/path
+  #       
+  #        
+  #     
+  #      Some examples of valid file URI formats are:  
+  #     
+  #       * file:///path
+  #        * file:///C:/path
+  #        * file://unc-server/path
+  #       
+  #        
+  #     
+  #      When the transfer endpoint is a file or datastore location, the server can import the file directly from the storage backing without the overhead of streaming over HTTP.
+  # @!attribute [rw] ssl_certificate_thumbprint
+  #     @return [String, nil]
+  #     Thumbprint of the expected SSL certificate for this endpoint. Only used for HTTPS connections. The thumbprint is the SHA-1 hash of the DER encoding of the remote endpoint's SSL certificate. If set, the remote endpoint's SSL certificate is only accepted if it matches this thumbprint, and no other certificate validation is performed.
+  #     If not specified, standard certificate validation is performed.
+  class TransferEndpoint < VAPI::Bindings::VapiStruct
+    class << self
+      # Holds (gets or creates) the binding type metadata for this structure type.
+      # @scope class
+      # @return [VAPI::Bindings::StructType] the binding type
+      def binding_type
+        @binding_type ||= VAPI::Bindings::StructType.new(
+          'com.vmware.content.library.item.transfer_endpoint',
+          {
+            'uri' => VAPI::Bindings::URIType.instance,
+            'ssl_certificate_thumbprint' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::StringType.instance)
+          },
+          TransferEndpoint,
+          false,
+          nil
+        )
+      end
     end
 
+    attr_accessor :uri,
+                  :ssl_certificate_thumbprint
 
-    # The  ``Com::Vmware::Content::Library::Item::TransferEndpoint``   class  encapsulates a URI along with extra information about it.
-    # @!attribute [rw] uri
-    #     @return [URI]
-    #     Transfer endpoint URI. The supported URI schemes are:  ``http`` ,  ``https`` ,  ``file`` , and  ``ds`` .  
-    #     
-    #      An endpoint URI with the  ``ds``  scheme specifies the location of the file on the datastore. The format of the datastore URI is:  
-    #     
-    #       * ds:///vmfs/volumes/uuid/path
-    #       
-    #        
-    #     
-    #      Some examples of valid file URI formats are:  
-    #     
-    #       * file:///path
-    #        * file:///C:/path
-    #        * file://unc-server/path
-    #       
-    #        
-    #     
-    #      When the transfer endpoint is a file or datastore location, the server can import the file directly from the storage backing without the overhead of streaming over HTTP.
-    # @!attribute [rw] ssl_certificate_thumbprint
-    #     @return [String, nil]
-    #     Thumbprint of the expected SSL certificate for this endpoint. Only used for HTTPS connections. The thumbprint is the SHA-1 hash of the DER encoding of the remote endpoint's SSL certificate. If set, the remote endpoint's SSL certificate is only accepted if it matches this thumbprint, and no other certificate validation is performed.
-    #     If not specified, standard certificate validation is performed.
-    class TransferEndpoint < VAPI::Bindings::VapiStruct
-
-        class << self
-            # Holds (gets or creates) the binding type metadata for this structure type.
-            # @scope class
-            # @return [VAPI::Bindings::StructType] the binding type
-            def binding_type
-                @binding_type ||= VAPI::Bindings::StructType.new(
-                    'com.vmware.content.library.item.transfer_endpoint',
-                    {
-                        'uri' => VAPI::Bindings::URIType.instance,
-                        'ssl_certificate_thumbprint' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::StringType.instance),
-                    },
-                    TransferEndpoint,
-                    false,
-                    nil)
-            end
-        end
-
-        attr_accessor :uri,
-                      :ssl_certificate_thumbprint
-
-        # Constructs a new instance.
-        # @param ruby_values [Hash] a map of initial property values (optional)
-        # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
-        def initialize(ruby_values=nil, struct_value=nil)
-            super(self.class.binding_type, ruby_values, struct_value)
-        end
+    # Constructs a new instance.
+    # @param ruby_values [Hash] a map of initial property values (optional)
+    # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
+    def initialize(ruby_values = nil, struct_value = nil)
+      super(self.class.binding_type, ruby_values, struct_value)
+    end
+  end
+  # The  ``Com::Vmware::Content::Library::Item::UpdateSessionModel``   class  provides information on an active   :class:`Com::Vmware::Content::Library::Item::UpdateSession`   resource.
+  # @!attribute [rw] id
+  #     @return [String]
+  #     The identifier of this update session.
+  #     This  field  is not used for the  ``create``   method . It will not be present in the  result  of the  ``get``  or  ``list``   methods . It is not used for the  ``update``   method .
+  # @!attribute [rw] library_item_id
+  #     @return [String]
+  #     The identifier of the library item to which content will be uploaded or removed.
+  #     This  field  must be provided for the  ``create``   method . It will always be present in the  result  of the  ``get``  or  ``list``   methods . It is not used for the  ``update``   method .
+  # @!attribute [rw] library_item_content_version
+  #     @return [String]
+  #     The content version of the library item whose content is being modified. This value is the   :attr:`Com::Vmware::Content::Library::ItemModel.content_version`   at the time when the session is created for the library item.
+  #     This  field  is not used for the  ``create``   method . It will always be present in the  result  of the  ``get``  or  ``list``   methods . It is not used for the  ``update``   method .
+  # @!attribute [rw] error_message
+  #     @return [Com::Vmware::Vapi::Std::LocalizableMessage]
+  #     If the session is in the   :attr:`Com::Vmware::Content::Library::Item::UpdateSessionModel::State.ERROR`   status this property will have more details about the error.
+  #     This  field  is not used for the  ``create``   method . It is optional in the  result  of the  ``get``  or  ``list``   methods . It is not used for the  ``update``   method .
+  # @!attribute [rw] client_progress
+  #     @return [Fixnum]
+  #     The progress that has been made with the upload. This property is to be updated by the client during the upload process to indicate the progress of its work in completing the upload. The initial progress is 0 until updated by the client. The maximum value is 100, which indicates that the update is complete.
+  #     This  field  is not used for the  ``create``   method . It will always be present in the  result  of the  ``get``  or  ``list``   methods . It is not used for the  ``update``   method .
+  # @!attribute [rw] state
+  #     @return [Com::Vmware::Content::Library::Item::UpdateSessionModel::State]
+  #     The current state ( ``ACTIVE``, ``DONE``, ``ERROR``, ``CANCELED`` ) of the update session.
+  #     This  field  is not used for the  ``create``   method . It will always be present in the  result  of the  ``get``  or  ``list``   methods . It is not used for the  ``update``   method .
+  # @!attribute [rw] expiration_time
+  #     @return [DateTime]
+  #     Indicates the time after which the session will expire. The session is guaranteed not to expire earlier than this time.
+  #     This  field  is not used for the  ``create``   method . It will always be present in the  result  of the  ``get``  or  ``list``   methods . It is not used for the  ``update``   method .
+  class UpdateSessionModel < VAPI::Bindings::VapiStruct
+    class << self
+      # Holds (gets or creates) the binding type metadata for this structure type.
+      # @scope class
+      # @return [VAPI::Bindings::StructType] the binding type
+      def binding_type
+        @binding_type ||= VAPI::Bindings::StructType.new(
+          'com.vmware.content.library.item.update_session_model',
+          {
+            'id' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::IdType.new),
+            'library_item_id' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::IdType.new),
+            'library_item_content_version' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::StringType.instance),
+            'error_message' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::LocalizableMessage')),
+            'client_progress' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::IntegerType.instance),
+            'state' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Content::Library::Item::UpdateSessionModel::State')),
+            'expiration_time' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::DateTimeType.instance)
+          },
+          UpdateSessionModel,
+          true,
+          ["id"]
+        )
+      end
     end
 
+    attr_accessor :id,
+                  :library_item_id,
+                  :library_item_content_version,
+                  :error_message,
+                  :client_progress,
+                  :state,
+                  :expiration_time
 
-    # The  ``Com::Vmware::Content::Library::Item::UpdateSessionModel``   class  provides information on an active   :class:`Com::Vmware::Content::Library::Item::UpdateSession`   resource.
-    # @!attribute [rw] id
-    #     @return [String]
-    #     The identifier of this update session.
-    #     This  field  is not used for the  ``create``   method . It will not be present in the  result  of the  ``get``  or  ``list``   methods . It is not used for the  ``update``   method .
-    # @!attribute [rw] library_item_id
-    #     @return [String]
-    #     The identifier of the library item to which content will be uploaded or removed.
-    #     This  field  must be provided for the  ``create``   method . It will always be present in the  result  of the  ``get``  or  ``list``   methods . It is not used for the  ``update``   method .
-    # @!attribute [rw] library_item_content_version
-    #     @return [String]
-    #     The content version of the library item whose content is being modified. This value is the   :attr:`Com::Vmware::Content::Library::ItemModel.content_version`   at the time when the session is created for the library item.
-    #     This  field  is not used for the  ``create``   method . It will always be present in the  result  of the  ``get``  or  ``list``   methods . It is not used for the  ``update``   method .
-    # @!attribute [rw] error_message
-    #     @return [Com::Vmware::Vapi::Std::LocalizableMessage]
-    #     If the session is in the   :attr:`Com::Vmware::Content::Library::Item::UpdateSessionModel::State.ERROR`   status this property will have more details about the error.
-    #     This  field  is not used for the  ``create``   method . It is optional in the  result  of the  ``get``  or  ``list``   methods . It is not used for the  ``update``   method .
-    # @!attribute [rw] client_progress
-    #     @return [Fixnum]
-    #     The progress that has been made with the upload. This property is to be updated by the client during the upload process to indicate the progress of its work in completing the upload. The initial progress is 0 until updated by the client. The maximum value is 100, which indicates that the update is complete.
-    #     This  field  is not used for the  ``create``   method . It will always be present in the  result  of the  ``get``  or  ``list``   methods . It is not used for the  ``update``   method .
-    # @!attribute [rw] state
+    # Constructs a new instance.
+    # @param ruby_values [Hash] a map of initial property values (optional)
+    # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
+    def initialize(ruby_values = nil, struct_value = nil)
+      super(self.class.binding_type, ruby_values, struct_value)
+    end
+
+    # The state of an update session.
+    # @!attribute [rw] active
     #     @return [Com::Vmware::Content::Library::Item::UpdateSessionModel::State]
-    #     The current state ( ``ACTIVE``, ``DONE``, ``ERROR``, ``CANCELED`` ) of the update session.
-    #     This  field  is not used for the  ``create``   method . It will always be present in the  result  of the  ``get``  or  ``list``   methods . It is not used for the  ``update``   method .
-    # @!attribute [rw] expiration_time
-    #     @return [DateTime]
-    #     Indicates the time after which the session will expire. The session is guaranteed not to expire earlier than this time.
-    #     This  field  is not used for the  ``create``   method . It will always be present in the  result  of the  ``get``  or  ``list``   methods . It is not used for the  ``update``   method .
-    class UpdateSessionModel < VAPI::Bindings::VapiStruct
-
-        class << self
-            # Holds (gets or creates) the binding type metadata for this structure type.
-            # @scope class
-            # @return [VAPI::Bindings::StructType] the binding type
-            def binding_type
-                @binding_type ||= VAPI::Bindings::StructType.new(
-                    'com.vmware.content.library.item.update_session_model',
-                    {
-                        'id' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::IdType.new),
-                        'library_item_id' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::IdType.new),
-                        'library_item_content_version' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::StringType.instance),
-                        'error_message' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::LocalizableMessage')),
-                        'client_progress' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::IntegerType.instance),
-                        'state' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Content::Library::Item::UpdateSessionModel::State')),
-                        'expiration_time' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::DateTimeType.instance),
-                    },
-                    UpdateSessionModel,
-                    true,
-                    ["id"])
-            end
+    #     The session is currently active. This is the initial state when the session is created. Files may be uploaded by the client or pulled by the Content Library Service at this stage.
+    # @!attribute [rw] done
+    #     @return [Com::Vmware::Content::Library::Item::UpdateSessionModel::State]
+    #     The session is done and all its effects are now visible.
+    # @!attribute [rw] error
+    #     @return [Com::Vmware::Content::Library::Item::UpdateSessionModel::State]
+    #     There was an error during the session.
+    # @!attribute [rw] canceled
+    #     @return [Com::Vmware::Content::Library::Item::UpdateSessionModel::State]
+    #     The session has been canceled.
+    class State < VAPI::Bindings::VapiEnum
+      class << self
+        # Holds (gets or creates) the binding type metadata for this enumeration type.
+        # @scope class
+        # @return [VAPI::Bindings::EnumType] the binding type
+        def binding_type
+          @binding_type ||= VAPI::Bindings::EnumType.new(
+            'com.vmware.content.library.item.update_session_model.state',
+            State
+          )
         end
 
-        attr_accessor :id,
-                      :library_item_id,
-                      :library_item_content_version,
-                      :error_message,
-                      :client_progress,
-                      :state,
-                      :expiration_time
-
-        # Constructs a new instance.
-        # @param ruby_values [Hash] a map of initial property values (optional)
-        # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
-        def initialize(ruby_values=nil, struct_value=nil)
-            super(self.class.binding_type, ruby_values, struct_value)
+        # Converts from a string value (perhaps off the wire) to an instance
+        # of this enum type.
+        # @param value [String] the actual value of the enum instance
+        # @return [State] the instance found for the value, otherwise
+        #         an unknown instance will be built for the value
+        def from_string(value)
+          const_get(value)
+        rescue NameError
+          State.send(:new, 'UNKNOWN', value)
         end
+      end
 
+      # Constructs a new instance.
+      # @param value [String] the actual value of the enum instance
+      # @param unknown [String] the unknown value when value is 'UKNOWN'
+      def initialize(value, unknown = nil)
+        super(self.class.binding_type, value, unknown)
+      end
 
-        # The state of an update session.
-        # @!attribute [rw] active
-        #     @return [Com::Vmware::Content::Library::Item::UpdateSessionModel::State]
-        #     The session is currently active. This is the initial state when the session is created. Files may be uploaded by the client or pulled by the Content Library Service at this stage.
-        # @!attribute [rw] done
-        #     @return [Com::Vmware::Content::Library::Item::UpdateSessionModel::State]
-        #     The session is done and all its effects are now visible.
-        # @!attribute [rw] error
-        #     @return [Com::Vmware::Content::Library::Item::UpdateSessionModel::State]
-        #     There was an error during the session.
-        # @!attribute [rw] canceled
-        #     @return [Com::Vmware::Content::Library::Item::UpdateSessionModel::State]
-        #     The session has been canceled.
-        class State < VAPI::Bindings::VapiEnum
+      private_class_method :new
 
-            class << self
-                # Holds (gets or creates) the binding type metadata for this enumeration type.
-                # @scope class
-                # @return [VAPI::Bindings::EnumType] the binding type
-                def binding_type
-                    @binding_type ||= VAPI::Bindings::EnumType.new(
-                        'com.vmware.content.library.item.update_session_model.state',
-                        State)
-                end
+      # @!attribute [rw] active
+      #     @return [Com::Vmware::Content::Library::Item::UpdateSessionModel::State]
+      #     The session is currently active. This is the initial state when the session is created. Files may be uploaded by the client or pulled by the Content Library Service at this stage.
+      ACTIVE = State.send(:new, 'ACTIVE')
 
-                # Converts from a string value (perhaps off the wire) to an instance
-                # of this enum type.
-                # @param value [String] the actual value of the enum instance
-                # @return [State] the instance found for the value, otherwise
-                #         an unknown instance will be built for the value
-                def from_string(value)
-                    begin
-                        const_get(value)
-                    rescue NameError
-                        State.new('UNKNOWN', value)
-                    end
-                end
-            end
+      # @!attribute [rw] done
+      #     @return [Com::Vmware::Content::Library::Item::UpdateSessionModel::State]
+      #     The session is done and all its effects are now visible.
+      DONE = State.send(:new, 'DONE')
 
-            private
+      # @!attribute [rw] error
+      #     @return [Com::Vmware::Content::Library::Item::UpdateSessionModel::State]
+      #     There was an error during the session.
+      ERROR = State.send(:new, 'ERROR')
 
-            # Constructs a new instance.
-            # @param value [String] the actual value of the enum instance
-            # @param unknown [String] the unknown value when value is 'UKNOWN'
-            def initialize(value, unknown=nil)
-                super(self.class.binding_type, value, unknown)
-            end
+      # @!attribute [rw] canceled
+      #     @return [Com::Vmware::Content::Library::Item::UpdateSessionModel::State]
+      #     The session has been canceled.
+      CANCELED = State.send(:new, 'CANCELED')
+    end
+  end
+  # The  ``Com::Vmware::Content::Library::Item::TransferStatus``   enumerated type  defines the transfer state of a file.
+  # @!attribute [rw] waiting_for_transfer
+  #     @return [Com::Vmware::Content::Library::Item::TransferStatus]
+  #     Indicates that a file has been defined for a library item and its content needs to be uploaded.
+  # @!attribute [rw] transferring
+  #     @return [Com::Vmware::Content::Library::Item::TransferStatus]
+  #     Indicates that data is being transferred to the file.
+  # @!attribute [rw] ready
+  #     @return [Com::Vmware::Content::Library::Item::TransferStatus]
+  #     Indicates that the file has been fully transferred and is ready to be used.
+  # @!attribute [rw] validating
+  #     @return [Com::Vmware::Content::Library::Item::TransferStatus]
+  #     Indicates that the file is being validated (checksum, type adapters).
+  # @!attribute [rw] error
+  #     @return [Com::Vmware::Content::Library::Item::TransferStatus]
+  #     Indicates that there was an error transferring or validating the file.
+  class TransferStatus < VAPI::Bindings::VapiEnum
+    class << self
+      # Holds (gets or creates) the binding type metadata for this enumeration type.
+      # @scope class
+      # @return [VAPI::Bindings::EnumType] the binding type
+      def binding_type
+        @binding_type ||= VAPI::Bindings::EnumType.new(
+          'com.vmware.content.library.item.transfer_status',
+          TransferStatus
+        )
+      end
 
-            public
-
-            # @!attribute [rw] active
-            #     @return [Com::Vmware::Content::Library::Item::UpdateSessionModel::State]
-            #     The session is currently active. This is the initial state when the session is created. Files may be uploaded by the client or pulled by the Content Library Service at this stage.
-            ACTIVE = State.new('ACTIVE')
-
-            # @!attribute [rw] done
-            #     @return [Com::Vmware::Content::Library::Item::UpdateSessionModel::State]
-            #     The session is done and all its effects are now visible.
-            DONE = State.new('DONE')
-
-            # @!attribute [rw] error
-            #     @return [Com::Vmware::Content::Library::Item::UpdateSessionModel::State]
-            #     There was an error during the session.
-            ERROR = State.new('ERROR')
-
-            # @!attribute [rw] canceled
-            #     @return [Com::Vmware::Content::Library::Item::UpdateSessionModel::State]
-            #     The session has been canceled.
-            CANCELED = State.new('CANCELED')
-
-        end
-
-
+      # Converts from a string value (perhaps off the wire) to an instance
+      # of this enum type.
+      # @param value [String] the actual value of the enum instance
+      # @return [TransferStatus] the instance found for the value, otherwise
+      #         an unknown instance will be built for the value
+      def from_string(value)
+        const_get(value)
+      rescue NameError
+        TransferStatus.send(:new, 'UNKNOWN', value)
+      end
     end
 
+    # Constructs a new instance.
+    # @param value [String] the actual value of the enum instance
+    # @param unknown [String] the unknown value when value is 'UKNOWN'
+    def initialize(value, unknown = nil)
+      super(self.class.binding_type, value, unknown)
+    end
 
-    # The  ``Com::Vmware::Content::Library::Item::TransferStatus``   enumerated type  defines the transfer state of a file.
+    private_class_method :new
+
     # @!attribute [rw] waiting_for_transfer
     #     @return [Com::Vmware::Content::Library::Item::TransferStatus]
     #     Indicates that a file has been defined for a library item and its content needs to be uploaded.
+    WAITING_FOR_TRANSFER = TransferStatus.send(:new, 'WAITING_FOR_TRANSFER')
+
     # @!attribute [rw] transferring
     #     @return [Com::Vmware::Content::Library::Item::TransferStatus]
     #     Indicates that data is being transferred to the file.
+    TRANSFERRING = TransferStatus.send(:new, 'TRANSFERRING')
+
     # @!attribute [rw] ready
     #     @return [Com::Vmware::Content::Library::Item::TransferStatus]
     #     Indicates that the file has been fully transferred and is ready to be used.
+    READY = TransferStatus.send(:new, 'READY')
+
     # @!attribute [rw] validating
     #     @return [Com::Vmware::Content::Library::Item::TransferStatus]
     #     Indicates that the file is being validated (checksum, type adapters).
+    VALIDATING = TransferStatus.send(:new, 'VALIDATING')
+
     # @!attribute [rw] error
     #     @return [Com::Vmware::Content::Library::Item::TransferStatus]
     #     Indicates that there was an error transferring or validating the file.
-    class TransferStatus < VAPI::Bindings::VapiEnum
-
-        class << self
-            # Holds (gets or creates) the binding type metadata for this enumeration type.
-            # @scope class
-            # @return [VAPI::Bindings::EnumType] the binding type
-            def binding_type
-                @binding_type ||= VAPI::Bindings::EnumType.new(
-                    'com.vmware.content.library.item.transfer_status',
-                    TransferStatus)
-            end
-
-            # Converts from a string value (perhaps off the wire) to an instance
-            # of this enum type.
-            # @param value [String] the actual value of the enum instance
-            # @return [TransferStatus] the instance found for the value, otherwise
-            #         an unknown instance will be built for the value
-            def from_string(value)
-                begin
-                    const_get(value)
-                rescue NameError
-                    TransferStatus.new('UNKNOWN', value)
-                end
-            end
-        end
-
-        private
-
-        # Constructs a new instance.
-        # @param value [String] the actual value of the enum instance
-        # @param unknown [String] the unknown value when value is 'UKNOWN'
-        def initialize(value, unknown=nil)
-            super(self.class.binding_type, value, unknown)
-        end
-
-        public
-
-        # @!attribute [rw] waiting_for_transfer
-        #     @return [Com::Vmware::Content::Library::Item::TransferStatus]
-        #     Indicates that a file has been defined for a library item and its content needs to be uploaded.
-        WAITING_FOR_TRANSFER = TransferStatus.new('WAITING_FOR_TRANSFER')
-
-        # @!attribute [rw] transferring
-        #     @return [Com::Vmware::Content::Library::Item::TransferStatus]
-        #     Indicates that data is being transferred to the file.
-        TRANSFERRING = TransferStatus.new('TRANSFERRING')
-
-        # @!attribute [rw] ready
-        #     @return [Com::Vmware::Content::Library::Item::TransferStatus]
-        #     Indicates that the file has been fully transferred and is ready to be used.
-        READY = TransferStatus.new('READY')
-
-        # @!attribute [rw] validating
-        #     @return [Com::Vmware::Content::Library::Item::TransferStatus]
-        #     Indicates that the file is being validated (checksum, type adapters).
-        VALIDATING = TransferStatus.new('VALIDATING')
-
-        # @!attribute [rw] error
-        #     @return [Com::Vmware::Content::Library::Item::TransferStatus]
-        #     Indicates that there was an error transferring or validating the file.
-        ERROR = TransferStatus.new('ERROR')
-
-    end
-
-
+    ERROR = TransferStatus.send(:new, 'ERROR')
+  end
 end

--- a/client/sdk/com/vmware/content/library/item/downloadsession.rb
+++ b/client/sdk/com/vmware/content/library/item/downloadsession.rb
@@ -1,5 +1,6 @@
 #---------------------------------------------------------------------------
-# Copyright 2016 VMware, Inc.  All rights reserved.
+# Copyright 2017 VMware, Inc.  All rights reserved.
+#
 # AUTO GENERATED FILE -- DO NOT MODIFY!
 #
 # vAPI type descriptors for package com.vmware.content.library.item.downloadsession.
@@ -8,361 +9,332 @@ require 'vapi'
 
 # declare the module hierarchy before we use the shorthand syntax below
 module Com
-    module Vmware
-        module Content
-            module Library
-                module Item
-                    module Downloadsession
-                    end
-                end
-            end
+  module Vmware
+    module Content
+      module Library
+        module Item
+          module Downloadsession
+          end
         end
+      end
     end
+  end
 end
 
 # The Content Library Item Download Session  package  provides  classes  and  classs  for downloading files in a session.
 module Com::Vmware::Content::Library::Item::Downloadsession
+  # The  ``Com::Vmware::Content::Library::Item::Downloadsession::File``   class  provides  methods  for accessing files within a download session.  
+  # 
+  #  After a download session is created against a library item, the  ``Com::Vmware::Content::Library::Item::Downloadsession::File``   class  can be used to retrieve all downloadable content within the library item. Since the content may not be available immediately in a downloadable form on the server side, the client will have to prepare the file and wait for the file status to become   :attr:`Com::Vmware::Content::Library::Item::Downloadsession::File::PrepareStatus.PREPARED`  .  
+  # 
+  #  See   :class:`Com::Vmware::Content::Library::Item::DownloadSession`  .
+  class File < VAPI::Bindings::VapiService
+    # static metamodel definitions
+    SERVICE_ID = VAPI::Core::ServiceIdentifier.new('com.vmware.content.library.item.downloadsession.file')
 
-    # The  ``Com::Vmware::Content::Library::Item::Downloadsession::File``   class  provides  methods  for accessing files within a download session.  
-    # 
-    #  After a download session is created against a library item, the  ``Com::Vmware::Content::Library::Item::Downloadsession::File``   class  can be used to retrieve all downloadable content within the library item. Since the content may not be available immediately in a downloadable form on the server side, the client will have to prepare the file and wait for the file status to become   :attr:`Com::Vmware::Content::Library::Item::Downloadsession::File::PrepareStatus.PREPARED`  .  
-    # 
-    #  See   :class:`Com::Vmware::Content::Library::Item::DownloadSession`  .
-    class File < VAPI::Bindings::VapiService
+    LIST_INFO = VAPI::Bindings::OperationInfo.new(
+      VAPI::Core::OperationIdentifier.new('list', SERVICE_ID),
+      VAPI::Bindings::OperationInputType.new(
+        'download_session_id' => VAPI::Bindings::IdType.new('com.vmware.content.library.item.DownloadSession')
+      ),
+      VAPI::Bindings::ListType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Content::Library::Item::Downloadsession::File::Info')),
+      {
+        'com.vmware.vapi.std.errors.not_found' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::NotFound')
+      },
+      [],
+      []
+    )
 
-        protected
+    PREPARE_INFO = VAPI::Bindings::OperationInfo.new(
+      VAPI::Core::OperationIdentifier.new('prepare', SERVICE_ID),
+      VAPI::Bindings::OperationInputType.new(
+        'download_session_id' => VAPI::Bindings::IdType.new('com.vmware.content.library.item.DownloadSession'),
+        'file_name' => VAPI::Bindings::StringType.instance,
+        'endpoint_type' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Content::Library::Item::Downloadsession::File::EndpointType'))
+      ),
+      VAPI::Bindings::ReferenceType.new('Com::Vmware::Content::Library::Item::Downloadsession::File::Info'),
+      {
+        'com.vmware.vapi.std.errors.not_found' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::NotFound'),
+        'com.vmware.vapi.std.errors.invalid_argument' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::InvalidArgument'),
+        'com.vmware.vapi.std.errors.unauthorized' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Unauthorized')
+      },
+      [],
+      []
+    )
 
-        # static metamodel definitions
-        @@service_id = VAPI::Core::ServiceIdentifier.new('com.vmware.content.library.item.downloadsession.file')
+    GET_INFO = VAPI::Bindings::OperationInfo.new(
+      VAPI::Core::OperationIdentifier.new('get', SERVICE_ID),
+      VAPI::Bindings::OperationInputType.new(
+        'download_session_id' => VAPI::Bindings::IdType.new('com.vmware.content.library.item.DownloadSession'),
+        'file_name' => VAPI::Bindings::StringType.instance
+      ),
+      VAPI::Bindings::ReferenceType.new('Com::Vmware::Content::Library::Item::Downloadsession::File::Info'),
+      {
+        'com.vmware.vapi.std.errors.not_found' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::NotFound'),
+        'com.vmware.vapi.std.errors.invalid_argument' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::InvalidArgument')
+      },
+      [],
+      []
+    )
 
-        @@list_info = VAPI::Bindings::OperationInfo.new(
-            VAPI::Core::OperationIdentifier.new('list', @@service_id),
-            VAPI::Bindings::OperationInputType.new({
-                'download_session_id' => VAPI::Bindings::IdType.new(resource_types='com.vmware.content.library.item.DownloadSession'),
-            }),
-            VAPI::Bindings::ListType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Content::Library::Item::Downloadsession::File::Info')),
-            {
-                'com.vmware.vapi.std.errors.not_found' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::NotFound'),
+    SERVICE_INFO = VAPI::Bindings::ServiceInfo.new(
+      SERVICE_ID,
+      'list' => LIST_INFO,
+      'prepare' => PREPARE_INFO,
+      'get' => GET_INFO
+    )
 
-            },
-            [],
-            [])
-        @@prepare_info = VAPI::Bindings::OperationInfo.new(
-            VAPI::Core::OperationIdentifier.new('prepare', @@service_id),
-            VAPI::Bindings::OperationInputType.new({
-                'download_session_id' => VAPI::Bindings::IdType.new(resource_types='com.vmware.content.library.item.DownloadSession'),
-                'file_name' => VAPI::Bindings::StringType.instance,
-                'endpoint_type' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Content::Library::Item::Downloadsession::File::EndpointType')),
-            }),
-            VAPI::Bindings::ReferenceType.new('Com::Vmware::Content::Library::Item::Downloadsession::File::Info'),
-            {
-                'com.vmware.vapi.std.errors.not_found' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::NotFound'),
-                'com.vmware.vapi.std.errors.invalid_argument' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::InvalidArgument'),
-                'com.vmware.vapi.std.errors.unauthorized' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Unauthorized'),
-
-            },
-            [],
-            [])
-        @@get_info = VAPI::Bindings::OperationInfo.new(
-            VAPI::Core::OperationIdentifier.new('get', @@service_id),
-            VAPI::Bindings::OperationInputType.new({
-                'download_session_id' => VAPI::Bindings::IdType.new(resource_types='com.vmware.content.library.item.DownloadSession'),
-                'file_name' => VAPI::Bindings::StringType.instance,
-            }),
-            VAPI::Bindings::ReferenceType.new('Com::Vmware::Content::Library::Item::Downloadsession::File::Info'),
-            {
-                'com.vmware.vapi.std.errors.not_found' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::NotFound'),
-                'com.vmware.vapi.std.errors.invalid_argument' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::InvalidArgument'),
-
-            },
-            [],
-            [])
-
-        @@service_info = VAPI::Bindings::ServiceInfo.new(@@service_id, {
-            'list' => @@list_info,
-            'prepare' => @@prepare_info,
-            'get' => @@get_info,
-        })
-
-        public
-
-        # Constructs a new instance.
-        #
-        # @param config [VAPI::Bindings::StubConfig] A hash with the api provider details.
-        def initialize(config)
-            super(config, @@service_info)
-        end
-
-
-        # Lists the information of all the files in the library item associated with the download session.
-        #
-        # @param download_session_id [String]
-        #      Identifier of the download session.
-        # @return [Array<Com::Vmware::Content::Library::Item::Downloadsession::File::Info>]
-        #     The  list  of   :class:`Com::Vmware::Content::Library::Item::Downloadsession::File::Info`   instances.
-        # @raise [Com::Vmware::Vapi::Std::Errors::NotFound]
-        #      if the download session associated with  ``download_session_id``  doesn't exist.
-        def list(download_session_id)
-            invoke_with_info(@@list_info, {
-                'download_session_id' => download_session_id,
-            })
-        end
-
-
-        # Requests a file to be prepared for download.
-        #
-        # @param download_session_id [String]
-        #      Identifier of the download session.
-        # @param file_name [String]
-        #      Name of the file requested for download.
-        # @param endpoint_type [Com::Vmware::Content::Library::Item::Downloadsession::File::EndpointType, nil]
-        #      Endpoint type request, one of  ``HTTPS``, ``DIRECT`` . This will determine the type of the   :attr:`Com::Vmware::Content::Library::Item::Downloadsession::File::Info.download_endpoint`   that is generated when the file is prepared. The   :attr:`Com::Vmware::Content::Library::Item::Downloadsession::File::EndpointType.DIRECT`   is only available to users who have the ContentLibrary.ReadStorage privilege.
-        #     If not specified the default is   :attr:`Com::Vmware::Content::Library::Item::Downloadsession::File::EndpointType.HTTPS`  .
-        # @return [Com::Vmware::Content::Library::Item::Downloadsession::File::Info]
-        #     File information containing the status of the request and the download link to the file.
-        # @raise [Com::Vmware::Vapi::Std::Errors::NotFound]
-        #      if the download session does not exist.
-        # @raise [Com::Vmware::Vapi::Std::Errors::InvalidArgument]
-        #      if there is no file with the specified  ``file_name`` .
-        # @raise [Com::Vmware::Vapi::Std::Errors::Unauthorized]
-        #      if the the download session wasn't created with the ContentLibrary.ReadStorage privilege and the caller requested a   :attr:`Com::Vmware::Content::Library::Item::Downloadsession::File::EndpointType.DIRECT`   endpoint type.
-        def prepare(download_session_id, file_name, endpoint_type=nil)
-            invoke_with_info(@@prepare_info, {
-                'download_session_id' => download_session_id,
-                'file_name' => file_name,
-                'endpoint_type' => endpoint_type,
-            })
-        end
-
-
-        # Retrieves file download information for a specific file.
-        #
-        # @param download_session_id [String]
-        #      Identifier of the download session.
-        # @param file_name [String]
-        #      Name of the file requested.
-        # @return [Com::Vmware::Content::Library::Item::Downloadsession::File::Info]
-        #     The   :class:`Com::Vmware::Content::Library::Item::Downloadsession::File::Info`   instance containing the status of the file and its download link if available.
-        # @raise [Com::Vmware::Vapi::Std::Errors::NotFound]
-        #      if the download session associated with  ``download_session_id``  does not exist.
-        # @raise [Com::Vmware::Vapi::Std::Errors::InvalidArgument]
-        #      if there is no file with the specified  ``file_name`` .
-        def get(download_session_id, file_name)
-            invoke_with_info(@@get_info, {
-                'download_session_id' => download_session_id,
-                'file_name' => file_name,
-            })
-        end
-
-
-
-        # The  ``Com::Vmware::Content::Library::Item::Downloadsession::File::Info``   class  defines the downloaded file.
-        # @!attribute [rw] name
-        #     @return [String]
-        #     The name of the file.
-        # @!attribute [rw] size
-        #     @return [Fixnum, nil]
-        #     The file size, in bytes.
-        #     This  field  may not be available immediately. It is guaranteed to be set when the client finishes downloading the file.
-        # @!attribute [rw] bytes_transferred
-        #     @return [Fixnum]
-        #     The number of bytes that have been transferred by the server so far for making this file prepared for download. This value may stay at zero till the client starts downloading the file.
-        # @!attribute [rw] status
-        #     @return [Com::Vmware::Content::Library::Item::Downloadsession::File::PrepareStatus]
-        #     The preparation status ( ``UNPREPARED``, ``PREPARE_REQUESTED``, ``PREPARING``, ``PREPARED``, ``ERROR`` ) of the file.
-        # @!attribute [rw] download_endpoint
-        #     @return [Com::Vmware::Content::Library::Item::TransferEndpoint, nil]
-        #     Endpoint at which the file is available for download. The value is valid only when the   :attr:`Com::Vmware::Content::Library::Item::Downloadsession::File::Info.status`   is   :attr:`Com::Vmware::Content::Library::Item::Downloadsession::File::PrepareStatus.PREPARED`  .
-        #     This  field  won't be set until the file status is   :attr:`Com::Vmware::Content::Library::Item::Downloadsession::File::PrepareStatus.PREPARED`  .
-        # @!attribute [rw] checksum_info
-        #     @return [Com::Vmware::Content::Library::Item::File::ChecksumInfo, nil]
-        #     The checksum information of the file. When the download is complete, you can retrieve the checksum from the   :func:`Com::Vmware::Content::Library::Item::Downloadsession::File.get`    method  to verify the checksum for the downloaded file.
-        #     The checksum is always calculated for the downloaded file, but this  field  won't be set until the download is complete.
-        # @!attribute [rw] error_message
-        #     @return [Com::Vmware::Vapi::Std::LocalizableMessage, nil]
-        #     Error message for a failed preparation when the prepare status is   :attr:`Com::Vmware::Content::Library::Item::Downloadsession::File::PrepareStatus.ERROR`  .
-        #     This  field  won't be set unless there was an error with the file transfer.
-        class Info < VAPI::Bindings::VapiStruct
-
-            class << self
-                # Holds (gets or creates) the binding type metadata for this structure type.
-                # @scope class
-                # @return [VAPI::Bindings::StructType] the binding type
-                def binding_type
-                    @binding_type ||= VAPI::Bindings::StructType.new(
-                        'com.vmware.content.library.item.downloadsession.file.info',
-                        {
-                            'name' => VAPI::Bindings::StringType.instance,
-                            'size' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::IntegerType.instance),
-                            'bytes_transferred' => VAPI::Bindings::IntegerType.instance,
-                            'status' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Content::Library::Item::Downloadsession::File::PrepareStatus'),
-                            'download_endpoint' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Content::Library::Item::TransferEndpoint')),
-                            'checksum_info' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Content::Library::Item::File::ChecksumInfo')),
-                            'error_message' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::LocalizableMessage')),
-                        },
-                        Info,
-                        false,
-                        nil)
-                end
-            end
-
-            attr_accessor :name,
-                          :size,
-                          :bytes_transferred,
-                          :status,
-                          :download_endpoint,
-                          :checksum_info,
-                          :error_message
-
-            # Constructs a new instance.
-            # @param ruby_values [Hash] a map of initial property values (optional)
-            # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
-            def initialize(ruby_values=nil, struct_value=nil)
-                super(self.class.binding_type, ruby_values, struct_value)
-            end
-        end
-
-
-
-        # The  ``Com::Vmware::Content::Library::Item::Downloadsession::File::PrepareStatus``   enumerated type  defines the state of the file in preparation for download.
-        # @!attribute [rw] unprepared
-        #     @return [Com::Vmware::Content::Library::Item::Downloadsession::File::PrepareStatus]
-        #     The file hasn't been requested for preparation.
-        # @!attribute [rw] prepare_requested
-        #     @return [Com::Vmware::Content::Library::Item::Downloadsession::File::PrepareStatus]
-        #     A prepare has been requested, however the server hasn't started the preparation yet.
-        # @!attribute [rw] preparing
-        #     @return [Com::Vmware::Content::Library::Item::Downloadsession::File::PrepareStatus]
-        #     A prepare has been requested and the file is in the process of being prepared.
-        # @!attribute [rw] prepared
-        #     @return [Com::Vmware::Content::Library::Item::Downloadsession::File::PrepareStatus]
-        #     Prepare succeeded. The file is ready for download.
-        # @!attribute [rw] error
-        #     @return [Com::Vmware::Content::Library::Item::Downloadsession::File::PrepareStatus]
-        #     Prepare failed.
-        class PrepareStatus < VAPI::Bindings::VapiEnum
-
-            class << self
-                # Holds (gets or creates) the binding type metadata for this enumeration type.
-                # @scope class
-                # @return [VAPI::Bindings::EnumType] the binding type
-                def binding_type
-                    @binding_type ||= VAPI::Bindings::EnumType.new(
-                        'com.vmware.content.library.item.downloadsession.file.prepare_status',
-                        PrepareStatus)
-                end
-
-                # Converts from a string value (perhaps off the wire) to an instance
-                # of this enum type.
-                # @param value [String] the actual value of the enum instance
-                # @return [PrepareStatus] the instance found for the value, otherwise
-                #         an unknown instance will be built for the value
-                def from_string(value)
-                    begin
-                        const_get(value)
-                    rescue NameError
-                        PrepareStatus.new('UNKNOWN', value)
-                    end
-                end
-            end
-
-            private
-
-            # Constructs a new instance.
-            # @param value [String] the actual value of the enum instance
-            # @param unknown [String] the unknown value when value is 'UKNOWN'
-            def initialize(value, unknown=nil)
-                super(self.class.binding_type, value, unknown)
-            end
-
-            public
-
-            # @!attribute [rw] unprepared
-            #     @return [Com::Vmware::Content::Library::Item::Downloadsession::File::PrepareStatus]
-            #     The file hasn't been requested for preparation.
-            UNPREPARED = PrepareStatus.new('UNPREPARED')
-
-            # @!attribute [rw] prepare_requested
-            #     @return [Com::Vmware::Content::Library::Item::Downloadsession::File::PrepareStatus]
-            #     A prepare has been requested, however the server hasn't started the preparation yet.
-            PREPARE_REQUESTED = PrepareStatus.new('PREPARE_REQUESTED')
-
-            # @!attribute [rw] preparing
-            #     @return [Com::Vmware::Content::Library::Item::Downloadsession::File::PrepareStatus]
-            #     A prepare has been requested and the file is in the process of being prepared.
-            PREPARING = PrepareStatus.new('PREPARING')
-
-            # @!attribute [rw] prepared
-            #     @return [Com::Vmware::Content::Library::Item::Downloadsession::File::PrepareStatus]
-            #     Prepare succeeded. The file is ready for download.
-            PREPARED = PrepareStatus.new('PREPARED')
-
-            # @!attribute [rw] error
-            #     @return [Com::Vmware::Content::Library::Item::Downloadsession::File::PrepareStatus]
-            #     Prepare failed.
-            ERROR = PrepareStatus.new('ERROR')
-
-        end
-
-
-        # The  ``Com::Vmware::Content::Library::Item::Downloadsession::File::EndpointType``   enumerated type  defines the types of endpoints used to download the file.
-        # @!attribute [rw] https
-        #     @return [Com::Vmware::Content::Library::Item::Downloadsession::File::EndpointType]
-        #     An https download endpoint.
-        # @!attribute [rw] direct
-        #     @return [Com::Vmware::Content::Library::Item::Downloadsession::File::EndpointType]
-        #     A direct download endpoint indicating the location of the file on storage. The caller is responsible for retrieving the file from the storage location directly.
-        class EndpointType < VAPI::Bindings::VapiEnum
-
-            class << self
-                # Holds (gets or creates) the binding type metadata for this enumeration type.
-                # @scope class
-                # @return [VAPI::Bindings::EnumType] the binding type
-                def binding_type
-                    @binding_type ||= VAPI::Bindings::EnumType.new(
-                        'com.vmware.content.library.item.downloadsession.file.endpoint_type',
-                        EndpointType)
-                end
-
-                # Converts from a string value (perhaps off the wire) to an instance
-                # of this enum type.
-                # @param value [String] the actual value of the enum instance
-                # @return [EndpointType] the instance found for the value, otherwise
-                #         an unknown instance will be built for the value
-                def from_string(value)
-                    begin
-                        const_get(value)
-                    rescue NameError
-                        EndpointType.new('UNKNOWN', value)
-                    end
-                end
-            end
-
-            private
-
-            # Constructs a new instance.
-            # @param value [String] the actual value of the enum instance
-            # @param unknown [String] the unknown value when value is 'UKNOWN'
-            def initialize(value, unknown=nil)
-                super(self.class.binding_type, value, unknown)
-            end
-
-            public
-
-            # @!attribute [rw] https
-            #     @return [Com::Vmware::Content::Library::Item::Downloadsession::File::EndpointType]
-            #     An https download endpoint.
-            HTTPS = EndpointType.new('HTTPS')
-
-            # @!attribute [rw] direct
-            #     @return [Com::Vmware::Content::Library::Item::Downloadsession::File::EndpointType]
-            #     A direct download endpoint indicating the location of the file on storage. The caller is responsible for retrieving the file from the storage location directly.
-            DIRECT = EndpointType.new('DIRECT')
-
-        end
-
-
+    # Constructs a new instance.
+    #
+    # @param config [VAPI::Bindings::StubConfig] A hash with the api provider details.
+    def initialize(config)
+      super(config, SERVICE_INFO)
     end
 
+    # Lists the information of all the files in the library item associated with the download session.
+    #
+    # @param download_session_id [String]
+    #      Identifier of the download session.
+    # @return [Array<Com::Vmware::Content::Library::Item::Downloadsession::File::Info>]
+    #     The  list  of   :class:`Com::Vmware::Content::Library::Item::Downloadsession::File::Info`   instances.
+    # @raise [Com::Vmware::Vapi::Std::Errors::NotFound]
+    #      if the download session associated with  ``download_session_id``  doesn't exist.
+    def list(download_session_id)
+      invoke_with_info(LIST_INFO,
+                       'download_session_id' => download_session_id)
+    end
 
+    # Requests a file to be prepared for download.
+    #
+    # @param download_session_id [String]
+    #      Identifier of the download session.
+    # @param file_name [String]
+    #      Name of the file requested for download.
+    # @param endpoint_type [Com::Vmware::Content::Library::Item::Downloadsession::File::EndpointType, nil]
+    #      Endpoint type request, one of  ``HTTPS``, ``DIRECT`` . This will determine the type of the   :attr:`Com::Vmware::Content::Library::Item::Downloadsession::File::Info.download_endpoint`   that is generated when the file is prepared. The   :attr:`Com::Vmware::Content::Library::Item::Downloadsession::File::EndpointType.DIRECT`   is only available to users who have the ContentLibrary.ReadStorage privilege.
+    #     If not specified the default is   :attr:`Com::Vmware::Content::Library::Item::Downloadsession::File::EndpointType.HTTPS`  .
+    # @return [Com::Vmware::Content::Library::Item::Downloadsession::File::Info]
+    #     File information containing the status of the request and the download link to the file.
+    # @raise [Com::Vmware::Vapi::Std::Errors::NotFound]
+    #      if the download session does not exist.
+    # @raise [Com::Vmware::Vapi::Std::Errors::InvalidArgument]
+    #      if there is no file with the specified  ``file_name`` .
+    # @raise [Com::Vmware::Vapi::Std::Errors::Unauthorized]
+    #      if the the download session wasn't created with the ContentLibrary.ReadStorage privilege and the caller requested a   :attr:`Com::Vmware::Content::Library::Item::Downloadsession::File::EndpointType.DIRECT`   endpoint type.
+    def prepare(download_session_id, file_name, endpoint_type = nil)
+      invoke_with_info(PREPARE_INFO,
+                       'download_session_id' => download_session_id,
+                       'file_name' => file_name,
+                       'endpoint_type' => endpoint_type)
+    end
+
+    # Retrieves file download information for a specific file.
+    #
+    # @param download_session_id [String]
+    #      Identifier of the download session.
+    # @param file_name [String]
+    #      Name of the file requested.
+    # @return [Com::Vmware::Content::Library::Item::Downloadsession::File::Info]
+    #     The   :class:`Com::Vmware::Content::Library::Item::Downloadsession::File::Info`   instance containing the status of the file and its download link if available.
+    # @raise [Com::Vmware::Vapi::Std::Errors::NotFound]
+    #      if the download session associated with  ``download_session_id``  does not exist.
+    # @raise [Com::Vmware::Vapi::Std::Errors::InvalidArgument]
+    #      if there is no file with the specified  ``file_name`` .
+    def get(download_session_id, file_name)
+      invoke_with_info(GET_INFO,
+                       'download_session_id' => download_session_id,
+                       'file_name' => file_name)
+    end
+
+    # The  ``Com::Vmware::Content::Library::Item::Downloadsession::File::Info``   class  defines the downloaded file.
+    # @!attribute [rw] name
+    #     @return [String]
+    #     The name of the file.
+    # @!attribute [rw] size
+    #     @return [Fixnum, nil]
+    #     The file size, in bytes.
+    #     This  field  may not be available immediately. It is guaranteed to be set when the client finishes downloading the file.
+    # @!attribute [rw] bytes_transferred
+    #     @return [Fixnum]
+    #     The number of bytes that have been transferred by the server so far for making this file prepared for download. This value may stay at zero till the client starts downloading the file.
+    # @!attribute [rw] status
+    #     @return [Com::Vmware::Content::Library::Item::Downloadsession::File::PrepareStatus]
+    #     The preparation status ( ``UNPREPARED``, ``PREPARE_REQUESTED``, ``PREPARING``, ``PREPARED``, ``ERROR`` ) of the file.
+    # @!attribute [rw] download_endpoint
+    #     @return [Com::Vmware::Content::Library::Item::TransferEndpoint, nil]
+    #     Endpoint at which the file is available for download. The value is valid only when the   :attr:`Com::Vmware::Content::Library::Item::Downloadsession::File::Info.status`   is   :attr:`Com::Vmware::Content::Library::Item::Downloadsession::File::PrepareStatus.PREPARED`  .
+    #     This  field  won't be set until the file status is   :attr:`Com::Vmware::Content::Library::Item::Downloadsession::File::PrepareStatus.PREPARED`  .
+    # @!attribute [rw] checksum_info
+    #     @return [Com::Vmware::Content::Library::Item::File::ChecksumInfo, nil]
+    #     The checksum information of the file. When the download is complete, you can retrieve the checksum from the   :func:`Com::Vmware::Content::Library::Item::Downloadsession::File.get`    method  to verify the checksum for the downloaded file.
+    #     The checksum is always calculated for the downloaded file, but this  field  won't be set until the download is complete.
+    # @!attribute [rw] error_message
+    #     @return [Com::Vmware::Vapi::Std::LocalizableMessage, nil]
+    #     Error message for a failed preparation when the prepare status is   :attr:`Com::Vmware::Content::Library::Item::Downloadsession::File::PrepareStatus.ERROR`  .
+    #     This  field  won't be set unless there was an error with the file transfer.
+    class Info < VAPI::Bindings::VapiStruct
+      class << self
+        # Holds (gets or creates) the binding type metadata for this structure type.
+        # @scope class
+        # @return [VAPI::Bindings::StructType] the binding type
+        def binding_type
+          @binding_type ||= VAPI::Bindings::StructType.new(
+            'com.vmware.content.library.item.downloadsession.file.info',
+            {
+              'name' => VAPI::Bindings::StringType.instance,
+              'size' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::IntegerType.instance),
+              'bytes_transferred' => VAPI::Bindings::IntegerType.instance,
+              'status' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Content::Library::Item::Downloadsession::File::PrepareStatus'),
+              'download_endpoint' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Content::Library::Item::TransferEndpoint')),
+              'checksum_info' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Content::Library::Item::File::ChecksumInfo')),
+              'error_message' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::LocalizableMessage'))
+            },
+            Info,
+            false,
+            nil
+          )
+        end
+      end
+
+      attr_accessor :name,
+                    :size,
+                    :bytes_transferred,
+                    :status,
+                    :download_endpoint,
+                    :checksum_info,
+                    :error_message
+
+      # Constructs a new instance.
+      # @param ruby_values [Hash] a map of initial property values (optional)
+      # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
+      def initialize(ruby_values = nil, struct_value = nil)
+        super(self.class.binding_type, ruby_values, struct_value)
+      end
+    end
+
+    # The  ``Com::Vmware::Content::Library::Item::Downloadsession::File::PrepareStatus``   enumerated type  defines the state of the file in preparation for download.
+    # @!attribute [rw] unprepared
+    #     @return [Com::Vmware::Content::Library::Item::Downloadsession::File::PrepareStatus]
+    #     The file hasn't been requested for preparation.
+    # @!attribute [rw] prepare_requested
+    #     @return [Com::Vmware::Content::Library::Item::Downloadsession::File::PrepareStatus]
+    #     A prepare has been requested, however the server hasn't started the preparation yet.
+    # @!attribute [rw] preparing
+    #     @return [Com::Vmware::Content::Library::Item::Downloadsession::File::PrepareStatus]
+    #     A prepare has been requested and the file is in the process of being prepared.
+    # @!attribute [rw] prepared
+    #     @return [Com::Vmware::Content::Library::Item::Downloadsession::File::PrepareStatus]
+    #     Prepare succeeded. The file is ready for download.
+    # @!attribute [rw] error
+    #     @return [Com::Vmware::Content::Library::Item::Downloadsession::File::PrepareStatus]
+    #     Prepare failed.
+    class PrepareStatus < VAPI::Bindings::VapiEnum
+      class << self
+        # Holds (gets or creates) the binding type metadata for this enumeration type.
+        # @scope class
+        # @return [VAPI::Bindings::EnumType] the binding type
+        def binding_type
+          @binding_type ||= VAPI::Bindings::EnumType.new(
+            'com.vmware.content.library.item.downloadsession.file.prepare_status',
+            PrepareStatus
+          )
+        end
+
+        # Converts from a string value (perhaps off the wire) to an instance
+        # of this enum type.
+        # @param value [String] the actual value of the enum instance
+        # @return [PrepareStatus] the instance found for the value, otherwise
+        #         an unknown instance will be built for the value
+        def from_string(value)
+          const_get(value)
+        rescue NameError
+          PrepareStatus.send(:new, 'UNKNOWN', value)
+        end
+      end
+
+      # Constructs a new instance.
+      # @param value [String] the actual value of the enum instance
+      # @param unknown [String] the unknown value when value is 'UKNOWN'
+      def initialize(value, unknown = nil)
+        super(self.class.binding_type, value, unknown)
+      end
+
+      private_class_method :new
+
+      # @!attribute [rw] unprepared
+      #     @return [Com::Vmware::Content::Library::Item::Downloadsession::File::PrepareStatus]
+      #     The file hasn't been requested for preparation.
+      UNPREPARED = PrepareStatus.send(:new, 'UNPREPARED')
+
+      # @!attribute [rw] prepare_requested
+      #     @return [Com::Vmware::Content::Library::Item::Downloadsession::File::PrepareStatus]
+      #     A prepare has been requested, however the server hasn't started the preparation yet.
+      PREPARE_REQUESTED = PrepareStatus.send(:new, 'PREPARE_REQUESTED')
+
+      # @!attribute [rw] preparing
+      #     @return [Com::Vmware::Content::Library::Item::Downloadsession::File::PrepareStatus]
+      #     A prepare has been requested and the file is in the process of being prepared.
+      PREPARING = PrepareStatus.send(:new, 'PREPARING')
+
+      # @!attribute [rw] prepared
+      #     @return [Com::Vmware::Content::Library::Item::Downloadsession::File::PrepareStatus]
+      #     Prepare succeeded. The file is ready for download.
+      PREPARED = PrepareStatus.send(:new, 'PREPARED')
+
+      # @!attribute [rw] error
+      #     @return [Com::Vmware::Content::Library::Item::Downloadsession::File::PrepareStatus]
+      #     Prepare failed.
+      ERROR = PrepareStatus.send(:new, 'ERROR')
+    end
+    # The  ``Com::Vmware::Content::Library::Item::Downloadsession::File::EndpointType``   enumerated type  defines the types of endpoints used to download the file.
+    # @!attribute [rw] https
+    #     @return [Com::Vmware::Content::Library::Item::Downloadsession::File::EndpointType]
+    #     An https download endpoint.
+    # @!attribute [rw] direct
+    #     @return [Com::Vmware::Content::Library::Item::Downloadsession::File::EndpointType]
+    #     A direct download endpoint indicating the location of the file on storage. The caller is responsible for retrieving the file from the storage location directly.
+    class EndpointType < VAPI::Bindings::VapiEnum
+      class << self
+        # Holds (gets or creates) the binding type metadata for this enumeration type.
+        # @scope class
+        # @return [VAPI::Bindings::EnumType] the binding type
+        def binding_type
+          @binding_type ||= VAPI::Bindings::EnumType.new(
+            'com.vmware.content.library.item.downloadsession.file.endpoint_type',
+            EndpointType
+          )
+        end
+
+        # Converts from a string value (perhaps off the wire) to an instance
+        # of this enum type.
+        # @param value [String] the actual value of the enum instance
+        # @return [EndpointType] the instance found for the value, otherwise
+        #         an unknown instance will be built for the value
+        def from_string(value)
+          const_get(value)
+        rescue NameError
+          EndpointType.send(:new, 'UNKNOWN', value)
+        end
+      end
+
+      # Constructs a new instance.
+      # @param value [String] the actual value of the enum instance
+      # @param unknown [String] the unknown value when value is 'UKNOWN'
+      def initialize(value, unknown = nil)
+        super(self.class.binding_type, value, unknown)
+      end
+
+      private_class_method :new
+
+      # @!attribute [rw] https
+      #     @return [Com::Vmware::Content::Library::Item::Downloadsession::File::EndpointType]
+      #     An https download endpoint.
+      HTTPS = EndpointType.send(:new, 'HTTPS')
+
+      # @!attribute [rw] direct
+      #     @return [Com::Vmware::Content::Library::Item::Downloadsession::File::EndpointType]
+      #     A direct download endpoint indicating the location of the file on storage. The caller is responsible for retrieving the file from the storage location directly.
+      DIRECT = EndpointType.send(:new, 'DIRECT')
+    end
+  end
 end

--- a/client/sdk/com/vmware/content/library/item/updatesession.rb
+++ b/client/sdk/com/vmware/content/library/item/updatesession.rb
@@ -1,5 +1,6 @@
 #---------------------------------------------------------------------------
-# Copyright 2016 VMware, Inc.  All rights reserved.
+# Copyright 2017 VMware, Inc.  All rights reserved.
+#
 # AUTO GENERATED FILE -- DO NOT MODIFY!
 #
 # vAPI type descriptors for package com.vmware.content.library.item.updatesession.
@@ -8,504 +9,477 @@ require 'vapi'
 
 # declare the module hierarchy before we use the shorthand syntax below
 module Com
-    module Vmware
-        module Content
-            module Library
-                module Item
-                    module Updatesession
-                    end
-                end
-            end
+  module Vmware
+    module Content
+      module Library
+        module Item
+          module Updatesession
+          end
         end
+      end
     end
+  end
 end
 
 # The Content Library Item Update Session  package  provides  classes  and  classs  for updating files in a session.
 module Com::Vmware::Content::Library::Item::Updatesession
+  # The  ``Com::Vmware::Content::Library::Item::Updatesession::File``   class  provides  methods  for accessing files within an update session.  
+  # 
+  #  After an update session is created against a library item, the  ``Com::Vmware::Content::Library::Item::Updatesession::File``   class  can be used to make changes to the underlying library item metadata as well as the content of the files. The following changes can be made:  
+  # 
+  #   * deleting an existing file within the library item. This deletes both the metadata and the content.
+  #    * updating an existing file with new content.
+  #    * adding a new file to the library item.
+  #   
+  #    
+  # 
+  #  The above changes are not applied or visible until the session is completed. See   :class:`Com::Vmware::Content::Library::Item::UpdateSession`  .
+  class File < VAPI::Bindings::VapiService
+    # static metamodel definitions
+    SERVICE_ID = VAPI::Core::ServiceIdentifier.new('com.vmware.content.library.item.updatesession.file')
 
-    # The  ``Com::Vmware::Content::Library::Item::Updatesession::File``   class  provides  methods  for accessing files within an update session.  
-    # 
-    #  After an update session is created against a library item, the  ``Com::Vmware::Content::Library::Item::Updatesession::File``   class  can be used to make changes to the underlying library item metadata as well as the content of the files. The following changes can be made:  
-    # 
-    #   * deleting an existing file within the library item. This deletes both the metadata and the content.
-    #    * updating an existing file with new content.
-    #    * adding a new file to the library item.
-    #   
-    #    
-    # 
-    #  The above changes are not applied or visible until the session is completed. See   :class:`Com::Vmware::Content::Library::Item::UpdateSession`  .
-    class File < VAPI::Bindings::VapiService
+    VALIDATE_INFO = VAPI::Bindings::OperationInfo.new(
+      VAPI::Core::OperationIdentifier.new('validate', SERVICE_ID),
+      VAPI::Bindings::OperationInputType.new(
+        'update_session_id' => VAPI::Bindings::IdType.new('com.vmware.content.library.item.UpdateSession')
+      ),
+      VAPI::Bindings::ReferenceType.new('Com::Vmware::Content::Library::Item::Updatesession::File::ValidationResult'),
+      {
+        'com.vmware.vapi.std.errors.not_found' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::NotFound'),
+        'com.vmware.vapi.std.errors.not_allowed_in_current_state' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::NotAllowedInCurrentState')
+      },
+      [],
+      []
+    )
 
-        protected
+    ADD_INFO = VAPI::Bindings::OperationInfo.new(
+      VAPI::Core::OperationIdentifier.new('add', SERVICE_ID),
+      VAPI::Bindings::OperationInputType.new(
+        'update_session_id' => VAPI::Bindings::IdType.new('com.vmware.content.library.item.UpdateSession'),
+        'file_spec' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Content::Library::Item::Updatesession::File::AddSpec')
+      ),
+      VAPI::Bindings::ReferenceType.new('Com::Vmware::Content::Library::Item::Updatesession::File::Info'),
+      {
+        'com.vmware.vapi.std.errors.invalid_argument' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::InvalidArgument'),
+        'com.vmware.vapi.std.errors.not_found' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::NotFound'),
+        'com.vmware.vapi.std.errors.unauthorized' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Unauthorized')
+      },
+      [],
+      []
+    )
 
-        # static metamodel definitions
-        @@service_id = VAPI::Core::ServiceIdentifier.new('com.vmware.content.library.item.updatesession.file')
+    REMOVE_INFO = VAPI::Bindings::OperationInfo.new(
+      VAPI::Core::OperationIdentifier.new('remove', SERVICE_ID),
+      VAPI::Bindings::OperationInputType.new(
+        'update_session_id' => VAPI::Bindings::IdType.new('com.vmware.content.library.item.UpdateSession'),
+        'file_name' => VAPI::Bindings::StringType.instance
+      ),
+      VAPI::Bindings::VoidType.instance,
+      {
+        'com.vmware.vapi.std.errors.not_found' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::NotFound'),
+        'com.vmware.vapi.std.errors.invalid_argument' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::InvalidArgument')
+      },
+      [],
+      []
+    )
 
-        @@validate_info = VAPI::Bindings::OperationInfo.new(
-            VAPI::Core::OperationIdentifier.new('validate', @@service_id),
-            VAPI::Bindings::OperationInputType.new({
-                'update_session_id' => VAPI::Bindings::IdType.new(resource_types='com.vmware.content.library.item.UpdateSession'),
-            }),
-            VAPI::Bindings::ReferenceType.new('Com::Vmware::Content::Library::Item::Updatesession::File::ValidationResult'),
-            {
-                'com.vmware.vapi.std.errors.not_found' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::NotFound'),
-                'com.vmware.vapi.std.errors.not_allowed_in_current_state' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::NotAllowedInCurrentState'),
+    LIST_INFO = VAPI::Bindings::OperationInfo.new(
+      VAPI::Core::OperationIdentifier.new('list', SERVICE_ID),
+      VAPI::Bindings::OperationInputType.new(
+        'update_session_id' => VAPI::Bindings::IdType.new('com.vmware.content.library.item.UpdateSession')
+      ),
+      VAPI::Bindings::ListType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Content::Library::Item::Updatesession::File::Info')),
+      {
+        'com.vmware.vapi.std.errors.not_found' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::NotFound')
+      },
+      [],
+      []
+    )
 
-            },
-            [],
-            [])
-        @@add_info = VAPI::Bindings::OperationInfo.new(
-            VAPI::Core::OperationIdentifier.new('add', @@service_id),
-            VAPI::Bindings::OperationInputType.new({
-                'update_session_id' => VAPI::Bindings::IdType.new(resource_types='com.vmware.content.library.item.UpdateSession'),
-                'file_spec' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Content::Library::Item::Updatesession::File::AddSpec'),
-            }),
-            VAPI::Bindings::ReferenceType.new('Com::Vmware::Content::Library::Item::Updatesession::File::Info'),
-            {
-                'com.vmware.vapi.std.errors.invalid_argument' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::InvalidArgument'),
-                'com.vmware.vapi.std.errors.not_found' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::NotFound'),
-                'com.vmware.vapi.std.errors.unauthorized' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Unauthorized'),
+    GET_INFO = VAPI::Bindings::OperationInfo.new(
+      VAPI::Core::OperationIdentifier.new('get', SERVICE_ID),
+      VAPI::Bindings::OperationInputType.new(
+        'update_session_id' => VAPI::Bindings::IdType.new('com.vmware.content.library.item.UpdateSession'),
+        'file_name' => VAPI::Bindings::StringType.instance
+      ),
+      VAPI::Bindings::ReferenceType.new('Com::Vmware::Content::Library::Item::Updatesession::File::Info'),
+      {
+        'com.vmware.vapi.std.errors.not_found' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::NotFound'),
+        'com.vmware.vapi.std.errors.invalid_argument' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::InvalidArgument')
+      },
+      [],
+      []
+    )
 
-            },
-            [],
-            [])
-        @@remove_info = VAPI::Bindings::OperationInfo.new(
-            VAPI::Core::OperationIdentifier.new('remove', @@service_id),
-            VAPI::Bindings::OperationInputType.new({
-                'update_session_id' => VAPI::Bindings::IdType.new(resource_types='com.vmware.content.library.item.UpdateSession'),
-                'file_name' => VAPI::Bindings::StringType.instance,
-            }),
-            VAPI::Bindings::VoidType.instance,
-            {
-                'com.vmware.vapi.std.errors.not_found' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::NotFound'),
-                'com.vmware.vapi.std.errors.invalid_argument' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::InvalidArgument'),
+    SERVICE_INFO = VAPI::Bindings::ServiceInfo.new(
+      SERVICE_ID,
+      'validate' => VALIDATE_INFO,
+      'add' => ADD_INFO,
+      'remove' => REMOVE_INFO,
+      'list' => LIST_INFO,
+      'get' => GET_INFO
+    )
 
-            },
-            [],
-            [])
-        @@list_info = VAPI::Bindings::OperationInfo.new(
-            VAPI::Core::OperationIdentifier.new('list', @@service_id),
-            VAPI::Bindings::OperationInputType.new({
-                'update_session_id' => VAPI::Bindings::IdType.new(resource_types='com.vmware.content.library.item.UpdateSession'),
-            }),
-            VAPI::Bindings::ListType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Content::Library::Item::Updatesession::File::Info')),
-            {
-                'com.vmware.vapi.std.errors.not_found' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::NotFound'),
-
-            },
-            [],
-            [])
-        @@get_info = VAPI::Bindings::OperationInfo.new(
-            VAPI::Core::OperationIdentifier.new('get', @@service_id),
-            VAPI::Bindings::OperationInputType.new({
-                'update_session_id' => VAPI::Bindings::IdType.new(resource_types='com.vmware.content.library.item.UpdateSession'),
-                'file_name' => VAPI::Bindings::StringType.instance,
-            }),
-            VAPI::Bindings::ReferenceType.new('Com::Vmware::Content::Library::Item::Updatesession::File::Info'),
-            {
-                'com.vmware.vapi.std.errors.not_found' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::NotFound'),
-                'com.vmware.vapi.std.errors.invalid_argument' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::InvalidArgument'),
-
-            },
-            [],
-            [])
-
-        @@service_info = VAPI::Bindings::ServiceInfo.new(@@service_id, {
-            'validate' => @@validate_info,
-            'add' => @@add_info,
-            'remove' => @@remove_info,
-            'list' => @@list_info,
-            'get' => @@get_info,
-        })
-
-        public
-
-        # Constructs a new instance.
-        #
-        # @param config [VAPI::Bindings::StubConfig] A hash with the api provider details.
-        def initialize(config)
-            super(config, @@service_info)
-        end
-
-
-        # Validates the files in the update session with the referenced identifier and ensures all necessary files are received. In the case where a file is missing, this  method  will return its name in the   :attr:`Com::Vmware::Content::Library::Item::Updatesession::File::ValidationResult.missing_files`   set. The user can add the missing files and try re-validating. For other type of errors,   :attr:`Com::Vmware::Content::Library::Item::Updatesession::File::ValidationResult.invalid_files`   will contain the list of invalid files.
-        #
-        # @param update_session_id [String]
-        #      Identifier of the update session to validate.
-        # @return [Com::Vmware::Content::Library::Item::Updatesession::File::ValidationResult]
-        #     A validation result containing missing files or invalid files and the reason why they are invalid.
-        # @raise [Com::Vmware::Vapi::Std::Errors::NotFound]
-        #      if no update session with the given identifier exists.
-        # @raise [Com::Vmware::Vapi::Std::Errors::NotAllowedInCurrentState]
-        #      if the update session is not in the   :attr:`Com::Vmware::Content::Library::Item::UpdateSessionModel::State.ACTIVE`   state, or if some of the files that will be uploaded by the client aren't received correctly.
-        def validate(update_session_id)
-            invoke_with_info(@@validate_info, {
-                'update_session_id' => update_session_id,
-            })
-        end
-
-
-        # Requests file content to be changed (either created, or updated). Depending on the source type of the file, this  method  will either return an upload endpoint where the client can push the content, or the server will pull from the provided source endpoint. If a file with the same name already exists in this session, this  method  will be used to update the content of the existing file.  
-        # 
-        #  When importing a file directly from storage, where the source endpoint is a file or datastore URI, you will need to have the ContentLibrary.ReadStorage privilege on the library item. If the file is located in the same directory as the library storage backing folder, the server will move the file instead of copying it, thereby allowing instantaneous import of files for efficient backup and restore scenarios. In all other cases, a copy is performed rather than a move.
-        #
-        # @param update_session_id [String]
-        #      Identifier of the update session to be modified.
-        # @param file_spec [Com::Vmware::Content::Library::Item::Updatesession::File::AddSpec]
-        #      Specification for the file that needs to be added or updated. This includes whether the client wants to push the content or have the server pull it.
-        # @return [Com::Vmware::Content::Library::Item::Updatesession::File::Info]
-        #     An   :class:`Com::Vmware::Content::Library::Item::Updatesession::File::Info`    class  containing upload links as well as server side state tracking the transfer of the file.
-        # @raise [Com::Vmware::Vapi::Std::Errors::InvalidArgument]
-        #      if the  ``file_spec``  is invalid.
-        # @raise [Com::Vmware::Vapi::Std::Errors::NotFound]
-        #      if the update session doesn't exist.
-        # @raise [Com::Vmware::Vapi::Std::Errors::Unauthorized]
-        #      if the caller doesn't have ContentLibrary.ReadStorage privilege on the library item of the update session and source type   :attr:`Com::Vmware::Content::Library::Item::Updatesession::File::SourceType.PULL`   is requested for a file or datastore source endpoint (that is, not HTTP or HTTPs based endpoint).
-        def add(update_session_id, file_spec)
-            invoke_with_info(@@add_info, {
-                'update_session_id' => update_session_id,
-                'file_spec' => file_spec,
-            })
-        end
-
-
-        # Requests a file to be removed. The file will only be effectively removed when the update session is completed.
-        #
-        # @param update_session_id [String]
-        #      Identifier of the update session.
-        # @param file_name [String]
-        #      Name of the file to be removed.
-        # @return [Void]
-        # @raise [Com::Vmware::Vapi::Std::Errors::NotFound]
-        #      if the update session doesn't exist.
-        # @raise [Com::Vmware::Vapi::Std::Errors::InvalidArgument]
-        #      if the file doesn't exist in the library item associated with the update session.
-        def remove(update_session_id, file_name)
-            invoke_with_info(@@remove_info, {
-                'update_session_id' => update_session_id,
-                'file_name' => file_name,
-            })
-        end
-
-
-        # Lists all files in the library item associated with the update session.
-        #
-        # @param update_session_id [String]
-        #      Identifier of the update session.
-        # @return [Array<Com::Vmware::Content::Library::Item::Updatesession::File::Info>]
-        #     The  list  of the files in the library item associated with the update session. This  list  may be empty if the caller has removed all the files as part of this session (in which case completing the update session will result in an empty library item).
-        # @raise [Com::Vmware::Vapi::Std::Errors::NotFound]
-        #      if the update session doesn't exist.
-        def list(update_session_id)
-            invoke_with_info(@@list_info, {
-                'update_session_id' => update_session_id,
-            })
-        end
-
-
-        # Retrieves information about a specific file in the snapshot of the library item at the time when the update session was created.
-        #
-        # @param update_session_id [String]
-        #      Identifier of the update session.
-        # @param file_name [String]
-        #      Name of the file.
-        # @return [Com::Vmware::Content::Library::Item::Updatesession::File::Info]
-        #     Information about the file.
-        # @raise [Com::Vmware::Vapi::Std::Errors::NotFound]
-        #      if the update session doesn't exist.
-        # @raise [Com::Vmware::Vapi::Std::Errors::InvalidArgument]
-        #      if the file doesn't exist in the library item associated with the update session.
-        def get(update_session_id, file_name)
-            invoke_with_info(@@get_info, {
-                'update_session_id' => update_session_id,
-                'file_name' => file_name,
-            })
-        end
-
-
-
-        # The  ``Com::Vmware::Content::Library::Item::Updatesession::File::AddSpec``   class  describes the properties of the file to be uploaded.
-        # @!attribute [rw] name
-        #     @return [String]
-        #     The name of the file being uploaded.
-        # @!attribute [rw] source_type
-        #     @return [Com::Vmware::Content::Library::Item::Updatesession::File::SourceType]
-        #     The source type ( ``NONE``, ``PUSH``, ``PULL`` ) from which the file content will be retrieved.
-        # @!attribute [rw] source_endpoint
-        #     @return [Com::Vmware::Content::Library::Item::TransferEndpoint]
-        #     Location from which the Content Library Service will fetch the file, rather than requiring a client to upload the file.
-        #     This  field  is optional and it is only relevant when the value of  ``sourceType``  is   :attr:`Com::Vmware::Content::Library::Item::Updatesession::File::SourceType.PULL`  .
-        # @!attribute [rw] size
-        #     @return [Fixnum, nil]
-        #     The file size, in bytes.
-        #     If specified the server will verify it received the correct size.
-        # @!attribute [rw] checksum_info
-        #     @return [Com::Vmware::Content::Library::Item::File::ChecksumInfo, nil]
-        #     The checksum of the file. If specified, the server will verify the checksum once the file is received. If there is a mismatch, the upload will fail.
-        #     If not specified the server does not verify the checksum.
-        class AddSpec < VAPI::Bindings::VapiStruct
-
-            class << self
-                # Holds (gets or creates) the binding type metadata for this structure type.
-                # @scope class
-                # @return [VAPI::Bindings::StructType] the binding type
-                def binding_type
-                    @binding_type ||= VAPI::Bindings::StructType.new(
-                        'com.vmware.content.library.item.updatesession.file.add_spec',
-                        {
-                            'name' => VAPI::Bindings::StringType.instance,
-                            'source_type' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Content::Library::Item::Updatesession::File::SourceType'),
-                            'source_endpoint' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Content::Library::Item::TransferEndpoint')),
-                            'size' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::IntegerType.instance),
-                            'checksum_info' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Content::Library::Item::File::ChecksumInfo')),
-                        },
-                        AddSpec,
-                        false,
-                        nil)
-                end
-            end
-
-            attr_accessor :name,
-                          :source_type,
-                          :source_endpoint,
-                          :size,
-                          :checksum_info
-
-            # Constructs a new instance.
-            # @param ruby_values [Hash] a map of initial property values (optional)
-            # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
-            def initialize(ruby_values=nil, struct_value=nil)
-                super(self.class.binding_type, ruby_values, struct_value)
-            end
-        end
-
-
-        # The  ``Com::Vmware::Content::Library::Item::Updatesession::File::Info``   class  defines the uploaded file.
-        # @!attribute [rw] name
-        #     @return [String]
-        #     The name of the file.
-        # @!attribute [rw] source_type
-        #     @return [Com::Vmware::Content::Library::Item::Updatesession::File::SourceType]
-        #     The source type ( ``NONE``, ``PUSH``, ``PULL`` ) from which the file is being retrieved. This may be   :attr:`Com::Vmware::Content::Library::Item::Updatesession::File::SourceType.NONE`   if the file is not being changed.
-        # @!attribute [rw] size
-        #     @return [Fixnum, nil]
-        #     The file size, in bytes as received by the server. This  field  is guaranteed to be set when the server has completely received the file.
-        #     This  field  won't be set until the file status is   :attr:`Com::Vmware::Content::Library::Item::TransferStatus.READY`  .
-        # @!attribute [rw] checksum_info
-        #     @return [Com::Vmware::Content::Library::Item::File::ChecksumInfo, nil]
-        #     The checksum information of the file received by the server.
-        #     If not specified the server does not verify the checksum.
-        # @!attribute [rw] source_endpoint
-        #     @return [Com::Vmware::Content::Library::Item::TransferEndpoint]
-        #     A source endpoint from which to retrieve the file.
-        #     This  field  is optional and it is only relevant when the value of  ``sourceType``  is   :attr:`Com::Vmware::Content::Library::Item::Updatesession::File::SourceType.PULL`  .
-        # @!attribute [rw] upload_endpoint
-        #     @return [Com::Vmware::Content::Library::Item::TransferEndpoint]
-        #     An upload endpoint to which the client can push the content.
-        #     This  field  is optional and it is only relevant when the value of  ``sourceType``  is   :attr:`Com::Vmware::Content::Library::Item::Updatesession::File::SourceType.PUSH`  .
-        # @!attribute [rw] bytes_transferred
-        #     @return [Fixnum]
-        #     The number of bytes of this file that have been received by the server.
-        # @!attribute [rw] status
-        #     @return [Com::Vmware::Content::Library::Item::TransferStatus]
-        #     The transfer status ( ``WAITING_FOR_TRANSFER``, ``TRANSFERRING``, ``READY``, ``VALIDATING``, ``ERROR`` ) of this file.
-        # @!attribute [rw] error_message
-        #     @return [Com::Vmware::Vapi::Std::LocalizableMessage, nil]
-        #     Details about the transfer error.
-        #     An error message is set if the status is   :attr:`Com::Vmware::Content::Library::Item::TransferStatus.ERROR`  .
-        class Info < VAPI::Bindings::VapiStruct
-
-            class << self
-                # Holds (gets or creates) the binding type metadata for this structure type.
-                # @scope class
-                # @return [VAPI::Bindings::StructType] the binding type
-                def binding_type
-                    @binding_type ||= VAPI::Bindings::StructType.new(
-                        'com.vmware.content.library.item.updatesession.file.info',
-                        {
-                            'name' => VAPI::Bindings::StringType.instance,
-                            'source_type' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Content::Library::Item::Updatesession::File::SourceType'),
-                            'size' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::IntegerType.instance),
-                            'checksum_info' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Content::Library::Item::File::ChecksumInfo')),
-                            'source_endpoint' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Content::Library::Item::TransferEndpoint')),
-                            'upload_endpoint' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Content::Library::Item::TransferEndpoint')),
-                            'bytes_transferred' => VAPI::Bindings::IntegerType.instance,
-                            'status' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Content::Library::Item::TransferStatus'),
-                            'error_message' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::LocalizableMessage')),
-                        },
-                        Info,
-                        false,
-                        nil)
-                end
-            end
-
-            attr_accessor :name,
-                          :source_type,
-                          :size,
-                          :checksum_info,
-                          :source_endpoint,
-                          :upload_endpoint,
-                          :bytes_transferred,
-                          :status,
-                          :error_message
-
-            # Constructs a new instance.
-            # @param ruby_values [Hash] a map of initial property values (optional)
-            # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
-            def initialize(ruby_values=nil, struct_value=nil)
-                super(self.class.binding_type, ruby_values, struct_value)
-            end
-        end
-
-
-        # The  ``Com::Vmware::Content::Library::Item::Updatesession::File::ValidationError``   class  defines the validation error of a file in the session.
-        # @!attribute [rw] name
-        #     @return [String]
-        #     The name of the file.
-        # @!attribute [rw] error_message
-        #     @return [Com::Vmware::Vapi::Std::LocalizableMessage]
-        #     A message indicating why the file was considered invalid.
-        class ValidationError < VAPI::Bindings::VapiStruct
-
-            class << self
-                # Holds (gets or creates) the binding type metadata for this structure type.
-                # @scope class
-                # @return [VAPI::Bindings::StructType] the binding type
-                def binding_type
-                    @binding_type ||= VAPI::Bindings::StructType.new(
-                        'com.vmware.content.library.item.updatesession.file.validation_error',
-                        {
-                            'name' => VAPI::Bindings::StringType.instance,
-                            'error_message' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::LocalizableMessage'),
-                        },
-                        ValidationError,
-                        false,
-                        nil)
-                end
-            end
-
-            attr_accessor :name,
-                          :error_message
-
-            # Constructs a new instance.
-            # @param ruby_values [Hash] a map of initial property values (optional)
-            # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
-            def initialize(ruby_values=nil, struct_value=nil)
-                super(self.class.binding_type, ruby_values, struct_value)
-            end
-        end
-
-
-        # The  ``Com::Vmware::Content::Library::Item::Updatesession::File::ValidationResult``   class  defines the result of validating the files in the session.
-        # @!attribute [rw] has_errors
-        #     @return [Boolean]
-        #     Whether the validation was succesful or not. In case of errors, the   :attr:`Com::Vmware::Content::Library::Item::Updatesession::File::ValidationResult.missing_files`   and   :attr:`Com::Vmware::Content::Library::Item::Updatesession::File::ValidationResult.invalid_files`   will contain at least one entry.
-        # @!attribute [rw] missing_files
-        #     @return [Set<String>]
-        #     A  set  containing the names of the files that are required but the client hasn't added.
-        # @!attribute [rw] invalid_files
-        #     @return [Array<Com::Vmware::Content::Library::Item::Updatesession::File::ValidationError>]
-        #     A  list  containing the files that have been identified as invalid and details about the error.
-        class ValidationResult < VAPI::Bindings::VapiStruct
-
-            class << self
-                # Holds (gets or creates) the binding type metadata for this structure type.
-                # @scope class
-                # @return [VAPI::Bindings::StructType] the binding type
-                def binding_type
-                    @binding_type ||= VAPI::Bindings::StructType.new(
-                        'com.vmware.content.library.item.updatesession.file.validation_result',
-                        {
-                            'has_errors' => VAPI::Bindings::BooleanType.instance,
-                            'missing_files' => VAPI::Bindings::SetType.new(VAPI::Bindings::StringType.instance),
-                            'invalid_files' => VAPI::Bindings::ListType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Content::Library::Item::Updatesession::File::ValidationError')),
-                        },
-                        ValidationResult,
-                        false,
-                        nil)
-                end
-            end
-
-            attr_accessor :has_errors,
-                          :missing_files,
-                          :invalid_files
-
-            # Constructs a new instance.
-            # @param ruby_values [Hash] a map of initial property values (optional)
-            # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
-            def initialize(ruby_values=nil, struct_value=nil)
-                super(self.class.binding_type, ruby_values, struct_value)
-            end
-        end
-
-
-
-        # The  ``Com::Vmware::Content::Library::Item::Updatesession::File::SourceType``   enumerated type  defines how the file content is retrieved.
-        # @!attribute [rw] none
-        #     @return [Com::Vmware::Content::Library::Item::Updatesession::File::SourceType]
-        #     No source type has been requested.
-        # @!attribute [rw] push
-        #     @return [Com::Vmware::Content::Library::Item::Updatesession::File::SourceType]
-        #     The client is uploading content using HTTP(S) PUT requests.
-        # @!attribute [rw] pull
-        #     @return [Com::Vmware::Content::Library::Item::Updatesession::File::SourceType]
-        #     The server is pulling content from a URL. The URL scheme can be  ``http`` ,  ``https`` ,  ``file`` , or  ``ds`` .
-        class SourceType < VAPI::Bindings::VapiEnum
-
-            class << self
-                # Holds (gets or creates) the binding type metadata for this enumeration type.
-                # @scope class
-                # @return [VAPI::Bindings::EnumType] the binding type
-                def binding_type
-                    @binding_type ||= VAPI::Bindings::EnumType.new(
-                        'com.vmware.content.library.item.updatesession.file.source_type',
-                        SourceType)
-                end
-
-                # Converts from a string value (perhaps off the wire) to an instance
-                # of this enum type.
-                # @param value [String] the actual value of the enum instance
-                # @return [SourceType] the instance found for the value, otherwise
-                #         an unknown instance will be built for the value
-                def from_string(value)
-                    begin
-                        const_get(value)
-                    rescue NameError
-                        SourceType.new('UNKNOWN', value)
-                    end
-                end
-            end
-
-            private
-
-            # Constructs a new instance.
-            # @param value [String] the actual value of the enum instance
-            # @param unknown [String] the unknown value when value is 'UKNOWN'
-            def initialize(value, unknown=nil)
-                super(self.class.binding_type, value, unknown)
-            end
-
-            public
-
-            # @!attribute [rw] none
-            #     @return [Com::Vmware::Content::Library::Item::Updatesession::File::SourceType]
-            #     No source type has been requested.
-            NONE = SourceType.new('NONE')
-
-            # @!attribute [rw] push
-            #     @return [Com::Vmware::Content::Library::Item::Updatesession::File::SourceType]
-            #     The client is uploading content using HTTP(S) PUT requests.
-            PUSH = SourceType.new('PUSH')
-
-            # @!attribute [rw] pull
-            #     @return [Com::Vmware::Content::Library::Item::Updatesession::File::SourceType]
-            #     The server is pulling content from a URL. The URL scheme can be  ``http`` ,  ``https`` ,  ``file`` , or  ``ds`` .
-            PULL = SourceType.new('PULL')
-
-        end
-
-
+    # Constructs a new instance.
+    #
+    # @param config [VAPI::Bindings::StubConfig] A hash with the api provider details.
+    def initialize(config)
+      super(config, SERVICE_INFO)
     end
 
+    # Validates the files in the update session with the referenced identifier and ensures all necessary files are received. In the case where a file is missing, this  method  will return its name in the   :attr:`Com::Vmware::Content::Library::Item::Updatesession::File::ValidationResult.missing_files`   set. The user can add the missing files and try re-validating. For other type of errors,   :attr:`Com::Vmware::Content::Library::Item::Updatesession::File::ValidationResult.invalid_files`   will contain the list of invalid files.
+    #
+    # @param update_session_id [String]
+    #      Identifier of the update session to validate.
+    # @return [Com::Vmware::Content::Library::Item::Updatesession::File::ValidationResult]
+    #     A validation result containing missing files or invalid files and the reason why they are invalid.
+    # @raise [Com::Vmware::Vapi::Std::Errors::NotFound]
+    #      if no update session with the given identifier exists.
+    # @raise [Com::Vmware::Vapi::Std::Errors::NotAllowedInCurrentState]
+    #      if the update session is not in the   :attr:`Com::Vmware::Content::Library::Item::UpdateSessionModel::State.ACTIVE`   state, or if some of the files that will be uploaded by the client aren't received correctly.
+    def validate(update_session_id)
+      invoke_with_info(VALIDATE_INFO,
+                       'update_session_id' => update_session_id)
+    end
 
+    # Requests file content to be changed (either created, or updated). Depending on the source type of the file, this  method  will either return an upload endpoint where the client can push the content, or the server will pull from the provided source endpoint. If a file with the same name already exists in this session, this  method  will be used to update the content of the existing file.  
+    # 
+    #  When importing a file directly from storage, where the source endpoint is a file or datastore URI, you will need to have the ContentLibrary.ReadStorage privilege on the library item. If the file is located in the same directory as the library storage backing folder, the server will move the file instead of copying it, thereby allowing instantaneous import of files for efficient backup and restore scenarios. In all other cases, a copy is performed rather than a move.
+    #
+    # @param update_session_id [String]
+    #      Identifier of the update session to be modified.
+    # @param file_spec [Com::Vmware::Content::Library::Item::Updatesession::File::AddSpec]
+    #      Specification for the file that needs to be added or updated. This includes whether the client wants to push the content or have the server pull it.
+    # @return [Com::Vmware::Content::Library::Item::Updatesession::File::Info]
+    #     An   :class:`Com::Vmware::Content::Library::Item::Updatesession::File::Info`    class  containing upload links as well as server side state tracking the transfer of the file.
+    # @raise [Com::Vmware::Vapi::Std::Errors::InvalidArgument]
+    #      if the  ``file_spec``  is invalid.
+    # @raise [Com::Vmware::Vapi::Std::Errors::NotFound]
+    #      if the update session doesn't exist.
+    # @raise [Com::Vmware::Vapi::Std::Errors::Unauthorized]
+    #      if the caller doesn't have ContentLibrary.ReadStorage privilege on the library item of the update session and source type   :attr:`Com::Vmware::Content::Library::Item::Updatesession::File::SourceType.PULL`   is requested for a file or datastore source endpoint (that is, not HTTP or HTTPs based endpoint).
+    def add(update_session_id, file_spec)
+      invoke_with_info(ADD_INFO,
+                       'update_session_id' => update_session_id,
+                       'file_spec' => file_spec)
+    end
+
+    # Requests a file to be removed. The file will only be effectively removed when the update session is completed.
+    #
+    # @param update_session_id [String]
+    #      Identifier of the update session.
+    # @param file_name [String]
+    #      Name of the file to be removed.
+    # @return [Void]
+    # @raise [Com::Vmware::Vapi::Std::Errors::NotFound]
+    #      if the update session doesn't exist.
+    # @raise [Com::Vmware::Vapi::Std::Errors::InvalidArgument]
+    #      if the file doesn't exist in the library item associated with the update session.
+    def remove(update_session_id, file_name)
+      invoke_with_info(REMOVE_INFO,
+                       'update_session_id' => update_session_id,
+                       'file_name' => file_name)
+    end
+
+    # Lists all files in the library item associated with the update session.
+    #
+    # @param update_session_id [String]
+    #      Identifier of the update session.
+    # @return [Array<Com::Vmware::Content::Library::Item::Updatesession::File::Info>]
+    #     The  list  of the files in the library item associated with the update session. This  list  may be empty if the caller has removed all the files as part of this session (in which case completing the update session will result in an empty library item).
+    # @raise [Com::Vmware::Vapi::Std::Errors::NotFound]
+    #      if the update session doesn't exist.
+    def list(update_session_id)
+      invoke_with_info(LIST_INFO,
+                       'update_session_id' => update_session_id)
+    end
+
+    # Retrieves information about a specific file in the snapshot of the library item at the time when the update session was created.
+    #
+    # @param update_session_id [String]
+    #      Identifier of the update session.
+    # @param file_name [String]
+    #      Name of the file.
+    # @return [Com::Vmware::Content::Library::Item::Updatesession::File::Info]
+    #     Information about the file.
+    # @raise [Com::Vmware::Vapi::Std::Errors::NotFound]
+    #      if the update session doesn't exist.
+    # @raise [Com::Vmware::Vapi::Std::Errors::InvalidArgument]
+    #      if the file doesn't exist in the library item associated with the update session.
+    def get(update_session_id, file_name)
+      invoke_with_info(GET_INFO,
+                       'update_session_id' => update_session_id,
+                       'file_name' => file_name)
+    end
+
+    # The  ``Com::Vmware::Content::Library::Item::Updatesession::File::AddSpec``   class  describes the properties of the file to be uploaded.
+    # @!attribute [rw] name
+    #     @return [String]
+    #     The name of the file being uploaded.
+    # @!attribute [rw] source_type
+    #     @return [Com::Vmware::Content::Library::Item::Updatesession::File::SourceType]
+    #     The source type ( ``NONE``, ``PUSH``, ``PULL`` ) from which the file content will be retrieved.
+    # @!attribute [rw] source_endpoint
+    #     @return [Com::Vmware::Content::Library::Item::TransferEndpoint]
+    #     Location from which the Content Library Service will fetch the file, rather than requiring a client to upload the file.
+    #     This  field  is optional and it is only relevant when the value of  ``sourceType``  is   :attr:`Com::Vmware::Content::Library::Item::Updatesession::File::SourceType.PULL`  .
+    # @!attribute [rw] size
+    #     @return [Fixnum, nil]
+    #     The file size, in bytes.
+    #     If specified the server will verify it received the correct size.
+    # @!attribute [rw] checksum_info
+    #     @return [Com::Vmware::Content::Library::Item::File::ChecksumInfo, nil]
+    #     The checksum of the file. If specified, the server will verify the checksum once the file is received. If there is a mismatch, the upload will fail.
+    #     If not specified the server does not verify the checksum.
+    class AddSpec < VAPI::Bindings::VapiStruct
+      class << self
+        # Holds (gets or creates) the binding type metadata for this structure type.
+        # @scope class
+        # @return [VAPI::Bindings::StructType] the binding type
+        def binding_type
+          @binding_type ||= VAPI::Bindings::StructType.new(
+            'com.vmware.content.library.item.updatesession.file.add_spec',
+            {
+              'name' => VAPI::Bindings::StringType.instance,
+              'source_type' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Content::Library::Item::Updatesession::File::SourceType'),
+              'source_endpoint' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Content::Library::Item::TransferEndpoint')),
+              'size' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::IntegerType.instance),
+              'checksum_info' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Content::Library::Item::File::ChecksumInfo'))
+            },
+            AddSpec,
+            false,
+            nil
+          )
+        end
+      end
+
+      attr_accessor :name,
+                    :source_type,
+                    :source_endpoint,
+                    :size,
+                    :checksum_info
+
+      # Constructs a new instance.
+      # @param ruby_values [Hash] a map of initial property values (optional)
+      # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
+      def initialize(ruby_values = nil, struct_value = nil)
+        super(self.class.binding_type, ruby_values, struct_value)
+      end
+    end
+
+    # The  ``Com::Vmware::Content::Library::Item::Updatesession::File::Info``   class  defines the uploaded file.
+    # @!attribute [rw] name
+    #     @return [String]
+    #     The name of the file.
+    # @!attribute [rw] source_type
+    #     @return [Com::Vmware::Content::Library::Item::Updatesession::File::SourceType]
+    #     The source type ( ``NONE``, ``PUSH``, ``PULL`` ) from which the file is being retrieved. This may be   :attr:`Com::Vmware::Content::Library::Item::Updatesession::File::SourceType.NONE`   if the file is not being changed.
+    # @!attribute [rw] size
+    #     @return [Fixnum, nil]
+    #     The file size, in bytes as received by the server. This  field  is guaranteed to be set when the server has completely received the file.
+    #     This  field  won't be set until the file status is   :attr:`Com::Vmware::Content::Library::Item::TransferStatus.READY`  .
+    # @!attribute [rw] checksum_info
+    #     @return [Com::Vmware::Content::Library::Item::File::ChecksumInfo, nil]
+    #     The checksum information of the file received by the server.
+    #     If not specified the server does not verify the checksum.
+    # @!attribute [rw] source_endpoint
+    #     @return [Com::Vmware::Content::Library::Item::TransferEndpoint]
+    #     A source endpoint from which to retrieve the file.
+    #     This  field  is optional and it is only relevant when the value of  ``sourceType``  is   :attr:`Com::Vmware::Content::Library::Item::Updatesession::File::SourceType.PULL`  .
+    # @!attribute [rw] upload_endpoint
+    #     @return [Com::Vmware::Content::Library::Item::TransferEndpoint]
+    #     An upload endpoint to which the client can push the content.
+    #     This  field  is optional and it is only relevant when the value of  ``sourceType``  is   :attr:`Com::Vmware::Content::Library::Item::Updatesession::File::SourceType.PUSH`  .
+    # @!attribute [rw] bytes_transferred
+    #     @return [Fixnum]
+    #     The number of bytes of this file that have been received by the server.
+    # @!attribute [rw] status
+    #     @return [Com::Vmware::Content::Library::Item::TransferStatus]
+    #     The transfer status ( ``WAITING_FOR_TRANSFER``, ``TRANSFERRING``, ``READY``, ``VALIDATING``, ``ERROR`` ) of this file.
+    # @!attribute [rw] error_message
+    #     @return [Com::Vmware::Vapi::Std::LocalizableMessage, nil]
+    #     Details about the transfer error.
+    #     An error message is set if the status is   :attr:`Com::Vmware::Content::Library::Item::TransferStatus.ERROR`  .
+    class Info < VAPI::Bindings::VapiStruct
+      class << self
+        # Holds (gets or creates) the binding type metadata for this structure type.
+        # @scope class
+        # @return [VAPI::Bindings::StructType] the binding type
+        def binding_type
+          @binding_type ||= VAPI::Bindings::StructType.new(
+            'com.vmware.content.library.item.updatesession.file.info',
+            {
+              'name' => VAPI::Bindings::StringType.instance,
+              'source_type' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Content::Library::Item::Updatesession::File::SourceType'),
+              'size' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::IntegerType.instance),
+              'checksum_info' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Content::Library::Item::File::ChecksumInfo')),
+              'source_endpoint' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Content::Library::Item::TransferEndpoint')),
+              'upload_endpoint' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Content::Library::Item::TransferEndpoint')),
+              'bytes_transferred' => VAPI::Bindings::IntegerType.instance,
+              'status' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Content::Library::Item::TransferStatus'),
+              'error_message' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::LocalizableMessage'))
+            },
+            Info,
+            false,
+            nil
+          )
+        end
+      end
+
+      attr_accessor :name,
+                    :source_type,
+                    :size,
+                    :checksum_info,
+                    :source_endpoint,
+                    :upload_endpoint,
+                    :bytes_transferred,
+                    :status,
+                    :error_message
+
+      # Constructs a new instance.
+      # @param ruby_values [Hash] a map of initial property values (optional)
+      # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
+      def initialize(ruby_values = nil, struct_value = nil)
+        super(self.class.binding_type, ruby_values, struct_value)
+      end
+    end
+
+    # The  ``Com::Vmware::Content::Library::Item::Updatesession::File::ValidationError``   class  defines the validation error of a file in the session.
+    # @!attribute [rw] name
+    #     @return [String]
+    #     The name of the file.
+    # @!attribute [rw] error_message
+    #     @return [Com::Vmware::Vapi::Std::LocalizableMessage]
+    #     A message indicating why the file was considered invalid.
+    class ValidationError < VAPI::Bindings::VapiStruct
+      class << self
+        # Holds (gets or creates) the binding type metadata for this structure type.
+        # @scope class
+        # @return [VAPI::Bindings::StructType] the binding type
+        def binding_type
+          @binding_type ||= VAPI::Bindings::StructType.new(
+            'com.vmware.content.library.item.updatesession.file.validation_error',
+            {
+              'name' => VAPI::Bindings::StringType.instance,
+              'error_message' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::LocalizableMessage')
+            },
+            ValidationError,
+            false,
+            nil
+          )
+        end
+      end
+
+      attr_accessor :name,
+                    :error_message
+
+      # Constructs a new instance.
+      # @param ruby_values [Hash] a map of initial property values (optional)
+      # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
+      def initialize(ruby_values = nil, struct_value = nil)
+        super(self.class.binding_type, ruby_values, struct_value)
+      end
+    end
+
+    # The  ``Com::Vmware::Content::Library::Item::Updatesession::File::ValidationResult``   class  defines the result of validating the files in the session.
+    # @!attribute [rw] has_errors
+    #     @return [Boolean]
+    #     Whether the validation was succesful or not. In case of errors, the   :attr:`Com::Vmware::Content::Library::Item::Updatesession::File::ValidationResult.missing_files`   and   :attr:`Com::Vmware::Content::Library::Item::Updatesession::File::ValidationResult.invalid_files`   will contain at least one entry.
+    # @!attribute [rw] missing_files
+    #     @return [Set<String>]
+    #     A  set  containing the names of the files that are required but the client hasn't added.
+    # @!attribute [rw] invalid_files
+    #     @return [Array<Com::Vmware::Content::Library::Item::Updatesession::File::ValidationError>]
+    #     A  list  containing the files that have been identified as invalid and details about the error.
+    class ValidationResult < VAPI::Bindings::VapiStruct
+      class << self
+        # Holds (gets or creates) the binding type metadata for this structure type.
+        # @scope class
+        # @return [VAPI::Bindings::StructType] the binding type
+        def binding_type
+          @binding_type ||= VAPI::Bindings::StructType.new(
+            'com.vmware.content.library.item.updatesession.file.validation_result',
+            {
+              'has_errors' => VAPI::Bindings::BooleanType.instance,
+              'missing_files' => VAPI::Bindings::SetType.new(VAPI::Bindings::StringType.instance),
+              'invalid_files' => VAPI::Bindings::ListType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Content::Library::Item::Updatesession::File::ValidationError'))
+            },
+            ValidationResult,
+            false,
+            nil
+          )
+        end
+      end
+
+      attr_accessor :has_errors,
+                    :missing_files,
+                    :invalid_files
+
+      # Constructs a new instance.
+      # @param ruby_values [Hash] a map of initial property values (optional)
+      # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
+      def initialize(ruby_values = nil, struct_value = nil)
+        super(self.class.binding_type, ruby_values, struct_value)
+      end
+    end
+
+    # The  ``Com::Vmware::Content::Library::Item::Updatesession::File::SourceType``   enumerated type  defines how the file content is retrieved.
+    # @!attribute [rw] none
+    #     @return [Com::Vmware::Content::Library::Item::Updatesession::File::SourceType]
+    #     No source type has been requested.
+    # @!attribute [rw] push
+    #     @return [Com::Vmware::Content::Library::Item::Updatesession::File::SourceType]
+    #     The client is uploading content using HTTP(S) PUT requests.
+    # @!attribute [rw] pull
+    #     @return [Com::Vmware::Content::Library::Item::Updatesession::File::SourceType]
+    #     The server is pulling content from a URL. The URL scheme can be  ``http`` ,  ``https`` ,  ``file`` , or  ``ds`` .
+    class SourceType < VAPI::Bindings::VapiEnum
+      class << self
+        # Holds (gets or creates) the binding type metadata for this enumeration type.
+        # @scope class
+        # @return [VAPI::Bindings::EnumType] the binding type
+        def binding_type
+          @binding_type ||= VAPI::Bindings::EnumType.new(
+            'com.vmware.content.library.item.updatesession.file.source_type',
+            SourceType
+          )
+        end
+
+        # Converts from a string value (perhaps off the wire) to an instance
+        # of this enum type.
+        # @param value [String] the actual value of the enum instance
+        # @return [SourceType] the instance found for the value, otherwise
+        #         an unknown instance will be built for the value
+        def from_string(value)
+          const_get(value)
+        rescue NameError
+          SourceType.send(:new, 'UNKNOWN', value)
+        end
+      end
+
+      # Constructs a new instance.
+      # @param value [String] the actual value of the enum instance
+      # @param unknown [String] the unknown value when value is 'UKNOWN'
+      def initialize(value, unknown = nil)
+        super(self.class.binding_type, value, unknown)
+      end
+
+      private_class_method :new
+
+      # @!attribute [rw] none
+      #     @return [Com::Vmware::Content::Library::Item::Updatesession::File::SourceType]
+      #     No source type has been requested.
+      NONE = SourceType.send(:new, 'NONE')
+
+      # @!attribute [rw] push
+      #     @return [Com::Vmware::Content::Library::Item::Updatesession::File::SourceType]
+      #     The client is uploading content using HTTP(S) PUT requests.
+      PUSH = SourceType.send(:new, 'PUSH')
+
+      # @!attribute [rw] pull
+      #     @return [Com::Vmware::Content::Library::Item::Updatesession::File::SourceType]
+      #     The server is pulling content from a URL. The URL scheme can be  ``http`` ,  ``https`` ,  ``file`` , or  ``ds`` .
+      PULL = SourceType.send(:new, 'PULL')
+    end
+  end
 end

--- a/client/sdk/com/vmware/content/vapi.rb
+++ b/client/sdk/com/vmware/content/vapi.rb
@@ -1,5 +1,6 @@
 #---------------------------------------------------------------------------
-# Copyright 2016 VMware, Inc.  All rights reserved.
+# Copyright 2017 VMware, Inc.  All rights reserved.
+#
 # AUTO GENERATED FILE -- DO NOT MODIFY!
 #---------------------------------------------------------------------------
 require 'vapi'

--- a/client/sdk/com/vmware/vapi/metadata.rb
+++ b/client/sdk/com/vmware/vapi/metadata.rb
@@ -1,5 +1,6 @@
 #---------------------------------------------------------------------------
-# Copyright 2016 VMware, Inc.  All rights reserved.
+# Copyright 2017 VMware, Inc.  All rights reserved.
+#
 # AUTO GENERATED FILE -- DO NOT MODIFY!
 #
 # vAPI type descriptors for package com.vmware.vapi.metadata.
@@ -8,12 +9,12 @@ require 'vapi'
 
 # declare the module hierarchy before we use the shorthand syntax below
 module Com
-    module Vmware
-        module Vapi
-            module Metadata
-            end
-        end
+  module Vmware
+    module Vapi
+      module Metadata
+      end
     end
+  end
 end
 
 # The   :mod:`com.vmware.vapi.metadata`    package  provides metadata  classs . These are  classs  that provide different facets of API information. Clients can use these  classs  to:  
@@ -23,165 +24,153 @@ end
 #    *  Fetch authentication and authorization metadata. 
 #   
 module Com::Vmware::Vapi::Metadata
-
-    # The  ``Com::Vmware::Vapi::Metadata::SourceCreateSpec``   class  contains the registration information for a metadata source.
-    # @!attribute [rw] description
-    #     @return [String]
-    #     English language human readable description of the source.
-    # @!attribute [rw] type
-    #     @return [Com::Vmware::Vapi::Metadata::SourceType]
-    #     Type of the metadata source.
-    # @!attribute [rw] filepath
-    #     @return [String]
-    #     Absolute file path of the metamodel metadata file that has the metamodel information about one component element.
-    #     This  field  is optional and it is only relevant when the value of  ``type``  is   :attr:`Com::Vmware::Vapi::Metadata::SourceType.FILE`  .
-    # @!attribute [rw] address
-    #     @return [URI]
-    #     Connection information of the remote server. This should be of the format http(s)://IP:port/namespace.  
-    #     
-    #      The remote server should contain the  classs  in   :mod:`com.vmware.vapi.metadata.metamodel`    package . It could expose metamodel information of one or more components.
-    #     This  field  is optional and it is only relevant when the value of  ``type``  is   :attr:`Com::Vmware::Vapi::Metadata::SourceType.REMOTE`  .
-    class SourceCreateSpec < VAPI::Bindings::VapiStruct
-
-        class << self
-            # Holds (gets or creates) the binding type metadata for this structure type.
-            # @scope class
-            # @return [VAPI::Bindings::StructType] the binding type
-            def binding_type
-                @binding_type ||= VAPI::Bindings::StructType.new(
-                    'com.vmware.vapi.metadata.source_create_spec',
-                    {
-                        'description' => VAPI::Bindings::StringType.instance,
-                        'type' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Metadata::SourceType'),
-                        'filepath' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::StringType.instance),
-                        'address' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::URIType.instance),
-                    },
-                    SourceCreateSpec,
-                    false,
-                    nil)
-            end
-        end
-
-        attr_accessor :description,
-                      :type,
-                      :filepath,
-                      :address
-
-        # Constructs a new instance.
-        # @param ruby_values [Hash] a map of initial property values (optional)
-        # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
-        def initialize(ruby_values=nil, struct_value=nil)
-            super(self.class.binding_type, ruby_values, struct_value)
-        end
+  # The  ``Com::Vmware::Vapi::Metadata::SourceCreateSpec``   class  contains the registration information for a metadata source.
+  # @!attribute [rw] description
+  #     @return [String]
+  #     English language human readable description of the source.
+  # @!attribute [rw] type
+  #     @return [Com::Vmware::Vapi::Metadata::SourceType]
+  #     Type of the metadata source.
+  # @!attribute [rw] filepath
+  #     @return [String]
+  #     Absolute file path of the metamodel metadata file that has the metamodel information about one component element.
+  #     This  field  is optional and it is only relevant when the value of  ``type``  is   :attr:`Com::Vmware::Vapi::Metadata::SourceType.FILE`  .
+  # @!attribute [rw] address
+  #     @return [URI]
+  #     Connection information of the remote server. This should be of the format http(s)://IP:port/namespace.  
+  #     
+  #      The remote server should contain the  classs  in   :mod:`com.vmware.vapi.metadata.metamodel`    package . It could expose metamodel information of one or more components.
+  #     This  field  is optional and it is only relevant when the value of  ``type``  is   :attr:`Com::Vmware::Vapi::Metadata::SourceType.REMOTE`  .
+  class SourceCreateSpec < VAPI::Bindings::VapiStruct
+    class << self
+      # Holds (gets or creates) the binding type metadata for this structure type.
+      # @scope class
+      # @return [VAPI::Bindings::StructType] the binding type
+      def binding_type
+        @binding_type ||= VAPI::Bindings::StructType.new(
+          'com.vmware.vapi.metadata.source_create_spec',
+          {
+            'description' => VAPI::Bindings::StringType.instance,
+            'type' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Metadata::SourceType'),
+            'filepath' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::StringType.instance),
+            'address' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::URIType.instance)
+          },
+          SourceCreateSpec,
+          false,
+          nil
+        )
+      end
     end
 
+    attr_accessor :description,
+                  :type,
+                  :filepath,
+                  :address
 
-    # Metadata source info
-    # @!attribute [rw] type
-    #     @return [Com::Vmware::Vapi::Metadata::SourceType]
-    #     Type of the metadata source
-    # @!attribute [rw] file_name
-    #     @return [String]
-    #     Name of the metadata source file
-    #     This  field  is optional and it is only relevant when the value of  ``type``  is   :attr:`Com::Vmware::Vapi::Metadata::SourceType.FILE`  .
-    # @!attribute [rw] remote_addr
-    #     @return [String]
-    #     Address of the remote metadata source
-    #     This  field  is optional and it is only relevant when the value of  ``type``  is   :attr:`Com::Vmware::Vapi::Metadata::SourceType.REMOTE`  .
-    # @!attribute [rw] msg_protocol
-    #     @return [String]
-    #     Message protocol to be used
-    #     This  field  is optional and it is only relevant when the value of  ``type``  is   :attr:`Com::Vmware::Vapi::Metadata::SourceType.REMOTE`  .
-    class SourceInfo < VAPI::Bindings::VapiStruct
-
-        class << self
-            # Holds (gets or creates) the binding type metadata for this structure type.
-            # @scope class
-            # @return [VAPI::Bindings::StructType] the binding type
-            def binding_type
-                @binding_type ||= VAPI::Bindings::StructType.new(
-                    'com.vmware.vapi.metadata.source_info',
-                    {
-                        'type' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Metadata::SourceType'),
-                        'file_name' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::StringType.instance),
-                        'remote_addr' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::StringType.instance),
-                        'msg_protocol' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::StringType.instance),
-                    },
-                    SourceInfo,
-                    false,
-                    nil)
-            end
-        end
-
-        attr_accessor :type,
-                      :file_name,
-                      :remote_addr,
-                      :msg_protocol
-
-        # Constructs a new instance.
-        # @param ruby_values [Hash] a map of initial property values (optional)
-        # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
-        def initialize(ruby_values=nil, struct_value=nil)
-            super(self.class.binding_type, ruby_values, struct_value)
-        end
+    # Constructs a new instance.
+    # @param ruby_values [Hash] a map of initial property values (optional)
+    # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
+    def initialize(ruby_values = nil, struct_value = nil)
+      super(self.class.binding_type, ruby_values, struct_value)
+    end
+  end
+  # Metadata source info
+  # @!attribute [rw] type
+  #     @return [Com::Vmware::Vapi::Metadata::SourceType]
+  #     Type of the metadata source
+  # @!attribute [rw] file_name
+  #     @return [String]
+  #     Name of the metadata source file
+  #     This  field  is optional and it is only relevant when the value of  ``type``  is   :attr:`Com::Vmware::Vapi::Metadata::SourceType.FILE`  .
+  # @!attribute [rw] remote_addr
+  #     @return [String]
+  #     Address of the remote metadata source
+  #     This  field  is optional and it is only relevant when the value of  ``type``  is   :attr:`Com::Vmware::Vapi::Metadata::SourceType.REMOTE`  .
+  # @!attribute [rw] msg_protocol
+  #     @return [String]
+  #     Message protocol to be used
+  #     This  field  is optional and it is only relevant when the value of  ``type``  is   :attr:`Com::Vmware::Vapi::Metadata::SourceType.REMOTE`  .
+  class SourceInfo < VAPI::Bindings::VapiStruct
+    class << self
+      # Holds (gets or creates) the binding type metadata for this structure type.
+      # @scope class
+      # @return [VAPI::Bindings::StructType] the binding type
+      def binding_type
+        @binding_type ||= VAPI::Bindings::StructType.new(
+          'com.vmware.vapi.metadata.source_info',
+          {
+            'type' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Metadata::SourceType'),
+            'file_name' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::StringType.instance),
+            'remote_addr' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::StringType.instance),
+            'msg_protocol' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::StringType.instance)
+          },
+          SourceInfo,
+          false,
+          nil
+        )
+      end
     end
 
+    attr_accessor :type,
+                  :file_name,
+                  :remote_addr,
+                  :msg_protocol
 
-    # The  ``Com::Vmware::Vapi::Metadata::SourceType``   enumerated type  defines the types of sources for API metadata. You specify the type of source when adding a metadata source to a metadata service.
+    # Constructs a new instance.
+    # @param ruby_values [Hash] a map of initial property values (optional)
+    # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
+    def initialize(ruby_values = nil, struct_value = nil)
+      super(self.class.binding_type, ruby_values, struct_value)
+    end
+  end
+  # The  ``Com::Vmware::Vapi::Metadata::SourceType``   enumerated type  defines the types of sources for API metadata. You specify the type of source when adding a metadata source to a metadata service.
+  # @!attribute [rw] file
+  #     @return [Com::Vmware::Vapi::Metadata::SourceType]
+  #     Indicates the metadata source is a JSON file.
+  # @!attribute [rw] remote
+  #     @return [Com::Vmware::Vapi::Metadata::SourceType]
+  #     Indicates the metadata source is a remote server.
+  class SourceType < VAPI::Bindings::VapiEnum
+    class << self
+      # Holds (gets or creates) the binding type metadata for this enumeration type.
+      # @scope class
+      # @return [VAPI::Bindings::EnumType] the binding type
+      def binding_type
+        @binding_type ||= VAPI::Bindings::EnumType.new(
+          'com.vmware.vapi.metadata.source_type',
+          SourceType
+        )
+      end
+
+      # Converts from a string value (perhaps off the wire) to an instance
+      # of this enum type.
+      # @param value [String] the actual value of the enum instance
+      # @return [SourceType] the instance found for the value, otherwise
+      #         an unknown instance will be built for the value
+      def from_string(value)
+        const_get(value)
+      rescue NameError
+        SourceType.send(:new, 'UNKNOWN', value)
+      end
+    end
+
+    # Constructs a new instance.
+    # @param value [String] the actual value of the enum instance
+    # @param unknown [String] the unknown value when value is 'UKNOWN'
+    def initialize(value, unknown = nil)
+      super(self.class.binding_type, value, unknown)
+    end
+
+    private_class_method :new
+
     # @!attribute [rw] file
     #     @return [Com::Vmware::Vapi::Metadata::SourceType]
     #     Indicates the metadata source is a JSON file.
+    FILE = SourceType.send(:new, 'FILE')
+
     # @!attribute [rw] remote
     #     @return [Com::Vmware::Vapi::Metadata::SourceType]
     #     Indicates the metadata source is a remote server.
-    class SourceType < VAPI::Bindings::VapiEnum
-
-        class << self
-            # Holds (gets or creates) the binding type metadata for this enumeration type.
-            # @scope class
-            # @return [VAPI::Bindings::EnumType] the binding type
-            def binding_type
-                @binding_type ||= VAPI::Bindings::EnumType.new(
-                    'com.vmware.vapi.metadata.source_type',
-                    SourceType)
-            end
-
-            # Converts from a string value (perhaps off the wire) to an instance
-            # of this enum type.
-            # @param value [String] the actual value of the enum instance
-            # @return [SourceType] the instance found for the value, otherwise
-            #         an unknown instance will be built for the value
-            def from_string(value)
-                begin
-                    const_get(value)
-                rescue NameError
-                    SourceType.new('UNKNOWN', value)
-                end
-            end
-        end
-
-        private
-
-        # Constructs a new instance.
-        # @param value [String] the actual value of the enum instance
-        # @param unknown [String] the unknown value when value is 'UKNOWN'
-        def initialize(value, unknown=nil)
-            super(self.class.binding_type, value, unknown)
-        end
-
-        public
-
-        # @!attribute [rw] file
-        #     @return [Com::Vmware::Vapi::Metadata::SourceType]
-        #     Indicates the metadata source is a JSON file.
-        FILE = SourceType.new('FILE')
-
-        # @!attribute [rw] remote
-        #     @return [Com::Vmware::Vapi::Metadata::SourceType]
-        #     Indicates the metadata source is a remote server.
-        REMOTE = SourceType.new('REMOTE')
-
-    end
-
-
+    REMOTE = SourceType.send(:new, 'REMOTE')
+  end
 end

--- a/client/sdk/com/vmware/vapi/metadata/authentication.rb
+++ b/client/sdk/com/vmware/vapi/metadata/authentication.rb
@@ -1,5 +1,6 @@
 #---------------------------------------------------------------------------
-# Copyright 2016 VMware, Inc.  All rights reserved.
+# Copyright 2017 VMware, Inc.  All rights reserved.
+#
 # AUTO GENERATED FILE -- DO NOT MODIFY!
 #
 # vAPI type descriptors for package com.vmware.vapi.metadata.authentication.
@@ -8,874 +9,809 @@ require 'vapi'
 
 # declare the module hierarchy before we use the shorthand syntax below
 module Com
-    module Vmware
-        module Vapi
-            module Metadata
-                module Authentication
-                end
-            end
+  module Vmware
+    module Vapi
+      module Metadata
+        module Authentication
         end
+      end
     end
+  end
 end
 
 # The  ``com.vmware.vapi.metadata.authentication``   package  provides  classs  that expose authentication information for operation elements across all the service elements.  
 # 
 #  To calculate the effective authentication information for an operation element, you should first see if there is an authentication scheme specified for the operation element. If it is not specified, then authentication scheme for the service element that contains this operation element is used. If it is not specified for the service element as well, then the authentication scheme for the package element that contains this service element is used.
 module Com::Vmware::Vapi::Metadata::Authentication
+  # The  ``Com::Vmware::Vapi::Metadata::Authentication::Component``   class  provides  methods  to retrieve authentication information of a component element.  
+  # 
+  #  A component element is said to contain authentication information if any one of package elements contained in it has authentication information.
+  class Component < VAPI::Bindings::VapiService
+    # static metamodel definitions
+    SERVICE_ID = VAPI::Core::ServiceIdentifier.new('com.vmware.vapi.metadata.authentication.component')
 
-    # The  ``Com::Vmware::Vapi::Metadata::Authentication::Component``   class  provides  methods  to retrieve authentication information of a component element.  
-    # 
-    #  A component element is said to contain authentication information if any one of package elements contained in it has authentication information.
-    class Component < VAPI::Bindings::VapiService
+    LIST_INFO = VAPI::Bindings::OperationInfo.new(
+      VAPI::Core::OperationIdentifier.new('list', SERVICE_ID),
+      VAPI::Bindings::OperationInputType.new,
+      VAPI::Bindings::ListType.new(VAPI::Bindings::IdType.new),
+      {},
+      [],
+      []
+    )
 
-        protected
+    GET_INFO = VAPI::Bindings::OperationInfo.new(
+      VAPI::Core::OperationIdentifier.new('get', SERVICE_ID),
+      VAPI::Bindings::OperationInputType.new(
+        'component_id' => VAPI::Bindings::IdType.new('com.vmware.vapi.component')
+      ),
+      VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Metadata::Authentication::ComponentData'),
+      {
+        'com.vmware.vapi.std.errors.not_found' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::NotFound')
+      },
+      [],
+      []
+    )
 
-        # static metamodel definitions
-        @@service_id = VAPI::Core::ServiceIdentifier.new('com.vmware.vapi.metadata.authentication.component')
+    FINGERPRINT_INFO = VAPI::Bindings::OperationInfo.new(
+      VAPI::Core::OperationIdentifier.new('fingerprint', SERVICE_ID),
+      VAPI::Bindings::OperationInputType.new(
+        'component_id' => VAPI::Bindings::IdType.new('com.vmware.vapi.component')
+      ),
+      VAPI::Bindings::StringType.instance,
+      {
+        'com.vmware.vapi.std.errors.not_found' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::NotFound')
+      },
+      [],
+      []
+    )
 
-        @@list_info = VAPI::Bindings::OperationInfo.new(
-            VAPI::Core::OperationIdentifier.new('list', @@service_id),
-            VAPI::Bindings::OperationInputType.new,
-            VAPI::Bindings::ListType.new(VAPI::Bindings::IdType.new),
-            {},
-            [],
-            [])
-        @@get_info = VAPI::Bindings::OperationInfo.new(
-            VAPI::Core::OperationIdentifier.new('get', @@service_id),
-            VAPI::Bindings::OperationInputType.new({
-                'component_id' => VAPI::Bindings::IdType.new(resource_types='com.vmware.vapi.component'),
-            }),
-            VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Metadata::Authentication::ComponentData'),
-            {
-                'com.vmware.vapi.std.errors.not_found' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::NotFound'),
+    SERVICE_INFO = VAPI::Bindings::ServiceInfo.new(
+      SERVICE_ID,
+      'list' => LIST_INFO,
+      'get' => GET_INFO,
+      'fingerprint' => FINGERPRINT_INFO
+    )
 
-            },
-            [],
-            [])
-        @@fingerprint_info = VAPI::Bindings::OperationInfo.new(
-            VAPI::Core::OperationIdentifier.new('fingerprint', @@service_id),
-            VAPI::Bindings::OperationInputType.new({
-                'component_id' => VAPI::Bindings::IdType.new(resource_types='com.vmware.vapi.component'),
-            }),
-            VAPI::Bindings::StringType.instance,
-            {
-                'com.vmware.vapi.std.errors.not_found' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::NotFound'),
-
-            },
-            [],
-            [])
-
-        @@service_info = VAPI::Bindings::ServiceInfo.new(@@service_id, {
-            'list' => @@list_info,
-            'get' => @@get_info,
-            'fingerprint' => @@fingerprint_info,
-        })
-
-        public
-
-        # Constructs a new instance.
-        #
-        # @param config [VAPI::Bindings::StubConfig] A hash with the api provider details.
-        def initialize(config)
-            super(config, @@service_info)
-        end
-
-        RESOURCE_TYPE = 'com.vmware.vapi.component'
-
-
-        # Returns the identifiers for the component elements that have authentication information.
-        #
-        # @return [Array<String>]
-        #     The list of identifiers for the component elements that have authentication information.
-        def list()
-            invoke_with_info(@@list_info)
-        end
-
-
-        # Retrieves authentication information about the component element corresponding to  ``component_id`` .  
-        # 
-        #  The   :class:`Com::Vmware::Vapi::Metadata::Authentication::ComponentData`   contains the authentication information about the component element and it's fingerprint. It contains information about all the package elements that belong to this component element.
-        #
-        # @param component_id [String]
-        #     Identifier of the component element.
-        # @return [Com::Vmware::Vapi::Metadata::Authentication::ComponentData]
-        #     The   :class:`Com::Vmware::Vapi::Metadata::Authentication::ComponentData`   instance that corresponds to  ``component_id``
-        # @raise [Com::Vmware::Vapi::Std::Errors::NotFound]
-        #     if the component element associated with  ``component_id``  does not have any authentication information.
-        def get(component_id)
-            invoke_with_info(@@get_info, {
-                'component_id' => component_id,
-            })
-        end
-
-
-        # Retrieves the fingerprint computed from the authentication metadata of the component element corresponding to  ``component_id`` .  
-        # 
-        #  The fingerprint provides clients an efficient way to check if the metadata for a particular component has been modified on the server. The client can do this by comparing the result of this operation with the fingerprint returned in the result of   :func:`Com::Vmware::Vapi::Metadata::Authentication::Component.get`  .
-        #
-        # @param component_id [String]
-        #     Identifier of the component element.
-        # @return [String]
-        #     The fingerprint computed from the authentication metadata of the component.
-        # @raise [Com::Vmware::Vapi::Std::Errors::NotFound]
-        #     if the component element associated with  ``component_id``  does not have any authentication information.
-        def fingerprint(component_id)
-            invoke_with_info(@@fingerprint_info, {
-                'component_id' => component_id,
-            })
-        end
-
-
+    # Constructs a new instance.
+    #
+    # @param config [VAPI::Bindings::StubConfig] A hash with the api provider details.
+    def initialize(config)
+      super(config, SERVICE_INFO)
     end
 
-
-    # The  ``Com::Vmware::Vapi::Metadata::Authentication::Package``   class  provides  methods  to retrieve authentication information of a package element.  
-    # 
-    #  A package element is said to contain authentication information if there is a default authentication assigned to all service elements contained in the package element or if one of the service element contained in this package element has authentication information.
-    class Package < VAPI::Bindings::VapiService
-
-        protected
-
-        # static metamodel definitions
-        @@service_id = VAPI::Core::ServiceIdentifier.new('com.vmware.vapi.metadata.authentication.package')
-
-        @@list_info = VAPI::Bindings::OperationInfo.new(
-            VAPI::Core::OperationIdentifier.new('list', @@service_id),
-            VAPI::Bindings::OperationInputType.new,
-            VAPI::Bindings::ListType.new(VAPI::Bindings::IdType.new),
-            {},
-            [],
-            [])
-        @@get_info = VAPI::Bindings::OperationInfo.new(
-            VAPI::Core::OperationIdentifier.new('get', @@service_id),
-            VAPI::Bindings::OperationInputType.new({
-                'package_id' => VAPI::Bindings::IdType.new(resource_types='com.vmware.vapi.package'),
-            }),
-            VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Metadata::Authentication::PackageInfo'),
-            {
-                'com.vmware.vapi.std.errors.not_found' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::NotFound'),
-
-            },
-            [],
-            [])
-
-        @@service_info = VAPI::Bindings::ServiceInfo.new(@@service_id, {
-            'list' => @@list_info,
-            'get' => @@get_info,
-        })
-
-        public
-
-        # Constructs a new instance.
-        #
-        # @param config [VAPI::Bindings::StubConfig] A hash with the api provider details.
-        def initialize(config)
-            super(config, @@service_info)
-        end
-
-        RESOURCE_TYPE = 'com.vmware.vapi.package'
-
-
-        # Returns the identifiers for the package elements that have authentication information.
-        #
-        # @return [Array<String>]
-        #     The list of identifiers for the package elements that have authentication information.
-        def list()
-            invoke_with_info(@@list_info)
-        end
-
-
-        # Retrieves authentication information about the package element corresponding to  ``package_id`` .
-        #
-        # @param package_id [String]
-        #     Identifier of the package element.
-        # @return [Com::Vmware::Vapi::Metadata::Authentication::PackageInfo]
-        #     The   :class:`Com::Vmware::Vapi::Metadata::Authentication::PackageInfo`   instance that corresponds to  ``package_id``
-        # @raise [Com::Vmware::Vapi::Std::Errors::NotFound]
-        #     if the package element associated with  ``package_id``  does not have any authentication information.
-        def get(package_id)
-            invoke_with_info(@@get_info, {
-                'package_id' => package_id,
-            })
-        end
-
-
+    RESOURCE_TYPE = 'com.vmware.vapi.component'
+    # Returns the identifiers for the component elements that have authentication information.
+    #
+    # @return [Array<String>]
+    #     The list of identifiers for the component elements that have authentication information.
+    def list
+      invoke_with_info(LIST_INFO)
     end
 
-
-    # The  ``Com::Vmware::Vapi::Metadata::Authentication::Service``   class  provides  methods  to retrieve authentication information of a service element.  
+    # Retrieves authentication information about the component element corresponding to  ``component_id`` .  
     # 
-    #  A service element is said to contain authentication information if there is a default authentication assigned to all operation elements contained in a service element or if one of the operation elements contained in this service element has authentication information.
-    class ServiceService < VAPI::Bindings::VapiService
-
-        protected
-
-        # static metamodel definitions
-        @@service_id = VAPI::Core::ServiceIdentifier.new('com.vmware.vapi.metadata.authentication.service')
-
-        @@list_info = VAPI::Bindings::OperationInfo.new(
-            VAPI::Core::OperationIdentifier.new('list', @@service_id),
-            VAPI::Bindings::OperationInputType.new,
-            VAPI::Bindings::ListType.new(VAPI::Bindings::IdType.new),
-            {},
-            [],
-            [])
-        @@get_info = VAPI::Bindings::OperationInfo.new(
-            VAPI::Core::OperationIdentifier.new('get', @@service_id),
-            VAPI::Bindings::OperationInputType.new({
-                'service_id' => VAPI::Bindings::IdType.new(resource_types='com.vmware.vapi.service'),
-            }),
-            VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Metadata::Authentication::ServiceInfo'),
-            {
-                'com.vmware.vapi.std.errors.not_found' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::NotFound'),
-
-            },
-            [],
-            [])
-
-        @@service_info = VAPI::Bindings::ServiceInfo.new(@@service_id, {
-            'list' => @@list_info,
-            'get' => @@get_info,
-        })
-
-        public
-
-        # Constructs a new instance.
-        #
-        # @param config [VAPI::Bindings::StubConfig] A hash with the api provider details.
-        def initialize(config)
-            super(config, @@service_info)
-        end
-
-        RESOURCE_TYPE = 'com.vmware.vapi.service'
-
-
-        # Returns the identifiers for the service elements that have authentication information.
-        #
-        # @return [Array<String>]
-        #     The list of identifiers for the service elements that have authentication information.
-        def list()
-            invoke_with_info(@@list_info)
-        end
-
-
-        # Retrieves authentication information about the service element corresponding to  ``service_id`` .
-        #
-        # @param service_id [String]
-        #     Identifier of the service element.
-        # @return [Com::Vmware::Vapi::Metadata::Authentication::ServiceInfo]
-        #     The   :class:`Com::Vmware::Vapi::Metadata::Authentication::ServiceInfo`   instance that corresponds to  ``service_id``
-        # @raise [Com::Vmware::Vapi::Std::Errors::NotFound]
-        #     if the service element associated with  ``service_id``  does not have any authentication information.
-        def get(service_id)
-            invoke_with_info(@@get_info, {
-                'service_id' => service_id,
-            })
-        end
-
-
+    #  The   :class:`Com::Vmware::Vapi::Metadata::Authentication::ComponentData`   contains the authentication information about the component element and it's fingerprint. It contains information about all the package elements that belong to this component element.
+    #
+    # @param component_id [String]
+    #     Identifier of the component element.
+    # @return [Com::Vmware::Vapi::Metadata::Authentication::ComponentData]
+    #     The   :class:`Com::Vmware::Vapi::Metadata::Authentication::ComponentData`   instance that corresponds to  ``component_id``
+    # @raise [Com::Vmware::Vapi::Std::Errors::NotFound]
+    #     if the component element associated with  ``component_id``  does not have any authentication information.
+    def get(component_id)
+      invoke_with_info(GET_INFO,
+                       'component_id' => component_id)
     end
 
-
-    # The  ``Com::Vmware::Vapi::Metadata::Authentication::Source``   class  provides  methods  to manage the sources of authentication metadata information.  
+    # Retrieves the fingerprint computed from the authentication metadata of the component element corresponding to  ``component_id`` .  
     # 
-    #  The interface definition language infrastructure provides tools to generate various kinds of metadata in JSON format from the interface definition files and additional properties files. One of the generated files contains authentication information. The generated file can be registered as a source of metadata.  
-    # 
-    #  The authentication file contains all the data present in the interface definition files. Each authentication file contains data about one component element. When a authentication file is added as a source, each source contributes only one component element's metadata.  
-    # 
-    #  Authentication metadata can also be discovered from a remote server that supports the authentication metadata  classs  (see   :mod:`com.vmware.vapi.metadata.authentication`  ). Since multiple components can be registered with a single metadata server, when a remote server is registered as a source, that source can contribute more than one component.
-    class Source < VAPI::Bindings::VapiService
-
-        protected
-
-        # static metamodel definitions
-        @@service_id = VAPI::Core::ServiceIdentifier.new('com.vmware.vapi.metadata.authentication.source')
-
-        @@create_info = VAPI::Bindings::OperationInfo.new(
-            VAPI::Core::OperationIdentifier.new('create', @@service_id),
-            VAPI::Bindings::OperationInputType.new({
-                'source_id' => VAPI::Bindings::IdType.new(resource_types='com.vmware.vapi.metadata.authentication.source'),
-                'spec' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Metadata::Authentication::Source::CreateSpec'),
-            }),
-            VAPI::Bindings::VoidType.instance,
-            {
-                'com.vmware.vapi.std.errors.already_exists' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::AlreadyExists'),
-                'com.vmware.vapi.std.errors.invalid_argument' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::InvalidArgument'),
-                'com.vmware.vapi.std.errors.not_found' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::NotFound'),
-
-            },
-            [],
-            [])
-        @@delete_info = VAPI::Bindings::OperationInfo.new(
-            VAPI::Core::OperationIdentifier.new('delete', @@service_id),
-            VAPI::Bindings::OperationInputType.new({
-                'source_id' => VAPI::Bindings::IdType.new(resource_types='com.vmware.vapi.metadata.authentication.source'),
-            }),
-            VAPI::Bindings::VoidType.instance,
-            {
-                'com.vmware.vapi.std.errors.not_found' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::NotFound'),
-
-            },
-            [],
-            [])
-        @@get_info = VAPI::Bindings::OperationInfo.new(
-            VAPI::Core::OperationIdentifier.new('get', @@service_id),
-            VAPI::Bindings::OperationInputType.new({
-                'source_id' => VAPI::Bindings::IdType.new(resource_types='com.vmware.vapi.metadata.authentication.source'),
-            }),
-            VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Metadata::Authentication::Source::Info'),
-            {
-                'com.vmware.vapi.std.errors.not_found' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::NotFound'),
-
-            },
-            [],
-            [])
-        @@list_info = VAPI::Bindings::OperationInfo.new(
-            VAPI::Core::OperationIdentifier.new('list', @@service_id),
-            VAPI::Bindings::OperationInputType.new,
-            VAPI::Bindings::ListType.new(VAPI::Bindings::IdType.new),
-            {},
-            [],
-            [])
-        @@reload_info = VAPI::Bindings::OperationInfo.new(
-            VAPI::Core::OperationIdentifier.new('reload', @@service_id),
-            VAPI::Bindings::OperationInputType.new({
-                'source_id' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::IdType.new),
-            }),
-            VAPI::Bindings::VoidType.instance,
-            {
-                'com.vmware.vapi.std.errors.not_found' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::NotFound'),
-
-            },
-            [],
-            [])
-        @@fingerprint_info = VAPI::Bindings::OperationInfo.new(
-            VAPI::Core::OperationIdentifier.new('fingerprint', @@service_id),
-            VAPI::Bindings::OperationInputType.new({
-                'source_id' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::IdType.new),
-            }),
-            VAPI::Bindings::StringType.instance,
-            {
-                'com.vmware.vapi.std.errors.not_found' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::NotFound'),
-
-            },
-            [],
-            [])
-
-        @@service_info = VAPI::Bindings::ServiceInfo.new(@@service_id, {
-            'create' => @@create_info,
-            'delete' => @@delete_info,
-            'get' => @@get_info,
-            'list' => @@list_info,
-            'reload' => @@reload_info,
-            'fingerprint' => @@fingerprint_info,
-        })
-
-        public
-
-        # Constructs a new instance.
-        #
-        # @param config [VAPI::Bindings::StubConfig] A hash with the api provider details.
-        def initialize(config)
-            super(config, @@service_info)
-        end
-
-        RESOURCE_TYPE = 'com.vmware.vapi.metadata.authentication.source'
-
-
-        # Creates a new metadata source. Once the server validates the registration information of the metadata source, the authentication metadata is retrieved from the source. This populates elements in all the  classs  defined in   :mod:`com.vmware.vapi.metadata.authentication`    package .
-        #
-        # @param source_id [String]
-        #     metadata source identifier.
-        # @param spec [Com::Vmware::Vapi::Metadata::Authentication::Source::CreateSpec]
-        #     create specification.
-        # @return [Void]
-        # @raise [Com::Vmware::Vapi::Std::Errors::AlreadyExists]
-        #     if the metadata source identifier is already registered with the infrastructure.
-        # @raise [Com::Vmware::Vapi::Std::Errors::InvalidArgument]
-        #     if the type of the source specified in  null  is invalid.
-        # @raise [Com::Vmware::Vapi::Std::Errors::InvalidArgument]
-        #     if the file specified in  null  is not a valid JSON file or if the format of the authentication metadata in the JSON file is invalid.
-        # @raise [Com::Vmware::Vapi::Std::Errors::InvalidArgument]
-        #     if the URI specified in  null  is unreachable or if there is a transport protocol or message protocol mismatch between the client and the server or if the remote server do not have  classs  present in   :mod:`com.vmware.vapi.metadata.authentication`    package .
-        # @raise [Com::Vmware::Vapi::Std::Errors::NotFound]
-        #     if the file specified in  null  does not exist.
-        def create(source_id, spec)
-            invoke_with_info(@@create_info, {
-                'source_id' => source_id,
-                'spec' => spec,
-            })
-        end
-
-
-        # Deletes an existing authentication metadata source from the infrastructure.
-        #
-        # @param source_id [String]
-        #     Identifier of the metadata source.
-        # @return [Void]
-        # @raise [Com::Vmware::Vapi::Std::Errors::NotFound]
-        #     if the metadata source identifier is not found.
-        def delete(source_id)
-            invoke_with_info(@@delete_info, {
-                'source_id' => source_id,
-            })
-        end
-
-
-        # Retrieves information about the metadata source corresponding to  ``source_id`` .
-        #
-        # @param source_id [String]
-        #     Identifier of the metadata source.
-        # @return [Com::Vmware::Vapi::Metadata::Authentication::Source::Info]
-        #     The   :class:`Com::Vmware::Vapi::Metadata::Authentication::Source::Info`   instance that corresponds to  ``source_id``
-        # @raise [Com::Vmware::Vapi::Std::Errors::NotFound]
-        #     if the metadata source associated with  ``source_id``  is not found.
-        def get(source_id)
-            invoke_with_info(@@get_info, {
-                'source_id' => source_id,
-            })
-        end
-
-
-        # Returns the identifiers of the metadata sources currently registered with the infrastructure.
-        #
-        # @return [Array<String>]
-        #     The list of identifiers for metadata sources currently registered.
-        def list()
-            invoke_with_info(@@list_info)
-        end
-
-
-        # Reloads the authentication metadata from all the metadata sources or of a particular metadata source if  ``source_id``  is specified.
-        #
-        # @param source_id [String, nil]
-        #     Identifier of the metadata source.
-        #     If unspecified, all the metadata sources are reloaded.
-        # @return [Void]
-        # @raise [Com::Vmware::Vapi::Std::Errors::NotFound]
-        #     if the metadata source associated with  ``source_id``  is not found.
-        def reload(source_id=nil)
-            invoke_with_info(@@reload_info, {
-                'source_id' => source_id,
-            })
-        end
-
-
-        # Returns the aggregate fingerprint of metadata from all the metadata sources or from a particular metadata source if  ``source_id``  is specified.
-        #
-        # @param source_id [String, nil]
-        #     Identifier of the metadata source.
-        #     If unspecified, the fingerprint of all the metadata sources is returned.
-        # @return [String]
-        #     Aggregate fingerprint of all the metadata sources or of a particular metadata source.
-        # @raise [Com::Vmware::Vapi::Std::Errors::NotFound]
-        #     if the metadata source associated with  ``source_id``  is not found.
-        def fingerprint(source_id=nil)
-            invoke_with_info(@@fingerprint_info, {
-                'source_id' => source_id,
-            })
-        end
-
-
-
-        # The  ``Com::Vmware::Vapi::Metadata::Authentication::Source::Info``   class  contains the metadata source information.
-        # @!attribute [rw] description
-        #     @return [String]
-        #     English language human readable description of the source.
-        # @!attribute [rw] type
-        #     @return [Com::Vmware::Vapi::Metadata::SourceType]
-        #     Type of the metadata source.
-        # @!attribute [rw] filepath
-        #     @return [String]
-        #     Absolute file path of the authentication metadata file that has the authentication information about one component element. The  ``filePath``  is the path to the file in the server's filesystem.
-        #     This  field  is optional and it is only relevant when the value of  ``type``  is  null .
-        # @!attribute [rw] address
-        #     @return [URI]
-        #     Connection information for the remote server. This must be in the format http(s)://IP:port/namespace.  
-        #     
-        #      The remote server must support the  classs  in the   :mod:`com.vmware.vapi.metadata.authentication`    package . It must expose authentication information of one or more components.
-        #     This  field  is optional and it is only relevant when the value of  ``type``  is  null .
-        class Info < VAPI::Bindings::VapiStruct
-
-            class << self
-                # Holds (gets or creates) the binding type metadata for this structure type.
-                # @scope class
-                # @return [VAPI::Bindings::StructType] the binding type
-                def binding_type
-                    @binding_type ||= VAPI::Bindings::StructType.new(
-                        'com.vmware.vapi.metadata.authentication.source.info',
-                        {
-                            'description' => VAPI::Bindings::StringType.instance,
-                            'type' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Metadata::SourceType'),
-                            'filepath' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::StringType.instance),
-                            'address' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::URIType.instance),
-                        },
-                        Info,
-                        false,
-                        nil)
-                end
-            end
-
-            attr_accessor :description,
-                          :type,
-                          :filepath,
-                          :address
-
-            # Constructs a new instance.
-            # @param ruby_values [Hash] a map of initial property values (optional)
-            # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
-            def initialize(ruby_values=nil, struct_value=nil)
-                super(self.class.binding_type, ruby_values, struct_value)
-            end
-        end
-
-
-        # The  ``Com::Vmware::Vapi::Metadata::Authentication::Source::CreateSpec``   class  contains the registration information of a authentication source.
-        class CreateSpec < VAPI::Bindings::VapiStruct
-
-            class << self
-                # Holds (gets or creates) the binding type metadata for this structure type.
-                # @scope class
-                # @return [VAPI::Bindings::StructType] the binding type
-                def binding_type
-                    @binding_type ||= VAPI::Bindings::StructType.new(
-                        'com.vmware.vapi.metadata.authentication.source.create_spec',
-                        {
-                            'description' => VAPI::Bindings::StringType.instance,
-                            'type' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Metadata::SourceType'),
-                            'filepath' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::StringType.instance),
-                            'address' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::URIType.instance),
-                        },
-                        CreateSpec,
-                        false,
-                        nil)
-                end
-            end
-
-            attr_accessor :description,
-                          :type,
-                          :filepath,
-                          :address
-
-            # Constructs a new instance.
-            # @param ruby_values [Hash] a map of initial property values (optional)
-            # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
-            def initialize(ruby_values=nil, struct_value=nil)
-                super(self.class.binding_type, ruby_values, struct_value)
-            end
-        end
-
-
+    #  The fingerprint provides clients an efficient way to check if the metadata for a particular component has been modified on the server. The client can do this by comparing the result of this operation with the fingerprint returned in the result of   :func:`Com::Vmware::Vapi::Metadata::Authentication::Component.get`  .
+    #
+    # @param component_id [String]
+    #     Identifier of the component element.
+    # @return [String]
+    #     The fingerprint computed from the authentication metadata of the component.
+    # @raise [Com::Vmware::Vapi::Std::Errors::NotFound]
+    #     if the component element associated with  ``component_id``  does not have any authentication information.
+    def fingerprint(component_id)
+      invoke_with_info(FINGERPRINT_INFO,
+                       'component_id' => component_id)
     end
 
+  end
+  # The  ``Com::Vmware::Vapi::Metadata::Authentication::Package``   class  provides  methods  to retrieve authentication information of a package element.  
+  # 
+  #  A package element is said to contain authentication information if there is a default authentication assigned to all service elements contained in the package element or if one of the service element contained in this package element has authentication information.
+  class Package < VAPI::Bindings::VapiService
+    # static metamodel definitions
+    SERVICE_ID = VAPI::Core::ServiceIdentifier.new('com.vmware.vapi.metadata.authentication.package')
 
+    LIST_INFO = VAPI::Bindings::OperationInfo.new(
+      VAPI::Core::OperationIdentifier.new('list', SERVICE_ID),
+      VAPI::Bindings::OperationInputType.new,
+      VAPI::Bindings::ListType.new(VAPI::Bindings::IdType.new),
+      {},
+      [],
+      []
+    )
 
-    # The  ``Com::Vmware::Vapi::Metadata::Authentication::AuthenticationInfo``   class  describes the authentication information. Authentication information could be specified for a package element, service elenent or an operation element.  
-    # 
-    #  Using the authentication scheme information, a client invoking an API call from any  class  can figure out what kind of credentials are needed for that API call.
-    # @!attribute [rw] scheme_type
+    GET_INFO = VAPI::Bindings::OperationInfo.new(
+      VAPI::Core::OperationIdentifier.new('get', SERVICE_ID),
+      VAPI::Bindings::OperationInputType.new(
+        'package_id' => VAPI::Bindings::IdType.new('com.vmware.vapi.package')
+      ),
+      VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Metadata::Authentication::PackageInfo'),
+      {
+        'com.vmware.vapi.std.errors.not_found' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::NotFound')
+      },
+      [],
+      []
+    )
+
+    SERVICE_INFO = VAPI::Bindings::ServiceInfo.new(
+      SERVICE_ID,
+      'list' => LIST_INFO,
+      'get' => GET_INFO
+    )
+
+    # Constructs a new instance.
+    #
+    # @param config [VAPI::Bindings::StubConfig] A hash with the api provider details.
+    def initialize(config)
+      super(config, SERVICE_INFO)
+    end
+
+    RESOURCE_TYPE = 'com.vmware.vapi.package'
+    # Returns the identifiers for the package elements that have authentication information.
+    #
+    # @return [Array<String>]
+    #     The list of identifiers for the package elements that have authentication information.
+    def list
+      invoke_with_info(LIST_INFO)
+    end
+
+    # Retrieves authentication information about the package element corresponding to  ``package_id`` .
+    #
+    # @param package_id [String]
+    #     Identifier of the package element.
+    # @return [Com::Vmware::Vapi::Metadata::Authentication::PackageInfo]
+    #     The   :class:`Com::Vmware::Vapi::Metadata::Authentication::PackageInfo`   instance that corresponds to  ``package_id``
+    # @raise [Com::Vmware::Vapi::Std::Errors::NotFound]
+    #     if the package element associated with  ``package_id``  does not have any authentication information.
+    def get(package_id)
+      invoke_with_info(GET_INFO,
+                       'package_id' => package_id)
+    end
+
+  end
+  # The  ``Com::Vmware::Vapi::Metadata::Authentication::Service``   class  provides  methods  to retrieve authentication information of a service element.  
+  # 
+  #  A service element is said to contain authentication information if there is a default authentication assigned to all operation elements contained in a service element or if one of the operation elements contained in this service element has authentication information.
+  class ServiceService < VAPI::Bindings::VapiService
+    # static metamodel definitions
+    SERVICE_ID = VAPI::Core::ServiceIdentifier.new('com.vmware.vapi.metadata.authentication.service')
+
+    LIST_INFO = VAPI::Bindings::OperationInfo.new(
+      VAPI::Core::OperationIdentifier.new('list', SERVICE_ID),
+      VAPI::Bindings::OperationInputType.new,
+      VAPI::Bindings::ListType.new(VAPI::Bindings::IdType.new),
+      {},
+      [],
+      []
+    )
+
+    GET_INFO = VAPI::Bindings::OperationInfo.new(
+      VAPI::Core::OperationIdentifier.new('get', SERVICE_ID),
+      VAPI::Bindings::OperationInputType.new(
+        'service_id' => VAPI::Bindings::IdType.new('com.vmware.vapi.service')
+      ),
+      VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Metadata::Authentication::ServiceInfo'),
+      {
+        'com.vmware.vapi.std.errors.not_found' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::NotFound')
+      },
+      [],
+      []
+    )
+
+    SERVICE_INFO = VAPI::Bindings::ServiceInfo.new(
+      SERVICE_ID,
+      'list' => LIST_INFO,
+      'get' => GET_INFO
+    )
+
+    # Constructs a new instance.
+    #
+    # @param config [VAPI::Bindings::StubConfig] A hash with the api provider details.
+    def initialize(config)
+      super(config, SERVICE_INFO)
+    end
+
+    RESOURCE_TYPE = 'com.vmware.vapi.service'
+    # Returns the identifiers for the service elements that have authentication information.
+    #
+    # @return [Array<String>]
+    #     The list of identifiers for the service elements that have authentication information.
+    def list
+      invoke_with_info(LIST_INFO)
+    end
+
+    # Retrieves authentication information about the service element corresponding to  ``service_id`` .
+    #
+    # @param service_id [String]
+    #     Identifier of the service element.
+    # @return [Com::Vmware::Vapi::Metadata::Authentication::ServiceInfo]
+    #     The   :class:`Com::Vmware::Vapi::Metadata::Authentication::ServiceInfo`   instance that corresponds to  ``service_id``
+    # @raise [Com::Vmware::Vapi::Std::Errors::NotFound]
+    #     if the service element associated with  ``service_id``  does not have any authentication information.
+    def get(service_id)
+      invoke_with_info(GET_INFO,
+                       'service_id' => service_id)
+    end
+
+  end
+  # The  ``Com::Vmware::Vapi::Metadata::Authentication::Source``   class  provides  methods  to manage the sources of authentication metadata information.  
+  # 
+  #  The interface definition language infrastructure provides tools to generate various kinds of metadata in JSON format from the interface definition files and additional properties files. One of the generated files contains authentication information. The generated file can be registered as a source of metadata.  
+  # 
+  #  The authentication file contains all the data present in the interface definition files. Each authentication file contains data about one component element. When a authentication file is added as a source, each source contributes only one component element's metadata.  
+  # 
+  #  Authentication metadata can also be discovered from a remote server that supports the authentication metadata  classs  (see   :mod:`com.vmware.vapi.metadata.authentication`  ). Since multiple components can be registered with a single metadata server, when a remote server is registered as a source, that source can contribute more than one component.
+  class Source < VAPI::Bindings::VapiService
+    # static metamodel definitions
+    SERVICE_ID = VAPI::Core::ServiceIdentifier.new('com.vmware.vapi.metadata.authentication.source')
+
+    CREATE_INFO = VAPI::Bindings::OperationInfo.new(
+      VAPI::Core::OperationIdentifier.new('create', SERVICE_ID),
+      VAPI::Bindings::OperationInputType.new(
+        'source_id' => VAPI::Bindings::IdType.new('com.vmware.vapi.metadata.authentication.source'),
+        'spec' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Metadata::Authentication::Source::CreateSpec')
+      ),
+      VAPI::Bindings::VoidType.instance,
+      {
+        'com.vmware.vapi.std.errors.already_exists' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::AlreadyExists'),
+        'com.vmware.vapi.std.errors.invalid_argument' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::InvalidArgument'),
+        'com.vmware.vapi.std.errors.not_found' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::NotFound')
+      },
+      [],
+      []
+    )
+
+    DELETE_INFO = VAPI::Bindings::OperationInfo.new(
+      VAPI::Core::OperationIdentifier.new('delete', SERVICE_ID),
+      VAPI::Bindings::OperationInputType.new(
+        'source_id' => VAPI::Bindings::IdType.new('com.vmware.vapi.metadata.authentication.source')
+      ),
+      VAPI::Bindings::VoidType.instance,
+      {
+        'com.vmware.vapi.std.errors.not_found' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::NotFound')
+      },
+      [],
+      []
+    )
+
+    GET_INFO = VAPI::Bindings::OperationInfo.new(
+      VAPI::Core::OperationIdentifier.new('get', SERVICE_ID),
+      VAPI::Bindings::OperationInputType.new(
+        'source_id' => VAPI::Bindings::IdType.new('com.vmware.vapi.metadata.authentication.source')
+      ),
+      VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Metadata::Authentication::Source::Info'),
+      {
+        'com.vmware.vapi.std.errors.not_found' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::NotFound')
+      },
+      [],
+      []
+    )
+
+    LIST_INFO = VAPI::Bindings::OperationInfo.new(
+      VAPI::Core::OperationIdentifier.new('list', SERVICE_ID),
+      VAPI::Bindings::OperationInputType.new,
+      VAPI::Bindings::ListType.new(VAPI::Bindings::IdType.new),
+      {},
+      [],
+      []
+    )
+
+    RELOAD_INFO = VAPI::Bindings::OperationInfo.new(
+      VAPI::Core::OperationIdentifier.new('reload', SERVICE_ID),
+      VAPI::Bindings::OperationInputType.new(
+        'source_id' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::IdType.new)
+      ),
+      VAPI::Bindings::VoidType.instance,
+      {
+        'com.vmware.vapi.std.errors.not_found' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::NotFound')
+      },
+      [],
+      []
+    )
+
+    FINGERPRINT_INFO = VAPI::Bindings::OperationInfo.new(
+      VAPI::Core::OperationIdentifier.new('fingerprint', SERVICE_ID),
+      VAPI::Bindings::OperationInputType.new(
+        'source_id' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::IdType.new)
+      ),
+      VAPI::Bindings::StringType.instance,
+      {
+        'com.vmware.vapi.std.errors.not_found' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::NotFound')
+      },
+      [],
+      []
+    )
+
+    SERVICE_INFO = VAPI::Bindings::ServiceInfo.new(
+      SERVICE_ID,
+      'create' => CREATE_INFO,
+      'delete' => DELETE_INFO,
+      'get' => GET_INFO,
+      'list' => LIST_INFO,
+      'reload' => RELOAD_INFO,
+      'fingerprint' => FINGERPRINT_INFO
+    )
+
+    # Constructs a new instance.
+    #
+    # @param config [VAPI::Bindings::StubConfig] A hash with the api provider details.
+    def initialize(config)
+      super(config, SERVICE_INFO)
+    end
+
+    RESOURCE_TYPE = 'com.vmware.vapi.metadata.authentication.source'
+    # Creates a new metadata source. Once the server validates the registration information of the metadata source, the authentication metadata is retrieved from the source. This populates elements in all the  classs  defined in   :mod:`com.vmware.vapi.metadata.authentication`    package .
+    #
+    # @param source_id [String]
+    #     metadata source identifier.
+    # @param spec [Com::Vmware::Vapi::Metadata::Authentication::Source::CreateSpec]
+    #     create specification.
+    # @return [Void]
+    # @raise [Com::Vmware::Vapi::Std::Errors::AlreadyExists]
+    #     if the metadata source identifier is already registered with the infrastructure.
+    # @raise [Com::Vmware::Vapi::Std::Errors::InvalidArgument]
+    #     if the type of the source specified in  null  is invalid.
+    # @raise [Com::Vmware::Vapi::Std::Errors::InvalidArgument]
+    #     if the file specified in  null  is not a valid JSON file or if the format of the authentication metadata in the JSON file is invalid.
+    # @raise [Com::Vmware::Vapi::Std::Errors::InvalidArgument]
+    #     if the URI specified in  null  is unreachable or if there is a transport protocol or message protocol mismatch between the client and the server or if the remote server do not have  classs  present in   :mod:`com.vmware.vapi.metadata.authentication`    package .
+    # @raise [Com::Vmware::Vapi::Std::Errors::NotFound]
+    #     if the file specified in  null  does not exist.
+    def create(source_id, spec)
+      invoke_with_info(CREATE_INFO,
+                       'source_id' => source_id,
+                       'spec' => spec)
+    end
+
+    # Deletes an existing authentication metadata source from the infrastructure.
+    #
+    # @param source_id [String]
+    #     Identifier of the metadata source.
+    # @return [Void]
+    # @raise [Com::Vmware::Vapi::Std::Errors::NotFound]
+    #     if the metadata source identifier is not found.
+    def delete(source_id)
+      invoke_with_info(DELETE_INFO,
+                       'source_id' => source_id)
+    end
+
+    # Retrieves information about the metadata source corresponding to  ``source_id`` .
+    #
+    # @param source_id [String]
+    #     Identifier of the metadata source.
+    # @return [Com::Vmware::Vapi::Metadata::Authentication::Source::Info]
+    #     The   :class:`Com::Vmware::Vapi::Metadata::Authentication::Source::Info`   instance that corresponds to  ``source_id``
+    # @raise [Com::Vmware::Vapi::Std::Errors::NotFound]
+    #     if the metadata source associated with  ``source_id``  is not found.
+    def get(source_id)
+      invoke_with_info(GET_INFO,
+                       'source_id' => source_id)
+    end
+
+    # Returns the identifiers of the metadata sources currently registered with the infrastructure.
+    #
+    # @return [Array<String>]
+    #     The list of identifiers for metadata sources currently registered.
+    def list
+      invoke_with_info(LIST_INFO)
+    end
+
+    # Reloads the authentication metadata from all the metadata sources or of a particular metadata source if  ``source_id``  is specified.
+    #
+    # @param source_id [String, nil]
+    #     Identifier of the metadata source.
+    #     If unspecified, all the metadata sources are reloaded.
+    # @return [Void]
+    # @raise [Com::Vmware::Vapi::Std::Errors::NotFound]
+    #     if the metadata source associated with  ``source_id``  is not found.
+    def reload(source_id = nil)
+      invoke_with_info(RELOAD_INFO,
+                       'source_id' => source_id)
+    end
+
+    # Returns the aggregate fingerprint of metadata from all the metadata sources or from a particular metadata source if  ``source_id``  is specified.
+    #
+    # @param source_id [String, nil]
+    #     Identifier of the metadata source.
+    #     If unspecified, the fingerprint of all the metadata sources is returned.
+    # @return [String]
+    #     Aggregate fingerprint of all the metadata sources or of a particular metadata source.
+    # @raise [Com::Vmware::Vapi::Std::Errors::NotFound]
+    #     if the metadata source associated with  ``source_id``  is not found.
+    def fingerprint(source_id = nil)
+      invoke_with_info(FINGERPRINT_INFO,
+                       'source_id' => source_id)
+    end
+
+    # The  ``Com::Vmware::Vapi::Metadata::Authentication::Source::Info``   class  contains the metadata source information.
+    # @!attribute [rw] description
+    #     @return [String]
+    #     English language human readable description of the source.
+    # @!attribute [rw] type
+    #     @return [Com::Vmware::Vapi::Metadata::SourceType]
+    #     Type of the metadata source.
+    # @!attribute [rw] filepath
+    #     @return [String]
+    #     Absolute file path of the authentication metadata file that has the authentication information about one component element. The  ``filePath``  is the path to the file in the server's filesystem.
+    #     This  field  is optional and it is only relevant when the value of  ``type``  is  null .
+    # @!attribute [rw] address
+    #     @return [URI]
+    #     Connection information for the remote server. This must be in the format http(s)://IP:port/namespace.  
+    #     
+    #      The remote server must support the  classs  in the   :mod:`com.vmware.vapi.metadata.authentication`    package . It must expose authentication information of one or more components.
+    #     This  field  is optional and it is only relevant when the value of  ``type``  is  null .
+    class Info < VAPI::Bindings::VapiStruct
+      class << self
+        # Holds (gets or creates) the binding type metadata for this structure type.
+        # @scope class
+        # @return [VAPI::Bindings::StructType] the binding type
+        def binding_type
+          @binding_type ||= VAPI::Bindings::StructType.new(
+            'com.vmware.vapi.metadata.authentication.source.info',
+            {
+              'description' => VAPI::Bindings::StringType.instance,
+              'type' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Metadata::SourceType'),
+              'filepath' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::StringType.instance),
+              'address' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::URIType.instance)
+            },
+            Info,
+            false,
+            nil
+          )
+        end
+      end
+
+      attr_accessor :description,
+                    :type,
+                    :filepath,
+                    :address
+
+      # Constructs a new instance.
+      # @param ruby_values [Hash] a map of initial property values (optional)
+      # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
+      def initialize(ruby_values = nil, struct_value = nil)
+        super(self.class.binding_type, ruby_values, struct_value)
+      end
+    end
+
+    # The  ``Com::Vmware::Vapi::Metadata::Authentication::Source::CreateSpec``   class  contains the registration information of a authentication source.
+    class CreateSpec < VAPI::Bindings::VapiStruct
+      class << self
+        # Holds (gets or creates) the binding type metadata for this structure type.
+        # @scope class
+        # @return [VAPI::Bindings::StructType] the binding type
+        def binding_type
+          @binding_type ||= VAPI::Bindings::StructType.new(
+            'com.vmware.vapi.metadata.authentication.source.create_spec',
+            {
+              'description' => VAPI::Bindings::StringType.instance,
+              'type' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Metadata::SourceType'),
+              'filepath' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::StringType.instance),
+              'address' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::URIType.instance)
+            },
+            CreateSpec,
+            false,
+            nil
+          )
+        end
+      end
+
+      attr_accessor :description,
+                    :type,
+                    :filepath,
+                    :address
+
+      # Constructs a new instance.
+      # @param ruby_values [Hash] a map of initial property values (optional)
+      # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
+      def initialize(ruby_values = nil, struct_value = nil)
+        super(self.class.binding_type, ruby_values, struct_value)
+      end
+    end
+
+  end
+  # The  ``Com::Vmware::Vapi::Metadata::Authentication::AuthenticationInfo``   class  describes the authentication information. Authentication information could be specified for a package element, service elenent or an operation element.  
+  # 
+  #  Using the authentication scheme information, a client invoking an API call from any  class  can figure out what kind of credentials are needed for that API call.
+  # @!attribute [rw] scheme_type
+  #     @return [Com::Vmware::Vapi::Metadata::Authentication::AuthenticationInfo::SchemeType]
+  #     The type of the authentication scheme.
+  # @!attribute [rw] session_manager
+  #     @return [String]
+  #     In a session aware authentication scheme, a session manager is required that supports  ``create`` ,  ``delete``  and  ``keepAlive``   methods . The fully qualified  class  name of the session manager is provided in   :attr:`Com::Vmware::Vapi::Metadata::Authentication::AuthenticationInfo.session_manager`    field . This  class  is responsible for handling sessions.
+  #     This  field  is optional and it is only relevant when the value of  ``schemeType``  is   :attr:`Com::Vmware::Vapi::Metadata::Authentication::AuthenticationInfo::SchemeType.SESSION_AWARE`  .
+  # @!attribute [rw] scheme
+  #     @return [String]
+  #     String identifier of the authentication scheme.  
+  #     
+  #      Following are the supported authentication schemes by the infrastructure:  
+  #     
+  #       * The identifier  ``com.vmware.vapi.std.security.saml_hok_token``  for SAML holder of key token based authentication mechanism. 
+  #        * The identifier  ``com.vmware.vapi.std.security.bearer_token``  for SAML bearer token based authentication mechanism. 
+  #        * The identifier  ``com.vmware.vapi.std.security.session_id``  for session based authentication mechanism. 
+  #        * The identifier  ``com.vmware.vapi.std.security.user_pass``  for username and password based authentication mechanism. 
+  #       
+  class AuthenticationInfo < VAPI::Bindings::VapiStruct
+    class << self
+      # Holds (gets or creates) the binding type metadata for this structure type.
+      # @scope class
+      # @return [VAPI::Bindings::StructType] the binding type
+      def binding_type
+        @binding_type ||= VAPI::Bindings::StructType.new(
+          'com.vmware.vapi.metadata.authentication.authentication_info',
+          {
+            'scheme_type' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Metadata::Authentication::AuthenticationInfo::SchemeType'),
+            'session_manager' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::StringType.instance),
+            'scheme' => VAPI::Bindings::StringType.instance
+          },
+          AuthenticationInfo,
+          false,
+          nil
+        )
+      end
+    end
+
+    attr_accessor :scheme_type,
+                  :session_manager,
+                  :scheme
+
+    # Constructs a new instance.
+    # @param ruby_values [Hash] a map of initial property values (optional)
+    # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
+    def initialize(ruby_values = nil, struct_value = nil)
+      super(self.class.binding_type, ruby_values, struct_value)
+    end
+
+    # The  ``Com::Vmware::Vapi::Metadata::Authentication::AuthenticationInfo::SchemeType``   enumerated type  provides  enumeration values  for the set of valid authentication scheme types.
+    # @!attribute [rw] sessionless
     #     @return [Com::Vmware::Vapi::Metadata::Authentication::AuthenticationInfo::SchemeType]
-    #     The type of the authentication scheme.
-    # @!attribute [rw] session_manager
-    #     @return [String]
-    #     In a session aware authentication scheme, a session manager is required that supports  ``create`` ,  ``delete``  and  ``keepAlive``   methods . The fully qualified  class  name of the session manager is provided in   :attr:`Com::Vmware::Vapi::Metadata::Authentication::AuthenticationInfo.session_manager`    field . This  class  is responsible for handling sessions.
-    #     This  field  is optional and it is only relevant when the value of  ``schemeType``  is   :attr:`Com::Vmware::Vapi::Metadata::Authentication::AuthenticationInfo::SchemeType.SESSION_AWARE`  .
-    # @!attribute [rw] scheme
-    #     @return [String]
-    #     String identifier of the authentication scheme.  
-    #     
-    #      Following are the supported authentication schemes by the infrastructure:  
-    #     
-    #       * The identifier  ``com.vmware.vapi.std.security.saml_hok_token``  for SAML holder of key token based authentication mechanism. 
-    #        * The identifier  ``com.vmware.vapi.std.security.bearer_token``  for SAML bearer token based authentication mechanism. 
-    #        * The identifier  ``com.vmware.vapi.std.security.session_id``  for session based authentication mechanism. 
-    #        * The identifier  ``com.vmware.vapi.std.security.user_pass``  for username and password based authentication mechanism. 
-    #       
-    class AuthenticationInfo < VAPI::Bindings::VapiStruct
-
-        class << self
-            # Holds (gets or creates) the binding type metadata for this structure type.
-            # @scope class
-            # @return [VAPI::Bindings::StructType] the binding type
-            def binding_type
-                @binding_type ||= VAPI::Bindings::StructType.new(
-                    'com.vmware.vapi.metadata.authentication.authentication_info',
-                    {
-                        'scheme_type' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Metadata::Authentication::AuthenticationInfo::SchemeType'),
-                        'session_manager' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::StringType.instance),
-                        'scheme' => VAPI::Bindings::StringType.instance,
-                    },
-                    AuthenticationInfo,
-                    false,
-                    nil)
-            end
+    #     Indicates that the scheme is a session less authentication scheme, the user is authenticated on every  method . There is no explicit session establishment.
+    # @!attribute [rw] session_aware
+    #     @return [Com::Vmware::Vapi::Metadata::Authentication::AuthenticationInfo::SchemeType]
+    #     Indicates that the scheme is a session aware authentication scheme. It requires an explicit login before executing a  method  and logout when a session terminates. A  class  might choose to have a session aware scheme if it wants to associate some state corresponding to the user until the user logs out or if it wants to mitigate the cost of authenticating the user on every  method .
+    class SchemeType < VAPI::Bindings::VapiEnum
+      class << self
+        # Holds (gets or creates) the binding type metadata for this enumeration type.
+        # @scope class
+        # @return [VAPI::Bindings::EnumType] the binding type
+        def binding_type
+          @binding_type ||= VAPI::Bindings::EnumType.new(
+            'com.vmware.vapi.metadata.authentication.authentication_info.scheme_type',
+            SchemeType
+          )
         end
 
-        attr_accessor :scheme_type,
-                      :session_manager,
-                      :scheme
-
-        # Constructs a new instance.
-        # @param ruby_values [Hash] a map of initial property values (optional)
-        # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
-        def initialize(ruby_values=nil, struct_value=nil)
-            super(self.class.binding_type, ruby_values, struct_value)
+        # Converts from a string value (perhaps off the wire) to an instance
+        # of this enum type.
+        # @param value [String] the actual value of the enum instance
+        # @return [SchemeType] the instance found for the value, otherwise
+        #         an unknown instance will be built for the value
+        def from_string(value)
+          const_get(value)
+        rescue NameError
+          SchemeType.send(:new, 'UNKNOWN', value)
         end
+      end
 
+      # Constructs a new instance.
+      # @param value [String] the actual value of the enum instance
+      # @param unknown [String] the unknown value when value is 'UKNOWN'
+      def initialize(value, unknown = nil)
+        super(self.class.binding_type, value, unknown)
+      end
 
-        # The  ``Com::Vmware::Vapi::Metadata::Authentication::AuthenticationInfo::SchemeType``   enumerated type  provides  enumeration values  for the set of valid authentication scheme types.
-        # @!attribute [rw] sessionless
-        #     @return [Com::Vmware::Vapi::Metadata::Authentication::AuthenticationInfo::SchemeType]
-        #     Indicates that the scheme is a session less authentication scheme, the user is authenticated on every  method . There is no explicit session establishment.
-        # @!attribute [rw] session_aware
-        #     @return [Com::Vmware::Vapi::Metadata::Authentication::AuthenticationInfo::SchemeType]
-        #     Indicates that the scheme is a session aware authentication scheme. It requires an explicit login before executing a  method  and logout when a session terminates. A  class  might choose to have a session aware scheme if it wants to associate some state corresponding to the user until the user logs out or if it wants to mitigate the cost of authenticating the user on every  method .
-        class SchemeType < VAPI::Bindings::VapiEnum
+      private_class_method :new
 
-            class << self
-                # Holds (gets or creates) the binding type metadata for this enumeration type.
-                # @scope class
-                # @return [VAPI::Bindings::EnumType] the binding type
-                def binding_type
-                    @binding_type ||= VAPI::Bindings::EnumType.new(
-                        'com.vmware.vapi.metadata.authentication.authentication_info.scheme_type',
-                        SchemeType)
-                end
+      # @!attribute [rw] sessionless
+      #     @return [Com::Vmware::Vapi::Metadata::Authentication::AuthenticationInfo::SchemeType]
+      #     Indicates that the scheme is a session less authentication scheme, the user is authenticated on every  method . There is no explicit session establishment.
+      SESSIONLESS = SchemeType.send(:new, 'SESSIONLESS')
 
-                # Converts from a string value (perhaps off the wire) to an instance
-                # of this enum type.
-                # @param value [String] the actual value of the enum instance
-                # @return [SchemeType] the instance found for the value, otherwise
-                #         an unknown instance will be built for the value
-                def from_string(value)
-                    begin
-                        const_get(value)
-                    rescue NameError
-                        SchemeType.new('UNKNOWN', value)
-                    end
-                end
-            end
-
-            private
-
-            # Constructs a new instance.
-            # @param value [String] the actual value of the enum instance
-            # @param unknown [String] the unknown value when value is 'UKNOWN'
-            def initialize(value, unknown=nil)
-                super(self.class.binding_type, value, unknown)
-            end
-
-            public
-
-            # @!attribute [rw] sessionless
-            #     @return [Com::Vmware::Vapi::Metadata::Authentication::AuthenticationInfo::SchemeType]
-            #     Indicates that the scheme is a session less authentication scheme, the user is authenticated on every  method . There is no explicit session establishment.
-            SESSIONLESS = SchemeType.new('SESSIONLESS')
-
-            # @!attribute [rw] session_aware
-            #     @return [Com::Vmware::Vapi::Metadata::Authentication::AuthenticationInfo::SchemeType]
-            #     Indicates that the scheme is a session aware authentication scheme. It requires an explicit login before executing a  method  and logout when a session terminates. A  class  might choose to have a session aware scheme if it wants to associate some state corresponding to the user until the user logs out or if it wants to mitigate the cost of authenticating the user on every  method .
-            SESSION_AWARE = SchemeType.new('SESSION_AWARE')
-
-        end
-
-
+      # @!attribute [rw] session_aware
+      #     @return [Com::Vmware::Vapi::Metadata::Authentication::AuthenticationInfo::SchemeType]
+      #     Indicates that the scheme is a session aware authentication scheme. It requires an explicit login before executing a  method  and logout when a session terminates. A  class  might choose to have a session aware scheme if it wants to associate some state corresponding to the user until the user logs out or if it wants to mitigate the cost of authenticating the user on every  method .
+      SESSION_AWARE = SchemeType.send(:new, 'SESSION_AWARE')
+    end
+  end
+  # The  ``Com::Vmware::Vapi::Metadata::Authentication::ComponentData``   class  contains the authentication information of the component along with its fingerprint.
+  # @!attribute [rw] info
+  #     @return [Com::Vmware::Vapi::Metadata::Authentication::ComponentInfo]
+  #     Authentication information of the component. This includes information about all the  packages  in the component.
+  # @!attribute [rw] fingerprint
+  #     @return [String]
+  #     Fingerprint of the metadata of the component.  
+  #     
+  #      Authentication information could change when there is an infrastructure update. Since the data present in   :attr:`Com::Vmware::Vapi::Metadata::Authentication::ComponentData.info`   could be quite large,  ``fingerprint``  provides a convenient way to check if the data for a particular component is updated.  
+  #     
+  #      You should store the fingerprint associated with a component. After an update, by invoking the   :func:`Com::Vmware::Vapi::Metadata::Authentication::Component.fingerprint`    method , you can retrieve the new fingerprint for the component. If the new fingerprint and the previously stored fingerprint do not match, clients can then use the   :func:`Com::Vmware::Vapi::Metadata::Authentication::Component.get`   to retrieve the new authentication information for the component.
+  class ComponentData < VAPI::Bindings::VapiStruct
+    class << self
+      # Holds (gets or creates) the binding type metadata for this structure type.
+      # @scope class
+      # @return [VAPI::Bindings::StructType] the binding type
+      def binding_type
+        @binding_type ||= VAPI::Bindings::StructType.new(
+          'com.vmware.vapi.metadata.authentication.component_data',
+          {
+            'info' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Metadata::Authentication::ComponentInfo'),
+            'fingerprint' => VAPI::Bindings::StringType.instance
+          },
+          ComponentData,
+          false,
+          nil
+        )
+      end
     end
 
+    attr_accessor :info,
+                  :fingerprint
 
-    # The  ``Com::Vmware::Vapi::Metadata::Authentication::ComponentData``   class  contains the authentication information of the component along with its fingerprint.
-    # @!attribute [rw] info
-    #     @return [Com::Vmware::Vapi::Metadata::Authentication::ComponentInfo]
-    #     Authentication information of the component. This includes information about all the  packages  in the component.
-    # @!attribute [rw] fingerprint
-    #     @return [String]
-    #     Fingerprint of the metadata of the component.  
-    #     
-    #      Authentication information could change when there is an infrastructure update. Since the data present in   :attr:`Com::Vmware::Vapi::Metadata::Authentication::ComponentData.info`   could be quite large,  ``fingerprint``  provides a convenient way to check if the data for a particular component is updated.  
-    #     
-    #      You should store the fingerprint associated with a component. After an update, by invoking the   :func:`Com::Vmware::Vapi::Metadata::Authentication::Component.fingerprint`    method , you can retrieve the new fingerprint for the component. If the new fingerprint and the previously stored fingerprint do not match, clients can then use the   :func:`Com::Vmware::Vapi::Metadata::Authentication::Component.get`   to retrieve the new authentication information for the component.
-    class ComponentData < VAPI::Bindings::VapiStruct
-
-        class << self
-            # Holds (gets or creates) the binding type metadata for this structure type.
-            # @scope class
-            # @return [VAPI::Bindings::StructType] the binding type
-            def binding_type
-                @binding_type ||= VAPI::Bindings::StructType.new(
-                    'com.vmware.vapi.metadata.authentication.component_data',
-                    {
-                        'info' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Metadata::Authentication::ComponentInfo'),
-                        'fingerprint' => VAPI::Bindings::StringType.instance,
-                    },
-                    ComponentData,
-                    false,
-                    nil)
-            end
-        end
-
-        attr_accessor :info,
-                      :fingerprint
-
-        # Constructs a new instance.
-        # @param ruby_values [Hash] a map of initial property values (optional)
-        # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
-        def initialize(ruby_values=nil, struct_value=nil)
-            super(self.class.binding_type, ruby_values, struct_value)
-        end
+    # Constructs a new instance.
+    # @param ruby_values [Hash] a map of initial property values (optional)
+    # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
+    def initialize(ruby_values = nil, struct_value = nil)
+      super(self.class.binding_type, ruby_values, struct_value)
+    end
+  end
+  # The  ``Com::Vmware::Vapi::Metadata::Authentication::ComponentInfo``   class  contains authentication information of a component element.  
+  # 
+  #  For an explanation of authentication information contained within component elements, see   :class:`Com::Vmware::Vapi::Metadata::Authentication::Component`  .
+  # @!attribute [rw] packages
+  #     @return [Hash<String, Com::Vmware::Vapi::Metadata::Authentication::PackageInfo>]
+  #     Authentication information of all the package elements. The key in the  map  is the identifier of the package element and the value in the  map  is the authentication information for the package element.  
+  #     
+  #      For an explanation of authentication information containment within package elements, see   :class:`Com::Vmware::Vapi::Metadata::Authentication::Package`  .
+  class ComponentInfo < VAPI::Bindings::VapiStruct
+    class << self
+      # Holds (gets or creates) the binding type metadata for this structure type.
+      # @scope class
+      # @return [VAPI::Bindings::StructType] the binding type
+      def binding_type
+        @binding_type ||= VAPI::Bindings::StructType.new(
+          'com.vmware.vapi.metadata.authentication.component_info',
+          {
+            'packages' => VAPI::Bindings::MapType.new(VAPI::Bindings::IdType.new, VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Metadata::Authentication::PackageInfo'))
+          },
+          ComponentInfo,
+          false,
+          nil
+        )
+      end
     end
 
+    attr_accessor :packages
 
-    # The  ``Com::Vmware::Vapi::Metadata::Authentication::ComponentInfo``   class  contains authentication information of a component element.  
-    # 
-    #  For an explanation of authentication information contained within component elements, see   :class:`Com::Vmware::Vapi::Metadata::Authentication::Component`  .
-    # @!attribute [rw] packages
-    #     @return [Hash<String, Com::Vmware::Vapi::Metadata::Authentication::PackageInfo>]
-    #     Authentication information of all the package elements. The key in the  map  is the identifier of the package element and the value in the  map  is the authentication information for the package element.  
-    #     
-    #      For an explanation of authentication information containment within package elements, see   :class:`Com::Vmware::Vapi::Metadata::Authentication::Package`  .
-    class ComponentInfo < VAPI::Bindings::VapiStruct
-
-        class << self
-            # Holds (gets or creates) the binding type metadata for this structure type.
-            # @scope class
-            # @return [VAPI::Bindings::StructType] the binding type
-            def binding_type
-                @binding_type ||= VAPI::Bindings::StructType.new(
-                    'com.vmware.vapi.metadata.authentication.component_info',
-                    {
-                        'packages' => VAPI::Bindings::MapType.new(VAPI::Bindings::IdType.new, VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Metadata::Authentication::PackageInfo')),
-                    },
-                    ComponentInfo,
-                    false,
-                    nil)
-            end
-        end
-
-        attr_accessor :packages
-
-        # Constructs a new instance.
-        # @param ruby_values [Hash] a map of initial property values (optional)
-        # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
-        def initialize(ruby_values=nil, struct_value=nil)
-            super(self.class.binding_type, ruby_values, struct_value)
-        end
+    # Constructs a new instance.
+    # @param ruby_values [Hash] a map of initial property values (optional)
+    # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
+    def initialize(ruby_values = nil, struct_value = nil)
+      super(self.class.binding_type, ruby_values, struct_value)
+    end
+  end
+  # The  ``Com::Vmware::Vapi::Metadata::Authentication::OperationInfo``   class  contains authentication information of an operation element.
+  # @!attribute [rw] schemes
+  #     @return [Array<Com::Vmware::Vapi::Metadata::Authentication::AuthenticationInfo>]
+  #     List of authentication schemes used by an operation element. The authentication scheme specified on the service element corresponding to this operation element is ignored.
+  class OperationInfo < VAPI::Bindings::VapiStruct
+    class << self
+      # Holds (gets or creates) the binding type metadata for this structure type.
+      # @scope class
+      # @return [VAPI::Bindings::StructType] the binding type
+      def binding_type
+        @binding_type ||= VAPI::Bindings::StructType.new(
+          'com.vmware.vapi.metadata.authentication.operation_info',
+          {
+            'schemes' => VAPI::Bindings::ListType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Metadata::Authentication::AuthenticationInfo'))
+          },
+          OperationInfo,
+          false,
+          nil
+        )
+      end
     end
 
+    attr_accessor :schemes
 
-    # The  ``Com::Vmware::Vapi::Metadata::Authentication::OperationInfo``   class  contains authentication information of an operation element.
-    # @!attribute [rw] schemes
-    #     @return [Array<Com::Vmware::Vapi::Metadata::Authentication::AuthenticationInfo>]
-    #     List of authentication schemes used by an operation element. The authentication scheme specified on the service element corresponding to this operation element is ignored.
-    class OperationInfo < VAPI::Bindings::VapiStruct
-
-        class << self
-            # Holds (gets or creates) the binding type metadata for this structure type.
-            # @scope class
-            # @return [VAPI::Bindings::StructType] the binding type
-            def binding_type
-                @binding_type ||= VAPI::Bindings::StructType.new(
-                    'com.vmware.vapi.metadata.authentication.operation_info',
-                    {
-                        'schemes' => VAPI::Bindings::ListType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Metadata::Authentication::AuthenticationInfo')),
-                    },
-                    OperationInfo,
-                    false,
-                    nil)
-            end
-        end
-
-        attr_accessor :schemes
-
-        # Constructs a new instance.
-        # @param ruby_values [Hash] a map of initial property values (optional)
-        # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
-        def initialize(ruby_values=nil, struct_value=nil)
-            super(self.class.binding_type, ruby_values, struct_value)
-        end
+    # Constructs a new instance.
+    # @param ruby_values [Hash] a map of initial property values (optional)
+    # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
+    def initialize(ruby_values = nil, struct_value = nil)
+      super(self.class.binding_type, ruby_values, struct_value)
+    end
+  end
+  # The  ``Com::Vmware::Vapi::Metadata::Authentication::PackageInfo``   class  contains authentication information of a package element.  
+  # 
+  #  For an explanation of authentication information contained within package elements, see   :class:`Com::Vmware::Vapi::Metadata::Authentication::Package`  .
+  # @!attribute [rw] schemes
+  #     @return [Array<Com::Vmware::Vapi::Metadata::Authentication::AuthenticationInfo>]
+  #     List of authentication schemes to be used for all the operation elements contained in this package element. If a particular service or operation element has no explicit authentications defined in the authentication defintion file, these authentication schemes are used for authenticating the user.
+  # @!attribute [rw] services
+  #     @return [Hash<String, Com::Vmware::Vapi::Metadata::Authentication::ServiceInfo>]
+  #     Information about all service elements contained in this package element that contain authentication information. The key in the  map  is the identifier of the service element and the value in the  map  is the authentication information for the service element.  
+  #     
+  #      For an explanation of authentication information containment within service elements, see   :class:`Com::Vmware::Vapi::Metadata::Authentication::Service`  .
+  class PackageInfo < VAPI::Bindings::VapiStruct
+    class << self
+      # Holds (gets or creates) the binding type metadata for this structure type.
+      # @scope class
+      # @return [VAPI::Bindings::StructType] the binding type
+      def binding_type
+        @binding_type ||= VAPI::Bindings::StructType.new(
+          'com.vmware.vapi.metadata.authentication.package_info',
+          {
+            'schemes' => VAPI::Bindings::ListType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Metadata::Authentication::AuthenticationInfo')),
+            'services' => VAPI::Bindings::MapType.new(VAPI::Bindings::IdType.new, VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Metadata::Authentication::ServiceInfo'))
+          },
+          PackageInfo,
+          false,
+          nil
+        )
+      end
     end
 
+    attr_accessor :schemes,
+                  :services
 
-    # The  ``Com::Vmware::Vapi::Metadata::Authentication::PackageInfo``   class  contains authentication information of a package element.  
-    # 
-    #  For an explanation of authentication information contained within package elements, see   :class:`Com::Vmware::Vapi::Metadata::Authentication::Package`  .
-    # @!attribute [rw] schemes
-    #     @return [Array<Com::Vmware::Vapi::Metadata::Authentication::AuthenticationInfo>]
-    #     List of authentication schemes to be used for all the operation elements contained in this package element. If a particular service or operation element has no explicit authentications defined in the authentication defintion file, these authentication schemes are used for authenticating the user.
-    # @!attribute [rw] services
-    #     @return [Hash<String, Com::Vmware::Vapi::Metadata::Authentication::ServiceInfo>]
-    #     Information about all service elements contained in this package element that contain authentication information. The key in the  map  is the identifier of the service element and the value in the  map  is the authentication information for the service element.  
-    #     
-    #      For an explanation of authentication information containment within service elements, see   :class:`Com::Vmware::Vapi::Metadata::Authentication::Service`  .
-    class PackageInfo < VAPI::Bindings::VapiStruct
-
-        class << self
-            # Holds (gets or creates) the binding type metadata for this structure type.
-            # @scope class
-            # @return [VAPI::Bindings::StructType] the binding type
-            def binding_type
-                @binding_type ||= VAPI::Bindings::StructType.new(
-                    'com.vmware.vapi.metadata.authentication.package_info',
-                    {
-                        'schemes' => VAPI::Bindings::ListType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Metadata::Authentication::AuthenticationInfo')),
-                        'services' => VAPI::Bindings::MapType.new(VAPI::Bindings::IdType.new, VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Metadata::Authentication::ServiceInfo')),
-                    },
-                    PackageInfo,
-                    false,
-                    nil)
-            end
-        end
-
-        attr_accessor :schemes,
-                      :services
-
-        # Constructs a new instance.
-        # @param ruby_values [Hash] a map of initial property values (optional)
-        # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
-        def initialize(ruby_values=nil, struct_value=nil)
-            super(self.class.binding_type, ruby_values, struct_value)
-        end
+    # Constructs a new instance.
+    # @param ruby_values [Hash] a map of initial property values (optional)
+    # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
+    def initialize(ruby_values = nil, struct_value = nil)
+      super(self.class.binding_type, ruby_values, struct_value)
+    end
+  end
+  # The  ``Com::Vmware::Vapi::Metadata::Authentication::ServiceInfo``   class  contains authentication information of a service element.  
+  # 
+  #  For an explanation of authentication information contained within service elements, see   :class:`Com::Vmware::Vapi::Metadata::Authentication::Service`  .
+  # @!attribute [rw] schemes
+  #     @return [Array<Com::Vmware::Vapi::Metadata::Authentication::AuthenticationInfo>]
+  #     List of authentication schemes to be used for all the operation elements contained in this service element. The authentication scheme specified on the package element corresponding to this service element is ignored.
+  # @!attribute [rw] operations
+  #     @return [Hash<String, Com::Vmware::Vapi::Metadata::Authentication::OperationInfo>]
+  #     Information about all operation elements contained in this service element that contain authentication information. The key in the  map  is the identifier of the operation element and the value in the  map  is the authentication information for the operation element.  
+  #     
+  #      For an explanation of containment of authentication information within operation elements, see   :class:`Com::Vmware::Vapi::Metadata::Authentication::Service::Operation`  .
+  class ServiceInfo < VAPI::Bindings::VapiStruct
+    class << self
+      # Holds (gets or creates) the binding type metadata for this structure type.
+      # @scope class
+      # @return [VAPI::Bindings::StructType] the binding type
+      def binding_type
+        @binding_type ||= VAPI::Bindings::StructType.new(
+          'com.vmware.vapi.metadata.authentication.service_info',
+          {
+            'schemes' => VAPI::Bindings::ListType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Metadata::Authentication::AuthenticationInfo')),
+            'operations' => VAPI::Bindings::MapType.new(VAPI::Bindings::IdType.new, VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Metadata::Authentication::OperationInfo'))
+          },
+          ServiceInfo,
+          false,
+          nil
+        )
+      end
     end
 
+    attr_accessor :schemes,
+                  :operations
 
-    # The  ``Com::Vmware::Vapi::Metadata::Authentication::ServiceInfo``   class  contains authentication information of a service element.  
-    # 
-    #  For an explanation of authentication information contained within service elements, see   :class:`Com::Vmware::Vapi::Metadata::Authentication::Service`  .
-    # @!attribute [rw] schemes
-    #     @return [Array<Com::Vmware::Vapi::Metadata::Authentication::AuthenticationInfo>]
-    #     List of authentication schemes to be used for all the operation elements contained in this service element. The authentication scheme specified on the package element corresponding to this service element is ignored.
-    # @!attribute [rw] operations
-    #     @return [Hash<String, Com::Vmware::Vapi::Metadata::Authentication::OperationInfo>]
-    #     Information about all operation elements contained in this service element that contain authentication information. The key in the  map  is the identifier of the operation element and the value in the  map  is the authentication information for the operation element.  
-    #     
-    #      For an explanation of containment of authentication information within operation elements, see   :class:`Com::Vmware::Vapi::Metadata::Authentication::Service::Operation`  .
-    class ServiceInfo < VAPI::Bindings::VapiStruct
-
-        class << self
-            # Holds (gets or creates) the binding type metadata for this structure type.
-            # @scope class
-            # @return [VAPI::Bindings::StructType] the binding type
-            def binding_type
-                @binding_type ||= VAPI::Bindings::StructType.new(
-                    'com.vmware.vapi.metadata.authentication.service_info',
-                    {
-                        'schemes' => VAPI::Bindings::ListType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Metadata::Authentication::AuthenticationInfo')),
-                        'operations' => VAPI::Bindings::MapType.new(VAPI::Bindings::IdType.new, VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Metadata::Authentication::OperationInfo')),
-                    },
-                    ServiceInfo,
-                    false,
-                    nil)
-            end
-        end
-
-        attr_accessor :schemes,
-                      :operations
-
-        # Constructs a new instance.
-        # @param ruby_values [Hash] a map of initial property values (optional)
-        # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
-        def initialize(ruby_values=nil, struct_value=nil)
-            super(self.class.binding_type, ruby_values, struct_value)
-        end
+    # Constructs a new instance.
+    # @param ruby_values [Hash] a map of initial property values (optional)
+    # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
+    def initialize(ruby_values = nil, struct_value = nil)
+      super(self.class.binding_type, ruby_values, struct_value)
     end
-
+  end
 end

--- a/client/sdk/com/vmware/vapi/metadata/authentication/service.rb
+++ b/client/sdk/com/vmware/vapi/metadata/authentication/service.rb
@@ -1,5 +1,6 @@
 #---------------------------------------------------------------------------
-# Copyright 2016 VMware, Inc.  All rights reserved.
+# Copyright 2017 VMware, Inc.  All rights reserved.
+#
 # AUTO GENERATED FILE -- DO NOT MODIFY!
 #
 # vAPI type descriptors for package com.vmware.vapi.metadata.authentication.service.
@@ -8,112 +9,100 @@ require 'vapi'
 
 # declare the module hierarchy before we use the shorthand syntax below
 module Com
-    module Vmware
-        module Vapi
-            module Metadata
-                module Authentication
-                    module Service
-                    end
-                end
-            end
+  module Vmware
+    module Vapi
+      module Metadata
+        module Authentication
+          module Service
+          end
         end
+      end
     end
+  end
 end
 
 # The  ``com.vmware.vapi.metadata.authentication.service``   package  provides  classs  to retrieve authentication information for operation elements.
 module Com::Vmware::Vapi::Metadata::Authentication::Service
+  # The  ``Com::Vmware::Vapi::Metadata::Authentication::Service::Operation``   class  provides  methods  to retrieve authentication information of an operation element.  
+  # 
+  #  An operation element is said to contain authentication information if authentication schemes are specified in the authentication definition file.
+  class Operation < VAPI::Bindings::VapiService
+    # static metamodel definitions
+    SERVICE_ID = VAPI::Core::ServiceIdentifier.new('com.vmware.vapi.metadata.authentication.service.operation')
 
-    # The  ``Com::Vmware::Vapi::Metadata::Authentication::Service::Operation``   class  provides  methods  to retrieve authentication information of an operation element.  
-    # 
-    #  An operation element is said to contain authentication information if authentication schemes are specified in the authentication definition file.
-    class Operation < VAPI::Bindings::VapiService
+    LIST_INFO = VAPI::Bindings::OperationInfo.new(
+      VAPI::Core::OperationIdentifier.new('list', SERVICE_ID),
+      VAPI::Bindings::OperationInputType.new(
+        'service_id' => VAPI::Bindings::IdType.new('com.vmware.vapi.service')
+      ),
+      VAPI::Bindings::ListType.new(VAPI::Bindings::IdType.new),
+      {
+        'com.vmware.vapi.std.errors.not_found' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::NotFound')
+      },
+      [],
+      []
+    )
 
-        protected
+    GET_INFO = VAPI::Bindings::OperationInfo.new(
+      VAPI::Core::OperationIdentifier.new('get', SERVICE_ID),
+      VAPI::Bindings::OperationInputType.new(
+        'service_id' => VAPI::Bindings::IdType.new('com.vmware.vapi.service'),
+        'operation_id' => VAPI::Bindings::IdType.new('com.vmware.vapi.operation')
+      ),
+      VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Metadata::Authentication::OperationInfo'),
+      {
+        'com.vmware.vapi.std.errors.not_found' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::NotFound')
+      },
+      [],
+      []
+    )
 
-        # static metamodel definitions
-        @@service_id = VAPI::Core::ServiceIdentifier.new('com.vmware.vapi.metadata.authentication.service.operation')
+    SERVICE_INFO = VAPI::Bindings::ServiceInfo.new(
+      SERVICE_ID,
+      'list' => LIST_INFO,
+      'get' => GET_INFO
+    )
 
-        @@list_info = VAPI::Bindings::OperationInfo.new(
-            VAPI::Core::OperationIdentifier.new('list', @@service_id),
-            VAPI::Bindings::OperationInputType.new({
-                'service_id' => VAPI::Bindings::IdType.new(resource_types='com.vmware.vapi.service'),
-            }),
-            VAPI::Bindings::ListType.new(VAPI::Bindings::IdType.new),
-            {
-                'com.vmware.vapi.std.errors.not_found' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::NotFound'),
-
-            },
-            [],
-            [])
-        @@get_info = VAPI::Bindings::OperationInfo.new(
-            VAPI::Core::OperationIdentifier.new('get', @@service_id),
-            VAPI::Bindings::OperationInputType.new({
-                'service_id' => VAPI::Bindings::IdType.new(resource_types='com.vmware.vapi.service'),
-                'operation_id' => VAPI::Bindings::IdType.new(resource_types='com.vmware.vapi.operation'),
-            }),
-            VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Metadata::Authentication::OperationInfo'),
-            {
-                'com.vmware.vapi.std.errors.not_found' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::NotFound'),
-
-            },
-            [],
-            [])
-
-        @@service_info = VAPI::Bindings::ServiceInfo.new(@@service_id, {
-            'list' => @@list_info,
-            'get' => @@get_info,
-        })
-
-        public
-
-        # Constructs a new instance.
-        #
-        # @param config [VAPI::Bindings::StubConfig] A hash with the api provider details.
-        def initialize(config)
-            super(config, @@service_info)
-        end
-
-        RESOURCE_TYPE = 'com.vmware.vapi.operation'
-
-
-        # Returns the identifiers for the operation elements contained in the service element corresponding to  ``service_id``  that have authentication information.
-        #
-        # @param service_id [String]
-        #     Identifier of the service element.
-        # @return [Array<String>]
-        #     List of identifiers for the operation elements contained in the service element that have authentication information.
-        # @raise [Com::Vmware::Vapi::Std::Errors::NotFound]
-        #     if the service element associated with  ``service_id``  does not have any operation elements that have authentication information.
-        def list(service_id)
-            invoke_with_info(@@list_info, {
-                'service_id' => service_id,
-            })
-        end
-
-
-        # Retrieves the authentication information about an operation element corresponding to  ``operation_id``  contained in the service element corresponding to  ``service_id`` .
-        #
-        # @param service_id [String]
-        #     Identifier of the service element.
-        # @param operation_id [String]
-        #     Identifier of the operation element.
-        # @return [Com::Vmware::Vapi::Metadata::Authentication::OperationInfo]
-        #     The   :class:`Com::Vmware::Vapi::Metadata::Authentication::OperationInfo`   instance that corresponds to  ``operation_id`` .
-        # @raise [Com::Vmware::Vapi::Std::Errors::NotFound]
-        #     if the service element associated with  ``service_id``  does not exist.
-        # @raise [Com::Vmware::Vapi::Std::Errors::NotFound]
-        #     if the operation element associated with  ``operation_id``  does not exist.
-        # @raise [Com::Vmware::Vapi::Std::Errors::NotFound]
-        #     if the operation element associated with  ``operation_id``  does not have any authentication information.
-        def get(service_id, operation_id)
-            invoke_with_info(@@get_info, {
-                'service_id' => service_id,
-                'operation_id' => operation_id,
-            })
-        end
-
-
+    # Constructs a new instance.
+    #
+    # @param config [VAPI::Bindings::StubConfig] A hash with the api provider details.
+    def initialize(config)
+      super(config, SERVICE_INFO)
     end
 
+    RESOURCE_TYPE = 'com.vmware.vapi.operation'
+    # Returns the identifiers for the operation elements contained in the service element corresponding to  ``service_id``  that have authentication information.
+    #
+    # @param service_id [String]
+    #     Identifier of the service element.
+    # @return [Array<String>]
+    #     List of identifiers for the operation elements contained in the service element that have authentication information.
+    # @raise [Com::Vmware::Vapi::Std::Errors::NotFound]
+    #     if the service element associated with  ``service_id``  does not have any operation elements that have authentication information.
+    def list(service_id)
+      invoke_with_info(LIST_INFO,
+                       'service_id' => service_id)
+    end
 
+    # Retrieves the authentication information about an operation element corresponding to  ``operation_id``  contained in the service element corresponding to  ``service_id`` .
+    #
+    # @param service_id [String]
+    #     Identifier of the service element.
+    # @param operation_id [String]
+    #     Identifier of the operation element.
+    # @return [Com::Vmware::Vapi::Metadata::Authentication::OperationInfo]
+    #     The   :class:`Com::Vmware::Vapi::Metadata::Authentication::OperationInfo`   instance that corresponds to  ``operation_id`` .
+    # @raise [Com::Vmware::Vapi::Std::Errors::NotFound]
+    #     if the service element associated with  ``service_id``  does not exist.
+    # @raise [Com::Vmware::Vapi::Std::Errors::NotFound]
+    #     if the operation element associated with  ``operation_id``  does not exist.
+    # @raise [Com::Vmware::Vapi::Std::Errors::NotFound]
+    #     if the operation element associated with  ``operation_id``  does not have any authentication information.
+    def get(service_id, operation_id)
+      invoke_with_info(GET_INFO,
+                       'service_id' => service_id,
+                       'operation_id' => operation_id)
+    end
+
+  end
 end

--- a/client/sdk/com/vmware/vapi/metadata/cli.rb
+++ b/client/sdk/com/vmware/vapi/metadata/cli.rb
@@ -1,5 +1,6 @@
 #---------------------------------------------------------------------------
-# Copyright 2016 VMware, Inc.  All rights reserved.
+# Copyright 2017 VMware, Inc.  All rights reserved.
+#
 # AUTO GENERATED FILE -- DO NOT MODIFY!
 #
 # vAPI type descriptors for package com.vmware.vapi.metadata.cli.
@@ -8,996 +9,940 @@ require 'vapi'
 
 # declare the module hierarchy before we use the shorthand syntax below
 module Com
-    module Vmware
-        module Vapi
-            module Metadata
-                module Cli
-                end
-            end
+  module Vmware
+    module Vapi
+      module Metadata
+        module Cli
         end
+      end
     end
+  end
 end
 
 # The  ``com.vmware.vapi.metadata.cli``   package  provides  classs  that expose all the information required to display namespace or command help, execute a command and display it's result.
 module Com::Vmware::Vapi::Metadata::Cli
-
-    # The  ``Com::Vmware::Vapi::Metadata::Cli::Command``   class  provides  methods  to get information about command line interface (CLI) commands.
-    class Command < VAPI::Bindings::VapiService
-
-        protected
-
-        # static metamodel definitions
-        @@service_id = VAPI::Core::ServiceIdentifier.new('com.vmware.vapi.metadata.cli.command')
-
-        @@list_info = VAPI::Bindings::OperationInfo.new(
-            VAPI::Core::OperationIdentifier.new('list', @@service_id),
-            VAPI::Bindings::OperationInputType.new({
-                'path' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::StringType.instance),
-            }),
-            VAPI::Bindings::ListType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Metadata::Cli::Command::Identity')),
-            {
-                'com.vmware.vapi.std.errors.not_found' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::NotFound'),
-
-            },
-            [],
-            [])
-        @@get_info = VAPI::Bindings::OperationInfo.new(
-            VAPI::Core::OperationIdentifier.new('get', @@service_id),
-            VAPI::Bindings::OperationInputType.new({
-                'identity' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Metadata::Cli::Command::Identity'),
-            }),
-            VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Metadata::Cli::Command::Info'),
-            {
-                'com.vmware.vapi.std.errors.not_found' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::NotFound'),
-
-            },
-            [],
-            [])
-        @@fingerprint_info = VAPI::Bindings::OperationInfo.new(
-            VAPI::Core::OperationIdentifier.new('fingerprint', @@service_id),
-            VAPI::Bindings::OperationInputType.new,
-            VAPI::Bindings::StringType.instance,
-            {},
-            [],
-            [])
-
-        @@service_info = VAPI::Bindings::ServiceInfo.new(@@service_id, {
-            'list' => @@list_info,
-            'get' => @@get_info,
-            'fingerprint' => @@fingerprint_info,
-        })
-
-        public
-
-        # Constructs a new instance.
-        #
-        # @param config [VAPI::Bindings::StubConfig] A hash with the api provider details.
-        def initialize(config)
-            super(config, @@service_info)
-        end
-
-
-        # Returns the identifiers of all commands, or commands in a specific namespace.
-        #
-        # @param path [String, nil]
-        #     The dot-separated path of the namespace for which command identifiers should be returned.
-        #     If  nil  identifiers of all commands registered with the infrastructure will be returned.
-        # @return [Array<Com::Vmware::Vapi::Metadata::Cli::Command::Identity>]
-        #     Identifiers of the requested commands.
-        # @raise [Com::Vmware::Vapi::Std::Errors::NotFound]
-        #     if a namespace corresponding to  ``path``  doesn't exist.
-        def list(path=nil)
-            invoke_with_info(@@list_info, {
-                'path' => path,
-            })
-        end
-
-
-        # Retrieves information about a command including information about how to execute that command.
-        #
-        # @param identity [Com::Vmware::Vapi::Metadata::Cli::Command::Identity]
-        #     Identifier of the command for which to retreive information.
-        # @return [Com::Vmware::Vapi::Metadata::Cli::Command::Info]
-        #     Information about the command including information about how to execute that command.
-        # @raise [Com::Vmware::Vapi::Std::Errors::NotFound]
-        #     if a command corresponding to  ``identity``  doesn't exist.
-        def get(identity)
-            invoke_with_info(@@get_info, {
-                'identity' => identity,
-            })
-        end
-
-
-        # Returns the aggregate fingerprint of all the command metadata from all the metadata sources.  
-        # 
-        #  The fingerprint provides clients an efficient way to check if the metadata for commands has been modified on the server.
-        #
-        # @return [String]
-        #     Fingerprint of all the command metadata present on the server.
-        def fingerprint()
-            invoke_with_info(@@fingerprint_info)
-        end
-
-
-
-        # The  ``Com::Vmware::Vapi::Metadata::Cli::Command::OutputFieldInfo``   class  describes the name used by the CLI to display a single  field  of a  class  element in the interface definition language.
-        # @!attribute [rw] field_name
-        #     @return [String]
-        #     Name of the  field .
-        # @!attribute [rw] display_name
-        #     @return [String]
-        #     Name used by the CLI to display the  field .
-        class OutputFieldInfo < VAPI::Bindings::VapiStruct
-
-            class << self
-                # Holds (gets or creates) the binding type metadata for this structure type.
-                # @scope class
-                # @return [VAPI::Bindings::StructType] the binding type
-                def binding_type
-                    @binding_type ||= VAPI::Bindings::StructType.new(
-                        'com.vmware.vapi.metadata.cli.command.output_field_info',
-                        {
-                            'field_name' => VAPI::Bindings::StringType.instance,
-                            'display_name' => VAPI::Bindings::StringType.instance,
-                        },
-                        OutputFieldInfo,
-                        false,
-                        nil)
-                end
-            end
-
-            attr_accessor :field_name,
-                          :display_name
-
-            # Constructs a new instance.
-            # @param ruby_values [Hash] a map of initial property values (optional)
-            # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
-            def initialize(ruby_values=nil, struct_value=nil)
-                super(self.class.binding_type, ruby_values, struct_value)
-            end
-        end
-
-
-        # The  ``Com::Vmware::Vapi::Metadata::Cli::Command::OutputInfo``   class  describes the names used by the CLI to display the  fields  of a  class  element in the interface definition language as well as the order in which the  fields  will be displayed.
-        # @!attribute [rw] structure_id
-        #     @return [String]
-        #     Name of the  class .
-        # @!attribute [rw] output_fields
-        #     @return [Array<Com::Vmware::Vapi::Metadata::Cli::Command::OutputFieldInfo>]
-        #     The order in which the  fields  of the  class  will be displayed by the CLI as well as the names used to display the  fields .
-        class OutputInfo < VAPI::Bindings::VapiStruct
-
-            class << self
-                # Holds (gets or creates) the binding type metadata for this structure type.
-                # @scope class
-                # @return [VAPI::Bindings::StructType] the binding type
-                def binding_type
-                    @binding_type ||= VAPI::Bindings::StructType.new(
-                        'com.vmware.vapi.metadata.cli.command.output_info',
-                        {
-                            'structure_id' => VAPI::Bindings::IdType.new(resource_types='com.vmware.vapi.structure'),
-                            'output_fields' => VAPI::Bindings::ListType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Metadata::Cli::Command::OutputFieldInfo')),
-                        },
-                        OutputInfo,
-                        false,
-                        nil)
-                end
-            end
-
-            attr_accessor :structure_id,
-                          :output_fields
-
-            # Constructs a new instance.
-            # @param ruby_values [Hash] a map of initial property values (optional)
-            # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
-            def initialize(ruby_values=nil, struct_value=nil)
-                super(self.class.binding_type, ruby_values, struct_value)
-            end
-        end
-
-
-        # The  ``Com::Vmware::Vapi::Metadata::Cli::Command::OptionInfo``   class  describes information about a specific input option of a command.
-        # @!attribute [rw] long_option
-        #     @return [String]
-        #     The long option name of the parameter as used by the user.
-        # @!attribute [rw] short_option
-        #     @return [String, nil]
-        #     The single character value option name.
-        #     If not present, there's no single character option for the parameter.
-        # @!attribute [rw] field_name
-        #     @return [String]
-        #     The fully qualified name of the option referred to by the operation element in   :attr:`Com::Vmware::Vapi::Metadata::Cli::Command::Info.operation_id`  .
-        # @!attribute [rw] description
-        #     @return [String]
-        #     The description of the option to be displayed to the user when they request usage information for a CLI command.
-        # @!attribute [rw] type
-        #     @return [String]
-        #     The type of option. This is used to display information about what kind of data is expected (string, number, boolean, etc.) for the option when they request usage information for a CLI command. For  enumerated type  this stores the fully qualified  enumerated type  id.
-        # @!attribute [rw] generic
-        #     @return [Com::Vmware::Vapi::Metadata::Cli::Command::GenericType]
-        #     This is used to tell the user whether the option is required or optional, or whether they can specify the option multiple times.
-        class OptionInfo < VAPI::Bindings::VapiStruct
-
-            class << self
-                # Holds (gets or creates) the binding type metadata for this structure type.
-                # @scope class
-                # @return [VAPI::Bindings::StructType] the binding type
-                def binding_type
-                    @binding_type ||= VAPI::Bindings::StructType.new(
-                        'com.vmware.vapi.metadata.cli.command.option_info',
-                        {
-                            'long_option' => VAPI::Bindings::StringType.instance,
-                            'short_option' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::StringType.instance),
-                            'field_name' => VAPI::Bindings::StringType.instance,
-                            'description' => VAPI::Bindings::StringType.instance,
-                            'type' => VAPI::Bindings::StringType.instance,
-                            'generic' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Metadata::Cli::Command::GenericType'),
-                        },
-                        OptionInfo,
-                        false,
-                        nil)
-                end
-            end
-
-            attr_accessor :long_option,
-                          :short_option,
-                          :field_name,
-                          :description,
-                          :type,
-                          :generic
-
-            # Constructs a new instance.
-            # @param ruby_values [Hash] a map of initial property values (optional)
-            # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
-            def initialize(ruby_values=nil, struct_value=nil)
-                super(self.class.binding_type, ruby_values, struct_value)
-            end
-        end
-
-
-        # The  ``Com::Vmware::Vapi::Metadata::Cli::Command::Identity``   class  uniquely identifies a command in the CLI commands tree.
-        # @!attribute [rw] path
-        #     @return [String]
-        #     The dot-separated path of the namespace containing the command in the CLI command tree.
-        # @!attribute [rw] name
-        #     @return [String]
-        #     Name of the command.
-        class Identity < VAPI::Bindings::VapiStruct
-
-            class << self
-                # Holds (gets or creates) the binding type metadata for this structure type.
-                # @scope class
-                # @return [VAPI::Bindings::StructType] the binding type
-                def binding_type
-                    @binding_type ||= VAPI::Bindings::StructType.new(
-                        'com.vmware.vapi.metadata.cli.command.identity',
-                        {
-                            'path' => VAPI::Bindings::StringType.instance,
-                            'name' => VAPI::Bindings::StringType.instance,
-                        },
-                        Identity,
-                        false,
-                        nil)
-                end
-            end
-
-            attr_accessor :path,
-                          :name
-
-            # Constructs a new instance.
-            # @param ruby_values [Hash] a map of initial property values (optional)
-            # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
-            def initialize(ruby_values=nil, struct_value=nil)
-                super(self.class.binding_type, ruby_values, struct_value)
-            end
-        end
-
-
-        # The  ``Com::Vmware::Vapi::Metadata::Cli::Command::Info``   class  contains information about a command. It includes the identity of the command, a description, information about the  class  and  method  that implement the command, and CLI-specific information for the command.
-        # @!attribute [rw] identity
-        #     @return [Com::Vmware::Vapi::Metadata::Cli::Command::Identity]
-        #     Basic command identity.
-        # @!attribute [rw] description
-        #     @return [String]
-        #     The text description displayed to the user in help output.
-        # @!attribute [rw] service_id
-        #     @return [String]
-        #     The service identifier that contains the operations for this CLI command.
-        # @!attribute [rw] operation_id
-        #     @return [String]
-        #     The operation identifier corresponding to this CLI command.
-        # @!attribute [rw] options
-        #     @return [Array<Com::Vmware::Vapi::Metadata::Cli::Command::OptionInfo>]
-        #     The input for this command.
-        # @!attribute [rw] formatter
-        #     @return [Com::Vmware::Vapi::Metadata::Cli::Command::FormatterType, nil]
-        #     The formatter to use when displaying the output of this command.
-        #     If not present, client can choose a default output formatter.
-        # @!attribute [rw] output_field_list
-        #     @return [Array<Com::Vmware::Vapi::Metadata::Cli::Command::OutputInfo>]
-        #     List of output structure name and output field info.
-        class Info < VAPI::Bindings::VapiStruct
-
-            class << self
-                # Holds (gets or creates) the binding type metadata for this structure type.
-                # @scope class
-                # @return [VAPI::Bindings::StructType] the binding type
-                def binding_type
-                    @binding_type ||= VAPI::Bindings::StructType.new(
-                        'com.vmware.vapi.metadata.cli.command.info',
-                        {
-                            'identity' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Metadata::Cli::Command::Identity'),
-                            'description' => VAPI::Bindings::StringType.instance,
-                            'service_id' => VAPI::Bindings::IdType.new(resource_types='com.vmware.vapi.service'),
-                            'operation_id' => VAPI::Bindings::IdType.new(resource_types='com.vmware.vapi.operation'),
-                            'options' => VAPI::Bindings::ListType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Metadata::Cli::Command::OptionInfo')),
-                            'formatter' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Metadata::Cli::Command::FormatterType')),
-                            'output_field_list' => VAPI::Bindings::ListType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Metadata::Cli::Command::OutputInfo')),
-                        },
-                        Info,
-                        false,
-                        nil)
-                end
-            end
-
-            attr_accessor :identity,
-                          :description,
-                          :service_id,
-                          :operation_id,
-                          :options,
-                          :formatter,
-                          :output_field_list
-
-            # Constructs a new instance.
-            # @param ruby_values [Hash] a map of initial property values (optional)
-            # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
-            def initialize(ruby_values=nil, struct_value=nil)
-                super(self.class.binding_type, ruby_values, struct_value)
-            end
-        end
-
-
-
-        # The  ``Com::Vmware::Vapi::Metadata::Cli::Command::FormatterType``   enumerated type  defines supported CLI output formatter types. See   :attr:`Com::Vmware::Vapi::Metadata::Cli::Command::Info.formatter`  .
-        # @!attribute [rw] simple
-        #     @return [Com::Vmware::Vapi::Metadata::Cli::Command::FormatterType]
-        #     Displays command output as it is.
-        # @!attribute [rw] table
-        #     @return [Com::Vmware::Vapi::Metadata::Cli::Command::FormatterType]
-        #     Displays command output in table format.
-        # @!attribute [rw] json
-        #     @return [Com::Vmware::Vapi::Metadata::Cli::Command::FormatterType]
-        #     Displays command output in JSON format.
-        # @!attribute [rw] xml
-        #     @return [Com::Vmware::Vapi::Metadata::Cli::Command::FormatterType]
-        #     Displays command output in XML format.
-        # @!attribute [rw] csv
-        #     @return [Com::Vmware::Vapi::Metadata::Cli::Command::FormatterType]
-        #     Displays command output in CSV format.
-        # @!attribute [rw] html
-        #     @return [Com::Vmware::Vapi::Metadata::Cli::Command::FormatterType]
-        #     Displays command output in HTML format.
-        class FormatterType < VAPI::Bindings::VapiEnum
-
-            class << self
-                # Holds (gets or creates) the binding type metadata for this enumeration type.
-                # @scope class
-                # @return [VAPI::Bindings::EnumType] the binding type
-                def binding_type
-                    @binding_type ||= VAPI::Bindings::EnumType.new(
-                        'com.vmware.vapi.metadata.cli.command.formatter_type',
-                        FormatterType)
-                end
-
-                # Converts from a string value (perhaps off the wire) to an instance
-                # of this enum type.
-                # @param value [String] the actual value of the enum instance
-                # @return [FormatterType] the instance found for the value, otherwise
-                #         an unknown instance will be built for the value
-                def from_string(value)
-                    begin
-                        const_get(value)
-                    rescue NameError
-                        FormatterType.new('UNKNOWN', value)
-                    end
-                end
-            end
-
-            private
-
-            # Constructs a new instance.
-            # @param value [String] the actual value of the enum instance
-            # @param unknown [String] the unknown value when value is 'UKNOWN'
-            def initialize(value, unknown=nil)
-                super(self.class.binding_type, value, unknown)
-            end
-
-            public
-
-            # @!attribute [rw] simple
-            #     @return [Com::Vmware::Vapi::Metadata::Cli::Command::FormatterType]
-            #     Displays command output as it is.
-            SIMPLE = FormatterType.new('SIMPLE')
-
-            # @!attribute [rw] table
-            #     @return [Com::Vmware::Vapi::Metadata::Cli::Command::FormatterType]
-            #     Displays command output in table format.
-            TABLE = FormatterType.new('TABLE')
-
-            # @!attribute [rw] json
-            #     @return [Com::Vmware::Vapi::Metadata::Cli::Command::FormatterType]
-            #     Displays command output in JSON format.
-            JSON = FormatterType.new('JSON')
-
-            # @!attribute [rw] xml
-            #     @return [Com::Vmware::Vapi::Metadata::Cli::Command::FormatterType]
-            #     Displays command output in XML format.
-            XML = FormatterType.new('XML')
-
-            # @!attribute [rw] csv
-            #     @return [Com::Vmware::Vapi::Metadata::Cli::Command::FormatterType]
-            #     Displays command output in CSV format.
-            CSV = FormatterType.new('CSV')
-
-            # @!attribute [rw] html
-            #     @return [Com::Vmware::Vapi::Metadata::Cli::Command::FormatterType]
-            #     Displays command output in HTML format.
-            HTML = FormatterType.new('HTML')
-
-        end
-
-
-        # The  ``Com::Vmware::Vapi::Metadata::Cli::Command::GenericType``   enumerated type  defines generic types supported by  ``Com::Vmware::Vapi::Metadata::Cli::Command``   class . See   :attr:`Com::Vmware::Vapi::Metadata::Cli::Command::OptionInfo.generic`  .
-        # @!attribute [rw] none
-        #     @return [Com::Vmware::Vapi::Metadata::Cli::Command::GenericType]
-        #     Default case.
-        # @!attribute [rw] optional
-        #     @return [Com::Vmware::Vapi::Metadata::Cli::Command::GenericType]
-        #     Input parameter is an optional.
-        # @!attribute [rw] list
-        #     @return [Com::Vmware::Vapi::Metadata::Cli::Command::GenericType]
-        #     Input parameter is a list.
-        # @!attribute [rw] optional_list
-        #     @return [Com::Vmware::Vapi::Metadata::Cli::Command::GenericType]
-        #     Input parameter is an optional of type list.  
-        #     
-        #      New in vSphere 6.5.
-        # @!attribute [rw] list_optional
-        #     @return [Com::Vmware::Vapi::Metadata::Cli::Command::GenericType]
-        #     Input parameter is a list of optionals.  
-        #     
-        #      New in vSphere 6.5.
-        class GenericType < VAPI::Bindings::VapiEnum
-
-            class << self
-                # Holds (gets or creates) the binding type metadata for this enumeration type.
-                # @scope class
-                # @return [VAPI::Bindings::EnumType] the binding type
-                def binding_type
-                    @binding_type ||= VAPI::Bindings::EnumType.new(
-                        'com.vmware.vapi.metadata.cli.command.generic_type',
-                        GenericType)
-                end
-
-                # Converts from a string value (perhaps off the wire) to an instance
-                # of this enum type.
-                # @param value [String] the actual value of the enum instance
-                # @return [GenericType] the instance found for the value, otherwise
-                #         an unknown instance will be built for the value
-                def from_string(value)
-                    begin
-                        const_get(value)
-                    rescue NameError
-                        GenericType.new('UNKNOWN', value)
-                    end
-                end
-            end
-
-            private
-
-            # Constructs a new instance.
-            # @param value [String] the actual value of the enum instance
-            # @param unknown [String] the unknown value when value is 'UKNOWN'
-            def initialize(value, unknown=nil)
-                super(self.class.binding_type, value, unknown)
-            end
-
-            public
-
-            # @!attribute [rw] none
-            #     @return [Com::Vmware::Vapi::Metadata::Cli::Command::GenericType]
-            #     Default case.
-            NONE = GenericType.new('NONE')
-
-            # @!attribute [rw] optional
-            #     @return [Com::Vmware::Vapi::Metadata::Cli::Command::GenericType]
-            #     Input parameter is an optional.
-            OPTIONAL = GenericType.new('OPTIONAL')
-
-            # @!attribute [rw] list
-            #     @return [Com::Vmware::Vapi::Metadata::Cli::Command::GenericType]
-            #     Input parameter is a list.
-            LIST = GenericType.new('LIST')
-
-            # @!attribute [rw] optional_list
-            #     @return [Com::Vmware::Vapi::Metadata::Cli::Command::GenericType]
-            #     Input parameter is an optional of type list.  
-            #     
-            #      New in vSphere 6.5.
-            OPTIONAL_LIST = GenericType.new('OPTIONAL_LIST')
-
-            # @!attribute [rw] list_optional
-            #     @return [Com::Vmware::Vapi::Metadata::Cli::Command::GenericType]
-            #     Input parameter is a list of optionals.  
-            #     
-            #      New in vSphere 6.5.
-            LIST_OPTIONAL = GenericType.new('LIST_OPTIONAL')
-
-        end
-
-
+  # The  ``Com::Vmware::Vapi::Metadata::Cli::Command``   class  provides  methods  to get information about command line interface (CLI) commands.
+  class Command < VAPI::Bindings::VapiService
+    # static metamodel definitions
+    SERVICE_ID = VAPI::Core::ServiceIdentifier.new('com.vmware.vapi.metadata.cli.command')
+
+    LIST_INFO = VAPI::Bindings::OperationInfo.new(
+      VAPI::Core::OperationIdentifier.new('list', SERVICE_ID),
+      VAPI::Bindings::OperationInputType.new(
+        'path' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::StringType.instance)
+      ),
+      VAPI::Bindings::ListType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Metadata::Cli::Command::Identity')),
+      {
+        'com.vmware.vapi.std.errors.not_found' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::NotFound')
+      },
+      [],
+      []
+    )
+
+    GET_INFO = VAPI::Bindings::OperationInfo.new(
+      VAPI::Core::OperationIdentifier.new('get', SERVICE_ID),
+      VAPI::Bindings::OperationInputType.new(
+        'identity' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Metadata::Cli::Command::Identity')
+      ),
+      VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Metadata::Cli::Command::Info'),
+      {
+        'com.vmware.vapi.std.errors.not_found' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::NotFound')
+      },
+      [],
+      []
+    )
+
+    FINGERPRINT_INFO = VAPI::Bindings::OperationInfo.new(
+      VAPI::Core::OperationIdentifier.new('fingerprint', SERVICE_ID),
+      VAPI::Bindings::OperationInputType.new,
+      VAPI::Bindings::StringType.instance,
+      {},
+      [],
+      []
+    )
+
+    SERVICE_INFO = VAPI::Bindings::ServiceInfo.new(
+      SERVICE_ID,
+      'list' => LIST_INFO,
+      'get' => GET_INFO,
+      'fingerprint' => FINGERPRINT_INFO
+    )
+
+    # Constructs a new instance.
+    #
+    # @param config [VAPI::Bindings::StubConfig] A hash with the api provider details.
+    def initialize(config)
+      super(config, SERVICE_INFO)
     end
 
-
-    # The  ``Com::Vmware::Vapi::Metadata::Cli::Namespace``   class  provides  methods  to get information about command line interface (CLI) namespaces.
-    class Namespace < VAPI::Bindings::VapiService
-
-        protected
-
-        # static metamodel definitions
-        @@service_id = VAPI::Core::ServiceIdentifier.new('com.vmware.vapi.metadata.cli.namespace')
-
-        @@list_info = VAPI::Bindings::OperationInfo.new(
-            VAPI::Core::OperationIdentifier.new('list', @@service_id),
-            VAPI::Bindings::OperationInputType.new,
-            VAPI::Bindings::ListType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Metadata::Cli::Namespace::Identity')),
-            {},
-            [],
-            [])
-        @@get_info = VAPI::Bindings::OperationInfo.new(
-            VAPI::Core::OperationIdentifier.new('get', @@service_id),
-            VAPI::Bindings::OperationInputType.new({
-                'identity' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Metadata::Cli::Namespace::Identity'),
-            }),
-            VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Metadata::Cli::Namespace::Info'),
-            {
-                'com.vmware.vapi.std.errors.not_found' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::NotFound'),
-
-            },
-            [],
-            [])
-        @@fingerprint_info = VAPI::Bindings::OperationInfo.new(
-            VAPI::Core::OperationIdentifier.new('fingerprint', @@service_id),
-            VAPI::Bindings::OperationInputType.new,
-            VAPI::Bindings::StringType.instance,
-            {},
-            [],
-            [])
-
-        @@service_info = VAPI::Bindings::ServiceInfo.new(@@service_id, {
-            'list' => @@list_info,
-            'get' => @@get_info,
-            'fingerprint' => @@fingerprint_info,
-        })
-
-        public
-
-        # Constructs a new instance.
-        #
-        # @param config [VAPI::Bindings::StubConfig] A hash with the api provider details.
-        def initialize(config)
-            super(config, @@service_info)
-        end
-
-
-        # Returns the identifiers of all namespaces registered with the infrastructure.
-        #
-        # @return [Array<Com::Vmware::Vapi::Metadata::Cli::Namespace::Identity>]
-        #     Identifiers of all the namespaces.
-        def list()
-            invoke_with_info(@@list_info)
-        end
-
-
-        # Retreives information about a namespace including information about children of that namespace.
-        #
-        # @param identity [Com::Vmware::Vapi::Metadata::Cli::Namespace::Identity]
-        #     Identifier of the namespace for which to retreive information.
-        # @return [Com::Vmware::Vapi::Metadata::Cli::Namespace::Info]
-        #     Information about the namespace including information about child of that namespace.
-        # @raise [Com::Vmware::Vapi::Std::Errors::NotFound]
-        #     if a namespace corresponding to  ``identity``  doesn't exist.
-        def get(identity)
-            invoke_with_info(@@get_info, {
-                'identity' => identity,
-            })
-        end
-
-
-        # Returns the aggregate fingerprint of all the namespace metadata from all the metadata sources.  
-        # 
-        #  The fingerprint provides clients an efficient way to check if the metadata for namespaces has been modified on the server.
-        #
-        # @return [String]
-        #     Fingerprint of all the namespace metadata present on the server.
-        def fingerprint()
-            invoke_with_info(@@fingerprint_info)
-        end
-
-
-
-        # The  ``Com::Vmware::Vapi::Metadata::Cli::Namespace::Identity``   class  uniquely identifies a namespace in the CLI namespace tree.
-        # @!attribute [rw] path
-        #     @return [String]
-        #     The dot-separated path of the namespace containing the namespace in the CLI node tree. For top-level namespace this will be empty.
-        # @!attribute [rw] name
-        #     @return [String]
-        #     The name displayed to the user for this namespace.
-        class Identity < VAPI::Bindings::VapiStruct
-
-            class << self
-                # Holds (gets or creates) the binding type metadata for this structure type.
-                # @scope class
-                # @return [VAPI::Bindings::StructType] the binding type
-                def binding_type
-                    @binding_type ||= VAPI::Bindings::StructType.new(
-                        'com.vmware.vapi.metadata.cli.namespace.identity',
-                        {
-                            'path' => VAPI::Bindings::StringType.instance,
-                            'name' => VAPI::Bindings::StringType.instance,
-                        },
-                        Identity,
-                        false,
-                        nil)
-                end
-            end
-
-            attr_accessor :path,
-                          :name
-
-            # Constructs a new instance.
-            # @param ruby_values [Hash] a map of initial property values (optional)
-            # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
-            def initialize(ruby_values=nil, struct_value=nil)
-                super(self.class.binding_type, ruby_values, struct_value)
-            end
-        end
-
-
-        # The  ``Com::Vmware::Vapi::Metadata::Cli::Namespace::Info``   class  contains information about a namespace. It includes the identity of the namespace, a description, information children namespaces.
-        # @!attribute [rw] identity
-        #     @return [Com::Vmware::Vapi::Metadata::Cli::Namespace::Identity]
-        #     Basic namespace identity.
-        # @!attribute [rw] description
-        #     @return [String]
-        #     The text description displayed to the user in help output.
-        # @!attribute [rw] children
-        #     @return [Array<Com::Vmware::Vapi::Metadata::Cli::Namespace::Identity>]
-        #     The children of this namespace in the tree of CLI namespaces.
-        class Info < VAPI::Bindings::VapiStruct
-
-            class << self
-                # Holds (gets or creates) the binding type metadata for this structure type.
-                # @scope class
-                # @return [VAPI::Bindings::StructType] the binding type
-                def binding_type
-                    @binding_type ||= VAPI::Bindings::StructType.new(
-                        'com.vmware.vapi.metadata.cli.namespace.info',
-                        {
-                            'identity' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Metadata::Cli::Namespace::Identity'),
-                            'description' => VAPI::Bindings::StringType.instance,
-                            'children' => VAPI::Bindings::ListType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Metadata::Cli::Namespace::Identity')),
-                        },
-                        Info,
-                        false,
-                        nil)
-                end
-            end
-
-            attr_accessor :identity,
-                          :description,
-                          :children
-
-            # Constructs a new instance.
-            # @param ruby_values [Hash] a map of initial property values (optional)
-            # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
-            def initialize(ruby_values=nil, struct_value=nil)
-                super(self.class.binding_type, ruby_values, struct_value)
-            end
-        end
-
-
+    # Returns the identifiers of all commands, or commands in a specific namespace.
+    #
+    # @param path [String, nil]
+    #     The dot-separated path of the namespace for which command identifiers should be returned.
+    #     If  nil  identifiers of all commands registered with the infrastructure will be returned.
+    # @return [Array<Com::Vmware::Vapi::Metadata::Cli::Command::Identity>]
+    #     Identifiers of the requested commands.
+    # @raise [Com::Vmware::Vapi::Std::Errors::NotFound]
+    #     if a namespace corresponding to  ``path``  doesn't exist.
+    def list(path = nil)
+      invoke_with_info(LIST_INFO,
+                       'path' => path)
     end
 
-
-    # The  ``Com::Vmware::Vapi::Metadata::Cli::Source``   class  provides  methods  to manage the sources of command line interface (CLI) metadata information.  
-    # 
-    #  The interface definition language infrastructure provides tools to generate various kinds of metadata in JSON format from the interface definition files and additional properties files. One of the generated files contains CLI information.  
-    # 
-    #  A CLI metadata file contains information about one component element. When a CLI metadata file is added as a source, each source contributes only one component element's metadata.  
-    # 
-    #  CLI metadata can also be discovered from a remote server that supports the CLI metadata services (see   :mod:`com.vmware.vapi.metadata.cli`  )  package . Since multiple components can be registered with a single metadata server, when a remote server is registered as a source, that source can contribute more than one component.
-    class Source < VAPI::Bindings::VapiService
-
-        protected
-
-        # static metamodel definitions
-        @@service_id = VAPI::Core::ServiceIdentifier.new('com.vmware.vapi.metadata.cli.source')
-
-        @@create_info = VAPI::Bindings::OperationInfo.new(
-            VAPI::Core::OperationIdentifier.new('create', @@service_id),
-            VAPI::Bindings::OperationInputType.new({
-                'source_id' => VAPI::Bindings::IdType.new(resource_types='com.vmware.vapi.metadata.source'),
-                'spec' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Metadata::Cli::Source::CreateSpec'),
-            }),
-            VAPI::Bindings::VoidType.instance,
-            {
-                'com.vmware.vapi.std.errors.already_exists' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::AlreadyExists'),
-                'com.vmware.vapi.std.errors.invalid_argument' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::InvalidArgument'),
-                'com.vmware.vapi.std.errors.not_found' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::NotFound'),
-
-            },
-            [],
-            [])
-        @@delete_info = VAPI::Bindings::OperationInfo.new(
-            VAPI::Core::OperationIdentifier.new('delete', @@service_id),
-            VAPI::Bindings::OperationInputType.new({
-                'source_id' => VAPI::Bindings::IdType.new(resource_types='com.vmware.vapi.metadata.source'),
-            }),
-            VAPI::Bindings::VoidType.instance,
-            {
-                'com.vmware.vapi.std.errors.not_found' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::NotFound'),
-
-            },
-            [],
-            [])
-        @@get_info = VAPI::Bindings::OperationInfo.new(
-            VAPI::Core::OperationIdentifier.new('get', @@service_id),
-            VAPI::Bindings::OperationInputType.new({
-                'source_id' => VAPI::Bindings::IdType.new(resource_types='com.vmware.vapi.metadata.source'),
-            }),
-            VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Metadata::Cli::Source::Info'),
-            {
-                'com.vmware.vapi.std.errors.not_found' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::NotFound'),
-
-            },
-            [],
-            [])
-        @@list_info = VAPI::Bindings::OperationInfo.new(
-            VAPI::Core::OperationIdentifier.new('list', @@service_id),
-            VAPI::Bindings::OperationInputType.new,
-            VAPI::Bindings::ListType.new(VAPI::Bindings::IdType.new),
-            {},
-            [],
-            [])
-        @@reload_info = VAPI::Bindings::OperationInfo.new(
-            VAPI::Core::OperationIdentifier.new('reload', @@service_id),
-            VAPI::Bindings::OperationInputType.new({
-                'source_id' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::IdType.new),
-            }),
-            VAPI::Bindings::VoidType.instance,
-            {
-                'com.vmware.vapi.std.errors.not_found' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::NotFound'),
-
-            },
-            [],
-            [])
-        @@fingerprint_info = VAPI::Bindings::OperationInfo.new(
-            VAPI::Core::OperationIdentifier.new('fingerprint', @@service_id),
-            VAPI::Bindings::OperationInputType.new({
-                'source_id' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::IdType.new),
-            }),
-            VAPI::Bindings::StringType.instance,
-            {
-                'com.vmware.vapi.std.errors.not_found' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::NotFound'),
-
-            },
-            [],
-            [])
-
-        @@service_info = VAPI::Bindings::ServiceInfo.new(@@service_id, {
-            'create' => @@create_info,
-            'delete' => @@delete_info,
-            'get' => @@get_info,
-            'list' => @@list_info,
-            'reload' => @@reload_info,
-            'fingerprint' => @@fingerprint_info,
-        })
-
-        public
-
-        # Constructs a new instance.
-        #
-        # @param config [VAPI::Bindings::StubConfig] A hash with the api provider details.
-        def initialize(config)
-            super(config, @@service_info)
-        end
-
-
-        # Creates a new metadata source. Once the server validates the registration information of the metadata source, the CLI metadata is retrieved from the source. This populates elements in all the  classs  defined in   :mod:`com.vmware.vapi.metadata.cli`    package .
-        #
-        # @param source_id [String]
-        #     metadata source identifier.
-        # @param spec [Com::Vmware::Vapi::Metadata::Cli::Source::CreateSpec]
-        #     create specification.
-        # @return [Void]
-        # @raise [Com::Vmware::Vapi::Std::Errors::AlreadyExists]
-        #     If the metadata source identifier is already registered with the infrastructure.
-        # @raise [Com::Vmware::Vapi::Std::Errors::InvalidArgument]
-        #     If type of the source specified in  null  is invalid.
-        # @raise [Com::Vmware::Vapi::Std::Errors::InvalidArgument]
-        #     If the file specified in  null  is not a valid JSON file or if the format of the CLI metadata in the JSON file is invalid.
-        # @raise [Com::Vmware::Vapi::Std::Errors::InvalidArgument]
-        #     If the URI specified in  null  is unreachable or if there is a transport protocol or message protocol mismatch between the client and the server or if the remote server do not have  classs  present in   :mod:`com.vmware.vapi.metadata.cli`    package .
-        # @raise [Com::Vmware::Vapi::Std::Errors::NotFound]
-        #     If the file specified in  null  does not exist.
-        def create(source_id, spec)
-            invoke_with_info(@@create_info, {
-                'source_id' => source_id,
-                'spec' => spec,
-            })
-        end
-
-
-        # Deletes an existing CLI metadata source from the infrastructure.
-        #
-        # @param source_id [String]
-        #     Identifier of the metadata source.
-        # @return [Void]
-        # @raise [Com::Vmware::Vapi::Std::Errors::NotFound]
-        #     If the metadata source identifier is not found.
-        def delete(source_id)
-            invoke_with_info(@@delete_info, {
-                'source_id' => source_id,
-            })
-        end
-
-
-        # Retrieves information about the metadata source corresponding to  ``source_id`` .
-        #
-        # @param source_id [String]
-        #     Identifier of the metadata source.
-        # @return [Com::Vmware::Vapi::Metadata::Cli::Source::Info]
-        #     The   :class:`Com::Vmware::Vapi::Metadata::Cli::Source::Info`   instance that corresponds to  ``source_id``
-        # @raise [Com::Vmware::Vapi::Std::Errors::NotFound]
-        #     If the metadata source identifier is not found.
-        def get(source_id)
-            invoke_with_info(@@get_info, {
-                'source_id' => source_id,
-            })
-        end
-
-
-        # Returns the identifiers of the metadata sources currently registered with the infrastructure.
-        #
-        # @return [Array<String>]
-        #     The list of identifiers for metadata sources currently registered.
-        def list()
-            invoke_with_info(@@list_info)
-        end
-
-
-        # Reloads the CLI metadata from all the metadata sources or of a particular metadata source if  ``source_id``  is specified.
-        #
-        # @param source_id [String, nil]
-        #     Identifier of the metadata source.
-        #     If unspecified, all the metadata sources are reloaded.
-        # @return [Void]
-        # @raise [Com::Vmware::Vapi::Std::Errors::NotFound]
-        #     If the metadata source identifier is not found.
-        def reload(source_id=nil)
-            invoke_with_info(@@reload_info, {
-                'source_id' => source_id,
-            })
-        end
-
-
-        # Returns the aggregate fingerprint of metadata from all the metadata sources or from a particular metadata source if  ``source_id``  is specified.
-        #
-        # @param source_id [String, nil]
-        #     Identifier of the metadata source.
-        #     If unspecified, the fingerprint of all the metadata sources is returned.
-        # @return [String]
-        #     Aggregate fingerprint of all the metadata sources or of a particular metadata source.
-        # @raise [Com::Vmware::Vapi::Std::Errors::NotFound]
-        #     If the metadata source identifier is not found.
-        def fingerprint(source_id=nil)
-            invoke_with_info(@@fingerprint_info, {
-                'source_id' => source_id,
-            })
-        end
-
-
-
-        # The  ``Com::Vmware::Vapi::Metadata::Cli::Source::Info``   class  contains the metadata source information.
-        # @!attribute [rw] description
-        #     @return [String]
-        #     English language human readable description of the source.
-        # @!attribute [rw] type
-        #     @return [Com::Vmware::Vapi::Metadata::SourceType]
-        #     The type ( ``FILE``, ``REMOTE`` ) of the metadata source.
-        # @!attribute [rw] filepath
-        #     @return [String]
-        #     Absolute file path of the CLI metadata file that has the CLI information about one component. The  ``filepath``  is the path to the file in the server's filesystem.
-        #     This  field  is optional and it is only relevant when the value of  ``type``  is  null .
-        # @!attribute [rw] address
-        #     @return [URI]
-        #     Connection information for the remote server. This should be in the format http(s)://IP:port/namespace.  
-        #     
-        #      The remote server must contain the  classs  in the   :mod:`com.vmware.vapi.metadata.cli`    package . It must expose CLI information of one or more components.
-        #     This  field  is optional and it is only relevant when the value of  ``type``  is  null .
-        class Info < VAPI::Bindings::VapiStruct
-
-            class << self
-                # Holds (gets or creates) the binding type metadata for this structure type.
-                # @scope class
-                # @return [VAPI::Bindings::StructType] the binding type
-                def binding_type
-                    @binding_type ||= VAPI::Bindings::StructType.new(
-                        'com.vmware.vapi.metadata.cli.source.info',
-                        {
-                            'description' => VAPI::Bindings::StringType.instance,
-                            'type' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Metadata::SourceType'),
-                            'filepath' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::StringType.instance),
-                            'address' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::URIType.instance),
-                        },
-                        Info,
-                        false,
-                        nil)
-                end
-            end
-
-            attr_accessor :description,
-                          :type,
-                          :filepath,
-                          :address
-
-            # Constructs a new instance.
-            # @param ruby_values [Hash] a map of initial property values (optional)
-            # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
-            def initialize(ruby_values=nil, struct_value=nil)
-                super(self.class.binding_type, ruby_values, struct_value)
-            end
-        end
-
-
-        # The  ``Com::Vmware::Vapi::Metadata::Cli::Source::CreateSpec``   class  contains the registration information of a CLI source.
-        class CreateSpec < VAPI::Bindings::VapiStruct
-
-            class << self
-                # Holds (gets or creates) the binding type metadata for this structure type.
-                # @scope class
-                # @return [VAPI::Bindings::StructType] the binding type
-                def binding_type
-                    @binding_type ||= VAPI::Bindings::StructType.new(
-                        'com.vmware.vapi.metadata.cli.source.create_spec',
-                        {
-                            'description' => VAPI::Bindings::StringType.instance,
-                            'type' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Metadata::SourceType'),
-                            'filepath' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::StringType.instance),
-                            'address' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::URIType.instance),
-                        },
-                        CreateSpec,
-                        false,
-                        nil)
-                end
-            end
-
-            attr_accessor :description,
-                          :type,
-                          :filepath,
-                          :address
-
-            # Constructs a new instance.
-            # @param ruby_values [Hash] a map of initial property values (optional)
-            # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
-            def initialize(ruby_values=nil, struct_value=nil)
-                super(self.class.binding_type, ruby_values, struct_value)
-            end
-        end
-
-
+    # Retrieves information about a command including information about how to execute that command.
+    #
+    # @param identity [Com::Vmware::Vapi::Metadata::Cli::Command::Identity]
+    #     Identifier of the command for which to retreive information.
+    # @return [Com::Vmware::Vapi::Metadata::Cli::Command::Info]
+    #     Information about the command including information about how to execute that command.
+    # @raise [Com::Vmware::Vapi::Std::Errors::NotFound]
+    #     if a command corresponding to  ``identity``  doesn't exist.
+    def get(identity)
+      invoke_with_info(GET_INFO,
+                       'identity' => identity)
     end
 
+    # Returns the aggregate fingerprint of all the command metadata from all the metadata sources.  
+    # 
+    #  The fingerprint provides clients an efficient way to check if the metadata for commands has been modified on the server.
+    #
+    # @return [String]
+    #     Fingerprint of all the command metadata present on the server.
+    def fingerprint
+      invoke_with_info(FINGERPRINT_INFO)
+    end
 
+    # The  ``Com::Vmware::Vapi::Metadata::Cli::Command::OutputFieldInfo``   class  describes the name used by the CLI to display a single  field  of a  class  element in the interface definition language.
+    # @!attribute [rw] field_name
+    #     @return [String]
+    #     Name of the  field .
+    # @!attribute [rw] display_name
+    #     @return [String]
+    #     Name used by the CLI to display the  field .
+    class OutputFieldInfo < VAPI::Bindings::VapiStruct
+      class << self
+        # Holds (gets or creates) the binding type metadata for this structure type.
+        # @scope class
+        # @return [VAPI::Bindings::StructType] the binding type
+        def binding_type
+          @binding_type ||= VAPI::Bindings::StructType.new(
+            'com.vmware.vapi.metadata.cli.command.output_field_info',
+            {
+              'field_name' => VAPI::Bindings::StringType.instance,
+              'display_name' => VAPI::Bindings::StringType.instance
+            },
+            OutputFieldInfo,
+            false,
+            nil
+          )
+        end
+      end
+
+      attr_accessor :field_name,
+                    :display_name
+
+      # Constructs a new instance.
+      # @param ruby_values [Hash] a map of initial property values (optional)
+      # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
+      def initialize(ruby_values = nil, struct_value = nil)
+        super(self.class.binding_type, ruby_values, struct_value)
+      end
+    end
+
+    # The  ``Com::Vmware::Vapi::Metadata::Cli::Command::OutputInfo``   class  describes the names used by the CLI to display the  fields  of a  class  element in the interface definition language as well as the order in which the  fields  will be displayed.
+    # @!attribute [rw] structure_id
+    #     @return [String]
+    #     Name of the  class .
+    # @!attribute [rw] output_fields
+    #     @return [Array<Com::Vmware::Vapi::Metadata::Cli::Command::OutputFieldInfo>]
+    #     The order in which the  fields  of the  class  will be displayed by the CLI as well as the names used to display the  fields .
+    class OutputInfo < VAPI::Bindings::VapiStruct
+      class << self
+        # Holds (gets or creates) the binding type metadata for this structure type.
+        # @scope class
+        # @return [VAPI::Bindings::StructType] the binding type
+        def binding_type
+          @binding_type ||= VAPI::Bindings::StructType.new(
+            'com.vmware.vapi.metadata.cli.command.output_info',
+            {
+              'structure_id' => VAPI::Bindings::IdType.new('com.vmware.vapi.structure'),
+              'output_fields' => VAPI::Bindings::ListType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Metadata::Cli::Command::OutputFieldInfo'))
+            },
+            OutputInfo,
+            false,
+            nil
+          )
+        end
+      end
+
+      attr_accessor :structure_id,
+                    :output_fields
+
+      # Constructs a new instance.
+      # @param ruby_values [Hash] a map of initial property values (optional)
+      # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
+      def initialize(ruby_values = nil, struct_value = nil)
+        super(self.class.binding_type, ruby_values, struct_value)
+      end
+    end
+
+    # The  ``Com::Vmware::Vapi::Metadata::Cli::Command::OptionInfo``   class  describes information about a specific input option of a command.
+    # @!attribute [rw] long_option
+    #     @return [String]
+    #     The long option name of the parameter as used by the user.
+    # @!attribute [rw] short_option
+    #     @return [String, nil]
+    #     The single character value option name.
+    #     If not present, there's no single character option for the parameter.
+    # @!attribute [rw] field_name
+    #     @return [String]
+    #     The fully qualified name of the option referred to by the operation element in   :attr:`Com::Vmware::Vapi::Metadata::Cli::Command::Info.operation_id`  .
+    # @!attribute [rw] description
+    #     @return [String]
+    #     The description of the option to be displayed to the user when they request usage information for a CLI command.
+    # @!attribute [rw] type
+    #     @return [String]
+    #     The type of option. This is used to display information about what kind of data is expected (string, number, boolean, etc.) for the option when they request usage information for a CLI command. For  enumerated type  this stores the fully qualified  enumerated type  id.
+    # @!attribute [rw] generic
+    #     @return [Com::Vmware::Vapi::Metadata::Cli::Command::GenericType]
+    #     This is used to tell the user whether the option is required or optional, or whether they can specify the option multiple times.
+    class OptionInfo < VAPI::Bindings::VapiStruct
+      class << self
+        # Holds (gets or creates) the binding type metadata for this structure type.
+        # @scope class
+        # @return [VAPI::Bindings::StructType] the binding type
+        def binding_type
+          @binding_type ||= VAPI::Bindings::StructType.new(
+            'com.vmware.vapi.metadata.cli.command.option_info',
+            {
+              'long_option' => VAPI::Bindings::StringType.instance,
+              'short_option' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::StringType.instance),
+              'field_name' => VAPI::Bindings::StringType.instance,
+              'description' => VAPI::Bindings::StringType.instance,
+              'type' => VAPI::Bindings::StringType.instance,
+              'generic' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Metadata::Cli::Command::GenericType')
+            },
+            OptionInfo,
+            false,
+            nil
+          )
+        end
+      end
+
+      attr_accessor :long_option,
+                    :short_option,
+                    :field_name,
+                    :description,
+                    :type,
+                    :generic
+
+      # Constructs a new instance.
+      # @param ruby_values [Hash] a map of initial property values (optional)
+      # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
+      def initialize(ruby_values = nil, struct_value = nil)
+        super(self.class.binding_type, ruby_values, struct_value)
+      end
+    end
+
+    # The  ``Com::Vmware::Vapi::Metadata::Cli::Command::Identity``   class  uniquely identifies a command in the CLI commands tree.
+    # @!attribute [rw] path
+    #     @return [String]
+    #     The dot-separated path of the namespace containing the command in the CLI command tree.
+    # @!attribute [rw] name
+    #     @return [String]
+    #     Name of the command.
+    class Identity < VAPI::Bindings::VapiStruct
+      class << self
+        # Holds (gets or creates) the binding type metadata for this structure type.
+        # @scope class
+        # @return [VAPI::Bindings::StructType] the binding type
+        def binding_type
+          @binding_type ||= VAPI::Bindings::StructType.new(
+            'com.vmware.vapi.metadata.cli.command.identity',
+            {
+              'path' => VAPI::Bindings::StringType.instance,
+              'name' => VAPI::Bindings::StringType.instance
+            },
+            Identity,
+            false,
+            nil
+          )
+        end
+      end
+
+      attr_accessor :path,
+                    :name
+
+      # Constructs a new instance.
+      # @param ruby_values [Hash] a map of initial property values (optional)
+      # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
+      def initialize(ruby_values = nil, struct_value = nil)
+        super(self.class.binding_type, ruby_values, struct_value)
+      end
+    end
+
+    # The  ``Com::Vmware::Vapi::Metadata::Cli::Command::Info``   class  contains information about a command. It includes the identity of the command, a description, information about the  class  and  method  that implement the command, and CLI-specific information for the command.
+    # @!attribute [rw] identity
+    #     @return [Com::Vmware::Vapi::Metadata::Cli::Command::Identity]
+    #     Basic command identity.
+    # @!attribute [rw] description
+    #     @return [String]
+    #     The text description displayed to the user in help output.
+    # @!attribute [rw] service_id
+    #     @return [String]
+    #     The service identifier that contains the operations for this CLI command.
+    # @!attribute [rw] operation_id
+    #     @return [String]
+    #     The operation identifier corresponding to this CLI command.
+    # @!attribute [rw] options
+    #     @return [Array<Com::Vmware::Vapi::Metadata::Cli::Command::OptionInfo>]
+    #     The input for this command.
+    # @!attribute [rw] formatter
+    #     @return [Com::Vmware::Vapi::Metadata::Cli::Command::FormatterType, nil]
+    #     The formatter to use when displaying the output of this command.
+    #     If not present, client can choose a default output formatter.
+    # @!attribute [rw] output_field_list
+    #     @return [Array<Com::Vmware::Vapi::Metadata::Cli::Command::OutputInfo>]
+    #     List of output structure name and output field info.
+    class Info < VAPI::Bindings::VapiStruct
+      class << self
+        # Holds (gets or creates) the binding type metadata for this structure type.
+        # @scope class
+        # @return [VAPI::Bindings::StructType] the binding type
+        def binding_type
+          @binding_type ||= VAPI::Bindings::StructType.new(
+            'com.vmware.vapi.metadata.cli.command.info',
+            {
+              'identity' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Metadata::Cli::Command::Identity'),
+              'description' => VAPI::Bindings::StringType.instance,
+              'service_id' => VAPI::Bindings::IdType.new('com.vmware.vapi.service'),
+              'operation_id' => VAPI::Bindings::IdType.new('com.vmware.vapi.operation'),
+              'options' => VAPI::Bindings::ListType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Metadata::Cli::Command::OptionInfo')),
+              'formatter' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Metadata::Cli::Command::FormatterType')),
+              'output_field_list' => VAPI::Bindings::ListType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Metadata::Cli::Command::OutputInfo'))
+            },
+            Info,
+            false,
+            nil
+          )
+        end
+      end
+
+      attr_accessor :identity,
+                    :description,
+                    :service_id,
+                    :operation_id,
+                    :options,
+                    :formatter,
+                    :output_field_list
+
+      # Constructs a new instance.
+      # @param ruby_values [Hash] a map of initial property values (optional)
+      # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
+      def initialize(ruby_values = nil, struct_value = nil)
+        super(self.class.binding_type, ruby_values, struct_value)
+      end
+    end
+
+    # The  ``Com::Vmware::Vapi::Metadata::Cli::Command::FormatterType``   enumerated type  defines supported CLI output formatter types. See   :attr:`Com::Vmware::Vapi::Metadata::Cli::Command::Info.formatter`  .
+    # @!attribute [rw] simple
+    #     @return [Com::Vmware::Vapi::Metadata::Cli::Command::FormatterType]
+    #     Displays command output as it is.
+    # @!attribute [rw] table
+    #     @return [Com::Vmware::Vapi::Metadata::Cli::Command::FormatterType]
+    #     Displays command output in table format.
+    # @!attribute [rw] json
+    #     @return [Com::Vmware::Vapi::Metadata::Cli::Command::FormatterType]
+    #     Displays command output in JSON format.
+    # @!attribute [rw] xml
+    #     @return [Com::Vmware::Vapi::Metadata::Cli::Command::FormatterType]
+    #     Displays command output in XML format.
+    # @!attribute [rw] csv
+    #     @return [Com::Vmware::Vapi::Metadata::Cli::Command::FormatterType]
+    #     Displays command output in CSV format.
+    # @!attribute [rw] html
+    #     @return [Com::Vmware::Vapi::Metadata::Cli::Command::FormatterType]
+    #     Displays command output in HTML format.
+    class FormatterType < VAPI::Bindings::VapiEnum
+      class << self
+        # Holds (gets or creates) the binding type metadata for this enumeration type.
+        # @scope class
+        # @return [VAPI::Bindings::EnumType] the binding type
+        def binding_type
+          @binding_type ||= VAPI::Bindings::EnumType.new(
+            'com.vmware.vapi.metadata.cli.command.formatter_type',
+            FormatterType
+          )
+        end
+
+        # Converts from a string value (perhaps off the wire) to an instance
+        # of this enum type.
+        # @param value [String] the actual value of the enum instance
+        # @return [FormatterType] the instance found for the value, otherwise
+        #         an unknown instance will be built for the value
+        def from_string(value)
+          const_get(value)
+        rescue NameError
+          FormatterType.send(:new, 'UNKNOWN', value)
+        end
+      end
+
+      # Constructs a new instance.
+      # @param value [String] the actual value of the enum instance
+      # @param unknown [String] the unknown value when value is 'UKNOWN'
+      def initialize(value, unknown = nil)
+        super(self.class.binding_type, value, unknown)
+      end
+
+      private_class_method :new
+
+      # @!attribute [rw] simple
+      #     @return [Com::Vmware::Vapi::Metadata::Cli::Command::FormatterType]
+      #     Displays command output as it is.
+      SIMPLE = FormatterType.send(:new, 'SIMPLE')
+
+      # @!attribute [rw] table
+      #     @return [Com::Vmware::Vapi::Metadata::Cli::Command::FormatterType]
+      #     Displays command output in table format.
+      TABLE = FormatterType.send(:new, 'TABLE')
+
+      # @!attribute [rw] json
+      #     @return [Com::Vmware::Vapi::Metadata::Cli::Command::FormatterType]
+      #     Displays command output in JSON format.
+      JSON = FormatterType.send(:new, 'JSON')
+
+      # @!attribute [rw] xml
+      #     @return [Com::Vmware::Vapi::Metadata::Cli::Command::FormatterType]
+      #     Displays command output in XML format.
+      XML = FormatterType.send(:new, 'XML')
+
+      # @!attribute [rw] csv
+      #     @return [Com::Vmware::Vapi::Metadata::Cli::Command::FormatterType]
+      #     Displays command output in CSV format.
+      CSV = FormatterType.send(:new, 'CSV')
+
+      # @!attribute [rw] html
+      #     @return [Com::Vmware::Vapi::Metadata::Cli::Command::FormatterType]
+      #     Displays command output in HTML format.
+      HTML = FormatterType.send(:new, 'HTML')
+    end
+    # The  ``Com::Vmware::Vapi::Metadata::Cli::Command::GenericType``   enumerated type  defines generic types supported by  ``Com::Vmware::Vapi::Metadata::Cli::Command``   class . See   :attr:`Com::Vmware::Vapi::Metadata::Cli::Command::OptionInfo.generic`  .
+    # @!attribute [rw] none
+    #     @return [Com::Vmware::Vapi::Metadata::Cli::Command::GenericType]
+    #     Default case.
+    # @!attribute [rw] optional
+    #     @return [Com::Vmware::Vapi::Metadata::Cli::Command::GenericType]
+    #     Input parameter is an optional.
+    # @!attribute [rw] list
+    #     @return [Com::Vmware::Vapi::Metadata::Cli::Command::GenericType]
+    #     Input parameter is a list.
+    # @!attribute [rw] optional_list
+    #     @return [Com::Vmware::Vapi::Metadata::Cli::Command::GenericType]
+    #     Input parameter is an optional of type list.  
+    #     
+    #      New in vSphere 6.5.
+    # @!attribute [rw] list_optional
+    #     @return [Com::Vmware::Vapi::Metadata::Cli::Command::GenericType]
+    #     Input parameter is a list of optionals.  
+    #     
+    #      New in vSphere 6.5.
+    class GenericType < VAPI::Bindings::VapiEnum
+      class << self
+        # Holds (gets or creates) the binding type metadata for this enumeration type.
+        # @scope class
+        # @return [VAPI::Bindings::EnumType] the binding type
+        def binding_type
+          @binding_type ||= VAPI::Bindings::EnumType.new(
+            'com.vmware.vapi.metadata.cli.command.generic_type',
+            GenericType
+          )
+        end
+
+        # Converts from a string value (perhaps off the wire) to an instance
+        # of this enum type.
+        # @param value [String] the actual value of the enum instance
+        # @return [GenericType] the instance found for the value, otherwise
+        #         an unknown instance will be built for the value
+        def from_string(value)
+          const_get(value)
+        rescue NameError
+          GenericType.send(:new, 'UNKNOWN', value)
+        end
+      end
+
+      # Constructs a new instance.
+      # @param value [String] the actual value of the enum instance
+      # @param unknown [String] the unknown value when value is 'UKNOWN'
+      def initialize(value, unknown = nil)
+        super(self.class.binding_type, value, unknown)
+      end
+
+      private_class_method :new
+
+      # @!attribute [rw] none
+      #     @return [Com::Vmware::Vapi::Metadata::Cli::Command::GenericType]
+      #     Default case.
+      NONE = GenericType.send(:new, 'NONE')
+
+      # @!attribute [rw] optional
+      #     @return [Com::Vmware::Vapi::Metadata::Cli::Command::GenericType]
+      #     Input parameter is an optional.
+      OPTIONAL = GenericType.send(:new, 'OPTIONAL')
+
+      # @!attribute [rw] list
+      #     @return [Com::Vmware::Vapi::Metadata::Cli::Command::GenericType]
+      #     Input parameter is a list.
+      LIST = GenericType.send(:new, 'LIST')
+
+      # @!attribute [rw] optional_list
+      #     @return [Com::Vmware::Vapi::Metadata::Cli::Command::GenericType]
+      #     Input parameter is an optional of type list.  
+      #     
+      #      New in vSphere 6.5.
+      OPTIONAL_LIST = GenericType.send(:new, 'OPTIONAL_LIST')
+
+      # @!attribute [rw] list_optional
+      #     @return [Com::Vmware::Vapi::Metadata::Cli::Command::GenericType]
+      #     Input parameter is a list of optionals.  
+      #     
+      #      New in vSphere 6.5.
+      LIST_OPTIONAL = GenericType.send(:new, 'LIST_OPTIONAL')
+    end
+  end
+  # The  ``Com::Vmware::Vapi::Metadata::Cli::Namespace``   class  provides  methods  to get information about command line interface (CLI) namespaces.
+  class Namespace < VAPI::Bindings::VapiService
+    # static metamodel definitions
+    SERVICE_ID = VAPI::Core::ServiceIdentifier.new('com.vmware.vapi.metadata.cli.namespace')
+
+    LIST_INFO = VAPI::Bindings::OperationInfo.new(
+      VAPI::Core::OperationIdentifier.new('list', SERVICE_ID),
+      VAPI::Bindings::OperationInputType.new,
+      VAPI::Bindings::ListType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Metadata::Cli::Namespace::Identity')),
+      {},
+      [],
+      []
+    )
+
+    GET_INFO = VAPI::Bindings::OperationInfo.new(
+      VAPI::Core::OperationIdentifier.new('get', SERVICE_ID),
+      VAPI::Bindings::OperationInputType.new(
+        'identity' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Metadata::Cli::Namespace::Identity')
+      ),
+      VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Metadata::Cli::Namespace::Info'),
+      {
+        'com.vmware.vapi.std.errors.not_found' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::NotFound')
+      },
+      [],
+      []
+    )
+
+    FINGERPRINT_INFO = VAPI::Bindings::OperationInfo.new(
+      VAPI::Core::OperationIdentifier.new('fingerprint', SERVICE_ID),
+      VAPI::Bindings::OperationInputType.new,
+      VAPI::Bindings::StringType.instance,
+      {},
+      [],
+      []
+    )
+
+    SERVICE_INFO = VAPI::Bindings::ServiceInfo.new(
+      SERVICE_ID,
+      'list' => LIST_INFO,
+      'get' => GET_INFO,
+      'fingerprint' => FINGERPRINT_INFO
+    )
+
+    # Constructs a new instance.
+    #
+    # @param config [VAPI::Bindings::StubConfig] A hash with the api provider details.
+    def initialize(config)
+      super(config, SERVICE_INFO)
+    end
+
+    # Returns the identifiers of all namespaces registered with the infrastructure.
+    #
+    # @return [Array<Com::Vmware::Vapi::Metadata::Cli::Namespace::Identity>]
+    #     Identifiers of all the namespaces.
+    def list
+      invoke_with_info(LIST_INFO)
+    end
+
+    # Retreives information about a namespace including information about children of that namespace.
+    #
+    # @param identity [Com::Vmware::Vapi::Metadata::Cli::Namespace::Identity]
+    #     Identifier of the namespace for which to retreive information.
+    # @return [Com::Vmware::Vapi::Metadata::Cli::Namespace::Info]
+    #     Information about the namespace including information about child of that namespace.
+    # @raise [Com::Vmware::Vapi::Std::Errors::NotFound]
+    #     if a namespace corresponding to  ``identity``  doesn't exist.
+    def get(identity)
+      invoke_with_info(GET_INFO,
+                       'identity' => identity)
+    end
+
+    # Returns the aggregate fingerprint of all the namespace metadata from all the metadata sources.  
+    # 
+    #  The fingerprint provides clients an efficient way to check if the metadata for namespaces has been modified on the server.
+    #
+    # @return [String]
+    #     Fingerprint of all the namespace metadata present on the server.
+    def fingerprint
+      invoke_with_info(FINGERPRINT_INFO)
+    end
+
+    # The  ``Com::Vmware::Vapi::Metadata::Cli::Namespace::Identity``   class  uniquely identifies a namespace in the CLI namespace tree.
+    # @!attribute [rw] path
+    #     @return [String]
+    #     The dot-separated path of the namespace containing the namespace in the CLI node tree. For top-level namespace this will be empty.
+    # @!attribute [rw] name
+    #     @return [String]
+    #     The name displayed to the user for this namespace.
+    class Identity < VAPI::Bindings::VapiStruct
+      class << self
+        # Holds (gets or creates) the binding type metadata for this structure type.
+        # @scope class
+        # @return [VAPI::Bindings::StructType] the binding type
+        def binding_type
+          @binding_type ||= VAPI::Bindings::StructType.new(
+            'com.vmware.vapi.metadata.cli.namespace.identity',
+            {
+              'path' => VAPI::Bindings::StringType.instance,
+              'name' => VAPI::Bindings::StringType.instance
+            },
+            Identity,
+            false,
+            nil
+          )
+        end
+      end
+
+      attr_accessor :path,
+                    :name
+
+      # Constructs a new instance.
+      # @param ruby_values [Hash] a map of initial property values (optional)
+      # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
+      def initialize(ruby_values = nil, struct_value = nil)
+        super(self.class.binding_type, ruby_values, struct_value)
+      end
+    end
+
+    # The  ``Com::Vmware::Vapi::Metadata::Cli::Namespace::Info``   class  contains information about a namespace. It includes the identity of the namespace, a description, information children namespaces.
+    # @!attribute [rw] identity
+    #     @return [Com::Vmware::Vapi::Metadata::Cli::Namespace::Identity]
+    #     Basic namespace identity.
+    # @!attribute [rw] description
+    #     @return [String]
+    #     The text description displayed to the user in help output.
+    # @!attribute [rw] children
+    #     @return [Array<Com::Vmware::Vapi::Metadata::Cli::Namespace::Identity>]
+    #     The children of this namespace in the tree of CLI namespaces.
+    class Info < VAPI::Bindings::VapiStruct
+      class << self
+        # Holds (gets or creates) the binding type metadata for this structure type.
+        # @scope class
+        # @return [VAPI::Bindings::StructType] the binding type
+        def binding_type
+          @binding_type ||= VAPI::Bindings::StructType.new(
+            'com.vmware.vapi.metadata.cli.namespace.info',
+            {
+              'identity' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Metadata::Cli::Namespace::Identity'),
+              'description' => VAPI::Bindings::StringType.instance,
+              'children' => VAPI::Bindings::ListType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Metadata::Cli::Namespace::Identity'))
+            },
+            Info,
+            false,
+            nil
+          )
+        end
+      end
+
+      attr_accessor :identity,
+                    :description,
+                    :children
+
+      # Constructs a new instance.
+      # @param ruby_values [Hash] a map of initial property values (optional)
+      # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
+      def initialize(ruby_values = nil, struct_value = nil)
+        super(self.class.binding_type, ruby_values, struct_value)
+      end
+    end
+
+  end
+  # The  ``Com::Vmware::Vapi::Metadata::Cli::Source``   class  provides  methods  to manage the sources of command line interface (CLI) metadata information.  
+  # 
+  #  The interface definition language infrastructure provides tools to generate various kinds of metadata in JSON format from the interface definition files and additional properties files. One of the generated files contains CLI information.  
+  # 
+  #  A CLI metadata file contains information about one component element. When a CLI metadata file is added as a source, each source contributes only one component element's metadata.  
+  # 
+  #  CLI metadata can also be discovered from a remote server that supports the CLI metadata services (see   :mod:`com.vmware.vapi.metadata.cli`  )  package . Since multiple components can be registered with a single metadata server, when a remote server is registered as a source, that source can contribute more than one component.
+  class Source < VAPI::Bindings::VapiService
+    # static metamodel definitions
+    SERVICE_ID = VAPI::Core::ServiceIdentifier.new('com.vmware.vapi.metadata.cli.source')
+
+    CREATE_INFO = VAPI::Bindings::OperationInfo.new(
+      VAPI::Core::OperationIdentifier.new('create', SERVICE_ID),
+      VAPI::Bindings::OperationInputType.new(
+        'source_id' => VAPI::Bindings::IdType.new('com.vmware.vapi.metadata.source'),
+        'spec' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Metadata::Cli::Source::CreateSpec')
+      ),
+      VAPI::Bindings::VoidType.instance,
+      {
+        'com.vmware.vapi.std.errors.already_exists' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::AlreadyExists'),
+        'com.vmware.vapi.std.errors.invalid_argument' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::InvalidArgument'),
+        'com.vmware.vapi.std.errors.not_found' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::NotFound')
+      },
+      [],
+      []
+    )
+
+    DELETE_INFO = VAPI::Bindings::OperationInfo.new(
+      VAPI::Core::OperationIdentifier.new('delete', SERVICE_ID),
+      VAPI::Bindings::OperationInputType.new(
+        'source_id' => VAPI::Bindings::IdType.new('com.vmware.vapi.metadata.source')
+      ),
+      VAPI::Bindings::VoidType.instance,
+      {
+        'com.vmware.vapi.std.errors.not_found' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::NotFound')
+      },
+      [],
+      []
+    )
+
+    GET_INFO = VAPI::Bindings::OperationInfo.new(
+      VAPI::Core::OperationIdentifier.new('get', SERVICE_ID),
+      VAPI::Bindings::OperationInputType.new(
+        'source_id' => VAPI::Bindings::IdType.new('com.vmware.vapi.metadata.source')
+      ),
+      VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Metadata::Cli::Source::Info'),
+      {
+        'com.vmware.vapi.std.errors.not_found' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::NotFound')
+      },
+      [],
+      []
+    )
+
+    LIST_INFO = VAPI::Bindings::OperationInfo.new(
+      VAPI::Core::OperationIdentifier.new('list', SERVICE_ID),
+      VAPI::Bindings::OperationInputType.new,
+      VAPI::Bindings::ListType.new(VAPI::Bindings::IdType.new),
+      {},
+      [],
+      []
+    )
+
+    RELOAD_INFO = VAPI::Bindings::OperationInfo.new(
+      VAPI::Core::OperationIdentifier.new('reload', SERVICE_ID),
+      VAPI::Bindings::OperationInputType.new(
+        'source_id' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::IdType.new)
+      ),
+      VAPI::Bindings::VoidType.instance,
+      {
+        'com.vmware.vapi.std.errors.not_found' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::NotFound')
+      },
+      [],
+      []
+    )
+
+    FINGERPRINT_INFO = VAPI::Bindings::OperationInfo.new(
+      VAPI::Core::OperationIdentifier.new('fingerprint', SERVICE_ID),
+      VAPI::Bindings::OperationInputType.new(
+        'source_id' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::IdType.new)
+      ),
+      VAPI::Bindings::StringType.instance,
+      {
+        'com.vmware.vapi.std.errors.not_found' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::NotFound')
+      },
+      [],
+      []
+    )
+
+    SERVICE_INFO = VAPI::Bindings::ServiceInfo.new(
+      SERVICE_ID,
+      'create' => CREATE_INFO,
+      'delete' => DELETE_INFO,
+      'get' => GET_INFO,
+      'list' => LIST_INFO,
+      'reload' => RELOAD_INFO,
+      'fingerprint' => FINGERPRINT_INFO
+    )
+
+    # Constructs a new instance.
+    #
+    # @param config [VAPI::Bindings::StubConfig] A hash with the api provider details.
+    def initialize(config)
+      super(config, SERVICE_INFO)
+    end
+
+    # Creates a new metadata source. Once the server validates the registration information of the metadata source, the CLI metadata is retrieved from the source. This populates elements in all the  classs  defined in   :mod:`com.vmware.vapi.metadata.cli`    package .
+    #
+    # @param source_id [String]
+    #     metadata source identifier.
+    # @param spec [Com::Vmware::Vapi::Metadata::Cli::Source::CreateSpec]
+    #     create specification.
+    # @return [Void]
+    # @raise [Com::Vmware::Vapi::Std::Errors::AlreadyExists]
+    #     If the metadata source identifier is already registered with the infrastructure.
+    # @raise [Com::Vmware::Vapi::Std::Errors::InvalidArgument]
+    #     If type of the source specified in  null  is invalid.
+    # @raise [Com::Vmware::Vapi::Std::Errors::InvalidArgument]
+    #     If the file specified in  null  is not a valid JSON file or if the format of the CLI metadata in the JSON file is invalid.
+    # @raise [Com::Vmware::Vapi::Std::Errors::InvalidArgument]
+    #     If the URI specified in  null  is unreachable or if there is a transport protocol or message protocol mismatch between the client and the server or if the remote server do not have  classs  present in   :mod:`com.vmware.vapi.metadata.cli`    package .
+    # @raise [Com::Vmware::Vapi::Std::Errors::NotFound]
+    #     If the file specified in  null  does not exist.
+    def create(source_id, spec)
+      invoke_with_info(CREATE_INFO,
+                       'source_id' => source_id,
+                       'spec' => spec)
+    end
+
+    # Deletes an existing CLI metadata source from the infrastructure.
+    #
+    # @param source_id [String]
+    #     Identifier of the metadata source.
+    # @return [Void]
+    # @raise [Com::Vmware::Vapi::Std::Errors::NotFound]
+    #     If the metadata source identifier is not found.
+    def delete(source_id)
+      invoke_with_info(DELETE_INFO,
+                       'source_id' => source_id)
+    end
+
+    # Retrieves information about the metadata source corresponding to  ``source_id`` .
+    #
+    # @param source_id [String]
+    #     Identifier of the metadata source.
+    # @return [Com::Vmware::Vapi::Metadata::Cli::Source::Info]
+    #     The   :class:`Com::Vmware::Vapi::Metadata::Cli::Source::Info`   instance that corresponds to  ``source_id``
+    # @raise [Com::Vmware::Vapi::Std::Errors::NotFound]
+    #     If the metadata source identifier is not found.
+    def get(source_id)
+      invoke_with_info(GET_INFO,
+                       'source_id' => source_id)
+    end
+
+    # Returns the identifiers of the metadata sources currently registered with the infrastructure.
+    #
+    # @return [Array<String>]
+    #     The list of identifiers for metadata sources currently registered.
+    def list
+      invoke_with_info(LIST_INFO)
+    end
+
+    # Reloads the CLI metadata from all the metadata sources or of a particular metadata source if  ``source_id``  is specified.
+    #
+    # @param source_id [String, nil]
+    #     Identifier of the metadata source.
+    #     If unspecified, all the metadata sources are reloaded.
+    # @return [Void]
+    # @raise [Com::Vmware::Vapi::Std::Errors::NotFound]
+    #     If the metadata source identifier is not found.
+    def reload(source_id = nil)
+      invoke_with_info(RELOAD_INFO,
+                       'source_id' => source_id)
+    end
+
+    # Returns the aggregate fingerprint of metadata from all the metadata sources or from a particular metadata source if  ``source_id``  is specified.
+    #
+    # @param source_id [String, nil]
+    #     Identifier of the metadata source.
+    #     If unspecified, the fingerprint of all the metadata sources is returned.
+    # @return [String]
+    #     Aggregate fingerprint of all the metadata sources or of a particular metadata source.
+    # @raise [Com::Vmware::Vapi::Std::Errors::NotFound]
+    #     If the metadata source identifier is not found.
+    def fingerprint(source_id = nil)
+      invoke_with_info(FINGERPRINT_INFO,
+                       'source_id' => source_id)
+    end
+
+    # The  ``Com::Vmware::Vapi::Metadata::Cli::Source::Info``   class  contains the metadata source information.
+    # @!attribute [rw] description
+    #     @return [String]
+    #     English language human readable description of the source.
+    # @!attribute [rw] type
+    #     @return [Com::Vmware::Vapi::Metadata::SourceType]
+    #     The type ( ``FILE``, ``REMOTE`` ) of the metadata source.
+    # @!attribute [rw] filepath
+    #     @return [String]
+    #     Absolute file path of the CLI metadata file that has the CLI information about one component. The  ``filepath``  is the path to the file in the server's filesystem.
+    #     This  field  is optional and it is only relevant when the value of  ``type``  is  null .
+    # @!attribute [rw] address
+    #     @return [URI]
+    #     Connection information for the remote server. This should be in the format http(s)://IP:port/namespace.  
+    #     
+    #      The remote server must contain the  classs  in the   :mod:`com.vmware.vapi.metadata.cli`    package . It must expose CLI information of one or more components.
+    #     This  field  is optional and it is only relevant when the value of  ``type``  is  null .
+    class Info < VAPI::Bindings::VapiStruct
+      class << self
+        # Holds (gets or creates) the binding type metadata for this structure type.
+        # @scope class
+        # @return [VAPI::Bindings::StructType] the binding type
+        def binding_type
+          @binding_type ||= VAPI::Bindings::StructType.new(
+            'com.vmware.vapi.metadata.cli.source.info',
+            {
+              'description' => VAPI::Bindings::StringType.instance,
+              'type' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Metadata::SourceType'),
+              'filepath' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::StringType.instance),
+              'address' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::URIType.instance)
+            },
+            Info,
+            false,
+            nil
+          )
+        end
+      end
+
+      attr_accessor :description,
+                    :type,
+                    :filepath,
+                    :address
+
+      # Constructs a new instance.
+      # @param ruby_values [Hash] a map of initial property values (optional)
+      # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
+      def initialize(ruby_values = nil, struct_value = nil)
+        super(self.class.binding_type, ruby_values, struct_value)
+      end
+    end
+
+    # The  ``Com::Vmware::Vapi::Metadata::Cli::Source::CreateSpec``   class  contains the registration information of a CLI source.
+    class CreateSpec < VAPI::Bindings::VapiStruct
+      class << self
+        # Holds (gets or creates) the binding type metadata for this structure type.
+        # @scope class
+        # @return [VAPI::Bindings::StructType] the binding type
+        def binding_type
+          @binding_type ||= VAPI::Bindings::StructType.new(
+            'com.vmware.vapi.metadata.cli.source.create_spec',
+            {
+              'description' => VAPI::Bindings::StringType.instance,
+              'type' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Metadata::SourceType'),
+              'filepath' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::StringType.instance),
+              'address' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::URIType.instance)
+            },
+            CreateSpec,
+            false,
+            nil
+          )
+        end
+      end
+
+      attr_accessor :description,
+                    :type,
+                    :filepath,
+                    :address
+
+      # Constructs a new instance.
+      # @param ruby_values [Hash] a map of initial property values (optional)
+      # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
+      def initialize(ruby_values = nil, struct_value = nil)
+        super(self.class.binding_type, ruby_values, struct_value)
+      end
+    end
+
+  end
 end

--- a/client/sdk/com/vmware/vapi/metadata/metamodel.rb
+++ b/client/sdk/com/vmware/vapi/metadata/metamodel.rb
@@ -1,5 +1,6 @@
 #---------------------------------------------------------------------------
-# Copyright 2016 VMware, Inc.  All rights reserved.
+# Copyright 2017 VMware, Inc.  All rights reserved.
+#
 # AUTO GENERATED FILE -- DO NOT MODIFY!
 #
 # vAPI type descriptors for package com.vmware.vapi.metadata.metamodel.
@@ -8,14 +9,14 @@ require 'vapi'
 
 # declare the module hierarchy before we use the shorthand syntax below
 module Com
-    module Vmware
-        module Vapi
-            module Metadata
-                module Metamodel
-                end
-            end
+  module Vmware
+    module Vapi
+      module Metadata
+        module Metamodel
         end
+      end
     end
+  end
 end
 
 # The  ``com.vmware.vapi.metadata.metamodel``   package  provides  classs  that expose all the information present in the interface definition language (IDL) specification.  
@@ -36,2339 +37,2166 @@ end
 #    * A client can retrieve all the metamodel information in fewer  method  invocations using the   :class:`Com::Vmware::Vapi::Metadata::Metamodel::Component`    class  and cache the output locally. It can then poll on the fingerprint information exposed by the   :class:`Com::Vmware::Vapi::Metadata::Metamodel::Component`    class  to monitor changes in API definition.
 #   
 module Com::Vmware::Vapi::Metadata::Metamodel
+  # The  ``Com::Vmware::Vapi::Metadata::Metamodel::Component``   class  providers  methods  to retrieve metamodel information of a component element.  
+  # 
+  #  A component defines a set of functionality that is deployed together and versioned together. For example, all the  classs  that belong to VMware Content Library are part of a single component. A component element describes a component. A component element contains one or more package elements.  
+  # 
+  #  The  methods  for package elements are provided by  class    :class:`Com::Vmware::Vapi::Metadata::Metamodel::Package`  .
+  class Component < VAPI::Bindings::VapiService
+    # static metamodel definitions
+    SERVICE_ID = VAPI::Core::ServiceIdentifier.new('com.vmware.vapi.metadata.metamodel.component')
 
-    # The  ``Com::Vmware::Vapi::Metadata::Metamodel::Component``   class  providers  methods  to retrieve metamodel information of a component element.  
-    # 
-    #  A component defines a set of functionality that is deployed together and versioned together. For example, all the  classs  that belong to VMware Content Library are part of a single component. A component element describes a component. A component element contains one or more package elements.  
-    # 
-    #  The  methods  for package elements are provided by  class    :class:`Com::Vmware::Vapi::Metadata::Metamodel::Package`  .
-    class Component < VAPI::Bindings::VapiService
+    LIST_INFO = VAPI::Bindings::OperationInfo.new(
+      VAPI::Core::OperationIdentifier.new('list', SERVICE_ID),
+      VAPI::Bindings::OperationInputType.new,
+      VAPI::Bindings::ListType.new(VAPI::Bindings::IdType.new),
+      {},
+      [],
+      []
+    )
 
-        protected
+    GET_INFO = VAPI::Bindings::OperationInfo.new(
+      VAPI::Core::OperationIdentifier.new('get', SERVICE_ID),
+      VAPI::Bindings::OperationInputType.new(
+        'component_id' => VAPI::Bindings::IdType.new('com.vmware.vapi.component')
+      ),
+      VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Metadata::Metamodel::ComponentData'),
+      {
+        'com.vmware.vapi.std.errors.not_found' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::NotFound')
+      },
+      [],
+      []
+    )
 
-        # static metamodel definitions
-        @@service_id = VAPI::Core::ServiceIdentifier.new('com.vmware.vapi.metadata.metamodel.component')
+    FINGERPRINT_INFO = VAPI::Bindings::OperationInfo.new(
+      VAPI::Core::OperationIdentifier.new('fingerprint', SERVICE_ID),
+      VAPI::Bindings::OperationInputType.new(
+        'component_id' => VAPI::Bindings::IdType.new('com.vmware.vapi.component')
+      ),
+      VAPI::Bindings::StringType.instance,
+      {
+        'com.vmware.vapi.std.errors.not_found' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::NotFound')
+      },
+      [],
+      []
+    )
 
-        @@list_info = VAPI::Bindings::OperationInfo.new(
-            VAPI::Core::OperationIdentifier.new('list', @@service_id),
-            VAPI::Bindings::OperationInputType.new,
-            VAPI::Bindings::ListType.new(VAPI::Bindings::IdType.new),
-            {},
-            [],
-            [])
-        @@get_info = VAPI::Bindings::OperationInfo.new(
-            VAPI::Core::OperationIdentifier.new('get', @@service_id),
-            VAPI::Bindings::OperationInputType.new({
-                'component_id' => VAPI::Bindings::IdType.new(resource_types='com.vmware.vapi.component'),
-            }),
-            VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Metadata::Metamodel::ComponentData'),
-            {
-                'com.vmware.vapi.std.errors.not_found' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::NotFound'),
+    SERVICE_INFO = VAPI::Bindings::ServiceInfo.new(
+      SERVICE_ID,
+      'list' => LIST_INFO,
+      'get' => GET_INFO,
+      'fingerprint' => FINGERPRINT_INFO
+    )
 
-            },
-            [],
-            [])
-        @@fingerprint_info = VAPI::Bindings::OperationInfo.new(
-            VAPI::Core::OperationIdentifier.new('fingerprint', @@service_id),
-            VAPI::Bindings::OperationInputType.new({
-                'component_id' => VAPI::Bindings::IdType.new(resource_types='com.vmware.vapi.component'),
-            }),
-            VAPI::Bindings::StringType.instance,
-            {
-                'com.vmware.vapi.std.errors.not_found' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::NotFound'),
-
-            },
-            [],
-            [])
-
-        @@service_info = VAPI::Bindings::ServiceInfo.new(@@service_id, {
-            'list' => @@list_info,
-            'get' => @@get_info,
-            'fingerprint' => @@fingerprint_info,
-        })
-
-        public
-
-        # Constructs a new instance.
-        #
-        # @param config [VAPI::Bindings::StubConfig] A hash with the api provider details.
-        def initialize(config)
-            super(config, @@service_info)
-        end
-
-        RESOURCE_TYPE = 'com.vmware.vapi.component'
-
-
-        # Returns the identifiers for the component elements that are registered with the infrastructure.
-        #
-        # @return [Array<String>]
-        #     The list of identifiers for the component elements that are registered with the infrastructure.
-        def list()
-            invoke_with_info(@@list_info)
-        end
-
-
-        # Retrieves metamodel information about the component element corresponding to  ``component_id`` .  
-        # 
-        #  The   :class:`Com::Vmware::Vapi::Metadata::Metamodel::ComponentData`   contains the metamodel information about the component and it's fingerprint. It contains information about all the package elements that are contained in this component element.
-        #
-        # @param component_id [String]
-        #     Identifier of the component element.
-        # @return [Com::Vmware::Vapi::Metadata::Metamodel::ComponentData]
-        #     The   :class:`Com::Vmware::Vapi::Metadata::Metamodel::ComponentData`   instance that corresponds to  ``component_id`` .
-        # @raise [Com::Vmware::Vapi::Std::Errors::NotFound]
-        #     if the component element associated with  ``component_id``  is not registered with the infrastructure.
-        def get(component_id)
-            invoke_with_info(@@get_info, {
-                'component_id' => component_id,
-            })
-        end
-
-
-        # Retrieves the fingerprint computed from the metamodel metadata of the component element corresponding to  ``component_id`` .  
-        # 
-        #  The fingerprint provides clients an efficient way to check if the metadata for a particular component element has been modified on the server. The client can do this by comparing the result of this operation with the fingerprint returned in the result of   :func:`Com::Vmware::Vapi::Metadata::Metamodel::Component.get`  .
-        #
-        # @param component_id [String]
-        #     Identifier of the component element.
-        # @return [String]
-        #     The fingerprint computed from the metamodel metadata of the component element.
-        # @raise [Com::Vmware::Vapi::Std::Errors::NotFound]
-        #     if the component element associated with  ``component_id``  is not registered with the infrastructure.
-        def fingerprint(component_id)
-            invoke_with_info(@@fingerprint_info, {
-                'component_id' => component_id,
-            })
-        end
-
-
+    # Constructs a new instance.
+    #
+    # @param config [VAPI::Bindings::StubConfig] A hash with the api provider details.
+    def initialize(config)
+      super(config, SERVICE_INFO)
     end
 
-
-    # The  ``Com::Vmware::Vapi::Metadata::Metamodel::Enumeration``   class  provides  methods  to retrieve metamodel information about an enumeration element in the interface definition language.  
-    # 
-    #  The  ``Com::Vmware::Vapi::Metadata::Metamodel::Enumeration``  has a list of enumeration value elements.
-    class Enumeration < VAPI::Bindings::VapiService
-
-        protected
-
-        # static metamodel definitions
-        @@service_id = VAPI::Core::ServiceIdentifier.new('com.vmware.vapi.metadata.metamodel.enumeration')
-
-        @@list_info = VAPI::Bindings::OperationInfo.new(
-            VAPI::Core::OperationIdentifier.new('list', @@service_id),
-            VAPI::Bindings::OperationInputType.new,
-            VAPI::Bindings::ListType.new(VAPI::Bindings::IdType.new),
-            {},
-            [],
-            [])
-        @@get_info = VAPI::Bindings::OperationInfo.new(
-            VAPI::Core::OperationIdentifier.new('get', @@service_id),
-            VAPI::Bindings::OperationInputType.new({
-                'enumeration_id' => VAPI::Bindings::IdType.new(resource_types='com.vmware.vapi.enumeration'),
-            }),
-            VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Metadata::Metamodel::EnumerationInfo'),
-            {
-                'com.vmware.vapi.std.errors.not_found' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::NotFound'),
-
-            },
-            [],
-            [])
-
-        @@service_info = VAPI::Bindings::ServiceInfo.new(@@service_id, {
-            'list' => @@list_info,
-            'get' => @@get_info,
-        })
-
-        public
-
-        # Constructs a new instance.
-        #
-        # @param config [VAPI::Bindings::StubConfig] A hash with the api provider details.
-        def initialize(config)
-            super(config, @@service_info)
-        end
-
-        RESOURCE_TYPE = 'com.vmware.vapi.enumeration'
-
-
-        # Returns the identifiers for the enumeration elements that are contained in all the package elements, service elements and structure elements.
-        #
-        # @return [Array<String>]
-        #     The list of identifiers for the enumeration elements.
-        def list()
-            invoke_with_info(@@list_info)
-        end
-
-
-        # Retrieves information about the enumeration element corresponding to  ``enumeration_id`` .  
-        # 
-        #  The   :class:`Com::Vmware::Vapi::Metadata::Metamodel::EnumerationInfo`   contains the metamodel information about the enumeration value element contained in the enumeration element.
-        #
-        # @param enumeration_id [String]
-        #     Identifier of the enumeration element.
-        # @return [Com::Vmware::Vapi::Metadata::Metamodel::EnumerationInfo]
-        #     The   :class:`Com::Vmware::Vapi::Metadata::Metamodel::EnumerationInfo`   instance that corresponds to  ``enumeration_id``
-        # @raise [Com::Vmware::Vapi::Std::Errors::NotFound]
-        #     if the enumeration element associated with  ``enumeration_id``  is not contained in any of the package elements, service elements and structure elements.
-        def get(enumeration_id)
-            invoke_with_info(@@get_info, {
-                'enumeration_id' => enumeration_id,
-            })
-        end
-
-
+    RESOURCE_TYPE = 'com.vmware.vapi.component'
+    # Returns the identifiers for the component elements that are registered with the infrastructure.
+    #
+    # @return [Array<String>]
+    #     The list of identifiers for the component elements that are registered with the infrastructure.
+    def list
+      invoke_with_info(LIST_INFO)
     end
 
-
-    # The  ``Com::Vmware::Vapi::Metadata::Metamodel::MetadataIdentifier``   class  provides string constants that can be used as identifiers for the metadata elements.  
+    # Retrieves metamodel information about the component element corresponding to  ``component_id`` .  
     # 
-    #  Most of the types in   :mod:`com.vmware.vapi.metadata.metamodel`   package has a metadata field whose type is  ``Map<String, ElementMap>`` .   :class:`Com::Vmware::Vapi::Metadata::Metamodel::MetadataIdentifier`   contains the identifiers used in the keys of the above Map type.
-    class MetadataIdentifier < VAPI::Bindings::VapiService
-
-        protected
-
-        # static metamodel definitions
-        @@service_id = VAPI::Core::ServiceIdentifier.new('com.vmware.vapi.metadata.metamodel.metadata_identifier')
-
-
-        @@service_info = VAPI::Bindings::ServiceInfo.new(@@service_id, {
-        })
-
-        public
-
-        # Constructs a new instance.
-        #
-        # @param config [VAPI::Bindings::StubConfig] A hash with the api provider details.
-        def initialize(config)
-            super(config, @@service_info)
-        end
-
-        CANONICAL_NAME = 'CanonicalName'
-        COMPONENT = 'Component'
-        CREATE = 'Create'
-        CRUD = 'Crud'
-        HAS_FIELDS_OF = 'HasFieldsOf'
-        INCLUDABLE = 'Includable'
-        INCLUDE = 'Include'
-        IS_ONE_OF = 'IsOneOf'
-        MODEL = 'Model'
-        READ = 'Read'
-        RESOURCE = 'Resource'
-        UNION_CASE = 'UnionCase'
-        UNION_TAG = 'UnionTag'
-        UPDATE = 'Update'
-
+    #  The   :class:`Com::Vmware::Vapi::Metadata::Metamodel::ComponentData`   contains the metamodel information about the component and it's fingerprint. It contains information about all the package elements that are contained in this component element.
+    #
+    # @param component_id [String]
+    #     Identifier of the component element.
+    # @return [Com::Vmware::Vapi::Metadata::Metamodel::ComponentData]
+    #     The   :class:`Com::Vmware::Vapi::Metadata::Metamodel::ComponentData`   instance that corresponds to  ``component_id`` .
+    # @raise [Com::Vmware::Vapi::Std::Errors::NotFound]
+    #     if the component element associated with  ``component_id``  is not registered with the infrastructure.
+    def get(component_id)
+      invoke_with_info(GET_INFO,
+                       'component_id' => component_id)
     end
 
-
-    # The  ``Com::Vmware::Vapi::Metadata::Metamodel::Package``   class  provides  methods  to retrieve metamodel information about a package element in the interface definition language.  
+    # Retrieves the fingerprint computed from the metamodel metadata of the component element corresponding to  ``component_id`` .  
     # 
-    #  A package is a logical grouping of services, structures and enumerations. A package element describes the package. It contains the service elements, structure elements and enumeration elements that are grouped together.
-    class Package < VAPI::Bindings::VapiService
-
-        protected
-
-        # static metamodel definitions
-        @@service_id = VAPI::Core::ServiceIdentifier.new('com.vmware.vapi.metadata.metamodel.package')
-
-        @@list_info = VAPI::Bindings::OperationInfo.new(
-            VAPI::Core::OperationIdentifier.new('list', @@service_id),
-            VAPI::Bindings::OperationInputType.new,
-            VAPI::Bindings::ListType.new(VAPI::Bindings::IdType.new),
-            {},
-            [],
-            [])
-        @@get_info = VAPI::Bindings::OperationInfo.new(
-            VAPI::Core::OperationIdentifier.new('get', @@service_id),
-            VAPI::Bindings::OperationInputType.new({
-                'package_id' => VAPI::Bindings::IdType.new(resource_types='com.vmware.vapi.package'),
-            }),
-            VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Metadata::Metamodel::PackageInfo'),
-            {
-                'com.vmware.vapi.std.errors.not_found' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::NotFound'),
-
-            },
-            [],
-            [])
-
-        @@service_info = VAPI::Bindings::ServiceInfo.new(@@service_id, {
-            'list' => @@list_info,
-            'get' => @@get_info,
-        })
-
-        public
-
-        # Constructs a new instance.
-        #
-        # @param config [VAPI::Bindings::StubConfig] A hash with the api provider details.
-        def initialize(config)
-            super(config, @@service_info)
-        end
-
-        RESOURCE_TYPE = 'com.vmware.vapi.package'
-
-
-        # Returns the identifiers for the packages elements that are contained in all the registered component elements.
-        #
-        # @return [Array<String>]
-        #     The list of identifiers for the package elements that are contained in all the registered component elements.
-        def list()
-            invoke_with_info(@@list_info)
-        end
-
-
-        # Retrieves information about the package element corresponding to  ``package_id`` .
-        #
-        # @param package_id [String]
-        #     Identifier of the package element.
-        # @return [Com::Vmware::Vapi::Metadata::Metamodel::PackageInfo]
-        #     The   :class:`Com::Vmware::Vapi::Metadata::Metamodel::PackageInfo`   instance that corresponds to  ``package_id`` .
-        # @raise [Com::Vmware::Vapi::Std::Errors::NotFound]
-        #     if the package element associated with  ``package_id``  does not exist.
-        def get(package_id)
-            invoke_with_info(@@get_info, {
-                'package_id' => package_id,
-            })
-        end
-
-
+    #  The fingerprint provides clients an efficient way to check if the metadata for a particular component element has been modified on the server. The client can do this by comparing the result of this operation with the fingerprint returned in the result of   :func:`Com::Vmware::Vapi::Metadata::Metamodel::Component.get`  .
+    #
+    # @param component_id [String]
+    #     Identifier of the component element.
+    # @return [String]
+    #     The fingerprint computed from the metamodel metadata of the component element.
+    # @raise [Com::Vmware::Vapi::Std::Errors::NotFound]
+    #     if the component element associated with  ``component_id``  is not registered with the infrastructure.
+    def fingerprint(component_id)
+      invoke_with_info(FINGERPRINT_INFO,
+                       'component_id' => component_id)
     end
 
+  end
+  # The  ``Com::Vmware::Vapi::Metadata::Metamodel::Enumeration``   class  provides  methods  to retrieve metamodel information about an enumeration element in the interface definition language.  
+  # 
+  #  The  ``Com::Vmware::Vapi::Metadata::Metamodel::Enumeration``  has a list of enumeration value elements.
+  class Enumeration < VAPI::Bindings::VapiService
+    # static metamodel definitions
+    SERVICE_ID = VAPI::Core::ServiceIdentifier.new('com.vmware.vapi.metadata.metamodel.enumeration')
 
-    # The   :class:`Com::Vmware::Vapi::Metadata::Metamodel::Resource`    class  provides  methods  to retrieve information about resource types.  
-    # 
-    #  A service is a logical grouping of operations that operate on an entity. Each entity is identifier by a namespace (or resource type) and an unique identifier.
-    class ResourceService < VAPI::Bindings::VapiService
+    LIST_INFO = VAPI::Bindings::OperationInfo.new(
+      VAPI::Core::OperationIdentifier.new('list', SERVICE_ID),
+      VAPI::Bindings::OperationInputType.new,
+      VAPI::Bindings::ListType.new(VAPI::Bindings::IdType.new),
+      {},
+      [],
+      []
+    )
 
-        protected
+    GET_INFO = VAPI::Bindings::OperationInfo.new(
+      VAPI::Core::OperationIdentifier.new('get', SERVICE_ID),
+      VAPI::Bindings::OperationInputType.new(
+        'enumeration_id' => VAPI::Bindings::IdType.new('com.vmware.vapi.enumeration')
+      ),
+      VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Metadata::Metamodel::EnumerationInfo'),
+      {
+        'com.vmware.vapi.std.errors.not_found' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::NotFound')
+      },
+      [],
+      []
+    )
 
-        # static metamodel definitions
-        @@service_id = VAPI::Core::ServiceIdentifier.new('com.vmware.vapi.metadata.metamodel.resource')
+    SERVICE_INFO = VAPI::Bindings::ServiceInfo.new(
+      SERVICE_ID,
+      'list' => LIST_INFO,
+      'get' => GET_INFO
+    )
 
-        @@list_info = VAPI::Bindings::OperationInfo.new(
-            VAPI::Core::OperationIdentifier.new('list', @@service_id),
-            VAPI::Bindings::OperationInputType.new,
-            VAPI::Bindings::SetType.new(VAPI::Bindings::IdType.new),
-            {},
-            [],
-            [])
-
-        @@service_info = VAPI::Bindings::ServiceInfo.new(@@service_id, {
-            'list' => @@list_info,
-        })
-
-        public
-
-        # Constructs a new instance.
-        #
-        # @param config [VAPI::Bindings::StubConfig] A hash with the api provider details.
-        def initialize(config)
-            super(config, @@service_info)
-        end
-
-        RESOURCE_TYPE = 'com.vmware.vapi.resource'
-
-
-        # Returns the set of resource types present across all the service elements contained in all the package elements.
-        #
-        # @return [Set<String>]
-        #     Set of resource types
-        def list()
-            invoke_with_info(@@list_info)
-        end
-
-
+    # Constructs a new instance.
+    #
+    # @param config [VAPI::Bindings::StubConfig] A hash with the api provider details.
+    def initialize(config)
+      super(config, SERVICE_INFO)
     end
 
-
-    # The  ``Com::Vmware::Vapi::Metadata::Metamodel::Service``   class  provides  methods  to retrieve metamodel information about a service element in the interface definition language.  
-    # 
-    #  A service is a logical grouping of operations that operate on some entity. A service element describes a service. It contains operation elements that describe the operations grouped in the service. It also contains structure elements and enumeration elements corresponding to the structures and enumerations defined in the service.
-    class ServiceService < VAPI::Bindings::VapiService
-
-        protected
-
-        # static metamodel definitions
-        @@service_id = VAPI::Core::ServiceIdentifier.new('com.vmware.vapi.metadata.metamodel.service')
-
-        @@list_info = VAPI::Bindings::OperationInfo.new(
-            VAPI::Core::OperationIdentifier.new('list', @@service_id),
-            VAPI::Bindings::OperationInputType.new,
-            VAPI::Bindings::ListType.new(VAPI::Bindings::IdType.new),
-            {},
-            [],
-            [])
-        @@get_info = VAPI::Bindings::OperationInfo.new(
-            VAPI::Core::OperationIdentifier.new('get', @@service_id),
-            VAPI::Bindings::OperationInputType.new({
-                'service_id' => VAPI::Bindings::IdType.new(resource_types='com.vmware.vapi.service'),
-            }),
-            VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Metadata::Metamodel::ServiceInfo'),
-            {
-                'com.vmware.vapi.std.errors.not_found' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::NotFound'),
-
-            },
-            [],
-            [])
-
-        @@service_info = VAPI::Bindings::ServiceInfo.new(@@service_id, {
-            'list' => @@list_info,
-            'get' => @@get_info,
-        })
-
-        public
-
-        # Constructs a new instance.
-        #
-        # @param config [VAPI::Bindings::StubConfig] A hash with the api provider details.
-        def initialize(config)
-            super(config, @@service_info)
-        end
-
-        RESOURCE_TYPE = 'com.vmware.vapi.service'
-
-
-        # Returns the identifiers for the service elements that are currently registered with the infrastructure.  
-        # 
-        #  The list of service elements is an aggregate list of all the service elements contained in all the package elements.
-        #
-        # @return [Array<String>]
-        #     The list of identifiers for the service elements that are currently registered with the infrastructure.
-        def list()
-            invoke_with_info(@@list_info)
-        end
-
-
-        # Retrieves information about the service element corresponding to  ``service_id`` .  
-        # 
-        #  The   :class:`Com::Vmware::Vapi::Metadata::Metamodel::ServiceInfo`   contains the metamodel information for the operation elements, structure elements and enumeration elements contained in the service element.
-        #
-        # @param service_id [String]
-        #     Identifier of the service element.
-        # @return [Com::Vmware::Vapi::Metadata::Metamodel::ServiceInfo]
-        #     The   :class:`Com::Vmware::Vapi::Metadata::Metamodel::ServiceInfo`   instance that corresponds to  ``service_id``
-        # @raise [Com::Vmware::Vapi::Std::Errors::NotFound]
-        #     if the service element associated with  ``service_id``  is not registered with the infrastructure.
-        def get(service_id)
-            invoke_with_info(@@get_info, {
-                'service_id' => service_id,
-            })
-        end
-
-
+    RESOURCE_TYPE = 'com.vmware.vapi.enumeration'
+    # Returns the identifiers for the enumeration elements that are contained in all the package elements, service elements and structure elements.
+    #
+    # @return [Array<String>]
+    #     The list of identifiers for the enumeration elements.
+    def list
+      invoke_with_info(LIST_INFO)
     end
 
-
-    # The  ``Com::Vmware::Vapi::Metadata::Metamodel::Source``   class  provides  methods  to manage the sources of metamodel metadata information.  
+    # Retrieves information about the enumeration element corresponding to  ``enumeration_id`` .  
     # 
-    #  The interface definition language infrastructure provides tools to generate various kinds of metadata in JSON format from the interface definition files and additional properties files. One of the generated files contains metamodel information. The generated file can be registered as a source of metadata.  
-    # 
-    #  The metamodel file contains all the data present in the interface definition files. Each metamodel file contains data about one component element. When a metamodel file is added as a source, each source contributes only one component element's metadata.  
-    # 
-    #  Metamodel metadata can also be discovered from a remote server that supports the metamodel metadata  classs  (see   :mod:`com.vmware.vapi.metadata.metamodel`  ). Since multiple components can be registered with a single metadata server, when a remote server is registered as a source, that source can contribute more than one component.
-    class Source < VAPI::Bindings::VapiService
-
-        protected
-
-        # static metamodel definitions
-        @@service_id = VAPI::Core::ServiceIdentifier.new('com.vmware.vapi.metadata.metamodel.source')
-
-        @@create_info = VAPI::Bindings::OperationInfo.new(
-            VAPI::Core::OperationIdentifier.new('create', @@service_id),
-            VAPI::Bindings::OperationInputType.new({
-                'source_id' => VAPI::Bindings::IdType.new(resource_types='com.vmware.vapi.metadata.metamodel.source'),
-                'spec' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Metadata::Metamodel::Source::CreateSpec'),
-            }),
-            VAPI::Bindings::VoidType.instance,
-            {
-                'com.vmware.vapi.std.errors.already_exists' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::AlreadyExists'),
-                'com.vmware.vapi.std.errors.invalid_argument' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::InvalidArgument'),
-                'com.vmware.vapi.std.errors.not_found' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::NotFound'),
-
-            },
-            [],
-            [])
-        @@delete_info = VAPI::Bindings::OperationInfo.new(
-            VAPI::Core::OperationIdentifier.new('delete', @@service_id),
-            VAPI::Bindings::OperationInputType.new({
-                'source_id' => VAPI::Bindings::IdType.new(resource_types='com.vmware.vapi.metadata.metamodel.source'),
-            }),
-            VAPI::Bindings::VoidType.instance,
-            {
-                'com.vmware.vapi.std.errors.not_found' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::NotFound'),
-
-            },
-            [],
-            [])
-        @@get_info = VAPI::Bindings::OperationInfo.new(
-            VAPI::Core::OperationIdentifier.new('get', @@service_id),
-            VAPI::Bindings::OperationInputType.new({
-                'source_id' => VAPI::Bindings::IdType.new(resource_types='com.vmware.vapi.metadata.metamodel.source'),
-            }),
-            VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Metadata::Metamodel::Source::Info'),
-            {
-                'com.vmware.vapi.std.errors.not_found' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::NotFound'),
-
-            },
-            [],
-            [])
-        @@list_info = VAPI::Bindings::OperationInfo.new(
-            VAPI::Core::OperationIdentifier.new('list', @@service_id),
-            VAPI::Bindings::OperationInputType.new,
-            VAPI::Bindings::ListType.new(VAPI::Bindings::IdType.new),
-            {},
-            [],
-            [])
-        @@reload_info = VAPI::Bindings::OperationInfo.new(
-            VAPI::Core::OperationIdentifier.new('reload', @@service_id),
-            VAPI::Bindings::OperationInputType.new({
-                'source_id' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::IdType.new),
-            }),
-            VAPI::Bindings::VoidType.instance,
-            {
-                'com.vmware.vapi.std.errors.not_found' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::NotFound'),
-
-            },
-            [],
-            [])
-        @@fingerprint_info = VAPI::Bindings::OperationInfo.new(
-            VAPI::Core::OperationIdentifier.new('fingerprint', @@service_id),
-            VAPI::Bindings::OperationInputType.new({
-                'source_id' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::IdType.new),
-            }),
-            VAPI::Bindings::StringType.instance,
-            {
-                'com.vmware.vapi.std.errors.not_found' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::NotFound'),
-
-            },
-            [],
-            [])
-
-        @@service_info = VAPI::Bindings::ServiceInfo.new(@@service_id, {
-            'create' => @@create_info,
-            'delete' => @@delete_info,
-            'get' => @@get_info,
-            'list' => @@list_info,
-            'reload' => @@reload_info,
-            'fingerprint' => @@fingerprint_info,
-        })
-
-        public
-
-        # Constructs a new instance.
-        #
-        # @param config [VAPI::Bindings::StubConfig] A hash with the api provider details.
-        def initialize(config)
-            super(config, @@service_info)
-        end
-
-        RESOURCE_TYPE = 'com.vmware.vapi.metadata.metamodel.source'
-
-
-        # Creates a new metadata source. Once the server validates the registration information of the metadata source, the metamodel metadata is retrieved from the source. This populates elements in all the  classs  defined in   :mod:`com.vmware.vapi.metadata.metamodel`    package .
-        #
-        # @param source_id [String]
-        #     metadata source identifier.
-        # @param spec [Com::Vmware::Vapi::Metadata::Metamodel::Source::CreateSpec]
-        #     create specification.
-        # @return [Void]
-        # @raise [Com::Vmware::Vapi::Std::Errors::AlreadyExists]
-        #     if the metadata source identifier is already registered with the infrastructure.
-        # @raise [Com::Vmware::Vapi::Std::Errors::InvalidArgument]
-        #     if the type of the source specified in  null  is invalid.
-        # @raise [Com::Vmware::Vapi::Std::Errors::InvalidArgument]
-        #     if the file specified in  null  is not a valid JSON file or if the format of the metamodel metadata in the JSON file is invalid.
-        # @raise [Com::Vmware::Vapi::Std::Errors::InvalidArgument]
-        #     if the URI specified in  null  is unreachable or if there is a transport protocol or message protocol mismatch between the client and the server or if the remote server do not have  classs  present in   :mod:`com.vmware.vapi.metadata.metamodel`    package .
-        # @raise [Com::Vmware::Vapi::Std::Errors::NotFound]
-        #     if the file specified in  null  does not exist.
-        def create(source_id, spec)
-            invoke_with_info(@@create_info, {
-                'source_id' => source_id,
-                'spec' => spec,
-            })
-        end
-
-
-        # Deletes an existing metamodel metadata source from the infrastructure.
-        #
-        # @param source_id [String]
-        #     Identifier of the metadata source.
-        # @return [Void]
-        # @raise [Com::Vmware::Vapi::Std::Errors::NotFound]
-        #     if the metadata source associated with  ``source_id``  is not found.
-        def delete(source_id)
-            invoke_with_info(@@delete_info, {
-                'source_id' => source_id,
-            })
-        end
-
-
-        # Retrieves information about the metadata source corresponding to  ``source_id`` .
-        #
-        # @param source_id [String]
-        #     Identifier of the metadata source.
-        # @return [Com::Vmware::Vapi::Metadata::Metamodel::Source::Info]
-        #     The   :class:`Com::Vmware::Vapi::Metadata::Metamodel::Source::Info`   instance that corresponds to  ``source_id``
-        # @raise [Com::Vmware::Vapi::Std::Errors::NotFound]
-        #     if the metadata source associated with  ``source_id``  is not found.
-        def get(source_id)
-            invoke_with_info(@@get_info, {
-                'source_id' => source_id,
-            })
-        end
-
-
-        # Returns the identifiers of the metadata sources currently registered with the infrastructure.
-        #
-        # @return [Array<String>]
-        #     The list of identifiers for metadata sources currently registered.
-        def list()
-            invoke_with_info(@@list_info)
-        end
-
-
-        # Reloads the metamodel metadata from all the metadata sources or of a particular metadata source if  ``source_id``  is specified.
-        #
-        # @param source_id [String, nil]
-        #     Identifier of the metadata source.
-        #     If unspecified, all the metadata sources are reloaded.
-        # @return [Void]
-        # @raise [Com::Vmware::Vapi::Std::Errors::NotFound]
-        #     if the metadata source associated with  ``source_id``  is not found.
-        def reload(source_id=nil)
-            invoke_with_info(@@reload_info, {
-                'source_id' => source_id,
-            })
-        end
-
-
-        # Returns the aggregate fingerprint of metadata from all the metadata sources or from a particular metadata source if  ``source_id``  is specified.
-        #
-        # @param source_id [String, nil]
-        #     Identifier of the metadata source.
-        #     If unspecified, the fingerprint of all the metadata sources is returned.
-        # @return [String]
-        #     Aggregate fingerprint of all the metadata sources or of a particular metadata source.
-        # @raise [Com::Vmware::Vapi::Std::Errors::NotFound]
-        #     if the metadata source associated with  ``source_id``  is not found.
-        def fingerprint(source_id=nil)
-            invoke_with_info(@@fingerprint_info, {
-                'source_id' => source_id,
-            })
-        end
-
-
-
-        # The  ``Com::Vmware::Vapi::Metadata::Metamodel::Source::Info``   class  contains the metadata source information.
-        # @!attribute [rw] description
-        #     @return [String]
-        #     English language human readable description of the source.
-        # @!attribute [rw] type
-        #     @return [Com::Vmware::Vapi::Metadata::SourceType]
-        #     Type of the metadata source.
-        # @!attribute [rw] filepath
-        #     @return [String]
-        #     Absolute file path of the metamodel metadata file that has the metamodel information about one component element. The  ``filePath``  is the path to the file in the server's filesystem.
-        #     This  field  is optional and it is only relevant when the value of  ``type``  is  null .
-        # @!attribute [rw] address
-        #     @return [URI]
-        #     Connection information for the remote server. This must be in the format http(s)://IP:port/namespace.  
-        #     
-        #      The remote server must support the  classs  in the   :mod:`com.vmware.vapi.metadata.metamodel`    package . It must expose metamodel information of one or more components.
-        #     This  field  is optional and it is only relevant when the value of  ``type``  is  null .
-        class Info < VAPI::Bindings::VapiStruct
-
-            class << self
-                # Holds (gets or creates) the binding type metadata for this structure type.
-                # @scope class
-                # @return [VAPI::Bindings::StructType] the binding type
-                def binding_type
-                    @binding_type ||= VAPI::Bindings::StructType.new(
-                        'com.vmware.vapi.metadata.metamodel.source.info',
-                        {
-                            'description' => VAPI::Bindings::StringType.instance,
-                            'type' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Metadata::SourceType'),
-                            'filepath' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::StringType.instance),
-                            'address' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::URIType.instance),
-                        },
-                        Info,
-                        false,
-                        nil)
-                end
-            end
-
-            attr_accessor :description,
-                          :type,
-                          :filepath,
-                          :address
-
-            # Constructs a new instance.
-            # @param ruby_values [Hash] a map of initial property values (optional)
-            # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
-            def initialize(ruby_values=nil, struct_value=nil)
-                super(self.class.binding_type, ruby_values, struct_value)
-            end
-        end
-
-
-        # The  ``Com::Vmware::Vapi::Metadata::Metamodel::Source::CreateSpec``   class  contains the registration information of a metamodel source.
-        class CreateSpec < VAPI::Bindings::VapiStruct
-
-            class << self
-                # Holds (gets or creates) the binding type metadata for this structure type.
-                # @scope class
-                # @return [VAPI::Bindings::StructType] the binding type
-                def binding_type
-                    @binding_type ||= VAPI::Bindings::StructType.new(
-                        'com.vmware.vapi.metadata.metamodel.source.create_spec',
-                        {
-                            'description' => VAPI::Bindings::StringType.instance,
-                            'type' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Metadata::SourceType'),
-                            'filepath' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::StringType.instance),
-                            'address' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::URIType.instance),
-                        },
-                        CreateSpec,
-                        false,
-                        nil)
-                end
-            end
-
-            attr_accessor :description,
-                          :type,
-                          :filepath,
-                          :address
-
-            # Constructs a new instance.
-            # @param ruby_values [Hash] a map of initial property values (optional)
-            # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
-            def initialize(ruby_values=nil, struct_value=nil)
-                super(self.class.binding_type, ruby_values, struct_value)
-            end
-        end
-
-
+    #  The   :class:`Com::Vmware::Vapi::Metadata::Metamodel::EnumerationInfo`   contains the metamodel information about the enumeration value element contained in the enumeration element.
+    #
+    # @param enumeration_id [String]
+    #     Identifier of the enumeration element.
+    # @return [Com::Vmware::Vapi::Metadata::Metamodel::EnumerationInfo]
+    #     The   :class:`Com::Vmware::Vapi::Metadata::Metamodel::EnumerationInfo`   instance that corresponds to  ``enumeration_id``
+    # @raise [Com::Vmware::Vapi::Std::Errors::NotFound]
+    #     if the enumeration element associated with  ``enumeration_id``  is not contained in any of the package elements, service elements and structure elements.
+    def get(enumeration_id)
+      invoke_with_info(GET_INFO,
+                       'enumeration_id' => enumeration_id)
     end
 
+  end
+  # The  ``Com::Vmware::Vapi::Metadata::Metamodel::MetadataIdentifier``   class  provides string constants that can be used as identifiers for the metadata elements.  
+  # 
+  #  Most of the types in   :mod:`com.vmware.vapi.metadata.metamodel`   package has a metadata field whose type is  ``Map<String, ElementMap>`` .   :class:`Com::Vmware::Vapi::Metadata::Metamodel::MetadataIdentifier`   contains the identifiers used in the keys of the above Map type.
+  class MetadataIdentifier < VAPI::Bindings::VapiService
+    # static metamodel definitions
+    SERVICE_ID = VAPI::Core::ServiceIdentifier.new('com.vmware.vapi.metadata.metamodel.metadata_identifier')
 
-    # The  ``Com::Vmware::Vapi::Metadata::Metamodel::Structure``   class  providers  methods  to retrieve metamodel information about a structure element in the interface definition language.
-    class Structure < VAPI::Bindings::VapiService
+    SERVICE_INFO = VAPI::Bindings::ServiceInfo.new(SERVICE_ID, {})
 
-        protected
-
-        # static metamodel definitions
-        @@service_id = VAPI::Core::ServiceIdentifier.new('com.vmware.vapi.metadata.metamodel.structure')
-
-        @@list_info = VAPI::Bindings::OperationInfo.new(
-            VAPI::Core::OperationIdentifier.new('list', @@service_id),
-            VAPI::Bindings::OperationInputType.new,
-            VAPI::Bindings::ListType.new(VAPI::Bindings::IdType.new),
-            {},
-            [],
-            [])
-        @@get_info = VAPI::Bindings::OperationInfo.new(
-            VAPI::Core::OperationIdentifier.new('get', @@service_id),
-            VAPI::Bindings::OperationInputType.new({
-                'structure_id' => VAPI::Bindings::IdType.new(resource_types='com.vmware.vapi.structure'),
-            }),
-            VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Metadata::Metamodel::StructureInfo'),
-            {
-                'com.vmware.vapi.std.errors.not_found' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::NotFound'),
-
-            },
-            [],
-            [])
-
-        @@service_info = VAPI::Bindings::ServiceInfo.new(@@service_id, {
-            'list' => @@list_info,
-            'get' => @@get_info,
-        })
-
-        public
-
-        # Constructs a new instance.
-        #
-        # @param config [VAPI::Bindings::StubConfig] A hash with the api provider details.
-        def initialize(config)
-            super(config, @@service_info)
-        end
-
-        RESOURCE_TYPE = 'com.vmware.vapi.structure'
-
-
-        # Returns the identifiers for the structure elements that are contained in all the package elements and service elements.
-        #
-        # @return [Array<String>]
-        #     The list of identifiers for the structure elements.
-        def list()
-            invoke_with_info(@@list_info)
-        end
-
-
-        # Retrieves information about the structure element corresponding to  ``structure_id`` .  
-        # 
-        #  The   :class:`Com::Vmware::Vapi::Metadata::Metamodel::StructureInfo`   contains the metamodel information about the structure element. It contains information about all the field elements and enumeration elements contained in this structure element.
-        #
-        # @param structure_id [String]
-        #     Identifier of the structure element.
-        # @return [Com::Vmware::Vapi::Metadata::Metamodel::StructureInfo]
-        #     The   :class:`Com::Vmware::Vapi::Metadata::Metamodel::StructureInfo`   instance that corresponds to  ``structure_id`` .
-        # @raise [Com::Vmware::Vapi::Std::Errors::NotFound]
-        #     if the structure element associated with  ``structure_id``  is not contained in any of the package elements or service elements.
-        def get(structure_id)
-            invoke_with_info(@@get_info, {
-                'structure_id' => structure_id,
-            })
-        end
-
-
+    # Constructs a new instance.
+    #
+    # @param config [VAPI::Bindings::StubConfig] A hash with the api provider details.
+    def initialize(config)
+      super(config, SERVICE_INFO)
     end
 
+    CANONICAL_NAME = 'CanonicalName'
+    COMPONENT = 'Component'
+    CREATE = 'Create'
+    CRUD = 'Crud'
+    HAS_FIELDS_OF = 'HasFieldsOf'
+    INCLUDABLE = 'Includable'
+    INCLUDE = 'Include'
+    IS_ONE_OF = 'IsOneOf'
+    MODEL = 'Model'
+    READ = 'Read'
+    RESOURCE = 'Resource'
+    UNION_CASE = 'UnionCase'
+    UNION_TAG = 'UnionTag'
+    UPDATE = 'Update'
+  end
+  # The  ``Com::Vmware::Vapi::Metadata::Metamodel::Package``   class  provides  methods  to retrieve metamodel information about a package element in the interface definition language.  
+  # 
+  #  A package is a logical grouping of services, structures and enumerations. A package element describes the package. It contains the service elements, structure elements and enumeration elements that are grouped together.
+  class Package < VAPI::Bindings::VapiService
+    # static metamodel definitions
+    SERVICE_ID = VAPI::Core::ServiceIdentifier.new('com.vmware.vapi.metadata.metamodel.package')
 
+    LIST_INFO = VAPI::Bindings::OperationInfo.new(
+      VAPI::Core::OperationIdentifier.new('list', SERVICE_ID),
+      VAPI::Bindings::OperationInputType.new,
+      VAPI::Bindings::ListType.new(VAPI::Bindings::IdType.new),
+      {},
+      [],
+      []
+    )
 
-    # The  ``Com::Vmware::Vapi::Metadata::Metamodel::ComponentData``   class  contains the metamodel metadata information of a component element along with its fingerprint.
-    # @!attribute [rw] info
-    #     @return [Com::Vmware::Vapi::Metadata::Metamodel::ComponentInfo]
-    #     Metamodel information of the component element. This includes information about all the package elements contained in this component element.  
-    #     
-    #      The metamodel information about a component could be quite large if there are a lot of package elements contained in this component.
-    # @!attribute [rw] fingerprint
+    GET_INFO = VAPI::Bindings::OperationInfo.new(
+      VAPI::Core::OperationIdentifier.new('get', SERVICE_ID),
+      VAPI::Bindings::OperationInputType.new(
+        'package_id' => VAPI::Bindings::IdType.new('com.vmware.vapi.package')
+      ),
+      VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Metadata::Metamodel::PackageInfo'),
+      {
+        'com.vmware.vapi.std.errors.not_found' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::NotFound')
+      },
+      [],
+      []
+    )
+
+    SERVICE_INFO = VAPI::Bindings::ServiceInfo.new(
+      SERVICE_ID,
+      'list' => LIST_INFO,
+      'get' => GET_INFO
+    )
+
+    # Constructs a new instance.
+    #
+    # @param config [VAPI::Bindings::StubConfig] A hash with the api provider details.
+    def initialize(config)
+      super(config, SERVICE_INFO)
+    end
+
+    RESOURCE_TYPE = 'com.vmware.vapi.package'
+    # Returns the identifiers for the packages elements that are contained in all the registered component elements.
+    #
+    # @return [Array<String>]
+    #     The list of identifiers for the package elements that are contained in all the registered component elements.
+    def list
+      invoke_with_info(LIST_INFO)
+    end
+
+    # Retrieves information about the package element corresponding to  ``package_id`` .
+    #
+    # @param package_id [String]
+    #     Identifier of the package element.
+    # @return [Com::Vmware::Vapi::Metadata::Metamodel::PackageInfo]
+    #     The   :class:`Com::Vmware::Vapi::Metadata::Metamodel::PackageInfo`   instance that corresponds to  ``package_id`` .
+    # @raise [Com::Vmware::Vapi::Std::Errors::NotFound]
+    #     if the package element associated with  ``package_id``  does not exist.
+    def get(package_id)
+      invoke_with_info(GET_INFO,
+                       'package_id' => package_id)
+    end
+
+  end
+  # The   :class:`Com::Vmware::Vapi::Metadata::Metamodel::Resource`    class  provides  methods  to retrieve information about resource types.  
+  # 
+  #  A service is a logical grouping of operations that operate on an entity. Each entity is identifier by a namespace (or resource type) and an unique identifier.
+  class ResourceService < VAPI::Bindings::VapiService
+    # static metamodel definitions
+    SERVICE_ID = VAPI::Core::ServiceIdentifier.new('com.vmware.vapi.metadata.metamodel.resource')
+
+    LIST_INFO = VAPI::Bindings::OperationInfo.new(
+      VAPI::Core::OperationIdentifier.new('list', SERVICE_ID),
+      VAPI::Bindings::OperationInputType.new,
+      VAPI::Bindings::SetType.new(VAPI::Bindings::IdType.new),
+      {},
+      [],
+      []
+    )
+
+    SERVICE_INFO = VAPI::Bindings::ServiceInfo.new(
+      SERVICE_ID,
+      'list' => LIST_INFO
+    )
+
+    # Constructs a new instance.
+    #
+    # @param config [VAPI::Bindings::StubConfig] A hash with the api provider details.
+    def initialize(config)
+      super(config, SERVICE_INFO)
+    end
+
+    RESOURCE_TYPE = 'com.vmware.vapi.resource'
+    # Returns the set of resource types present across all the service elements contained in all the package elements.
+    #
+    # @return [Set<String>]
+    #     Set of resource types
+    def list
+      invoke_with_info(LIST_INFO)
+    end
+
+  end
+  # The  ``Com::Vmware::Vapi::Metadata::Metamodel::Service``   class  provides  methods  to retrieve metamodel information about a service element in the interface definition language.  
+  # 
+  #  A service is a logical grouping of operations that operate on some entity. A service element describes a service. It contains operation elements that describe the operations grouped in the service. It also contains structure elements and enumeration elements corresponding to the structures and enumerations defined in the service.
+  class ServiceService < VAPI::Bindings::VapiService
+    # static metamodel definitions
+    SERVICE_ID = VAPI::Core::ServiceIdentifier.new('com.vmware.vapi.metadata.metamodel.service')
+
+    LIST_INFO = VAPI::Bindings::OperationInfo.new(
+      VAPI::Core::OperationIdentifier.new('list', SERVICE_ID),
+      VAPI::Bindings::OperationInputType.new,
+      VAPI::Bindings::ListType.new(VAPI::Bindings::IdType.new),
+      {},
+      [],
+      []
+    )
+
+    GET_INFO = VAPI::Bindings::OperationInfo.new(
+      VAPI::Core::OperationIdentifier.new('get', SERVICE_ID),
+      VAPI::Bindings::OperationInputType.new(
+        'service_id' => VAPI::Bindings::IdType.new('com.vmware.vapi.service')
+      ),
+      VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Metadata::Metamodel::ServiceInfo'),
+      {
+        'com.vmware.vapi.std.errors.not_found' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::NotFound')
+      },
+      [],
+      []
+    )
+
+    SERVICE_INFO = VAPI::Bindings::ServiceInfo.new(
+      SERVICE_ID,
+      'list' => LIST_INFO,
+      'get' => GET_INFO
+    )
+
+    # Constructs a new instance.
+    #
+    # @param config [VAPI::Bindings::StubConfig] A hash with the api provider details.
+    def initialize(config)
+      super(config, SERVICE_INFO)
+    end
+
+    RESOURCE_TYPE = 'com.vmware.vapi.service'
+    # Returns the identifiers for the service elements that are currently registered with the infrastructure.  
+    # 
+    #  The list of service elements is an aggregate list of all the service elements contained in all the package elements.
+    #
+    # @return [Array<String>]
+    #     The list of identifiers for the service elements that are currently registered with the infrastructure.
+    def list
+      invoke_with_info(LIST_INFO)
+    end
+
+    # Retrieves information about the service element corresponding to  ``service_id`` .  
+    # 
+    #  The   :class:`Com::Vmware::Vapi::Metadata::Metamodel::ServiceInfo`   contains the metamodel information for the operation elements, structure elements and enumeration elements contained in the service element.
+    #
+    # @param service_id [String]
+    #     Identifier of the service element.
+    # @return [Com::Vmware::Vapi::Metadata::Metamodel::ServiceInfo]
+    #     The   :class:`Com::Vmware::Vapi::Metadata::Metamodel::ServiceInfo`   instance that corresponds to  ``service_id``
+    # @raise [Com::Vmware::Vapi::Std::Errors::NotFound]
+    #     if the service element associated with  ``service_id``  is not registered with the infrastructure.
+    def get(service_id)
+      invoke_with_info(GET_INFO,
+                       'service_id' => service_id)
+    end
+
+  end
+  # The  ``Com::Vmware::Vapi::Metadata::Metamodel::Source``   class  provides  methods  to manage the sources of metamodel metadata information.  
+  # 
+  #  The interface definition language infrastructure provides tools to generate various kinds of metadata in JSON format from the interface definition files and additional properties files. One of the generated files contains metamodel information. The generated file can be registered as a source of metadata.  
+  # 
+  #  The metamodel file contains all the data present in the interface definition files. Each metamodel file contains data about one component element. When a metamodel file is added as a source, each source contributes only one component element's metadata.  
+  # 
+  #  Metamodel metadata can also be discovered from a remote server that supports the metamodel metadata  classs  (see   :mod:`com.vmware.vapi.metadata.metamodel`  ). Since multiple components can be registered with a single metadata server, when a remote server is registered as a source, that source can contribute more than one component.
+  class Source < VAPI::Bindings::VapiService
+    # static metamodel definitions
+    SERVICE_ID = VAPI::Core::ServiceIdentifier.new('com.vmware.vapi.metadata.metamodel.source')
+
+    CREATE_INFO = VAPI::Bindings::OperationInfo.new(
+      VAPI::Core::OperationIdentifier.new('create', SERVICE_ID),
+      VAPI::Bindings::OperationInputType.new(
+        'source_id' => VAPI::Bindings::IdType.new('com.vmware.vapi.metadata.metamodel.source'),
+        'spec' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Metadata::Metamodel::Source::CreateSpec')
+      ),
+      VAPI::Bindings::VoidType.instance,
+      {
+        'com.vmware.vapi.std.errors.already_exists' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::AlreadyExists'),
+        'com.vmware.vapi.std.errors.invalid_argument' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::InvalidArgument'),
+        'com.vmware.vapi.std.errors.not_found' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::NotFound')
+      },
+      [],
+      []
+    )
+
+    DELETE_INFO = VAPI::Bindings::OperationInfo.new(
+      VAPI::Core::OperationIdentifier.new('delete', SERVICE_ID),
+      VAPI::Bindings::OperationInputType.new(
+        'source_id' => VAPI::Bindings::IdType.new('com.vmware.vapi.metadata.metamodel.source')
+      ),
+      VAPI::Bindings::VoidType.instance,
+      {
+        'com.vmware.vapi.std.errors.not_found' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::NotFound')
+      },
+      [],
+      []
+    )
+
+    GET_INFO = VAPI::Bindings::OperationInfo.new(
+      VAPI::Core::OperationIdentifier.new('get', SERVICE_ID),
+      VAPI::Bindings::OperationInputType.new(
+        'source_id' => VAPI::Bindings::IdType.new('com.vmware.vapi.metadata.metamodel.source')
+      ),
+      VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Metadata::Metamodel::Source::Info'),
+      {
+        'com.vmware.vapi.std.errors.not_found' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::NotFound')
+      },
+      [],
+      []
+    )
+
+    LIST_INFO = VAPI::Bindings::OperationInfo.new(
+      VAPI::Core::OperationIdentifier.new('list', SERVICE_ID),
+      VAPI::Bindings::OperationInputType.new,
+      VAPI::Bindings::ListType.new(VAPI::Bindings::IdType.new),
+      {},
+      [],
+      []
+    )
+
+    RELOAD_INFO = VAPI::Bindings::OperationInfo.new(
+      VAPI::Core::OperationIdentifier.new('reload', SERVICE_ID),
+      VAPI::Bindings::OperationInputType.new(
+        'source_id' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::IdType.new)
+      ),
+      VAPI::Bindings::VoidType.instance,
+      {
+        'com.vmware.vapi.std.errors.not_found' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::NotFound')
+      },
+      [],
+      []
+    )
+
+    FINGERPRINT_INFO = VAPI::Bindings::OperationInfo.new(
+      VAPI::Core::OperationIdentifier.new('fingerprint', SERVICE_ID),
+      VAPI::Bindings::OperationInputType.new(
+        'source_id' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::IdType.new)
+      ),
+      VAPI::Bindings::StringType.instance,
+      {
+        'com.vmware.vapi.std.errors.not_found' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::NotFound')
+      },
+      [],
+      []
+    )
+
+    SERVICE_INFO = VAPI::Bindings::ServiceInfo.new(
+      SERVICE_ID,
+      'create' => CREATE_INFO,
+      'delete' => DELETE_INFO,
+      'get' => GET_INFO,
+      'list' => LIST_INFO,
+      'reload' => RELOAD_INFO,
+      'fingerprint' => FINGERPRINT_INFO
+    )
+
+    # Constructs a new instance.
+    #
+    # @param config [VAPI::Bindings::StubConfig] A hash with the api provider details.
+    def initialize(config)
+      super(config, SERVICE_INFO)
+    end
+
+    RESOURCE_TYPE = 'com.vmware.vapi.metadata.metamodel.source'
+    # Creates a new metadata source. Once the server validates the registration information of the metadata source, the metamodel metadata is retrieved from the source. This populates elements in all the  classs  defined in   :mod:`com.vmware.vapi.metadata.metamodel`    package .
+    #
+    # @param source_id [String]
+    #     metadata source identifier.
+    # @param spec [Com::Vmware::Vapi::Metadata::Metamodel::Source::CreateSpec]
+    #     create specification.
+    # @return [Void]
+    # @raise [Com::Vmware::Vapi::Std::Errors::AlreadyExists]
+    #     if the metadata source identifier is already registered with the infrastructure.
+    # @raise [Com::Vmware::Vapi::Std::Errors::InvalidArgument]
+    #     if the type of the source specified in  null  is invalid.
+    # @raise [Com::Vmware::Vapi::Std::Errors::InvalidArgument]
+    #     if the file specified in  null  is not a valid JSON file or if the format of the metamodel metadata in the JSON file is invalid.
+    # @raise [Com::Vmware::Vapi::Std::Errors::InvalidArgument]
+    #     if the URI specified in  null  is unreachable or if there is a transport protocol or message protocol mismatch between the client and the server or if the remote server do not have  classs  present in   :mod:`com.vmware.vapi.metadata.metamodel`    package .
+    # @raise [Com::Vmware::Vapi::Std::Errors::NotFound]
+    #     if the file specified in  null  does not exist.
+    def create(source_id, spec)
+      invoke_with_info(CREATE_INFO,
+                       'source_id' => source_id,
+                       'spec' => spec)
+    end
+
+    # Deletes an existing metamodel metadata source from the infrastructure.
+    #
+    # @param source_id [String]
+    #     Identifier of the metadata source.
+    # @return [Void]
+    # @raise [Com::Vmware::Vapi::Std::Errors::NotFound]
+    #     if the metadata source associated with  ``source_id``  is not found.
+    def delete(source_id)
+      invoke_with_info(DELETE_INFO,
+                       'source_id' => source_id)
+    end
+
+    # Retrieves information about the metadata source corresponding to  ``source_id`` .
+    #
+    # @param source_id [String]
+    #     Identifier of the metadata source.
+    # @return [Com::Vmware::Vapi::Metadata::Metamodel::Source::Info]
+    #     The   :class:`Com::Vmware::Vapi::Metadata::Metamodel::Source::Info`   instance that corresponds to  ``source_id``
+    # @raise [Com::Vmware::Vapi::Std::Errors::NotFound]
+    #     if the metadata source associated with  ``source_id``  is not found.
+    def get(source_id)
+      invoke_with_info(GET_INFO,
+                       'source_id' => source_id)
+    end
+
+    # Returns the identifiers of the metadata sources currently registered with the infrastructure.
+    #
+    # @return [Array<String>]
+    #     The list of identifiers for metadata sources currently registered.
+    def list
+      invoke_with_info(LIST_INFO)
+    end
+
+    # Reloads the metamodel metadata from all the metadata sources or of a particular metadata source if  ``source_id``  is specified.
+    #
+    # @param source_id [String, nil]
+    #     Identifier of the metadata source.
+    #     If unspecified, all the metadata sources are reloaded.
+    # @return [Void]
+    # @raise [Com::Vmware::Vapi::Std::Errors::NotFound]
+    #     if the metadata source associated with  ``source_id``  is not found.
+    def reload(source_id = nil)
+      invoke_with_info(RELOAD_INFO,
+                       'source_id' => source_id)
+    end
+
+    # Returns the aggregate fingerprint of metadata from all the metadata sources or from a particular metadata source if  ``source_id``  is specified.
+    #
+    # @param source_id [String, nil]
+    #     Identifier of the metadata source.
+    #     If unspecified, the fingerprint of all the metadata sources is returned.
+    # @return [String]
+    #     Aggregate fingerprint of all the metadata sources or of a particular metadata source.
+    # @raise [Com::Vmware::Vapi::Std::Errors::NotFound]
+    #     if the metadata source associated with  ``source_id``  is not found.
+    def fingerprint(source_id = nil)
+      invoke_with_info(FINGERPRINT_INFO,
+                       'source_id' => source_id)
+    end
+
+    # The  ``Com::Vmware::Vapi::Metadata::Metamodel::Source::Info``   class  contains the metadata source information.
+    # @!attribute [rw] description
     #     @return [String]
-    #     Fingerprint of the metamodel metadata of the component component.  
-    #     
-    #      Metamodel information could change when there is an infrastructure update and new functionality is added to an existing component.  
-    #     
-    #      Since the data present in   :attr:`Com::Vmware::Vapi::Metadata::Metamodel::ComponentData.info`   could be quite large,  ``fingerprint``  provides a convenient way to check if the data for a particular component is updated.  
-    #     
-    #      You should store the fingerprint associated with a component. After an update, by invoking the   :func:`Com::Vmware::Vapi::Metadata::Metamodel::Component.fingerprint`    method , you can retrieve the new fingerprint for the component. If the new fingerprint and the previously stored fingerprint do not match, clients can use the   :func:`Com::Vmware::Vapi::Metadata::Metamodel::Component.get`   to retrieve the new metamodel information for the component.
-    class ComponentData < VAPI::Bindings::VapiStruct
-
-        class << self
-            # Holds (gets or creates) the binding type metadata for this structure type.
-            # @scope class
-            # @return [VAPI::Bindings::StructType] the binding type
-            def binding_type
-                @binding_type ||= VAPI::Bindings::StructType.new(
-                    'com.vmware.vapi.metadata.metamodel.component_data',
-                    {
-                        'info' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Metadata::Metamodel::ComponentInfo'),
-                        'fingerprint' => VAPI::Bindings::StringType.instance,
-                    },
-                    ComponentData,
-                    false,
-                    nil)
-            end
-        end
-
-        attr_accessor :info,
-                      :fingerprint
-
-        # Constructs a new instance.
-        # @param ruby_values [Hash] a map of initial property values (optional)
-        # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
-        def initialize(ruby_values=nil, struct_value=nil)
-            super(self.class.binding_type, ruby_values, struct_value)
-        end
-    end
-
-
-    # The  ``Com::Vmware::Vapi::Metadata::Metamodel::ComponentInfo``   class  contains metamodel metadata information about a component element.
-    # @!attribute [rw] name
-    #     @return [String]
-    #     Dot separated name of the component element. The segments in the name reflect the organization of the APIs. The format of each segment is lower case with underscores. Each underscore represents a word boundary. If there are acronyms in the word, the capitalization is preserved. This format makes it easy to translate the segment into a different naming convention.
-    # @!attribute [rw] packages
-    #     @return [Hash<String, Com::Vmware::Vapi::Metadata::Metamodel::PackageInfo>]
-    #     Metamodel metadata information of all the package elements contained in the component element. The key in the  map  is the identifier of the package element and the value in the  map  is the metamodel information of the package element.
-    # @!attribute [rw] metadata
-    #     @return [Hash<String, Com::Vmware::Vapi::Metadata::Metamodel::ElementMap>]
-    #     Generic metadata for the component element. The key in the  map  is the name of the metadata element and the value is the data associated with that metadata element.  
-    #     
-    #      The   :class:`Com::Vmware::Vapi::Metadata::Metamodel::MetadataIdentifier`   contains possible string values for keys in the  map .
-    # @!attribute [rw] documentation
-    #     @return [String]
-    #     English language documentation for a component. It can contain HTML markup and documentation tags (similar to Javadoc tags). The first sentence of the package documentation is a complete sentence that identifies the component by name and summarizes the purpose of the component.
-    class ComponentInfo < VAPI::Bindings::VapiStruct
-
-        class << self
-            # Holds (gets or creates) the binding type metadata for this structure type.
-            # @scope class
-            # @return [VAPI::Bindings::StructType] the binding type
-            def binding_type
-                @binding_type ||= VAPI::Bindings::StructType.new(
-                    'com.vmware.vapi.metadata.metamodel.component_info',
-                    {
-                        'name' => VAPI::Bindings::StringType.instance,
-                        'packages' => VAPI::Bindings::MapType.new(VAPI::Bindings::IdType.new, VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Metadata::Metamodel::PackageInfo')),
-                        'metadata' => VAPI::Bindings::MapType.new(VAPI::Bindings::StringType.instance, VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Metadata::Metamodel::ElementMap')),
-                        'documentation' => VAPI::Bindings::StringType.instance,
-                    },
-                    ComponentInfo,
-                    false,
-                    nil)
-            end
-        end
-
-        attr_accessor :name,
-                      :packages,
-                      :metadata,
-                      :documentation
-
-        # Constructs a new instance.
-        # @param ruby_values [Hash] a map of initial property values (optional)
-        # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
-        def initialize(ruby_values=nil, struct_value=nil)
-            super(self.class.binding_type, ruby_values, struct_value)
-        end
-    end
-
-
-    # The  ``Com::Vmware::Vapi::Metadata::Metamodel::ConstantInfo``   class  contains metamodel information of the constant elements.
+    #     English language human readable description of the source.
     # @!attribute [rw] type
-    #     @return [Com::Vmware::Vapi::Metadata::Metamodel::Type]
-    #     Type of the constant element.
-    # @!attribute [rw] value
-    #     @return [Com::Vmware::Vapi::Metadata::Metamodel::ConstantValue]
-    #     Value of the constant element.
-    # @!attribute [rw] documentation
+    #     @return [Com::Vmware::Vapi::Metadata::SourceType]
+    #     Type of the metadata source.
+    # @!attribute [rw] filepath
     #     @return [String]
-    #     English language documentation for the constant element. It can contain HTML markup and documentation tags (similar to Javadoc tags).
-    class ConstantInfo < VAPI::Bindings::VapiStruct
-
-        class << self
-            # Holds (gets or creates) the binding type metadata for this structure type.
-            # @scope class
-            # @return [VAPI::Bindings::StructType] the binding type
-            def binding_type
-                @binding_type ||= VAPI::Bindings::StructType.new(
-                    'com.vmware.vapi.metadata.metamodel.constant_info',
-                    {
-                        'type' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Metadata::Metamodel::Type'),
-                        'value' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Metadata::Metamodel::ConstantValue'),
-                        'documentation' => VAPI::Bindings::StringType.instance,
-                    },
-                    ConstantInfo,
-                    false,
-                    nil)
-            end
+    #     Absolute file path of the metamodel metadata file that has the metamodel information about one component element. The  ``filePath``  is the path to the file in the server's filesystem.
+    #     This  field  is optional and it is only relevant when the value of  ``type``  is  null .
+    # @!attribute [rw] address
+    #     @return [URI]
+    #     Connection information for the remote server. This must be in the format http(s)://IP:port/namespace.  
+    #     
+    #      The remote server must support the  classs  in the   :mod:`com.vmware.vapi.metadata.metamodel`    package . It must expose metamodel information of one or more components.
+    #     This  field  is optional and it is only relevant when the value of  ``type``  is  null .
+    class Info < VAPI::Bindings::VapiStruct
+      class << self
+        # Holds (gets or creates) the binding type metadata for this structure type.
+        # @scope class
+        # @return [VAPI::Bindings::StructType] the binding type
+        def binding_type
+          @binding_type ||= VAPI::Bindings::StructType.new(
+            'com.vmware.vapi.metadata.metamodel.source.info',
+            {
+              'description' => VAPI::Bindings::StringType.instance,
+              'type' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Metadata::SourceType'),
+              'filepath' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::StringType.instance),
+              'address' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::URIType.instance)
+            },
+            Info,
+            false,
+            nil
+          )
         end
+      end
 
-        attr_accessor :type,
-                      :value,
-                      :documentation
+      attr_accessor :description,
+                    :type,
+                    :filepath,
+                    :address
 
-        # Constructs a new instance.
-        # @param ruby_values [Hash] a map of initial property values (optional)
-        # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
-        def initialize(ruby_values=nil, struct_value=nil)
-            super(self.class.binding_type, ruby_values, struct_value)
-        end
+      # Constructs a new instance.
+      # @param ruby_values [Hash] a map of initial property values (optional)
+      # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
+      def initialize(ruby_values = nil, struct_value = nil)
+        super(self.class.binding_type, ruby_values, struct_value)
+      end
     end
 
-
-    # The  ``Com::Vmware::Vapi::Metadata::Metamodel::ConstantValue``   class  contains the metamodel information of the constant element.
-    # @!attribute [rw] category
-    #     @return [Com::Vmware::Vapi::Metadata::Metamodel::ConstantValue::Category]
-    #     Category of the type of constant value.
-    # @!attribute [rw] primitive_value
-    #     @return [Com::Vmware::Vapi::Metadata::Metamodel::PrimitiveValue]
-    #     Primitive value of the constant element.
-    #     This  field  is optional and it is only relevant when the value of  ``category``  is   :attr:`Com::Vmware::Vapi::Metadata::Metamodel::ConstantValue::Category.PRIMITIVE`  .
-    # @!attribute [rw] list_value
-    #     @return [Array<Com::Vmware::Vapi::Metadata::Metamodel::PrimitiveValue>]
-    #     List value of the constant element.
-    #     This  field  is optional and it is only relevant when the value of  ``category``  is   :attr:`Com::Vmware::Vapi::Metadata::Metamodel::ConstantValue::Category.LIST`  .
-    class ConstantValue < VAPI::Bindings::VapiStruct
-
-        class << self
-            # Holds (gets or creates) the binding type metadata for this structure type.
-            # @scope class
-            # @return [VAPI::Bindings::StructType] the binding type
-            def binding_type
-                @binding_type ||= VAPI::Bindings::StructType.new(
-                    'com.vmware.vapi.metadata.metamodel.constant_value',
-                    {
-                        'category' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Metadata::Metamodel::ConstantValue::Category'),
-                        'primitive_value' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Metadata::Metamodel::PrimitiveValue')),
-                        'list_value' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::ListType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Metadata::Metamodel::PrimitiveValue'))),
-                    },
-                    ConstantValue,
-                    false,
-                    nil)
-            end
+    # The  ``Com::Vmware::Vapi::Metadata::Metamodel::Source::CreateSpec``   class  contains the registration information of a metamodel source.
+    class CreateSpec < VAPI::Bindings::VapiStruct
+      class << self
+        # Holds (gets or creates) the binding type metadata for this structure type.
+        # @scope class
+        # @return [VAPI::Bindings::StructType] the binding type
+        def binding_type
+          @binding_type ||= VAPI::Bindings::StructType.new(
+            'com.vmware.vapi.metadata.metamodel.source.create_spec',
+            {
+              'description' => VAPI::Bindings::StringType.instance,
+              'type' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Metadata::SourceType'),
+              'filepath' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::StringType.instance),
+              'address' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::URIType.instance)
+            },
+            CreateSpec,
+            false,
+            nil
+          )
         end
+      end
 
-        attr_accessor :category,
-                      :primitive_value,
-                      :list_value
+      attr_accessor :description,
+                    :type,
+                    :filepath,
+                    :address
 
-        # Constructs a new instance.
-        # @param ruby_values [Hash] a map of initial property values (optional)
-        # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
-        def initialize(ruby_values=nil, struct_value=nil)
-            super(self.class.binding_type, ruby_values, struct_value)
-        end
-
-
-        # The  ``Com::Vmware::Vapi::Metadata::Metamodel::ConstantValue::Category``   enumerated type  defines  enumeration values  for the valid kinds of values.
-        # @!attribute [rw] primitive
-        #     @return [Com::Vmware::Vapi::Metadata::Metamodel::ConstantValue::Category]
-        #     Indicates the type of constant value is primitive.
-        # @!attribute [rw] list
-        #     @return [Com::Vmware::Vapi::Metadata::Metamodel::ConstantValue::Category]
-        #     Indicates the type of constant value is a list.
-        class Category < VAPI::Bindings::VapiEnum
-
-            class << self
-                # Holds (gets or creates) the binding type metadata for this enumeration type.
-                # @scope class
-                # @return [VAPI::Bindings::EnumType] the binding type
-                def binding_type
-                    @binding_type ||= VAPI::Bindings::EnumType.new(
-                        'com.vmware.vapi.metadata.metamodel.constant_value.category',
-                        Category)
-                end
-
-                # Converts from a string value (perhaps off the wire) to an instance
-                # of this enum type.
-                # @param value [String] the actual value of the enum instance
-                # @return [Category] the instance found for the value, otherwise
-                #         an unknown instance will be built for the value
-                def from_string(value)
-                    begin
-                        const_get(value)
-                    rescue NameError
-                        Category.new('UNKNOWN', value)
-                    end
-                end
-            end
-
-            private
-
-            # Constructs a new instance.
-            # @param value [String] the actual value of the enum instance
-            # @param unknown [String] the unknown value when value is 'UKNOWN'
-            def initialize(value, unknown=nil)
-                super(self.class.binding_type, value, unknown)
-            end
-
-            public
-
-            # @!attribute [rw] primitive
-            #     @return [Com::Vmware::Vapi::Metadata::Metamodel::ConstantValue::Category]
-            #     Indicates the type of constant value is primitive.
-            PRIMITIVE = Category.new('PRIMITIVE')
-
-            # @!attribute [rw] list
-            #     @return [Com::Vmware::Vapi::Metadata::Metamodel::ConstantValue::Category]
-            #     Indicates the type of constant value is a list.
-            LIST = Category.new('LIST')
-
-        end
-
-
+      # Constructs a new instance.
+      # @param ruby_values [Hash] a map of initial property values (optional)
+      # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
+      def initialize(ruby_values = nil, struct_value = nil)
+        super(self.class.binding_type, ruby_values, struct_value)
+      end
     end
 
+  end
+  # The  ``Com::Vmware::Vapi::Metadata::Metamodel::Structure``   class  providers  methods  to retrieve metamodel information about a structure element in the interface definition language.
+  class Structure < VAPI::Bindings::VapiService
+    # static metamodel definitions
+    SERVICE_ID = VAPI::Core::ServiceIdentifier.new('com.vmware.vapi.metadata.metamodel.structure')
 
-    # The  ``Com::Vmware::Vapi::Metadata::Metamodel::ElementMap``   class  contains the metadata elements.  
+    LIST_INFO = VAPI::Bindings::OperationInfo.new(
+      VAPI::Core::OperationIdentifier.new('list', SERVICE_ID),
+      VAPI::Bindings::OperationInputType.new,
+      VAPI::Bindings::ListType.new(VAPI::Bindings::IdType.new),
+      {},
+      [],
+      []
+    )
+
+    GET_INFO = VAPI::Bindings::OperationInfo.new(
+      VAPI::Core::OperationIdentifier.new('get', SERVICE_ID),
+      VAPI::Bindings::OperationInputType.new(
+        'structure_id' => VAPI::Bindings::IdType.new('com.vmware.vapi.structure')
+      ),
+      VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Metadata::Metamodel::StructureInfo'),
+      {
+        'com.vmware.vapi.std.errors.not_found' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::NotFound')
+      },
+      [],
+      []
+    )
+
+    SERVICE_INFO = VAPI::Bindings::ServiceInfo.new(
+      SERVICE_ID,
+      'list' => LIST_INFO,
+      'get' => GET_INFO
+    )
+
+    # Constructs a new instance.
+    #
+    # @param config [VAPI::Bindings::StubConfig] A hash with the api provider details.
+    def initialize(config)
+      super(config, SERVICE_INFO)
+    end
+
+    RESOURCE_TYPE = 'com.vmware.vapi.structure'
+    # Returns the identifiers for the structure elements that are contained in all the package elements and service elements.
+    #
+    # @return [Array<String>]
+    #     The list of identifiers for the structure elements.
+    def list
+      invoke_with_info(LIST_INFO)
+    end
+
+    # Retrieves information about the structure element corresponding to  ``structure_id`` .  
     # 
-    #  One of the sources for metadata is the annotations present in the interface definition language. When an annotation is represented in the  ``Com::Vmware::Vapi::Metadata::Metamodel::ElementMap`` ,  ``Com::Vmware::Vapi::Metadata::Metamodel::ElementMap``  describes the data specified in the arguments for the annotation.  
-    # 
-    #  For example, in  ``\@UnionCase(tag="tag", value="SELECT")`` , ElementMap describes the keyword arguments tag and value.
-    # @!attribute [rw] elements
-    #     @return [Hash<String, Com::Vmware::Vapi::Metadata::Metamodel::ElementValue>]
-    #     Metamodel information of the metadata elements. The key parameter of the  map  is the identifier for the element and the value corresponds to the element value.
-    class ElementMap < VAPI::Bindings::VapiStruct
-
-        class << self
-            # Holds (gets or creates) the binding type metadata for this structure type.
-            # @scope class
-            # @return [VAPI::Bindings::StructType] the binding type
-            def binding_type
-                @binding_type ||= VAPI::Bindings::StructType.new(
-                    'com.vmware.vapi.metadata.metamodel.element_map',
-                    {
-                        'elements' => VAPI::Bindings::MapType.new(VAPI::Bindings::StringType.instance, VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Metadata::Metamodel::ElementValue')),
-                    },
-                    ElementMap,
-                    false,
-                    nil)
-            end
-        end
-
-        attr_accessor :elements
-
-        # Constructs a new instance.
-        # @param ruby_values [Hash] a map of initial property values (optional)
-        # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
-        def initialize(ruby_values=nil, struct_value=nil)
-            super(self.class.binding_type, ruby_values, struct_value)
-        end
-    end
-
-
-    # The  ``Com::Vmware::Vapi::Metadata::Metamodel::ElementValue``   class  describes the value of the metadata element.
-    # @!attribute [rw] type
-    #     @return [Com::Vmware::Vapi::Metadata::Metamodel::ElementValue::Type]
-    #     Type of the value.
-    # @!attribute [rw] long_value
-    #     @return [Fixnum]
-    #     Long value of the metadata element.
-    #     This  field  is optional and it is only relevant when the value of  ``type``  is   :attr:`Com::Vmware::Vapi::Metadata::Metamodel::ElementValue::Type.LONG`  .
-    # @!attribute [rw] string_value
-    #     @return [String]
-    #     String value of the metadata element.
-    #     This  field  is optional and it is only relevant when the value of  ``type``  is   :attr:`Com::Vmware::Vapi::Metadata::Metamodel::ElementValue::Type.STRING`  .
-    # @!attribute [rw] list_value
-    #     @return [Array<String>]
-    #     List of strings value of the metadata element.
-    #     This  field  is optional and it is only relevant when the value of  ``type``  is   :attr:`Com::Vmware::Vapi::Metadata::Metamodel::ElementValue::Type.STRING_LIST`  .
-    # @!attribute [rw] structure_id
-    #     @return [String]
+    #  The   :class:`Com::Vmware::Vapi::Metadata::Metamodel::StructureInfo`   contains the metamodel information about the structure element. It contains information about all the field elements and enumeration elements contained in this structure element.
+    #
+    # @param structure_id [String]
     #     Identifier of the structure element.
-    #     This  field  is optional and it is only relevant when the value of  ``type``  is   :attr:`Com::Vmware::Vapi::Metadata::Metamodel::ElementValue::Type.STRUCTURE_REFERENCE`  .
-    # @!attribute [rw] structure_ids
-    #     @return [Array<String>]
-    #     List of identifiers of the structure elements.
-    #     This  field  is optional and it is only relevant when the value of  ``type``  is   :attr:`Com::Vmware::Vapi::Metadata::Metamodel::ElementValue::Type.STRUCTURE_REFERENCE_LIST`  .
-    class ElementValue < VAPI::Bindings::VapiStruct
-
-        class << self
-            # Holds (gets or creates) the binding type metadata for this structure type.
-            # @scope class
-            # @return [VAPI::Bindings::StructType] the binding type
-            def binding_type
-                @binding_type ||= VAPI::Bindings::StructType.new(
-                    'com.vmware.vapi.metadata.metamodel.element_value',
-                    {
-                        'type' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Metadata::Metamodel::ElementValue::Type'),
-                        'long_value' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::IntegerType.instance),
-                        'string_value' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::StringType.instance),
-                        'list_value' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::ListType.new(VAPI::Bindings::StringType.instance)),
-                        'structure_id' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::IdType.new),
-                        'structure_ids' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::ListType.new(VAPI::Bindings::IdType.new)),
-                    },
-                    ElementValue,
-                    false,
-                    nil)
-            end
-        end
-
-        attr_accessor :type,
-                      :long_value,
-                      :string_value,
-                      :list_value,
-                      :structure_id,
-                      :structure_ids
-
-        # Constructs a new instance.
-        # @param ruby_values [Hash] a map of initial property values (optional)
-        # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
-        def initialize(ruby_values=nil, struct_value=nil)
-            super(self.class.binding_type, ruby_values, struct_value)
-        end
-
-
-        # The  ``Com::Vmware::Vapi::Metadata::Metamodel::ElementValue::Type``   enumerated type  defines the valid types for values in metadata elements.
-        # @!attribute [rw] long
-        #     @return [Com::Vmware::Vapi::Metadata::Metamodel::ElementValue::Type]
-        #     Indicates the type of the value is a long (64 bit signed integer).
-        # @!attribute [rw] string
-        #     @return [Com::Vmware::Vapi::Metadata::Metamodel::ElementValue::Type]
-        #     Indicates the type of the value is a string (a variable length sequence of characters). The encoding is UTF-8.
-        # @!attribute [rw] string_list
-        #     @return [Com::Vmware::Vapi::Metadata::Metamodel::ElementValue::Type]
-        #     Indicates the type of the value is a list of strings.
-        # @!attribute [rw] structure_reference
-        #     @return [Com::Vmware::Vapi::Metadata::Metamodel::ElementValue::Type]
-        #     Indicates the type of the value is an identifier for a structure element.
-        # @!attribute [rw] structure_reference_list
-        #     @return [Com::Vmware::Vapi::Metadata::Metamodel::ElementValue::Type]
-        #     Indicates the type of the value is a list of identifiers for a structure element.
-        class Type < VAPI::Bindings::VapiEnum
-
-            class << self
-                # Holds (gets or creates) the binding type metadata for this enumeration type.
-                # @scope class
-                # @return [VAPI::Bindings::EnumType] the binding type
-                def binding_type
-                    @binding_type ||= VAPI::Bindings::EnumType.new(
-                        'com.vmware.vapi.metadata.metamodel.element_value.type',
-                        Type)
-                end
-
-                # Converts from a string value (perhaps off the wire) to an instance
-                # of this enum type.
-                # @param value [String] the actual value of the enum instance
-                # @return [Type] the instance found for the value, otherwise
-                #         an unknown instance will be built for the value
-                def from_string(value)
-                    begin
-                        const_get(value)
-                    rescue NameError
-                        Type.new('UNKNOWN', value)
-                    end
-                end
-            end
-
-            private
-
-            # Constructs a new instance.
-            # @param value [String] the actual value of the enum instance
-            # @param unknown [String] the unknown value when value is 'UKNOWN'
-            def initialize(value, unknown=nil)
-                super(self.class.binding_type, value, unknown)
-            end
-
-            public
-
-            # @!attribute [rw] long
-            #     @return [Com::Vmware::Vapi::Metadata::Metamodel::ElementValue::Type]
-            #     Indicates the type of the value is a long (64 bit signed integer).
-            LONG = Type.new('LONG')
-
-            # @!attribute [rw] string
-            #     @return [Com::Vmware::Vapi::Metadata::Metamodel::ElementValue::Type]
-            #     Indicates the type of the value is a string (a variable length sequence of characters). The encoding is UTF-8.
-            STRING = Type.new('STRING')
-
-            # @!attribute [rw] string_list
-            #     @return [Com::Vmware::Vapi::Metadata::Metamodel::ElementValue::Type]
-            #     Indicates the type of the value is a list of strings.
-            STRING_LIST = Type.new('STRING_LIST')
-
-            # @!attribute [rw] structure_reference
-            #     @return [Com::Vmware::Vapi::Metadata::Metamodel::ElementValue::Type]
-            #     Indicates the type of the value is an identifier for a structure element.
-            STRUCTURE_REFERENCE = Type.new('STRUCTURE_REFERENCE')
-
-            # @!attribute [rw] structure_reference_list
-            #     @return [Com::Vmware::Vapi::Metadata::Metamodel::ElementValue::Type]
-            #     Indicates the type of the value is a list of identifiers for a structure element.
-            STRUCTURE_REFERENCE_LIST = Type.new('STRUCTURE_REFERENCE_LIST')
-
-        end
-
-
+    # @return [Com::Vmware::Vapi::Metadata::Metamodel::StructureInfo]
+    #     The   :class:`Com::Vmware::Vapi::Metadata::Metamodel::StructureInfo`   instance that corresponds to  ``structure_id`` .
+    # @raise [Com::Vmware::Vapi::Std::Errors::NotFound]
+    #     if the structure element associated with  ``structure_id``  is not contained in any of the package elements or service elements.
+    def get(structure_id)
+      invoke_with_info(GET_INFO,
+                       'structure_id' => structure_id)
     end
 
-
-    # The  ``Com::Vmware::Vapi::Metadata::Metamodel::EnumerationInfo``   class  contains the metamodel information of an enumeration element.
-    # @!attribute [rw] name
-    #     @return [String]
-    #     Dot separated name of the enumeration element. The segments in the name reflect the organization of the APIs. The format of each segment is lower case with underscores. Each underscore represents a word boundary. If there are acronyms in the word, the capitalization is preserved. This format makes it easy to translate the segment into a different naming convention.
-    # @!attribute [rw] values
-    #     @return [Array<Com::Vmware::Vapi::Metadata::Metamodel::EnumerationValueInfo>]
-    #     Metamodel information of all the enumeration value elements contained in this enumeration element. The order of the enumeration value elements in the list is same as the order in which they are defined in the interface definition file.
-    # @!attribute [rw] metadata
-    #     @return [Hash<String, Com::Vmware::Vapi::Metadata::Metamodel::ElementMap>]
-    #     Generic metadata elements for an enumeration element. The key in the  map  is the name of the metadata element and the value is the data associated with that metadata element.  
-    #     
-    #      The   :class:`Com::Vmware::Vapi::Metadata::Metamodel::MetadataIdentifier`   contains possible string values for keys in the  map .
-    # @!attribute [rw] documentation
-    #     @return [String]
-    #     English language documentation for an enumeration element. It can contain HTML markup and Javadoc tags. The first sentence of the enumeration documentation is a complete sentence that identifies the enumeration by name and summarizes the purpose of the enumeration. The documentation describes the context in which the enumeration is used.  
-    #     
-    #      The documentation also contains references to the context in which the enumeration is used. But if the enumeration is used in many contexts, the references may not be present.
-    class EnumerationInfo < VAPI::Bindings::VapiStruct
-
-        class << self
-            # Holds (gets or creates) the binding type metadata for this structure type.
-            # @scope class
-            # @return [VAPI::Bindings::StructType] the binding type
-            def binding_type
-                @binding_type ||= VAPI::Bindings::StructType.new(
-                    'com.vmware.vapi.metadata.metamodel.enumeration_info',
-                    {
-                        'name' => VAPI::Bindings::StringType.instance,
-                        'values' => VAPI::Bindings::ListType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Metadata::Metamodel::EnumerationValueInfo')),
-                        'metadata' => VAPI::Bindings::MapType.new(VAPI::Bindings::StringType.instance, VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Metadata::Metamodel::ElementMap')),
-                        'documentation' => VAPI::Bindings::StringType.instance,
-                    },
-                    EnumerationInfo,
-                    false,
-                    nil)
-            end
-        end
-
-        attr_accessor :name,
-                      :values,
-                      :metadata,
-                      :documentation
-
-        # Constructs a new instance.
-        # @param ruby_values [Hash] a map of initial property values (optional)
-        # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
-        def initialize(ruby_values=nil, struct_value=nil)
-            super(self.class.binding_type, ruby_values, struct_value)
-        end
+  end
+  # The  ``Com::Vmware::Vapi::Metadata::Metamodel::ComponentData``   class  contains the metamodel metadata information of a component element along with its fingerprint.
+  # @!attribute [rw] info
+  #     @return [Com::Vmware::Vapi::Metadata::Metamodel::ComponentInfo]
+  #     Metamodel information of the component element. This includes information about all the package elements contained in this component element.  
+  #     
+  #      The metamodel information about a component could be quite large if there are a lot of package elements contained in this component.
+  # @!attribute [rw] fingerprint
+  #     @return [String]
+  #     Fingerprint of the metamodel metadata of the component component.  
+  #     
+  #      Metamodel information could change when there is an infrastructure update and new functionality is added to an existing component.  
+  #     
+  #      Since the data present in   :attr:`Com::Vmware::Vapi::Metadata::Metamodel::ComponentData.info`   could be quite large,  ``fingerprint``  provides a convenient way to check if the data for a particular component is updated.  
+  #     
+  #      You should store the fingerprint associated with a component. After an update, by invoking the   :func:`Com::Vmware::Vapi::Metadata::Metamodel::Component.fingerprint`    method , you can retrieve the new fingerprint for the component. If the new fingerprint and the previously stored fingerprint do not match, clients can use the   :func:`Com::Vmware::Vapi::Metadata::Metamodel::Component.get`   to retrieve the new metamodel information for the component.
+  class ComponentData < VAPI::Bindings::VapiStruct
+    class << self
+      # Holds (gets or creates) the binding type metadata for this structure type.
+      # @scope class
+      # @return [VAPI::Bindings::StructType] the binding type
+      def binding_type
+        @binding_type ||= VAPI::Bindings::StructType.new(
+          'com.vmware.vapi.metadata.metamodel.component_data',
+          {
+            'info' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Metadata::Metamodel::ComponentInfo'),
+            'fingerprint' => VAPI::Bindings::StringType.instance
+          },
+          ComponentData,
+          false,
+          nil
+        )
+      end
     end
 
+    attr_accessor :info,
+                  :fingerprint
 
-    # The  ``Com::Vmware::Vapi::Metadata::Metamodel::EnumerationValueInfo``   class  describes the  enumeration value  in the  enumerated type .
-    # @!attribute [rw] value
-    #     @return [String]
-    #     Value in the enumerated type. All the characters in the string are capitalized.
-    # @!attribute [rw] metadata
-    #     @return [Hash<String, Com::Vmware::Vapi::Metadata::Metamodel::ElementMap>]
-    #     Additional metadata for enumeration value in the enumerated type. The key in the  map  is the name of the metadata element and the value is the data associated with that metadata element.  
-    #     
-    #      The   :class:`Com::Vmware::Vapi::Metadata::Metamodel::MetadataIdentifier`   contains possible string values for keys in the  map .
-    # @!attribute [rw] documentation
-    #     @return [String]
-    #     English language documentation for an enumeration value. It can contain HTML markup and documentation tags (similar to Javadoc tags). The first statement will be a noun or verb phrase that describes the purpose of the enumeration value.
-    class EnumerationValueInfo < VAPI::Bindings::VapiStruct
-
-        class << self
-            # Holds (gets or creates) the binding type metadata for this structure type.
-            # @scope class
-            # @return [VAPI::Bindings::StructType] the binding type
-            def binding_type
-                @binding_type ||= VAPI::Bindings::StructType.new(
-                    'com.vmware.vapi.metadata.metamodel.enumeration_value_info',
-                    {
-                        'value' => VAPI::Bindings::StringType.instance,
-                        'metadata' => VAPI::Bindings::MapType.new(VAPI::Bindings::StringType.instance, VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Metadata::Metamodel::ElementMap')),
-                        'documentation' => VAPI::Bindings::StringType.instance,
-                    },
-                    EnumerationValueInfo,
-                    false,
-                    nil)
-            end
-        end
-
-        attr_accessor :value,
-                      :metadata,
-                      :documentation
-
-        # Constructs a new instance.
-        # @param ruby_values [Hash] a map of initial property values (optional)
-        # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
-        def initialize(ruby_values=nil, struct_value=nil)
-            super(self.class.binding_type, ruby_values, struct_value)
-        end
+    # Constructs a new instance.
+    # @param ruby_values [Hash] a map of initial property values (optional)
+    # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
+    def initialize(ruby_values = nil, struct_value = nil)
+      super(self.class.binding_type, ruby_values, struct_value)
+    end
+  end
+  # The  ``Com::Vmware::Vapi::Metadata::Metamodel::ComponentInfo``   class  contains metamodel metadata information about a component element.
+  # @!attribute [rw] name
+  #     @return [String]
+  #     Dot separated name of the component element. The segments in the name reflect the organization of the APIs. The format of each segment is lower case with underscores. Each underscore represents a word boundary. If there are acronyms in the word, the capitalization is preserved. This format makes it easy to translate the segment into a different naming convention.
+  # @!attribute [rw] packages
+  #     @return [Hash<String, Com::Vmware::Vapi::Metadata::Metamodel::PackageInfo>]
+  #     Metamodel metadata information of all the package elements contained in the component element. The key in the  map  is the identifier of the package element and the value in the  map  is the metamodel information of the package element.
+  # @!attribute [rw] metadata
+  #     @return [Hash<String, Com::Vmware::Vapi::Metadata::Metamodel::ElementMap>]
+  #     Generic metadata for the component element. The key in the  map  is the name of the metadata element and the value is the data associated with that metadata element.  
+  #     
+  #      The   :class:`Com::Vmware::Vapi::Metadata::Metamodel::MetadataIdentifier`   contains possible string values for keys in the  map .
+  # @!attribute [rw] documentation
+  #     @return [String]
+  #     English language documentation for a component. It can contain HTML markup and documentation tags (similar to Javadoc tags). The first sentence of the package documentation is a complete sentence that identifies the component by name and summarizes the purpose of the component.
+  class ComponentInfo < VAPI::Bindings::VapiStruct
+    class << self
+      # Holds (gets or creates) the binding type metadata for this structure type.
+      # @scope class
+      # @return [VAPI::Bindings::StructType] the binding type
+      def binding_type
+        @binding_type ||= VAPI::Bindings::StructType.new(
+          'com.vmware.vapi.metadata.metamodel.component_info',
+          {
+            'name' => VAPI::Bindings::StringType.instance,
+            'packages' => VAPI::Bindings::MapType.new(VAPI::Bindings::IdType.new, VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Metadata::Metamodel::PackageInfo')),
+            'metadata' => VAPI::Bindings::MapType.new(VAPI::Bindings::StringType.instance, VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Metadata::Metamodel::ElementMap')),
+            'documentation' => VAPI::Bindings::StringType.instance
+          },
+          ComponentInfo,
+          false,
+          nil
+        )
+      end
     end
 
+    attr_accessor :name,
+                  :packages,
+                  :metadata,
+                  :documentation
 
-    # The  ``Com::Vmware::Vapi::Metadata::Metamodel::ErrorInfo``   class  contains the metadata information about the error elements contained in an operation element.
-    # @!attribute [rw] structure_id
-    #     @return [String]
-    #     Identifier for the structure element corresponding to the error that is being reported by the operation.
-    # @!attribute [rw] documentation
-    #     @return [String]
-    #     The English language documentation for the service element. It can contain HTML markup and Javadoc tags.
-    class ErrorInfo < VAPI::Bindings::VapiStruct
-
-        class << self
-            # Holds (gets or creates) the binding type metadata for this structure type.
-            # @scope class
-            # @return [VAPI::Bindings::StructType] the binding type
-            def binding_type
-                @binding_type ||= VAPI::Bindings::StructType.new(
-                    'com.vmware.vapi.metadata.metamodel.error_info',
-                    {
-                        'structure_id' => VAPI::Bindings::IdType.new(resource_types='com.vmware.vapi.structure'),
-                        'documentation' => VAPI::Bindings::StringType.instance,
-                    },
-                    ErrorInfo,
-                    false,
-                    nil)
-            end
-        end
-
-        attr_accessor :structure_id,
-                      :documentation
-
-        # Constructs a new instance.
-        # @param ruby_values [Hash] a map of initial property values (optional)
-        # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
-        def initialize(ruby_values=nil, struct_value=nil)
-            super(self.class.binding_type, ruby_values, struct_value)
-        end
+    # Constructs a new instance.
+    # @param ruby_values [Hash] a map of initial property values (optional)
+    # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
+    def initialize(ruby_values = nil, struct_value = nil)
+      super(self.class.binding_type, ruby_values, struct_value)
+    end
+  end
+  # The  ``Com::Vmware::Vapi::Metadata::Metamodel::ConstantInfo``   class  contains metamodel information of the constant elements.
+  # @!attribute [rw] type
+  #     @return [Com::Vmware::Vapi::Metadata::Metamodel::Type]
+  #     Type of the constant element.
+  # @!attribute [rw] value
+  #     @return [Com::Vmware::Vapi::Metadata::Metamodel::ConstantValue]
+  #     Value of the constant element.
+  # @!attribute [rw] documentation
+  #     @return [String]
+  #     English language documentation for the constant element. It can contain HTML markup and documentation tags (similar to Javadoc tags).
+  class ConstantInfo < VAPI::Bindings::VapiStruct
+    class << self
+      # Holds (gets or creates) the binding type metadata for this structure type.
+      # @scope class
+      # @return [VAPI::Bindings::StructType] the binding type
+      def binding_type
+        @binding_type ||= VAPI::Bindings::StructType.new(
+          'com.vmware.vapi.metadata.metamodel.constant_info',
+          {
+            'type' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Metadata::Metamodel::Type'),
+            'value' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Metadata::Metamodel::ConstantValue'),
+            'documentation' => VAPI::Bindings::StringType.instance
+          },
+          ConstantInfo,
+          false,
+          nil
+        )
+      end
     end
 
+    attr_accessor :type,
+                  :value,
+                  :documentation
 
-    # The  ``Com::Vmware::Vapi::Metadata::Metamodel::FieldInfo``   class  contains metamodel information of a field element contained in a structure element.
-    # @!attribute [rw] name
-    #     @return [String]
-    #     Name of the field element in a canonical format. The format is lower case with underscores. Each underscore represents a word boundary. If there are acronyms in the word, the capitalization is preserved. This format makes it easy to translate the segment into a different naming convention.
-    # @!attribute [rw] type
-    #     @return [Com::Vmware::Vapi::Metadata::Metamodel::Type]
-    #     Type information.
-    # @!attribute [rw] metadata
-    #     @return [Hash<String, Com::Vmware::Vapi::Metadata::Metamodel::ElementMap>]
-    #     Generic metadata elements for the field element. The key in the  map  is the name of the metadata element and the value is the data associated with that metadata element.  
-    #     
-    #      The   :class:`Com::Vmware::Vapi::Metadata::Metamodel::MetadataIdentifier`   contains possible string values for keys in the  map .
-    # @!attribute [rw] documentation
-    #     @return [String]
-    #     English language documentation for the service element. It can contain HTML markup and Javadoc tags.
-    class FieldInfo < VAPI::Bindings::VapiStruct
-
-        class << self
-            # Holds (gets or creates) the binding type metadata for this structure type.
-            # @scope class
-            # @return [VAPI::Bindings::StructType] the binding type
-            def binding_type
-                @binding_type ||= VAPI::Bindings::StructType.new(
-                    'com.vmware.vapi.metadata.metamodel.field_info',
-                    {
-                        'name' => VAPI::Bindings::StringType.instance,
-                        'type' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Metadata::Metamodel::Type'),
-                        'metadata' => VAPI::Bindings::MapType.new(VAPI::Bindings::StringType.instance, VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Metadata::Metamodel::ElementMap')),
-                        'documentation' => VAPI::Bindings::StringType.instance,
-                    },
-                    FieldInfo,
-                    false,
-                    nil)
-            end
-        end
-
-        attr_accessor :name,
-                      :type,
-                      :metadata,
-                      :documentation
-
-        # Constructs a new instance.
-        # @param ruby_values [Hash] a map of initial property values (optional)
-        # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
-        def initialize(ruby_values=nil, struct_value=nil)
-            super(self.class.binding_type, ruby_values, struct_value)
-        end
+    # Constructs a new instance.
+    # @param ruby_values [Hash] a map of initial property values (optional)
+    # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
+    def initialize(ruby_values = nil, struct_value = nil)
+      super(self.class.binding_type, ruby_values, struct_value)
+    end
+  end
+  # The  ``Com::Vmware::Vapi::Metadata::Metamodel::ConstantValue``   class  contains the metamodel information of the constant element.
+  # @!attribute [rw] category
+  #     @return [Com::Vmware::Vapi::Metadata::Metamodel::ConstantValue::Category]
+  #     Category of the type of constant value.
+  # @!attribute [rw] primitive_value
+  #     @return [Com::Vmware::Vapi::Metadata::Metamodel::PrimitiveValue]
+  #     Primitive value of the constant element.
+  #     This  field  is optional and it is only relevant when the value of  ``category``  is   :attr:`Com::Vmware::Vapi::Metadata::Metamodel::ConstantValue::Category.PRIMITIVE`  .
+  # @!attribute [rw] list_value
+  #     @return [Array<Com::Vmware::Vapi::Metadata::Metamodel::PrimitiveValue>]
+  #     List value of the constant element.
+  #     This  field  is optional and it is only relevant when the value of  ``category``  is   :attr:`Com::Vmware::Vapi::Metadata::Metamodel::ConstantValue::Category.LIST`  .
+  class ConstantValue < VAPI::Bindings::VapiStruct
+    class << self
+      # Holds (gets or creates) the binding type metadata for this structure type.
+      # @scope class
+      # @return [VAPI::Bindings::StructType] the binding type
+      def binding_type
+        @binding_type ||= VAPI::Bindings::StructType.new(
+          'com.vmware.vapi.metadata.metamodel.constant_value',
+          {
+            'category' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Metadata::Metamodel::ConstantValue::Category'),
+            'primitive_value' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Metadata::Metamodel::PrimitiveValue')),
+            'list_value' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::ListType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Metadata::Metamodel::PrimitiveValue')))
+          },
+          ConstantValue,
+          false,
+          nil
+        )
+      end
     end
 
+    attr_accessor :category,
+                  :primitive_value,
+                  :list_value
 
-    # The  ``Com::Vmware::Vapi::Metadata::Metamodel::GenericInstantiation``   class  describes the type information of a typed element when the type is an instantiation of one of the generic types provided by the infrastructure.
-    # @!attribute [rw] generic_type
+    # Constructs a new instance.
+    # @param ruby_values [Hash] a map of initial property values (optional)
+    # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
+    def initialize(ruby_values = nil, struct_value = nil)
+      super(self.class.binding_type, ruby_values, struct_value)
+    end
+
+    # The  ``Com::Vmware::Vapi::Metadata::Metamodel::ConstantValue::Category``   enumerated type  defines  enumeration values  for the valid kinds of values.
+    # @!attribute [rw] primitive
+    #     @return [Com::Vmware::Vapi::Metadata::Metamodel::ConstantValue::Category]
+    #     Indicates the type of constant value is primitive.
+    # @!attribute [rw] list
+    #     @return [Com::Vmware::Vapi::Metadata::Metamodel::ConstantValue::Category]
+    #     Indicates the type of constant value is a list.
+    class Category < VAPI::Bindings::VapiEnum
+      class << self
+        # Holds (gets or creates) the binding type metadata for this enumeration type.
+        # @scope class
+        # @return [VAPI::Bindings::EnumType] the binding type
+        def binding_type
+          @binding_type ||= VAPI::Bindings::EnumType.new(
+            'com.vmware.vapi.metadata.metamodel.constant_value.category',
+            Category
+          )
+        end
+
+        # Converts from a string value (perhaps off the wire) to an instance
+        # of this enum type.
+        # @param value [String] the actual value of the enum instance
+        # @return [Category] the instance found for the value, otherwise
+        #         an unknown instance will be built for the value
+        def from_string(value)
+          const_get(value)
+        rescue NameError
+          Category.send(:new, 'UNKNOWN', value)
+        end
+      end
+
+      # Constructs a new instance.
+      # @param value [String] the actual value of the enum instance
+      # @param unknown [String] the unknown value when value is 'UKNOWN'
+      def initialize(value, unknown = nil)
+        super(self.class.binding_type, value, unknown)
+      end
+
+      private_class_method :new
+
+      # @!attribute [rw] primitive
+      #     @return [Com::Vmware::Vapi::Metadata::Metamodel::ConstantValue::Category]
+      #     Indicates the type of constant value is primitive.
+      PRIMITIVE = Category.send(:new, 'PRIMITIVE')
+
+      # @!attribute [rw] list
+      #     @return [Com::Vmware::Vapi::Metadata::Metamodel::ConstantValue::Category]
+      #     Indicates the type of constant value is a list.
+      LIST = Category.send(:new, 'LIST')
+    end
+  end
+  # The  ``Com::Vmware::Vapi::Metadata::Metamodel::ElementMap``   class  contains the metadata elements.  
+  # 
+  #  One of the sources for metadata is the annotations present in the interface definition language. When an annotation is represented in the  ``Com::Vmware::Vapi::Metadata::Metamodel::ElementMap`` ,  ``Com::Vmware::Vapi::Metadata::Metamodel::ElementMap``  describes the data specified in the arguments for the annotation.  
+  # 
+  #  For example, in  ``\@UnionCase(tag="tag", value="SELECT")`` , ElementMap describes the keyword arguments tag and value.
+  # @!attribute [rw] elements
+  #     @return [Hash<String, Com::Vmware::Vapi::Metadata::Metamodel::ElementValue>]
+  #     Metamodel information of the metadata elements. The key parameter of the  map  is the identifier for the element and the value corresponds to the element value.
+  class ElementMap < VAPI::Bindings::VapiStruct
+    class << self
+      # Holds (gets or creates) the binding type metadata for this structure type.
+      # @scope class
+      # @return [VAPI::Bindings::StructType] the binding type
+      def binding_type
+        @binding_type ||= VAPI::Bindings::StructType.new(
+          'com.vmware.vapi.metadata.metamodel.element_map',
+          {
+            'elements' => VAPI::Bindings::MapType.new(VAPI::Bindings::StringType.instance, VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Metadata::Metamodel::ElementValue'))
+          },
+          ElementMap,
+          false,
+          nil
+        )
+      end
+    end
+
+    attr_accessor :elements
+
+    # Constructs a new instance.
+    # @param ruby_values [Hash] a map of initial property values (optional)
+    # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
+    def initialize(ruby_values = nil, struct_value = nil)
+      super(self.class.binding_type, ruby_values, struct_value)
+    end
+  end
+  # The  ``Com::Vmware::Vapi::Metadata::Metamodel::ElementValue``   class  describes the value of the metadata element.
+  # @!attribute [rw] type
+  #     @return [Com::Vmware::Vapi::Metadata::Metamodel::ElementValue::Type]
+  #     Type of the value.
+  # @!attribute [rw] long_value
+  #     @return [Fixnum]
+  #     Long value of the metadata element.
+  #     This  field  is optional and it is only relevant when the value of  ``type``  is   :attr:`Com::Vmware::Vapi::Metadata::Metamodel::ElementValue::Type.LONG`  .
+  # @!attribute [rw] string_value
+  #     @return [String]
+  #     String value of the metadata element.
+  #     This  field  is optional and it is only relevant when the value of  ``type``  is   :attr:`Com::Vmware::Vapi::Metadata::Metamodel::ElementValue::Type.STRING`  .
+  # @!attribute [rw] list_value
+  #     @return [Array<String>]
+  #     List of strings value of the metadata element.
+  #     This  field  is optional and it is only relevant when the value of  ``type``  is   :attr:`Com::Vmware::Vapi::Metadata::Metamodel::ElementValue::Type.STRING_LIST`  .
+  # @!attribute [rw] structure_id
+  #     @return [String]
+  #     Identifier of the structure element.
+  #     This  field  is optional and it is only relevant when the value of  ``type``  is   :attr:`Com::Vmware::Vapi::Metadata::Metamodel::ElementValue::Type.STRUCTURE_REFERENCE`  .
+  # @!attribute [rw] structure_ids
+  #     @return [Array<String>]
+  #     List of identifiers of the structure elements.
+  #     This  field  is optional and it is only relevant when the value of  ``type``  is   :attr:`Com::Vmware::Vapi::Metadata::Metamodel::ElementValue::Type.STRUCTURE_REFERENCE_LIST`  .
+  class ElementValue < VAPI::Bindings::VapiStruct
+    class << self
+      # Holds (gets or creates) the binding type metadata for this structure type.
+      # @scope class
+      # @return [VAPI::Bindings::StructType] the binding type
+      def binding_type
+        @binding_type ||= VAPI::Bindings::StructType.new(
+          'com.vmware.vapi.metadata.metamodel.element_value',
+          {
+            'type' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Metadata::Metamodel::ElementValue::Type'),
+            'long_value' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::IntegerType.instance),
+            'string_value' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::StringType.instance),
+            'list_value' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::ListType.new(VAPI::Bindings::StringType.instance)),
+            'structure_id' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::IdType.new),
+            'structure_ids' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::ListType.new(VAPI::Bindings::IdType.new))
+          },
+          ElementValue,
+          false,
+          nil
+        )
+      end
+    end
+
+    attr_accessor :type,
+                  :long_value,
+                  :string_value,
+                  :list_value,
+                  :structure_id,
+                  :structure_ids
+
+    # Constructs a new instance.
+    # @param ruby_values [Hash] a map of initial property values (optional)
+    # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
+    def initialize(ruby_values = nil, struct_value = nil)
+      super(self.class.binding_type, ruby_values, struct_value)
+    end
+
+    # The  ``Com::Vmware::Vapi::Metadata::Metamodel::ElementValue::Type``   enumerated type  defines the valid types for values in metadata elements.
+    # @!attribute [rw] long
+    #     @return [Com::Vmware::Vapi::Metadata::Metamodel::ElementValue::Type]
+    #     Indicates the type of the value is a long (64 bit signed integer).
+    # @!attribute [rw] string
+    #     @return [Com::Vmware::Vapi::Metadata::Metamodel::ElementValue::Type]
+    #     Indicates the type of the value is a string (a variable length sequence of characters). The encoding is UTF-8.
+    # @!attribute [rw] string_list
+    #     @return [Com::Vmware::Vapi::Metadata::Metamodel::ElementValue::Type]
+    #     Indicates the type of the value is a list of strings.
+    # @!attribute [rw] structure_reference
+    #     @return [Com::Vmware::Vapi::Metadata::Metamodel::ElementValue::Type]
+    #     Indicates the type of the value is an identifier for a structure element.
+    # @!attribute [rw] structure_reference_list
+    #     @return [Com::Vmware::Vapi::Metadata::Metamodel::ElementValue::Type]
+    #     Indicates the type of the value is a list of identifiers for a structure element.
+    class Type < VAPI::Bindings::VapiEnum
+      class << self
+        # Holds (gets or creates) the binding type metadata for this enumeration type.
+        # @scope class
+        # @return [VAPI::Bindings::EnumType] the binding type
+        def binding_type
+          @binding_type ||= VAPI::Bindings::EnumType.new(
+            'com.vmware.vapi.metadata.metamodel.element_value.type',
+            Type
+          )
+        end
+
+        # Converts from a string value (perhaps off the wire) to an instance
+        # of this enum type.
+        # @param value [String] the actual value of the enum instance
+        # @return [Type] the instance found for the value, otherwise
+        #         an unknown instance will be built for the value
+        def from_string(value)
+          const_get(value)
+        rescue NameError
+          Type.send(:new, 'UNKNOWN', value)
+        end
+      end
+
+      # Constructs a new instance.
+      # @param value [String] the actual value of the enum instance
+      # @param unknown [String] the unknown value when value is 'UKNOWN'
+      def initialize(value, unknown = nil)
+        super(self.class.binding_type, value, unknown)
+      end
+
+      private_class_method :new
+
+      # @!attribute [rw] long
+      #     @return [Com::Vmware::Vapi::Metadata::Metamodel::ElementValue::Type]
+      #     Indicates the type of the value is a long (64 bit signed integer).
+      LONG = Type.send(:new, 'LONG')
+
+      # @!attribute [rw] string
+      #     @return [Com::Vmware::Vapi::Metadata::Metamodel::ElementValue::Type]
+      #     Indicates the type of the value is a string (a variable length sequence of characters). The encoding is UTF-8.
+      STRING = Type.send(:new, 'STRING')
+
+      # @!attribute [rw] string_list
+      #     @return [Com::Vmware::Vapi::Metadata::Metamodel::ElementValue::Type]
+      #     Indicates the type of the value is a list of strings.
+      STRING_LIST = Type.send(:new, 'STRING_LIST')
+
+      # @!attribute [rw] structure_reference
+      #     @return [Com::Vmware::Vapi::Metadata::Metamodel::ElementValue::Type]
+      #     Indicates the type of the value is an identifier for a structure element.
+      STRUCTURE_REFERENCE = Type.send(:new, 'STRUCTURE_REFERENCE')
+
+      # @!attribute [rw] structure_reference_list
+      #     @return [Com::Vmware::Vapi::Metadata::Metamodel::ElementValue::Type]
+      #     Indicates the type of the value is a list of identifiers for a structure element.
+      STRUCTURE_REFERENCE_LIST = Type.send(:new, 'STRUCTURE_REFERENCE_LIST')
+    end
+  end
+  # The  ``Com::Vmware::Vapi::Metadata::Metamodel::EnumerationInfo``   class  contains the metamodel information of an enumeration element.
+  # @!attribute [rw] name
+  #     @return [String]
+  #     Dot separated name of the enumeration element. The segments in the name reflect the organization of the APIs. The format of each segment is lower case with underscores. Each underscore represents a word boundary. If there are acronyms in the word, the capitalization is preserved. This format makes it easy to translate the segment into a different naming convention.
+  # @!attribute [rw] values
+  #     @return [Array<Com::Vmware::Vapi::Metadata::Metamodel::EnumerationValueInfo>]
+  #     Metamodel information of all the enumeration value elements contained in this enumeration element. The order of the enumeration value elements in the list is same as the order in which they are defined in the interface definition file.
+  # @!attribute [rw] metadata
+  #     @return [Hash<String, Com::Vmware::Vapi::Metadata::Metamodel::ElementMap>]
+  #     Generic metadata elements for an enumeration element. The key in the  map  is the name of the metadata element and the value is the data associated with that metadata element.  
+  #     
+  #      The   :class:`Com::Vmware::Vapi::Metadata::Metamodel::MetadataIdentifier`   contains possible string values for keys in the  map .
+  # @!attribute [rw] documentation
+  #     @return [String]
+  #     English language documentation for an enumeration element. It can contain HTML markup and Javadoc tags. The first sentence of the enumeration documentation is a complete sentence that identifies the enumeration by name and summarizes the purpose of the enumeration. The documentation describes the context in which the enumeration is used.  
+  #     
+  #      The documentation also contains references to the context in which the enumeration is used. But if the enumeration is used in many contexts, the references may not be present.
+  class EnumerationInfo < VAPI::Bindings::VapiStruct
+    class << self
+      # Holds (gets or creates) the binding type metadata for this structure type.
+      # @scope class
+      # @return [VAPI::Bindings::StructType] the binding type
+      def binding_type
+        @binding_type ||= VAPI::Bindings::StructType.new(
+          'com.vmware.vapi.metadata.metamodel.enumeration_info',
+          {
+            'name' => VAPI::Bindings::StringType.instance,
+            'values' => VAPI::Bindings::ListType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Metadata::Metamodel::EnumerationValueInfo')),
+            'metadata' => VAPI::Bindings::MapType.new(VAPI::Bindings::StringType.instance, VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Metadata::Metamodel::ElementMap')),
+            'documentation' => VAPI::Bindings::StringType.instance
+          },
+          EnumerationInfo,
+          false,
+          nil
+        )
+      end
+    end
+
+    attr_accessor :name,
+                  :values,
+                  :metadata,
+                  :documentation
+
+    # Constructs a new instance.
+    # @param ruby_values [Hash] a map of initial property values (optional)
+    # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
+    def initialize(ruby_values = nil, struct_value = nil)
+      super(self.class.binding_type, ruby_values, struct_value)
+    end
+  end
+  # The  ``Com::Vmware::Vapi::Metadata::Metamodel::EnumerationValueInfo``   class  describes the  enumeration value  in the  enumerated type .
+  # @!attribute [rw] value
+  #     @return [String]
+  #     Value in the enumerated type. All the characters in the string are capitalized.
+  # @!attribute [rw] metadata
+  #     @return [Hash<String, Com::Vmware::Vapi::Metadata::Metamodel::ElementMap>]
+  #     Additional metadata for enumeration value in the enumerated type. The key in the  map  is the name of the metadata element and the value is the data associated with that metadata element.  
+  #     
+  #      The   :class:`Com::Vmware::Vapi::Metadata::Metamodel::MetadataIdentifier`   contains possible string values for keys in the  map .
+  # @!attribute [rw] documentation
+  #     @return [String]
+  #     English language documentation for an enumeration value. It can contain HTML markup and documentation tags (similar to Javadoc tags). The first statement will be a noun or verb phrase that describes the purpose of the enumeration value.
+  class EnumerationValueInfo < VAPI::Bindings::VapiStruct
+    class << self
+      # Holds (gets or creates) the binding type metadata for this structure type.
+      # @scope class
+      # @return [VAPI::Bindings::StructType] the binding type
+      def binding_type
+        @binding_type ||= VAPI::Bindings::StructType.new(
+          'com.vmware.vapi.metadata.metamodel.enumeration_value_info',
+          {
+            'value' => VAPI::Bindings::StringType.instance,
+            'metadata' => VAPI::Bindings::MapType.new(VAPI::Bindings::StringType.instance, VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Metadata::Metamodel::ElementMap')),
+            'documentation' => VAPI::Bindings::StringType.instance
+          },
+          EnumerationValueInfo,
+          false,
+          nil
+        )
+      end
+    end
+
+    attr_accessor :value,
+                  :metadata,
+                  :documentation
+
+    # Constructs a new instance.
+    # @param ruby_values [Hash] a map of initial property values (optional)
+    # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
+    def initialize(ruby_values = nil, struct_value = nil)
+      super(self.class.binding_type, ruby_values, struct_value)
+    end
+  end
+  # The  ``Com::Vmware::Vapi::Metadata::Metamodel::ErrorInfo``   class  contains the metadata information about the error elements contained in an operation element.
+  # @!attribute [rw] structure_id
+  #     @return [String]
+  #     Identifier for the structure element corresponding to the error that is being reported by the operation.
+  # @!attribute [rw] documentation
+  #     @return [String]
+  #     The English language documentation for the service element. It can contain HTML markup and Javadoc tags.
+  class ErrorInfo < VAPI::Bindings::VapiStruct
+    class << self
+      # Holds (gets or creates) the binding type metadata for this structure type.
+      # @scope class
+      # @return [VAPI::Bindings::StructType] the binding type
+      def binding_type
+        @binding_type ||= VAPI::Bindings::StructType.new(
+          'com.vmware.vapi.metadata.metamodel.error_info',
+          {
+            'structure_id' => VAPI::Bindings::IdType.new('com.vmware.vapi.structure'),
+            'documentation' => VAPI::Bindings::StringType.instance
+          },
+          ErrorInfo,
+          false,
+          nil
+        )
+      end
+    end
+
+    attr_accessor :structure_id,
+                  :documentation
+
+    # Constructs a new instance.
+    # @param ruby_values [Hash] a map of initial property values (optional)
+    # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
+    def initialize(ruby_values = nil, struct_value = nil)
+      super(self.class.binding_type, ruby_values, struct_value)
+    end
+  end
+  # The  ``Com::Vmware::Vapi::Metadata::Metamodel::FieldInfo``   class  contains metamodel information of a field element contained in a structure element.
+  # @!attribute [rw] name
+  #     @return [String]
+  #     Name of the field element in a canonical format. The format is lower case with underscores. Each underscore represents a word boundary. If there are acronyms in the word, the capitalization is preserved. This format makes it easy to translate the segment into a different naming convention.
+  # @!attribute [rw] type
+  #     @return [Com::Vmware::Vapi::Metadata::Metamodel::Type]
+  #     Type information.
+  # @!attribute [rw] metadata
+  #     @return [Hash<String, Com::Vmware::Vapi::Metadata::Metamodel::ElementMap>]
+  #     Generic metadata elements for the field element. The key in the  map  is the name of the metadata element and the value is the data associated with that metadata element.  
+  #     
+  #      The   :class:`Com::Vmware::Vapi::Metadata::Metamodel::MetadataIdentifier`   contains possible string values for keys in the  map .
+  # @!attribute [rw] documentation
+  #     @return [String]
+  #     English language documentation for the service element. It can contain HTML markup and Javadoc tags.
+  class FieldInfo < VAPI::Bindings::VapiStruct
+    class << self
+      # Holds (gets or creates) the binding type metadata for this structure type.
+      # @scope class
+      # @return [VAPI::Bindings::StructType] the binding type
+      def binding_type
+        @binding_type ||= VAPI::Bindings::StructType.new(
+          'com.vmware.vapi.metadata.metamodel.field_info',
+          {
+            'name' => VAPI::Bindings::StringType.instance,
+            'type' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Metadata::Metamodel::Type'),
+            'metadata' => VAPI::Bindings::MapType.new(VAPI::Bindings::StringType.instance, VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Metadata::Metamodel::ElementMap')),
+            'documentation' => VAPI::Bindings::StringType.instance
+          },
+          FieldInfo,
+          false,
+          nil
+        )
+      end
+    end
+
+    attr_accessor :name,
+                  :type,
+                  :metadata,
+                  :documentation
+
+    # Constructs a new instance.
+    # @param ruby_values [Hash] a map of initial property values (optional)
+    # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
+    def initialize(ruby_values = nil, struct_value = nil)
+      super(self.class.binding_type, ruby_values, struct_value)
+    end
+  end
+  # The  ``Com::Vmware::Vapi::Metadata::Metamodel::GenericInstantiation``   class  describes the type information of a typed element when the type is an instantiation of one of the generic types provided by the infrastructure.
+  # @!attribute [rw] generic_type
+  #     @return [Com::Vmware::Vapi::Metadata::Metamodel::GenericInstantiation::GenericType]
+  #     The generic type that is being instantiated.
+  # @!attribute [rw] element_type
+  #     @return [Com::Vmware::Vapi::Metadata::Metamodel::Type]
+  #     Type of the element parameter if the generic type instantiation is a   :attr:`Com::Vmware::Vapi::Metadata::Metamodel::GenericInstantiation::GenericType.LIST`  ,   :attr:`Com::Vmware::Vapi::Metadata::Metamodel::GenericInstantiation::GenericType.OPTIONAL`   or   :attr:`Com::Vmware::Vapi::Metadata::Metamodel::GenericInstantiation::GenericType.SET`  .
+  #     This  field  is optional and it is only relevant when the value of  ``genericType``  is one of   :attr:`Com::Vmware::Vapi::Metadata::Metamodel::GenericInstantiation::GenericType.LIST`  ,   :attr:`Com::Vmware::Vapi::Metadata::Metamodel::GenericInstantiation::GenericType.OPTIONAL`  , or   :attr:`Com::Vmware::Vapi::Metadata::Metamodel::GenericInstantiation::GenericType.SET`  .
+  # @!attribute [rw] map_key_type
+  #     @return [Com::Vmware::Vapi::Metadata::Metamodel::Type]
+  #     Type of the key parameter of the map generic type instantiation. The map generic type has a key parameter and value parameter. The type of the value parameter is described by   :attr:`Com::Vmware::Vapi::Metadata::Metamodel::GenericInstantiation.map_value_type`  ..
+  #     This  field  is optional and it is only relevant when the value of  ``genericType``  is   :attr:`Com::Vmware::Vapi::Metadata::Metamodel::GenericInstantiation::GenericType.MAP`  .
+  # @!attribute [rw] map_value_type
+  #     @return [Com::Vmware::Vapi::Metadata::Metamodel::Type]
+  #     Type of the value parameter of the map generic type instantiation. The map generic type has a key parameter and value parameter. The type of the key parameter is described by   :attr:`Com::Vmware::Vapi::Metadata::Metamodel::GenericInstantiation.map_key_type`  ..
+  #     This  field  is optional and it is only relevant when the value of  ``genericType``  is   :attr:`Com::Vmware::Vapi::Metadata::Metamodel::GenericInstantiation::GenericType.MAP`  .
+  class GenericInstantiation < VAPI::Bindings::VapiStruct
+    class << self
+      # Holds (gets or creates) the binding type metadata for this structure type.
+      # @scope class
+      # @return [VAPI::Bindings::StructType] the binding type
+      def binding_type
+        @binding_type ||= VAPI::Bindings::StructType.new(
+          'com.vmware.vapi.metadata.metamodel.generic_instantiation',
+          {
+            'generic_type' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Metadata::Metamodel::GenericInstantiation::GenericType'),
+            'element_type' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Metadata::Metamodel::Type')),
+            'map_key_type' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Metadata::Metamodel::Type')),
+            'map_value_type' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Metadata::Metamodel::Type'))
+          },
+          GenericInstantiation,
+          false,
+          nil
+        )
+      end
+    end
+
+    attr_accessor :generic_type,
+                  :element_type,
+                  :map_key_type,
+                  :map_value_type
+
+    # Constructs a new instance.
+    # @param ruby_values [Hash] a map of initial property values (optional)
+    # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
+    def initialize(ruby_values = nil, struct_value = nil)
+      super(self.class.binding_type, ruby_values, struct_value)
+    end
+
+    # The  ``Com::Vmware::Vapi::Metadata::Metamodel::GenericInstantiation::GenericType``   enumerated type  provides  enumeration values  for each of the generic types provided by the infrastructure.
+    # @!attribute [rw] list
     #     @return [Com::Vmware::Vapi::Metadata::Metamodel::GenericInstantiation::GenericType]
-    #     The generic type that is being instantiated.
-    # @!attribute [rw] element_type
-    #     @return [Com::Vmware::Vapi::Metadata::Metamodel::Type]
-    #     Type of the element parameter if the generic type instantiation is a   :attr:`Com::Vmware::Vapi::Metadata::Metamodel::GenericInstantiation::GenericType.LIST`  ,   :attr:`Com::Vmware::Vapi::Metadata::Metamodel::GenericInstantiation::GenericType.OPTIONAL`   or   :attr:`Com::Vmware::Vapi::Metadata::Metamodel::GenericInstantiation::GenericType.SET`  .
-    #     This  field  is optional and it is only relevant when the value of  ``genericType``  is one of   :attr:`Com::Vmware::Vapi::Metadata::Metamodel::GenericInstantiation::GenericType.LIST`  ,   :attr:`Com::Vmware::Vapi::Metadata::Metamodel::GenericInstantiation::GenericType.OPTIONAL`  , or   :attr:`Com::Vmware::Vapi::Metadata::Metamodel::GenericInstantiation::GenericType.SET`  .
-    # @!attribute [rw] map_key_type
-    #     @return [Com::Vmware::Vapi::Metadata::Metamodel::Type]
-    #     Type of the key parameter of the map generic type instantiation. The map generic type has a key parameter and value parameter. The type of the value parameter is described by   :attr:`Com::Vmware::Vapi::Metadata::Metamodel::GenericInstantiation.map_value_type`  ..
-    #     This  field  is optional and it is only relevant when the value of  ``genericType``  is   :attr:`Com::Vmware::Vapi::Metadata::Metamodel::GenericInstantiation::GenericType.MAP`  .
-    # @!attribute [rw] map_value_type
-    #     @return [Com::Vmware::Vapi::Metadata::Metamodel::Type]
-    #     Type of the value parameter of the map generic type instantiation. The map generic type has a key parameter and value parameter. The type of the key parameter is described by   :attr:`Com::Vmware::Vapi::Metadata::Metamodel::GenericInstantiation.map_key_type`  ..
-    #     This  field  is optional and it is only relevant when the value of  ``genericType``  is   :attr:`Com::Vmware::Vapi::Metadata::Metamodel::GenericInstantiation::GenericType.MAP`  .
-    class GenericInstantiation < VAPI::Bindings::VapiStruct
-
-        class << self
-            # Holds (gets or creates) the binding type metadata for this structure type.
-            # @scope class
-            # @return [VAPI::Bindings::StructType] the binding type
-            def binding_type
-                @binding_type ||= VAPI::Bindings::StructType.new(
-                    'com.vmware.vapi.metadata.metamodel.generic_instantiation',
-                    {
-                        'generic_type' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Metadata::Metamodel::GenericInstantiation::GenericType'),
-                        'element_type' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Metadata::Metamodel::Type')),
-                        'map_key_type' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Metadata::Metamodel::Type')),
-                        'map_value_type' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Metadata::Metamodel::Type')),
-                    },
-                    GenericInstantiation,
-                    false,
-                    nil)
-            end
+    #     Indicates the generic type is a list.
+    # @!attribute [rw] map
+    #     @return [Com::Vmware::Vapi::Metadata::Metamodel::GenericInstantiation::GenericType]
+    #     Indicates the generic type is a map.
+    # @!attribute [rw] optional
+    #     @return [Com::Vmware::Vapi::Metadata::Metamodel::GenericInstantiation::GenericType]
+    #     Indicates the generic type is an optional.
+    # @!attribute [rw] set
+    #     @return [Com::Vmware::Vapi::Metadata::Metamodel::GenericInstantiation::GenericType]
+    #     Indicates the generic type is a set.
+    class GenericType < VAPI::Bindings::VapiEnum
+      class << self
+        # Holds (gets or creates) the binding type metadata for this enumeration type.
+        # @scope class
+        # @return [VAPI::Bindings::EnumType] the binding type
+        def binding_type
+          @binding_type ||= VAPI::Bindings::EnumType.new(
+            'com.vmware.vapi.metadata.metamodel.generic_instantiation.generic_type',
+            GenericType
+          )
         end
 
-        attr_accessor :generic_type,
-                      :element_type,
-                      :map_key_type,
-                      :map_value_type
-
-        # Constructs a new instance.
-        # @param ruby_values [Hash] a map of initial property values (optional)
-        # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
-        def initialize(ruby_values=nil, struct_value=nil)
-            super(self.class.binding_type, ruby_values, struct_value)
+        # Converts from a string value (perhaps off the wire) to an instance
+        # of this enum type.
+        # @param value [String] the actual value of the enum instance
+        # @return [GenericType] the instance found for the value, otherwise
+        #         an unknown instance will be built for the value
+        def from_string(value)
+          const_get(value)
+        rescue NameError
+          GenericType.send(:new, 'UNKNOWN', value)
         end
+      end
 
+      # Constructs a new instance.
+      # @param value [String] the actual value of the enum instance
+      # @param unknown [String] the unknown value when value is 'UKNOWN'
+      def initialize(value, unknown = nil)
+        super(self.class.binding_type, value, unknown)
+      end
 
-        # The  ``Com::Vmware::Vapi::Metadata::Metamodel::GenericInstantiation::GenericType``   enumerated type  provides  enumeration values  for each of the generic types provided by the infrastructure.
-        # @!attribute [rw] list
-        #     @return [Com::Vmware::Vapi::Metadata::Metamodel::GenericInstantiation::GenericType]
-        #     Indicates the generic type is a list.
-        # @!attribute [rw] map
-        #     @return [Com::Vmware::Vapi::Metadata::Metamodel::GenericInstantiation::GenericType]
-        #     Indicates the generic type is a map.
-        # @!attribute [rw] optional
-        #     @return [Com::Vmware::Vapi::Metadata::Metamodel::GenericInstantiation::GenericType]
-        #     Indicates the generic type is an optional.
-        # @!attribute [rw] set
-        #     @return [Com::Vmware::Vapi::Metadata::Metamodel::GenericInstantiation::GenericType]
-        #     Indicates the generic type is a set.
-        class GenericType < VAPI::Bindings::VapiEnum
+      private_class_method :new
 
-            class << self
-                # Holds (gets or creates) the binding type metadata for this enumeration type.
-                # @scope class
-                # @return [VAPI::Bindings::EnumType] the binding type
-                def binding_type
-                    @binding_type ||= VAPI::Bindings::EnumType.new(
-                        'com.vmware.vapi.metadata.metamodel.generic_instantiation.generic_type',
-                        GenericType)
-                end
+      # @!attribute [rw] list
+      #     @return [Com::Vmware::Vapi::Metadata::Metamodel::GenericInstantiation::GenericType]
+      #     Indicates the generic type is a list.
+      LIST = GenericType.send(:new, 'LIST')
 
-                # Converts from a string value (perhaps off the wire) to an instance
-                # of this enum type.
-                # @param value [String] the actual value of the enum instance
-                # @return [GenericType] the instance found for the value, otherwise
-                #         an unknown instance will be built for the value
-                def from_string(value)
-                    begin
-                        const_get(value)
-                    rescue NameError
-                        GenericType.new('UNKNOWN', value)
-                    end
-                end
-            end
+      # @!attribute [rw] map
+      #     @return [Com::Vmware::Vapi::Metadata::Metamodel::GenericInstantiation::GenericType]
+      #     Indicates the generic type is a map.
+      MAP = GenericType.send(:new, 'MAP')
 
-            private
+      # @!attribute [rw] optional
+      #     @return [Com::Vmware::Vapi::Metadata::Metamodel::GenericInstantiation::GenericType]
+      #     Indicates the generic type is an optional.
+      OPTIONAL = GenericType.send(:new, 'OPTIONAL')
 
-            # Constructs a new instance.
-            # @param value [String] the actual value of the enum instance
-            # @param unknown [String] the unknown value when value is 'UKNOWN'
-            def initialize(value, unknown=nil)
-                super(self.class.binding_type, value, unknown)
-            end
-
-            public
-
-            # @!attribute [rw] list
-            #     @return [Com::Vmware::Vapi::Metadata::Metamodel::GenericInstantiation::GenericType]
-            #     Indicates the generic type is a list.
-            LIST = GenericType.new('LIST')
-
-            # @!attribute [rw] map
-            #     @return [Com::Vmware::Vapi::Metadata::Metamodel::GenericInstantiation::GenericType]
-            #     Indicates the generic type is a map.
-            MAP = GenericType.new('MAP')
-
-            # @!attribute [rw] optional
-            #     @return [Com::Vmware::Vapi::Metadata::Metamodel::GenericInstantiation::GenericType]
-            #     Indicates the generic type is an optional.
-            OPTIONAL = GenericType.new('OPTIONAL')
-
-            # @!attribute [rw] set
-            #     @return [Com::Vmware::Vapi::Metadata::Metamodel::GenericInstantiation::GenericType]
-            #     Indicates the generic type is a set.
-            SET = GenericType.new('SET')
-
-        end
-
-
+      # @!attribute [rw] set
+      #     @return [Com::Vmware::Vapi::Metadata::Metamodel::GenericInstantiation::GenericType]
+      #     Indicates the generic type is a set.
+      SET = GenericType.send(:new, 'SET')
+    end
+  end
+  # The  ``Com::Vmware::Vapi::Metadata::Metamodel::OperationInfo``   class  contains metamodel information of an operation element.
+  # @!attribute [rw] name
+  #     @return [String]
+  #     Name of the operation element in a canonical format. The format is lower case with underscores. Each underscore represents a word boundary. If there are acronyms in the word, the capitalization is preserved. This format makes it easy to translate the segment into a different naming convention.
+  # @!attribute [rw] params
+  #     @return [Array<Com::Vmware::Vapi::Metadata::Metamodel::FieldInfo>]
+  #     Metamodel information for the parameter elements. The order of the parameters elements in the list is same as the order of the parameters declared in the interface definition file.
+  # @!attribute [rw] output
+  #     @return [Com::Vmware::Vapi::Metadata::Metamodel::OperationResultInfo]
+  #     Metamodel type for the output element.
+  # @!attribute [rw] errors
+  #     @return [Array<Com::Vmware::Vapi::Metadata::Metamodel::ErrorInfo>]
+  #     List of error elements that might be reported by the operation element. If the operation reports the same error for more than one reason, the list contains the error element associated with the error more than once with different documentation elements.
+  # @!attribute [rw] metadata
+  #     @return [Hash<String, Com::Vmware::Vapi::Metadata::Metamodel::ElementMap>]
+  #     Generic metadata elements for the operation element. The key in the  map  is the name of the metadata element and the value is the data associated with that metadata element.  
+  #     
+  #      The   :class:`Com::Vmware::Vapi::Metadata::Metamodel::MetadataIdentifier`   contains possible string values for key in the  map .
+  # @!attribute [rw] documentation
+  #     @return [String]
+  #     English language documentation for the service element. It can contain HTML markup and Javadoc tags.
+  class OperationInfo < VAPI::Bindings::VapiStruct
+    class << self
+      # Holds (gets or creates) the binding type metadata for this structure type.
+      # @scope class
+      # @return [VAPI::Bindings::StructType] the binding type
+      def binding_type
+        @binding_type ||= VAPI::Bindings::StructType.new(
+          'com.vmware.vapi.metadata.metamodel.operation_info',
+          {
+            'name' => VAPI::Bindings::StringType.instance,
+            'params' => VAPI::Bindings::ListType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Metadata::Metamodel::FieldInfo')),
+            'output' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Metadata::Metamodel::OperationResultInfo'),
+            'errors' => VAPI::Bindings::ListType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Metadata::Metamodel::ErrorInfo')),
+            'metadata' => VAPI::Bindings::MapType.new(VAPI::Bindings::StringType.instance, VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Metadata::Metamodel::ElementMap')),
+            'documentation' => VAPI::Bindings::StringType.instance
+          },
+          OperationInfo,
+          false,
+          nil
+        )
+      end
     end
 
+    attr_accessor :name,
+                  :params,
+                  :output,
+                  :errors,
+                  :metadata,
+                  :documentation
 
-    # The  ``Com::Vmware::Vapi::Metadata::Metamodel::OperationInfo``   class  contains metamodel information of an operation element.
-    # @!attribute [rw] name
-    #     @return [String]
-    #     Name of the operation element in a canonical format. The format is lower case with underscores. Each underscore represents a word boundary. If there are acronyms in the word, the capitalization is preserved. This format makes it easy to translate the segment into a different naming convention.
-    # @!attribute [rw] params
-    #     @return [Array<Com::Vmware::Vapi::Metadata::Metamodel::FieldInfo>]
-    #     Metamodel information for the parameter elements. The order of the parameters elements in the list is same as the order of the parameters declared in the interface definition file.
-    # @!attribute [rw] output
-    #     @return [Com::Vmware::Vapi::Metadata::Metamodel::OperationResultInfo]
-    #     Metamodel type for the output element.
-    # @!attribute [rw] errors
-    #     @return [Array<Com::Vmware::Vapi::Metadata::Metamodel::ErrorInfo>]
-    #     List of error elements that might be reported by the operation element. If the operation reports the same error for more than one reason, the list contains the error element associated with the error more than once with different documentation elements.
-    # @!attribute [rw] metadata
-    #     @return [Hash<String, Com::Vmware::Vapi::Metadata::Metamodel::ElementMap>]
-    #     Generic metadata elements for the operation element. The key in the  map  is the name of the metadata element and the value is the data associated with that metadata element.  
-    #     
-    #      The   :class:`Com::Vmware::Vapi::Metadata::Metamodel::MetadataIdentifier`   contains possible string values for key in the  map .
-    # @!attribute [rw] documentation
-    #     @return [String]
-    #     English language documentation for the service element. It can contain HTML markup and Javadoc tags.
-    class OperationInfo < VAPI::Bindings::VapiStruct
-
-        class << self
-            # Holds (gets or creates) the binding type metadata for this structure type.
-            # @scope class
-            # @return [VAPI::Bindings::StructType] the binding type
-            def binding_type
-                @binding_type ||= VAPI::Bindings::StructType.new(
-                    'com.vmware.vapi.metadata.metamodel.operation_info',
-                    {
-                        'name' => VAPI::Bindings::StringType.instance,
-                        'params' => VAPI::Bindings::ListType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Metadata::Metamodel::FieldInfo')),
-                        'output' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Metadata::Metamodel::OperationResultInfo'),
-                        'errors' => VAPI::Bindings::ListType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Metadata::Metamodel::ErrorInfo')),
-                        'metadata' => VAPI::Bindings::MapType.new(VAPI::Bindings::StringType.instance, VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Metadata::Metamodel::ElementMap')),
-                        'documentation' => VAPI::Bindings::StringType.instance,
-                    },
-                    OperationInfo,
-                    false,
-                    nil)
-            end
-        end
-
-        attr_accessor :name,
-                      :params,
-                      :output,
-                      :errors,
-                      :metadata,
-                      :documentation
-
-        # Constructs a new instance.
-        # @param ruby_values [Hash] a map of initial property values (optional)
-        # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
-        def initialize(ruby_values=nil, struct_value=nil)
-            super(self.class.binding_type, ruby_values, struct_value)
-        end
+    # Constructs a new instance.
+    # @param ruby_values [Hash] a map of initial property values (optional)
+    # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
+    def initialize(ruby_values = nil, struct_value = nil)
+      super(self.class.binding_type, ruby_values, struct_value)
+    end
+  end
+  # The  ``Com::Vmware::Vapi::Metadata::Metamodel::OperationResultInfo``   class  contains the metamodel information of an operation result element.  
+  # 
+  #  An operation accepts a list of parameters and returns a result or an error. The  ``Com::Vmware::Vapi::Metadata::Metamodel::OperationResultInfo``  describes the result element of an operation.
+  # @!attribute [rw] type
+  #     @return [Com::Vmware::Vapi::Metadata::Metamodel::Type]
+  #     Type information of the operation result element.
+  # @!attribute [rw] metadata
+  #     @return [Hash<String, Com::Vmware::Vapi::Metadata::Metamodel::ElementMap>]
+  #     Generic metadata elements for the service element. The key in the  map  is the name of the metadata element and the value is the data associated with that metadata element.  
+  #     
+  #      The   :class:`Com::Vmware::Vapi::Metadata::Metamodel::MetadataIdentifier`   contains possible string values for keys in the  map .
+  # @!attribute [rw] documentation
+  #     @return [String]
+  #     English language documentation for the operation result element. It can contain HTML markup and Javadoc tags.
+  class OperationResultInfo < VAPI::Bindings::VapiStruct
+    class << self
+      # Holds (gets or creates) the binding type metadata for this structure type.
+      # @scope class
+      # @return [VAPI::Bindings::StructType] the binding type
+      def binding_type
+        @binding_type ||= VAPI::Bindings::StructType.new(
+          'com.vmware.vapi.metadata.metamodel.operation_result_info',
+          {
+            'type' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Metadata::Metamodel::Type'),
+            'metadata' => VAPI::Bindings::MapType.new(VAPI::Bindings::StringType.instance, VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Metadata::Metamodel::ElementMap')),
+            'documentation' => VAPI::Bindings::StringType.instance
+          },
+          OperationResultInfo,
+          false,
+          nil
+        )
+      end
     end
 
+    attr_accessor :type,
+                  :metadata,
+                  :documentation
 
-    # The  ``Com::Vmware::Vapi::Metadata::Metamodel::OperationResultInfo``   class  contains the metamodel information of an operation result element.  
-    # 
-    #  An operation accepts a list of parameters and returns a result or an error. The  ``Com::Vmware::Vapi::Metadata::Metamodel::OperationResultInfo``  describes the result element of an operation.
-    # @!attribute [rw] type
-    #     @return [Com::Vmware::Vapi::Metadata::Metamodel::Type]
-    #     Type information of the operation result element.
-    # @!attribute [rw] metadata
-    #     @return [Hash<String, Com::Vmware::Vapi::Metadata::Metamodel::ElementMap>]
-    #     Generic metadata elements for the service element. The key in the  map  is the name of the metadata element and the value is the data associated with that metadata element.  
-    #     
-    #      The   :class:`Com::Vmware::Vapi::Metadata::Metamodel::MetadataIdentifier`   contains possible string values for keys in the  map .
-    # @!attribute [rw] documentation
-    #     @return [String]
-    #     English language documentation for the operation result element. It can contain HTML markup and Javadoc tags.
-    class OperationResultInfo < VAPI::Bindings::VapiStruct
-
-        class << self
-            # Holds (gets or creates) the binding type metadata for this structure type.
-            # @scope class
-            # @return [VAPI::Bindings::StructType] the binding type
-            def binding_type
-                @binding_type ||= VAPI::Bindings::StructType.new(
-                    'com.vmware.vapi.metadata.metamodel.operation_result_info',
-                    {
-                        'type' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Metadata::Metamodel::Type'),
-                        'metadata' => VAPI::Bindings::MapType.new(VAPI::Bindings::StringType.instance, VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Metadata::Metamodel::ElementMap')),
-                        'documentation' => VAPI::Bindings::StringType.instance,
-                    },
-                    OperationResultInfo,
-                    false,
-                    nil)
-            end
-        end
-
-        attr_accessor :type,
-                      :metadata,
-                      :documentation
-
-        # Constructs a new instance.
-        # @param ruby_values [Hash] a map of initial property values (optional)
-        # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
-        def initialize(ruby_values=nil, struct_value=nil)
-            super(self.class.binding_type, ruby_values, struct_value)
-        end
+    # Constructs a new instance.
+    # @param ruby_values [Hash] a map of initial property values (optional)
+    # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
+    def initialize(ruby_values = nil, struct_value = nil)
+      super(self.class.binding_type, ruby_values, struct_value)
+    end
+  end
+  # The  ``Com::Vmware::Vapi::Metadata::Metamodel::PackageInfo``   class  contains the metamodel information of all the service elements, structure elements and enumeration elements contained in the package element.
+  # @!attribute [rw] name
+  #     @return [String]
+  #     Dot separated name of the package element. The segments in the name reflect the organization of the APIs. The format of each segment is lower case with underscores. Each underscore represents a word boundary. If there are acronyms in the word, the capitalization is preserved. This format makes it easy to translate the segment into a different naming convention.
+  # @!attribute [rw] structures
+  #     @return [Hash<String, Com::Vmware::Vapi::Metadata::Metamodel::StructureInfo>]
+  #     Metamodel information of all the structure elements contained in the package element. The key in the  map  is the identifier of the structure element and the value in the  map  is the metamodel information for the structure element.  
+  #     
+  #      This does not include the structure elements contained in the service elements that are contained in this package element.
+  # @!attribute [rw] enumerations
+  #     @return [Hash<String, Com::Vmware::Vapi::Metadata::Metamodel::EnumerationInfo>]
+  #     Metamodel information of all the enumeration elements contained in the package element. The key in the  map  is the identifier of the enumeration element and the value in the  map  is the metamodel information for the enumeration element.  
+  #     
+  #      This does not include the enumeration elements that are contained in the service elements of this package element or structure elements of this package element.
+  # @!attribute [rw] services
+  #     @return [Hash<String, Com::Vmware::Vapi::Metadata::Metamodel::ServiceInfo>]
+  #     Metamodel information of all the service elements contained in the package element. The key in the  map  is the identifier of the service element and the value in the  map  is the metamodel information for the service element.
+  # @!attribute [rw] metadata
+  #     @return [Hash<String, Com::Vmware::Vapi::Metadata::Metamodel::ElementMap>]
+  #     Generic metadata elements for the package element. The key in the  map  is the name of the metadata element and the value is the data associated with that metadata element.  
+  #     
+  #      The   :class:`Com::Vmware::Vapi::Metadata::Metamodel::MetadataIdentifier`   contains possible string values for keys in the  map .
+  # @!attribute [rw] documentation
+  #     @return [String]
+  #     English language documentation for a package. It can contain HTML markup and Javadoc tags. The first sentence of the package documentation is a complete sentence that identifies the package by name and summarizes the purpose of the package.  
+  #     
+  #      The primary purpose of a package documentation is to provide high-level context that will provide a framework in which the users can put the detail about the package contents.
+  class PackageInfo < VAPI::Bindings::VapiStruct
+    class << self
+      # Holds (gets or creates) the binding type metadata for this structure type.
+      # @scope class
+      # @return [VAPI::Bindings::StructType] the binding type
+      def binding_type
+        @binding_type ||= VAPI::Bindings::StructType.new(
+          'com.vmware.vapi.metadata.metamodel.package_info',
+          {
+            'name' => VAPI::Bindings::StringType.instance,
+            'structures' => VAPI::Bindings::MapType.new(VAPI::Bindings::IdType.new, VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Metadata::Metamodel::StructureInfo')),
+            'enumerations' => VAPI::Bindings::MapType.new(VAPI::Bindings::IdType.new, VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Metadata::Metamodel::EnumerationInfo')),
+            'services' => VAPI::Bindings::MapType.new(VAPI::Bindings::IdType.new, VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Metadata::Metamodel::ServiceInfo')),
+            'metadata' => VAPI::Bindings::MapType.new(VAPI::Bindings::StringType.instance, VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Metadata::Metamodel::ElementMap')),
+            'documentation' => VAPI::Bindings::StringType.instance
+          },
+          PackageInfo,
+          false,
+          nil
+        )
+      end
     end
 
+    attr_accessor :name,
+                  :structures,
+                  :enumerations,
+                  :services,
+                  :metadata,
+                  :documentation
 
-    # The  ``Com::Vmware::Vapi::Metadata::Metamodel::PackageInfo``   class  contains the metamodel information of all the service elements, structure elements and enumeration elements contained in the package element.
-    # @!attribute [rw] name
-    #     @return [String]
-    #     Dot separated name of the package element. The segments in the name reflect the organization of the APIs. The format of each segment is lower case with underscores. Each underscore represents a word boundary. If there are acronyms in the word, the capitalization is preserved. This format makes it easy to translate the segment into a different naming convention.
-    # @!attribute [rw] structures
-    #     @return [Hash<String, Com::Vmware::Vapi::Metadata::Metamodel::StructureInfo>]
-    #     Metamodel information of all the structure elements contained in the package element. The key in the  map  is the identifier of the structure element and the value in the  map  is the metamodel information for the structure element.  
-    #     
-    #      This does not include the structure elements contained in the service elements that are contained in this package element.
-    # @!attribute [rw] enumerations
-    #     @return [Hash<String, Com::Vmware::Vapi::Metadata::Metamodel::EnumerationInfo>]
-    #     Metamodel information of all the enumeration elements contained in the package element. The key in the  map  is the identifier of the enumeration element and the value in the  map  is the metamodel information for the enumeration element.  
-    #     
-    #      This does not include the enumeration elements that are contained in the service elements of this package element or structure elements of this package element.
-    # @!attribute [rw] services
-    #     @return [Hash<String, Com::Vmware::Vapi::Metadata::Metamodel::ServiceInfo>]
-    #     Metamodel information of all the service elements contained in the package element. The key in the  map  is the identifier of the service element and the value in the  map  is the metamodel information for the service element.
-    # @!attribute [rw] metadata
-    #     @return [Hash<String, Com::Vmware::Vapi::Metadata::Metamodel::ElementMap>]
-    #     Generic metadata elements for the package element. The key in the  map  is the name of the metadata element and the value is the data associated with that metadata element.  
-    #     
-    #      The   :class:`Com::Vmware::Vapi::Metadata::Metamodel::MetadataIdentifier`   contains possible string values for keys in the  map .
-    # @!attribute [rw] documentation
-    #     @return [String]
-    #     English language documentation for a package. It can contain HTML markup and Javadoc tags. The first sentence of the package documentation is a complete sentence that identifies the package by name and summarizes the purpose of the package.  
-    #     
-    #      The primary purpose of a package documentation is to provide high-level context that will provide a framework in which the users can put the detail about the package contents.
-    class PackageInfo < VAPI::Bindings::VapiStruct
-
-        class << self
-            # Holds (gets or creates) the binding type metadata for this structure type.
-            # @scope class
-            # @return [VAPI::Bindings::StructType] the binding type
-            def binding_type
-                @binding_type ||= VAPI::Bindings::StructType.new(
-                    'com.vmware.vapi.metadata.metamodel.package_info',
-                    {
-                        'name' => VAPI::Bindings::StringType.instance,
-                        'structures' => VAPI::Bindings::MapType.new(VAPI::Bindings::IdType.new, VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Metadata::Metamodel::StructureInfo')),
-                        'enumerations' => VAPI::Bindings::MapType.new(VAPI::Bindings::IdType.new, VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Metadata::Metamodel::EnumerationInfo')),
-                        'services' => VAPI::Bindings::MapType.new(VAPI::Bindings::IdType.new, VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Metadata::Metamodel::ServiceInfo')),
-                        'metadata' => VAPI::Bindings::MapType.new(VAPI::Bindings::StringType.instance, VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Metadata::Metamodel::ElementMap')),
-                        'documentation' => VAPI::Bindings::StringType.instance,
-                    },
-                    PackageInfo,
-                    false,
-                    nil)
-            end
-        end
-
-        attr_accessor :name,
-                      :structures,
-                      :enumerations,
-                      :services,
-                      :metadata,
-                      :documentation
-
-        # Constructs a new instance.
-        # @param ruby_values [Hash] a map of initial property values (optional)
-        # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
-        def initialize(ruby_values=nil, struct_value=nil)
-            super(self.class.binding_type, ruby_values, struct_value)
-        end
+    # Constructs a new instance.
+    # @param ruby_values [Hash] a map of initial property values (optional)
+    # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
+    def initialize(ruby_values = nil, struct_value = nil)
+      super(self.class.binding_type, ruby_values, struct_value)
+    end
+  end
+  # The  ``Com::Vmware::Vapi::Metadata::Metamodel::PrimitiveValue``   class  contains value of the constant element.
+  # @!attribute [rw] type
+  #     @return [Com::Vmware::Vapi::Metadata::Metamodel::PrimitiveValue::Type]
+  #     Type of the constant value.
+  # @!attribute [rw] boolean_value
+  #     @return [Boolean]
+  #     Boolean value of the constant.
+  #     This  field  is optional and it is only relevant when the value of  ``type``  is   :attr:`Com::Vmware::Vapi::Metadata::Metamodel::PrimitiveValue::Type.BOOLEAN`  .
+  # @!attribute [rw] double_value
+  #     @return [Float]
+  #     Double value of the constant.
+  #     This  field  is optional and it is only relevant when the value of  ``type``  is   :attr:`Com::Vmware::Vapi::Metadata::Metamodel::PrimitiveValue::Type.DOUBLE`  .
+  # @!attribute [rw] long_value
+  #     @return [Fixnum]
+  #     Long value of the constant.
+  #     This  field  is optional and it is only relevant when the value of  ``type``  is   :attr:`Com::Vmware::Vapi::Metadata::Metamodel::PrimitiveValue::Type.LONG`  .
+  # @!attribute [rw] string_value
+  #     @return [String]
+  #     String value of the constant.
+  #     This  field  is optional and it is only relevant when the value of  ``type``  is   :attr:`Com::Vmware::Vapi::Metadata::Metamodel::PrimitiveValue::Type.STRING`  .
+  class PrimitiveValue < VAPI::Bindings::VapiStruct
+    class << self
+      # Holds (gets or creates) the binding type metadata for this structure type.
+      # @scope class
+      # @return [VAPI::Bindings::StructType] the binding type
+      def binding_type
+        @binding_type ||= VAPI::Bindings::StructType.new(
+          'com.vmware.vapi.metadata.metamodel.primitive_value',
+          {
+            'type' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Metadata::Metamodel::PrimitiveValue::Type'),
+            'boolean_value' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::BooleanType.instance),
+            'double_value' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::DoubleType.instance),
+            'long_value' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::IntegerType.instance),
+            'string_value' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::StringType.instance)
+          },
+          PrimitiveValue,
+          false,
+          nil
+        )
+      end
     end
 
+    attr_accessor :type,
+                  :boolean_value,
+                  :double_value,
+                  :long_value,
+                  :string_value
 
-    # The  ``Com::Vmware::Vapi::Metadata::Metamodel::PrimitiveValue``   class  contains value of the constant element.
-    # @!attribute [rw] type
+    # Constructs a new instance.
+    # @param ruby_values [Hash] a map of initial property values (optional)
+    # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
+    def initialize(ruby_values = nil, struct_value = nil)
+      super(self.class.binding_type, ruby_values, struct_value)
+    end
+
+    # The  ``Com::Vmware::Vapi::Metadata::Metamodel::PrimitiveValue::Type``   enumerated type  defines the valid types for values in constant elements.
+    # @!attribute [rw] boolean
     #     @return [Com::Vmware::Vapi::Metadata::Metamodel::PrimitiveValue::Type]
-    #     Type of the constant value.
-    # @!attribute [rw] boolean_value
-    #     @return [Boolean]
-    #     Boolean value of the constant.
-    #     This  field  is optional and it is only relevant when the value of  ``type``  is   :attr:`Com::Vmware::Vapi::Metadata::Metamodel::PrimitiveValue::Type.BOOLEAN`  .
-    # @!attribute [rw] double_value
-    #     @return [Float]
-    #     Double value of the constant.
-    #     This  field  is optional and it is only relevant when the value of  ``type``  is   :attr:`Com::Vmware::Vapi::Metadata::Metamodel::PrimitiveValue::Type.DOUBLE`  .
-    # @!attribute [rw] long_value
-    #     @return [Fixnum]
-    #     Long value of the constant.
-    #     This  field  is optional and it is only relevant when the value of  ``type``  is   :attr:`Com::Vmware::Vapi::Metadata::Metamodel::PrimitiveValue::Type.LONG`  .
-    # @!attribute [rw] string_value
-    #     @return [String]
-    #     String value of the constant.
-    #     This  field  is optional and it is only relevant when the value of  ``type``  is   :attr:`Com::Vmware::Vapi::Metadata::Metamodel::PrimitiveValue::Type.STRING`  .
-    class PrimitiveValue < VAPI::Bindings::VapiStruct
-
-        class << self
-            # Holds (gets or creates) the binding type metadata for this structure type.
-            # @scope class
-            # @return [VAPI::Bindings::StructType] the binding type
-            def binding_type
-                @binding_type ||= VAPI::Bindings::StructType.new(
-                    'com.vmware.vapi.metadata.metamodel.primitive_value',
-                    {
-                        'type' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Metadata::Metamodel::PrimitiveValue::Type'),
-                        'boolean_value' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::BooleanType.instance),
-                        'double_value' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::DoubleType.instance),
-                        'long_value' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::IntegerType.instance),
-                        'string_value' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::StringType.instance),
-                    },
-                    PrimitiveValue,
-                    false,
-                    nil)
-            end
+    #     Indicates the value is a boolean (true or false).
+    # @!attribute [rw] double
+    #     @return [Com::Vmware::Vapi::Metadata::Metamodel::PrimitiveValue::Type]
+    #     Indicates the value is a double (64 bit floating number).
+    # @!attribute [rw] long
+    #     @return [Com::Vmware::Vapi::Metadata::Metamodel::PrimitiveValue::Type]
+    #     Indicates the value is a long (64 bit signed integer).
+    # @!attribute [rw] string
+    #     @return [Com::Vmware::Vapi::Metadata::Metamodel::PrimitiveValue::Type]
+    #     Indicates the value is a string (a variable length sequence of characters). The encoding is UTF8.
+    class Type < VAPI::Bindings::VapiEnum
+      class << self
+        # Holds (gets or creates) the binding type metadata for this enumeration type.
+        # @scope class
+        # @return [VAPI::Bindings::EnumType] the binding type
+        def binding_type
+          @binding_type ||= VAPI::Bindings::EnumType.new(
+            'com.vmware.vapi.metadata.metamodel.primitive_value.type',
+            Type
+          )
         end
 
-        attr_accessor :type,
-                      :boolean_value,
-                      :double_value,
-                      :long_value,
-                      :string_value
-
-        # Constructs a new instance.
-        # @param ruby_values [Hash] a map of initial property values (optional)
-        # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
-        def initialize(ruby_values=nil, struct_value=nil)
-            super(self.class.binding_type, ruby_values, struct_value)
+        # Converts from a string value (perhaps off the wire) to an instance
+        # of this enum type.
+        # @param value [String] the actual value of the enum instance
+        # @return [Type] the instance found for the value, otherwise
+        #         an unknown instance will be built for the value
+        def from_string(value)
+          const_get(value)
+        rescue NameError
+          Type.send(:new, 'UNKNOWN', value)
         end
+      end
 
+      # Constructs a new instance.
+      # @param value [String] the actual value of the enum instance
+      # @param unknown [String] the unknown value when value is 'UKNOWN'
+      def initialize(value, unknown = nil)
+        super(self.class.binding_type, value, unknown)
+      end
 
-        # The  ``Com::Vmware::Vapi::Metadata::Metamodel::PrimitiveValue::Type``   enumerated type  defines the valid types for values in constant elements.
-        # @!attribute [rw] boolean
-        #     @return [Com::Vmware::Vapi::Metadata::Metamodel::PrimitiveValue::Type]
-        #     Indicates the value is a boolean (true or false).
-        # @!attribute [rw] double
-        #     @return [Com::Vmware::Vapi::Metadata::Metamodel::PrimitiveValue::Type]
-        #     Indicates the value is a double (64 bit floating number).
-        # @!attribute [rw] long
-        #     @return [Com::Vmware::Vapi::Metadata::Metamodel::PrimitiveValue::Type]
-        #     Indicates the value is a long (64 bit signed integer).
-        # @!attribute [rw] string
-        #     @return [Com::Vmware::Vapi::Metadata::Metamodel::PrimitiveValue::Type]
-        #     Indicates the value is a string (a variable length sequence of characters). The encoding is UTF8.
-        class Type < VAPI::Bindings::VapiEnum
+      private_class_method :new
 
-            class << self
-                # Holds (gets or creates) the binding type metadata for this enumeration type.
-                # @scope class
-                # @return [VAPI::Bindings::EnumType] the binding type
-                def binding_type
-                    @binding_type ||= VAPI::Bindings::EnumType.new(
-                        'com.vmware.vapi.metadata.metamodel.primitive_value.type',
-                        Type)
-                end
+      # @!attribute [rw] boolean
+      #     @return [Com::Vmware::Vapi::Metadata::Metamodel::PrimitiveValue::Type]
+      #     Indicates the value is a boolean (true or false).
+      BOOLEAN = Type.send(:new, 'BOOLEAN')
 
-                # Converts from a string value (perhaps off the wire) to an instance
-                # of this enum type.
-                # @param value [String] the actual value of the enum instance
-                # @return [Type] the instance found for the value, otherwise
-                #         an unknown instance will be built for the value
-                def from_string(value)
-                    begin
-                        const_get(value)
-                    rescue NameError
-                        Type.new('UNKNOWN', value)
-                    end
-                end
-            end
+      # @!attribute [rw] double
+      #     @return [Com::Vmware::Vapi::Metadata::Metamodel::PrimitiveValue::Type]
+      #     Indicates the value is a double (64 bit floating number).
+      DOUBLE = Type.send(:new, 'DOUBLE')
 
-            private
+      # @!attribute [rw] long
+      #     @return [Com::Vmware::Vapi::Metadata::Metamodel::PrimitiveValue::Type]
+      #     Indicates the value is a long (64 bit signed integer).
+      LONG = Type.send(:new, 'LONG')
 
-            # Constructs a new instance.
-            # @param value [String] the actual value of the enum instance
-            # @param unknown [String] the unknown value when value is 'UKNOWN'
-            def initialize(value, unknown=nil)
-                super(self.class.binding_type, value, unknown)
-            end
-
-            public
-
-            # @!attribute [rw] boolean
-            #     @return [Com::Vmware::Vapi::Metadata::Metamodel::PrimitiveValue::Type]
-            #     Indicates the value is a boolean (true or false).
-            BOOLEAN = Type.new('BOOLEAN')
-
-            # @!attribute [rw] double
-            #     @return [Com::Vmware::Vapi::Metadata::Metamodel::PrimitiveValue::Type]
-            #     Indicates the value is a double (64 bit floating number).
-            DOUBLE = Type.new('DOUBLE')
-
-            # @!attribute [rw] long
-            #     @return [Com::Vmware::Vapi::Metadata::Metamodel::PrimitiveValue::Type]
-            #     Indicates the value is a long (64 bit signed integer).
-            LONG = Type.new('LONG')
-
-            # @!attribute [rw] string
-            #     @return [Com::Vmware::Vapi::Metadata::Metamodel::PrimitiveValue::Type]
-            #     Indicates the value is a string (a variable length sequence of characters). The encoding is UTF8.
-            STRING = Type.new('STRING')
-
-        end
-
-
+      # @!attribute [rw] string
+      #     @return [Com::Vmware::Vapi::Metadata::Metamodel::PrimitiveValue::Type]
+      #     Indicates the value is a string (a variable length sequence of characters). The encoding is UTF8.
+      STRING = Type.send(:new, 'STRING')
+    end
+  end
+  # The  ``Com::Vmware::Vapi::Metadata::Metamodel::ServiceInfo``   class  contains the metamodel information of all the operation elements, structure elements and enumeration elements containted in a service element.
+  # @!attribute [rw] name
+  #     @return [String]
+  #     Dot separated name of the service element. The segments in the name reflect the organization of the APIs. The format of each segment is lower case with underscores. Each underscore represents a word boundary. If there are acronyms in the word, the capitalization is preserved. This format makes it easy to translate the segment into a different naming convention.
+  # @!attribute [rw] operations
+  #     @return [Hash<String, Com::Vmware::Vapi::Metadata::Metamodel::OperationInfo>]
+  #     Metamodel information of all the operation elements contained in the service element. The key in the  map  is the identifier of the operation element and the value in the  map  is the metamodel information for the operation element.
+  # @!attribute [rw] structures
+  #     @return [Hash<String, Com::Vmware::Vapi::Metadata::Metamodel::StructureInfo>]
+  #     Metamodel information of all the structure elements contained in the service element. The key in the  map  is the identifier of the structure element and the value in the  map  is the metamodel information for the structure element.
+  # @!attribute [rw] enumerations
+  #     @return [Hash<String, Com::Vmware::Vapi::Metadata::Metamodel::EnumerationInfo>]
+  #     Metamodel information of all the enumeration elements contained in the service element. The key in the  map  is the identifier of the enumeration element and the value in the  map  is the metamodel information for the enumeration element.
+  # @!attribute [rw] constants
+  #     @return [Hash<String, Com::Vmware::Vapi::Metadata::Metamodel::ConstantInfo>]
+  #     Metamodel information of all the constant elements contained in the service element. The key in the  map  is the name of the constant element and the value in the  map  is the metamodel information for the contant element.
+  # @!attribute [rw] metadata
+  #     @return [Hash<String, Com::Vmware::Vapi::Metadata::Metamodel::ElementMap>]
+  #     Generic metadata elements for the service element. The key in the  map  is the name of the metadata element and the value is the data associated with that metadata element.  
+  #     
+  #      The   :class:`Com::Vmware::Vapi::Metadata::Metamodel::MetadataIdentifier`   contains possible string values for keys in the  map .
+  # @!attribute [rw] documentation
+  #     @return [String]
+  #     English language documentation for the service element. It can contain HTML markup and Javadoc tags. The first sentence of the service documentation is a complete sentence that identifies the service by name and summarizes the purpose of the service. The remaining part of the documentation provides a summary of how to use the operations defined in the service.
+  class ServiceInfo < VAPI::Bindings::VapiStruct
+    class << self
+      # Holds (gets or creates) the binding type metadata for this structure type.
+      # @scope class
+      # @return [VAPI::Bindings::StructType] the binding type
+      def binding_type
+        @binding_type ||= VAPI::Bindings::StructType.new(
+          'com.vmware.vapi.metadata.metamodel.service_info',
+          {
+            'name' => VAPI::Bindings::StringType.instance,
+            'operations' => VAPI::Bindings::MapType.new(VAPI::Bindings::IdType.new, VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Metadata::Metamodel::OperationInfo')),
+            'structures' => VAPI::Bindings::MapType.new(VAPI::Bindings::IdType.new, VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Metadata::Metamodel::StructureInfo')),
+            'enumerations' => VAPI::Bindings::MapType.new(VAPI::Bindings::IdType.new, VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Metadata::Metamodel::EnumerationInfo')),
+            'constants' => VAPI::Bindings::MapType.new(VAPI::Bindings::StringType.instance, VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Metadata::Metamodel::ConstantInfo')),
+            'metadata' => VAPI::Bindings::MapType.new(VAPI::Bindings::StringType.instance, VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Metadata::Metamodel::ElementMap')),
+            'documentation' => VAPI::Bindings::StringType.instance
+          },
+          ServiceInfo,
+          false,
+          nil
+        )
+      end
     end
 
+    attr_accessor :name,
+                  :operations,
+                  :structures,
+                  :enumerations,
+                  :constants,
+                  :metadata,
+                  :documentation
 
-    # The  ``Com::Vmware::Vapi::Metadata::Metamodel::ServiceInfo``   class  contains the metamodel information of all the operation elements, structure elements and enumeration elements containted in a service element.
-    # @!attribute [rw] name
-    #     @return [String]
-    #     Dot separated name of the service element. The segments in the name reflect the organization of the APIs. The format of each segment is lower case with underscores. Each underscore represents a word boundary. If there are acronyms in the word, the capitalization is preserved. This format makes it easy to translate the segment into a different naming convention.
-    # @!attribute [rw] operations
-    #     @return [Hash<String, Com::Vmware::Vapi::Metadata::Metamodel::OperationInfo>]
-    #     Metamodel information of all the operation elements contained in the service element. The key in the  map  is the identifier of the operation element and the value in the  map  is the metamodel information for the operation element.
-    # @!attribute [rw] structures
-    #     @return [Hash<String, Com::Vmware::Vapi::Metadata::Metamodel::StructureInfo>]
-    #     Metamodel information of all the structure elements contained in the service element. The key in the  map  is the identifier of the structure element and the value in the  map  is the metamodel information for the structure element.
-    # @!attribute [rw] enumerations
-    #     @return [Hash<String, Com::Vmware::Vapi::Metadata::Metamodel::EnumerationInfo>]
-    #     Metamodel information of all the enumeration elements contained in the service element. The key in the  map  is the identifier of the enumeration element and the value in the  map  is the metamodel information for the enumeration element.
-    # @!attribute [rw] constants
-    #     @return [Hash<String, Com::Vmware::Vapi::Metadata::Metamodel::ConstantInfo>]
-    #     Metamodel information of all the constant elements contained in the service element. The key in the  map  is the name of the constant element and the value in the  map  is the metamodel information for the contant element.
-    # @!attribute [rw] metadata
-    #     @return [Hash<String, Com::Vmware::Vapi::Metadata::Metamodel::ElementMap>]
-    #     Generic metadata elements for the service element. The key in the  map  is the name of the metadata element and the value is the data associated with that metadata element.  
-    #     
-    #      The   :class:`Com::Vmware::Vapi::Metadata::Metamodel::MetadataIdentifier`   contains possible string values for keys in the  map .
-    # @!attribute [rw] documentation
-    #     @return [String]
-    #     English language documentation for the service element. It can contain HTML markup and Javadoc tags. The first sentence of the service documentation is a complete sentence that identifies the service by name and summarizes the purpose of the service. The remaining part of the documentation provides a summary of how to use the operations defined in the service.
-    class ServiceInfo < VAPI::Bindings::VapiStruct
-
-        class << self
-            # Holds (gets or creates) the binding type metadata for this structure type.
-            # @scope class
-            # @return [VAPI::Bindings::StructType] the binding type
-            def binding_type
-                @binding_type ||= VAPI::Bindings::StructType.new(
-                    'com.vmware.vapi.metadata.metamodel.service_info',
-                    {
-                        'name' => VAPI::Bindings::StringType.instance,
-                        'operations' => VAPI::Bindings::MapType.new(VAPI::Bindings::IdType.new, VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Metadata::Metamodel::OperationInfo')),
-                        'structures' => VAPI::Bindings::MapType.new(VAPI::Bindings::IdType.new, VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Metadata::Metamodel::StructureInfo')),
-                        'enumerations' => VAPI::Bindings::MapType.new(VAPI::Bindings::IdType.new, VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Metadata::Metamodel::EnumerationInfo')),
-                        'constants' => VAPI::Bindings::MapType.new(VAPI::Bindings::StringType.instance, VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Metadata::Metamodel::ConstantInfo')),
-                        'metadata' => VAPI::Bindings::MapType.new(VAPI::Bindings::StringType.instance, VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Metadata::Metamodel::ElementMap')),
-                        'documentation' => VAPI::Bindings::StringType.instance,
-                    },
-                    ServiceInfo,
-                    false,
-                    nil)
-            end
-        end
-
-        attr_accessor :name,
-                      :operations,
-                      :structures,
-                      :enumerations,
-                      :constants,
-                      :metadata,
-                      :documentation
-
-        # Constructs a new instance.
-        # @param ruby_values [Hash] a map of initial property values (optional)
-        # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
-        def initialize(ruby_values=nil, struct_value=nil)
-            super(self.class.binding_type, ruby_values, struct_value)
-        end
+    # Constructs a new instance.
+    # @param ruby_values [Hash] a map of initial property values (optional)
+    # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
+    def initialize(ruby_values = nil, struct_value = nil)
+      super(self.class.binding_type, ruby_values, struct_value)
+    end
+  end
+  # The  ``Com::Vmware::Vapi::Metadata::Metamodel::StructureInfo``   class  contains the metamodel information of all the field elements, constant elements and enumeration elements contained in the structure element.  
+  # 
+  #  In the interface definition language, API designers have the ability to include all the fields from one structure to another structure. This is done by using an annotation  ``\@Include``  on the structure in which we want to add the fields. If this annotation is present, the list of fields in the  ``Com::Vmware::Vapi::Metadata::Metamodel::StructureInfo``  will also contain the fields that are being included. The annotation information is also retained in the   :attr:`Com::Vmware::Vapi::Metadata::Metamodel::StructureInfo.metadata`   element as well.
+  # @!attribute [rw] name
+  #     @return [String]
+  #     Dot separated name of the structure element. The segments in the name reflect the organization of the APIs. The format of each segment is lower case with underscores. Each underscore represents a word boundary. If there are acronyms in the word, the capitalization is preserved. This format makes it easy to translate the segment into a different naming convention.
+  # @!attribute [rw] type
+  #     @return [Com::Vmware::Vapi::Metadata::Metamodel::StructureInfo::Type]
+  #     Type of the structure.
+  # @!attribute [rw] enumerations
+  #     @return [Hash<String, Com::Vmware::Vapi::Metadata::Metamodel::EnumerationInfo>]
+  #     Metamodel information of all the enumeration elements contained in the structure element. The key in the  map  is the identifier of the enumeration element and the value is the metamodel information of the enumeration element.
+  # @!attribute [rw] constants
+  #     @return [Hash<String, Com::Vmware::Vapi::Metadata::Metamodel::ConstantInfo>]
+  #     Metamodel information of all the constant elements contained in the structure element. The key in the  map  is the name of the constant element and the value in the  map  is the metamodel information for the constant element.
+  # @!attribute [rw] fields
+  #     @return [Array<Com::Vmware::Vapi::Metadata::Metamodel::FieldInfo>]
+  #     Metamodel information of all the field elements. The order of the field elements in the list matches the order in which the fields are defined in the service.
+  # @!attribute [rw] metadata
+  #     @return [Hash<String, Com::Vmware::Vapi::Metadata::Metamodel::ElementMap>]
+  #     Generic metadata elements for the structure element. The key in the  map  is the name of the metadata element and the value is the data associated with that metadata element.  
+  #     
+  #      The   :class:`Com::Vmware::Vapi::Metadata::Metamodel::MetadataIdentifier`   contains possible string values for keys in the  map .
+  # @!attribute [rw] documentation
+  #     @return [String]
+  #     English language documentation for a structure element. It can contain HTML markup and Javadoc tags. The first sentence of the structure documentation is a complete sentence that identifies the structure by name and summarizes the purpose of the structure.
+  class StructureInfo < VAPI::Bindings::VapiStruct
+    class << self
+      # Holds (gets or creates) the binding type metadata for this structure type.
+      # @scope class
+      # @return [VAPI::Bindings::StructType] the binding type
+      def binding_type
+        @binding_type ||= VAPI::Bindings::StructType.new(
+          'com.vmware.vapi.metadata.metamodel.structure_info',
+          {
+            'name' => VAPI::Bindings::StringType.instance,
+            'type' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Metadata::Metamodel::StructureInfo::Type'),
+            'enumerations' => VAPI::Bindings::MapType.new(VAPI::Bindings::IdType.new, VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Metadata::Metamodel::EnumerationInfo')),
+            'constants' => VAPI::Bindings::MapType.new(VAPI::Bindings::StringType.instance, VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Metadata::Metamodel::ConstantInfo')),
+            'fields' => VAPI::Bindings::ListType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Metadata::Metamodel::FieldInfo')),
+            'metadata' => VAPI::Bindings::MapType.new(VAPI::Bindings::StringType.instance, VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Metadata::Metamodel::ElementMap')),
+            'documentation' => VAPI::Bindings::StringType.instance
+          },
+          StructureInfo,
+          false,
+          nil
+        )
+      end
     end
 
+    attr_accessor :name,
+                  :type,
+                  :enumerations,
+                  :constants,
+                  :fields,
+                  :metadata,
+                  :documentation
 
-    # The  ``Com::Vmware::Vapi::Metadata::Metamodel::StructureInfo``   class  contains the metamodel information of all the field elements, constant elements and enumeration elements contained in the structure element.  
-    # 
-    #  In the interface definition language, API designers have the ability to include all the fields from one structure to another structure. This is done by using an annotation  ``\@Include``  on the structure in which we want to add the fields. If this annotation is present, the list of fields in the  ``Com::Vmware::Vapi::Metadata::Metamodel::StructureInfo``  will also contain the fields that are being included. The annotation information is also retained in the   :attr:`Com::Vmware::Vapi::Metadata::Metamodel::StructureInfo.metadata`   element as well.
-    # @!attribute [rw] name
-    #     @return [String]
-    #     Dot separated name of the structure element. The segments in the name reflect the organization of the APIs. The format of each segment is lower case with underscores. Each underscore represents a word boundary. If there are acronyms in the word, the capitalization is preserved. This format makes it easy to translate the segment into a different naming convention.
-    # @!attribute [rw] type
+    # Constructs a new instance.
+    # @param ruby_values [Hash] a map of initial property values (optional)
+    # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
+    def initialize(ruby_values = nil, struct_value = nil)
+      super(self.class.binding_type, ruby_values, struct_value)
+    end
+
+    # The  ``Com::Vmware::Vapi::Metadata::Metamodel::StructureInfo::Type``   enumerated type  defines the kind of this structure element. In the interface definition language, structure element and error element have similar characteristics. The difference is that only error elements can be used to describe the  errors  of an operation element.
+    # @!attribute [rw] structure
     #     @return [Com::Vmware::Vapi::Metadata::Metamodel::StructureInfo::Type]
-    #     Type of the structure.
-    # @!attribute [rw] enumerations
-    #     @return [Hash<String, Com::Vmware::Vapi::Metadata::Metamodel::EnumerationInfo>]
-    #     Metamodel information of all the enumeration elements contained in the structure element. The key in the  map  is the identifier of the enumeration element and the value is the metamodel information of the enumeration element.
-    # @!attribute [rw] constants
-    #     @return [Hash<String, Com::Vmware::Vapi::Metadata::Metamodel::ConstantInfo>]
-    #     Metamodel information of all the constant elements contained in the structure element. The key in the  map  is the name of the constant element and the value in the  map  is the metamodel information for the constant element.
-    # @!attribute [rw] fields
-    #     @return [Array<Com::Vmware::Vapi::Metadata::Metamodel::FieldInfo>]
-    #     Metamodel information of all the field elements. The order of the field elements in the list matches the order in which the fields are defined in the service.
-    # @!attribute [rw] metadata
-    #     @return [Hash<String, Com::Vmware::Vapi::Metadata::Metamodel::ElementMap>]
-    #     Generic metadata elements for the structure element. The key in the  map  is the name of the metadata element and the value is the data associated with that metadata element.  
-    #     
-    #      The   :class:`Com::Vmware::Vapi::Metadata::Metamodel::MetadataIdentifier`   contains possible string values for keys in the  map .
-    # @!attribute [rw] documentation
-    #     @return [String]
-    #     English language documentation for a structure element. It can contain HTML markup and Javadoc tags. The first sentence of the structure documentation is a complete sentence that identifies the structure by name and summarizes the purpose of the structure.
-    class StructureInfo < VAPI::Bindings::VapiStruct
-
-        class << self
-            # Holds (gets or creates) the binding type metadata for this structure type.
-            # @scope class
-            # @return [VAPI::Bindings::StructType] the binding type
-            def binding_type
-                @binding_type ||= VAPI::Bindings::StructType.new(
-                    'com.vmware.vapi.metadata.metamodel.structure_info',
-                    {
-                        'name' => VAPI::Bindings::StringType.instance,
-                        'type' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Metadata::Metamodel::StructureInfo::Type'),
-                        'enumerations' => VAPI::Bindings::MapType.new(VAPI::Bindings::IdType.new, VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Metadata::Metamodel::EnumerationInfo')),
-                        'constants' => VAPI::Bindings::MapType.new(VAPI::Bindings::StringType.instance, VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Metadata::Metamodel::ConstantInfo')),
-                        'fields' => VAPI::Bindings::ListType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Metadata::Metamodel::FieldInfo')),
-                        'metadata' => VAPI::Bindings::MapType.new(VAPI::Bindings::StringType.instance, VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Metadata::Metamodel::ElementMap')),
-                        'documentation' => VAPI::Bindings::StringType.instance,
-                    },
-                    StructureInfo,
-                    false,
-                    nil)
-            end
+    #     If the type is a structure element.
+    # @!attribute [rw] error
+    #     @return [Com::Vmware::Vapi::Metadata::Metamodel::StructureInfo::Type]
+    #     If the type is an error element.
+    class Type < VAPI::Bindings::VapiEnum
+      class << self
+        # Holds (gets or creates) the binding type metadata for this enumeration type.
+        # @scope class
+        # @return [VAPI::Bindings::EnumType] the binding type
+        def binding_type
+          @binding_type ||= VAPI::Bindings::EnumType.new(
+            'com.vmware.vapi.metadata.metamodel.structure_info.type',
+            Type
+          )
         end
 
-        attr_accessor :name,
-                      :type,
-                      :enumerations,
-                      :constants,
-                      :fields,
-                      :metadata,
-                      :documentation
-
-        # Constructs a new instance.
-        # @param ruby_values [Hash] a map of initial property values (optional)
-        # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
-        def initialize(ruby_values=nil, struct_value=nil)
-            super(self.class.binding_type, ruby_values, struct_value)
+        # Converts from a string value (perhaps off the wire) to an instance
+        # of this enum type.
+        # @param value [String] the actual value of the enum instance
+        # @return [Type] the instance found for the value, otherwise
+        #         an unknown instance will be built for the value
+        def from_string(value)
+          const_get(value)
+        rescue NameError
+          Type.send(:new, 'UNKNOWN', value)
         end
+      end
 
+      # Constructs a new instance.
+      # @param value [String] the actual value of the enum instance
+      # @param unknown [String] the unknown value when value is 'UKNOWN'
+      def initialize(value, unknown = nil)
+        super(self.class.binding_type, value, unknown)
+      end
 
-        # The  ``Com::Vmware::Vapi::Metadata::Metamodel::StructureInfo::Type``   enumerated type  defines the kind of this structure element. In the interface definition language, structure element and error element have similar characteristics. The difference is that only error elements can be used to describe the  errors  of an operation element.
-        # @!attribute [rw] structure
-        #     @return [Com::Vmware::Vapi::Metadata::Metamodel::StructureInfo::Type]
-        #     If the type is a structure element.
-        # @!attribute [rw] error
-        #     @return [Com::Vmware::Vapi::Metadata::Metamodel::StructureInfo::Type]
-        #     If the type is an error element.
-        class Type < VAPI::Bindings::VapiEnum
+      private_class_method :new
 
-            class << self
-                # Holds (gets or creates) the binding type metadata for this enumeration type.
-                # @scope class
-                # @return [VAPI::Bindings::EnumType] the binding type
-                def binding_type
-                    @binding_type ||= VAPI::Bindings::EnumType.new(
-                        'com.vmware.vapi.metadata.metamodel.structure_info.type',
-                        Type)
-                end
+      # @!attribute [rw] structure
+      #     @return [Com::Vmware::Vapi::Metadata::Metamodel::StructureInfo::Type]
+      #     If the type is a structure element.
+      STRUCTURE = Type.send(:new, 'STRUCTURE')
 
-                # Converts from a string value (perhaps off the wire) to an instance
-                # of this enum type.
-                # @param value [String] the actual value of the enum instance
-                # @return [Type] the instance found for the value, otherwise
-                #         an unknown instance will be built for the value
-                def from_string(value)
-                    begin
-                        const_get(value)
-                    rescue NameError
-                        Type.new('UNKNOWN', value)
-                    end
-                end
-            end
-
-            private
-
-            # Constructs a new instance.
-            # @param value [String] the actual value of the enum instance
-            # @param unknown [String] the unknown value when value is 'UKNOWN'
-            def initialize(value, unknown=nil)
-                super(self.class.binding_type, value, unknown)
-            end
-
-            public
-
-            # @!attribute [rw] structure
-            #     @return [Com::Vmware::Vapi::Metadata::Metamodel::StructureInfo::Type]
-            #     If the type is a structure element.
-            STRUCTURE = Type.new('STRUCTURE')
-
-            # @!attribute [rw] error
-            #     @return [Com::Vmware::Vapi::Metadata::Metamodel::StructureInfo::Type]
-            #     If the type is an error element.
-            ERROR = Type.new('ERROR')
-
-        end
-
-
+      # @!attribute [rw] error
+      #     @return [Com::Vmware::Vapi::Metadata::Metamodel::StructureInfo::Type]
+      #     If the type is an error element.
+      ERROR = Type.send(:new, 'ERROR')
+    end
+  end
+  # The  ``Com::Vmware::Vapi::Metadata::Metamodel::Type``   class  describes the type information of a typed element in the interface definiton language. The following elements in the metamodel are typed:  
+  # 
+  #   * Field element in a structure element. See   :attr:`Com::Vmware::Vapi::Metadata::Metamodel::StructureInfo.fields` 
+  #    * Parameter element in an operation element. See   :attr:`Com::Vmware::Vapi::Metadata::Metamodel::OperationInfo.params` 
+  #    * Result element in an operation element. See   :attr:`Com::Vmware::Vapi::Metadata::Metamodel::OperationInfo.output` 
+  #   
+  #   The type could be one of the three following categories:  
+  # 
+  #   * Built-in types: These are types present in the interface definition language type system. They are provided by the infrastructure. 
+  #    * User defined named type: API designers can create custom types and use them for the typed elements. These types have a unique identifier.
+  #    * Generic type instantiation: The language infrastructure also provides generic types such as list, map, set and so on. An instantiation of one of these generic types could also be used for the typed elements.
+  #   
+  # @!attribute [rw] category
+  #     @return [Com::Vmware::Vapi::Metadata::Metamodel::Type::Category]
+  #     Category of this type.
+  # @!attribute [rw] builtin_type
+  #     @return [Com::Vmware::Vapi::Metadata::Metamodel::Type::BuiltinType]
+  #     Category of the built-in type.
+  #     This  field  is optional and it is only relevant when the value of  ``category``  is   :attr:`Com::Vmware::Vapi::Metadata::Metamodel::Type::Category.BUILTIN`  .
+  # @!attribute [rw] user_defined_type
+  #     @return [Com::Vmware::Vapi::Metadata::Metamodel::UserDefinedType]
+  #     Identifier and type of the user defined type.
+  #     This  field  is optional and it is only relevant when the value of  ``category``  is   :attr:`Com::Vmware::Vapi::Metadata::Metamodel::Type::Category.USER_DEFINED`  .
+  # @!attribute [rw] generic_instantiation
+  #     @return [Com::Vmware::Vapi::Metadata::Metamodel::GenericInstantiation]
+  #     Instantiation of one of the generic types available in the interface definition language.
+  #     This  field  is optional and it is only relevant when the value of  ``category``  is   :attr:`Com::Vmware::Vapi::Metadata::Metamodel::Type::Category.GENERIC`  .
+  class Type < VAPI::Bindings::VapiStruct
+    class << self
+      # Holds (gets or creates) the binding type metadata for this structure type.
+      # @scope class
+      # @return [VAPI::Bindings::StructType] the binding type
+      def binding_type
+        @binding_type ||= VAPI::Bindings::StructType.new(
+          'com.vmware.vapi.metadata.metamodel.type',
+          {
+            'category' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Metadata::Metamodel::Type::Category'),
+            'builtin_type' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Metadata::Metamodel::Type::BuiltinType')),
+            'user_defined_type' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Metadata::Metamodel::UserDefinedType')),
+            'generic_instantiation' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Metadata::Metamodel::GenericInstantiation'))
+          },
+          Type,
+          false,
+          nil
+        )
+      end
     end
 
+    attr_accessor :category,
+                  :builtin_type,
+                  :user_defined_type,
+                  :generic_instantiation
 
-    # The  ``Com::Vmware::Vapi::Metadata::Metamodel::Type``   class  describes the type information of a typed element in the interface definiton language. The following elements in the metamodel are typed:  
-    # 
-    #   * Field element in a structure element. See   :attr:`Com::Vmware::Vapi::Metadata::Metamodel::StructureInfo.fields` 
-    #    * Parameter element in an operation element. See   :attr:`Com::Vmware::Vapi::Metadata::Metamodel::OperationInfo.params` 
-    #    * Result element in an operation element. See   :attr:`Com::Vmware::Vapi::Metadata::Metamodel::OperationInfo.output` 
-    #   
-    #   The type could be one of the three following categories:  
-    # 
-    #   * Built-in types: These are types present in the interface definition language type system. They are provided by the infrastructure. 
-    #    * User defined named type: API designers can create custom types and use them for the typed elements. These types have a unique identifier.
-    #    * Generic type instantiation: The language infrastructure also provides generic types such as list, map, set and so on. An instantiation of one of these generic types could also be used for the typed elements.
-    #   
-    # @!attribute [rw] category
+    # Constructs a new instance.
+    # @param ruby_values [Hash] a map of initial property values (optional)
+    # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
+    def initialize(ruby_values = nil, struct_value = nil)
+      super(self.class.binding_type, ruby_values, struct_value)
+    end
+
+    # The  ``Com::Vmware::Vapi::Metadata::Metamodel::Type::Category``   enumerated type  provides  enumeration value  for each category of the type.
+    # @!attribute [rw] builtin
     #     @return [Com::Vmware::Vapi::Metadata::Metamodel::Type::Category]
-    #     Category of this type.
-    # @!attribute [rw] builtin_type
+    #     The type is one of the built-in types specified in   :class:`Com::Vmware::Vapi::Metadata::Metamodel::Type::BuiltinType` 
+    # @!attribute [rw] user_defined
+    #     @return [Com::Vmware::Vapi::Metadata::Metamodel::Type::Category]
+    #     The type is one of the user defined named types.
+    # @!attribute [rw] generic
+    #     @return [Com::Vmware::Vapi::Metadata::Metamodel::Type::Category]
+    #     The type is an instantiation of one of the generic types.
+    class Category < VAPI::Bindings::VapiEnum
+      class << self
+        # Holds (gets or creates) the binding type metadata for this enumeration type.
+        # @scope class
+        # @return [VAPI::Bindings::EnumType] the binding type
+        def binding_type
+          @binding_type ||= VAPI::Bindings::EnumType.new(
+            'com.vmware.vapi.metadata.metamodel.type.category',
+            Category
+          )
+        end
+
+        # Converts from a string value (perhaps off the wire) to an instance
+        # of this enum type.
+        # @param value [String] the actual value of the enum instance
+        # @return [Category] the instance found for the value, otherwise
+        #         an unknown instance will be built for the value
+        def from_string(value)
+          const_get(value)
+        rescue NameError
+          Category.send(:new, 'UNKNOWN', value)
+        end
+      end
+
+      # Constructs a new instance.
+      # @param value [String] the actual value of the enum instance
+      # @param unknown [String] the unknown value when value is 'UKNOWN'
+      def initialize(value, unknown = nil)
+        super(self.class.binding_type, value, unknown)
+      end
+
+      private_class_method :new
+
+      # @!attribute [rw] builtin
+      #     @return [Com::Vmware::Vapi::Metadata::Metamodel::Type::Category]
+      #     The type is one of the built-in types specified in   :class:`Com::Vmware::Vapi::Metadata::Metamodel::Type::BuiltinType` 
+      BUILTIN = Category.send(:new, 'BUILTIN')
+
+      # @!attribute [rw] user_defined
+      #     @return [Com::Vmware::Vapi::Metadata::Metamodel::Type::Category]
+      #     The type is one of the user defined named types.
+      USER_DEFINED = Category.send(:new, 'USER_DEFINED')
+
+      # @!attribute [rw] generic
+      #     @return [Com::Vmware::Vapi::Metadata::Metamodel::Type::Category]
+      #     The type is an instantiation of one of the generic types.
+      GENERIC = Category.send(:new, 'GENERIC')
+    end
+
+    # The  ``Com::Vmware::Vapi::Metadata::Metamodel::Type::BuiltinType``   enumerated type  provides  enumeration value  for each of the built-in types present in the interface definition language type system.
+    # @!attribute [rw] void
     #     @return [Com::Vmware::Vapi::Metadata::Metamodel::Type::BuiltinType]
-    #     Category of the built-in type.
-    #     This  field  is optional and it is only relevant when the value of  ``category``  is   :attr:`Com::Vmware::Vapi::Metadata::Metamodel::Type::Category.BUILTIN`  .
-    # @!attribute [rw] user_defined_type
-    #     @return [Com::Vmware::Vapi::Metadata::Metamodel::UserDefinedType]
-    #     Identifier and type of the user defined type.
-    #     This  field  is optional and it is only relevant when the value of  ``category``  is   :attr:`Com::Vmware::Vapi::Metadata::Metamodel::Type::Category.USER_DEFINED`  .
-    # @!attribute [rw] generic_instantiation
-    #     @return [Com::Vmware::Vapi::Metadata::Metamodel::GenericInstantiation]
-    #     Instantiation of one of the generic types available in the interface definition language.
-    #     This  field  is optional and it is only relevant when the value of  ``category``  is   :attr:`Com::Vmware::Vapi::Metadata::Metamodel::Type::Category.GENERIC`  .
-    class Type < VAPI::Bindings::VapiStruct
-
-        class << self
-            # Holds (gets or creates) the binding type metadata for this structure type.
-            # @scope class
-            # @return [VAPI::Bindings::StructType] the binding type
-            def binding_type
-                @binding_type ||= VAPI::Bindings::StructType.new(
-                    'com.vmware.vapi.metadata.metamodel.type',
-                    {
-                        'category' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Metadata::Metamodel::Type::Category'),
-                        'builtin_type' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Metadata::Metamodel::Type::BuiltinType')),
-                        'user_defined_type' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Metadata::Metamodel::UserDefinedType')),
-                        'generic_instantiation' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Metadata::Metamodel::GenericInstantiation')),
-                    },
-                    Type,
-                    false,
-                    nil)
-            end
+    #     The built-in type is a void. The value is  nil .
+    # @!attribute [rw] boolean
+    #     @return [Com::Vmware::Vapi::Metadata::Metamodel::Type::BuiltinType]
+    #     The built-in type is a boolean. The value is true or false.
+    # @!attribute [rw] long
+    #     @return [Com::Vmware::Vapi::Metadata::Metamodel::Type::BuiltinType]
+    #     The built-in type is a long. The value is a 64 bit signed integer.
+    # @!attribute [rw] double
+    #     @return [Com::Vmware::Vapi::Metadata::Metamodel::Type::BuiltinType]
+    #     The built-in type is a double. The value is a 64 bit floating point number.
+    # @!attribute [rw] string
+    #     @return [Com::Vmware::Vapi::Metadata::Metamodel::Type::BuiltinType]
+    #     The built-in type is a string. The value is a variable-length sequence of zero or more unicode characters.
+    # @!attribute [rw] binary
+    #     @return [Com::Vmware::Vapi::Metadata::Metamodel::Type::BuiltinType]
+    #     The built-in type is a binary. The value is a variable-length sequence of zero or more bytes.
+    # @!attribute [rw] secret
+    #     @return [Com::Vmware::Vapi::Metadata::Metamodel::Type::BuiltinType]
+    #     The built-in type is a secret. The value is a variable-length sequence of zero or more unicode characters. The value contains sensitive data that should not be printed or displayed anywhere.
+    # @!attribute [rw] date_time
+    #     @return [Com::Vmware::Vapi::Metadata::Metamodel::Type::BuiltinType]
+    #     The built-in type is a datetime. The value should be in the UTC timezone and the precision is milliseconds.
+    # @!attribute [rw] id
+    #     @return [Com::Vmware::Vapi::Metadata::Metamodel::Type::BuiltinType]
+    #     The built-in type is an ID. The value represents an identifier for a resource.
+    # @!attribute [rw] uri
+    #     @return [Com::Vmware::Vapi::Metadata::Metamodel::Type::BuiltinType]
+    #     The built-in type is an URI. The value follows the IRI specification in RFC 3987.
+    # @!attribute [rw] any_error
+    #     @return [Com::Vmware::Vapi::Metadata::Metamodel::Type::BuiltinType]
+    #     The built-in type is an arbitrary  error  type. This is used if the value of a typed element can be one of any user defined named type which is an  error .
+    # @!attribute [rw] dynamic_structure
+    #     @return [Com::Vmware::Vapi::Metadata::Metamodel::Type::BuiltinType]
+    #     The built-in type is a dynamic structure. This is used if the value of a typed element can be one of any user defined named type.
+    # @!attribute [rw] opaque
+    #     @return [Com::Vmware::Vapi::Metadata::Metamodel::Type::BuiltinType]
+    #     The built-in type is an opaque. This is used if the value of a typed element could be of any type and the actual type will be known only during the execution of the API. This is mostly used in infrastructure  classs .
+    class BuiltinType < VAPI::Bindings::VapiEnum
+      class << self
+        # Holds (gets or creates) the binding type metadata for this enumeration type.
+        # @scope class
+        # @return [VAPI::Bindings::EnumType] the binding type
+        def binding_type
+          @binding_type ||= VAPI::Bindings::EnumType.new(
+            'com.vmware.vapi.metadata.metamodel.type.builtin_type',
+            BuiltinType
+          )
         end
 
-        attr_accessor :category,
-                      :builtin_type,
-                      :user_defined_type,
-                      :generic_instantiation
-
-        # Constructs a new instance.
-        # @param ruby_values [Hash] a map of initial property values (optional)
-        # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
-        def initialize(ruby_values=nil, struct_value=nil)
-            super(self.class.binding_type, ruby_values, struct_value)
+        # Converts from a string value (perhaps off the wire) to an instance
+        # of this enum type.
+        # @param value [String] the actual value of the enum instance
+        # @return [BuiltinType] the instance found for the value, otherwise
+        #         an unknown instance will be built for the value
+        def from_string(value)
+          const_get(value)
+        rescue NameError
+          BuiltinType.send(:new, 'UNKNOWN', value)
         end
+      end
 
+      # Constructs a new instance.
+      # @param value [String] the actual value of the enum instance
+      # @param unknown [String] the unknown value when value is 'UKNOWN'
+      def initialize(value, unknown = nil)
+        super(self.class.binding_type, value, unknown)
+      end
 
-        # The  ``Com::Vmware::Vapi::Metadata::Metamodel::Type::Category``   enumerated type  provides  enumeration value  for each category of the type.
-        # @!attribute [rw] builtin
-        #     @return [Com::Vmware::Vapi::Metadata::Metamodel::Type::Category]
-        #     The type is one of the built-in types specified in   :class:`Com::Vmware::Vapi::Metadata::Metamodel::Type::BuiltinType` 
-        # @!attribute [rw] user_defined
-        #     @return [Com::Vmware::Vapi::Metadata::Metamodel::Type::Category]
-        #     The type is one of the user defined named types.
-        # @!attribute [rw] generic
-        #     @return [Com::Vmware::Vapi::Metadata::Metamodel::Type::Category]
-        #     The type is an instantiation of one of the generic types.
-        class Category < VAPI::Bindings::VapiEnum
+      private_class_method :new
 
-            class << self
-                # Holds (gets or creates) the binding type metadata for this enumeration type.
-                # @scope class
-                # @return [VAPI::Bindings::EnumType] the binding type
-                def binding_type
-                    @binding_type ||= VAPI::Bindings::EnumType.new(
-                        'com.vmware.vapi.metadata.metamodel.type.category',
-                        Category)
-                end
+      # @!attribute [rw] void
+      #     @return [Com::Vmware::Vapi::Metadata::Metamodel::Type::BuiltinType]
+      #     The built-in type is a void. The value is  nil .
+      VOID = BuiltinType.send(:new, 'VOID')
 
-                # Converts from a string value (perhaps off the wire) to an instance
-                # of this enum type.
-                # @param value [String] the actual value of the enum instance
-                # @return [Category] the instance found for the value, otherwise
-                #         an unknown instance will be built for the value
-                def from_string(value)
-                    begin
-                        const_get(value)
-                    rescue NameError
-                        Category.new('UNKNOWN', value)
-                    end
-                end
-            end
+      # @!attribute [rw] boolean
+      #     @return [Com::Vmware::Vapi::Metadata::Metamodel::Type::BuiltinType]
+      #     The built-in type is a boolean. The value is true or false.
+      BOOLEAN = BuiltinType.send(:new, 'BOOLEAN')
 
-            private
+      # @!attribute [rw] long
+      #     @return [Com::Vmware::Vapi::Metadata::Metamodel::Type::BuiltinType]
+      #     The built-in type is a long. The value is a 64 bit signed integer.
+      LONG = BuiltinType.send(:new, 'LONG')
 
-            # Constructs a new instance.
-            # @param value [String] the actual value of the enum instance
-            # @param unknown [String] the unknown value when value is 'UKNOWN'
-            def initialize(value, unknown=nil)
-                super(self.class.binding_type, value, unknown)
-            end
+      # @!attribute [rw] double
+      #     @return [Com::Vmware::Vapi::Metadata::Metamodel::Type::BuiltinType]
+      #     The built-in type is a double. The value is a 64 bit floating point number.
+      DOUBLE = BuiltinType.send(:new, 'DOUBLE')
 
-            public
+      # @!attribute [rw] string
+      #     @return [Com::Vmware::Vapi::Metadata::Metamodel::Type::BuiltinType]
+      #     The built-in type is a string. The value is a variable-length sequence of zero or more unicode characters.
+      STRING = BuiltinType.send(:new, 'STRING')
 
-            # @!attribute [rw] builtin
-            #     @return [Com::Vmware::Vapi::Metadata::Metamodel::Type::Category]
-            #     The type is one of the built-in types specified in   :class:`Com::Vmware::Vapi::Metadata::Metamodel::Type::BuiltinType` 
-            BUILTIN = Category.new('BUILTIN')
+      # @!attribute [rw] binary
+      #     @return [Com::Vmware::Vapi::Metadata::Metamodel::Type::BuiltinType]
+      #     The built-in type is a binary. The value is a variable-length sequence of zero or more bytes.
+      BINARY = BuiltinType.send(:new, 'BINARY')
 
-            # @!attribute [rw] user_defined
-            #     @return [Com::Vmware::Vapi::Metadata::Metamodel::Type::Category]
-            #     The type is one of the user defined named types.
-            USER_DEFINED = Category.new('USER_DEFINED')
+      # @!attribute [rw] secret
+      #     @return [Com::Vmware::Vapi::Metadata::Metamodel::Type::BuiltinType]
+      #     The built-in type is a secret. The value is a variable-length sequence of zero or more unicode characters. The value contains sensitive data that should not be printed or displayed anywhere.
+      SECRET = BuiltinType.send(:new, 'SECRET')
 
-            # @!attribute [rw] generic
-            #     @return [Com::Vmware::Vapi::Metadata::Metamodel::Type::Category]
-            #     The type is an instantiation of one of the generic types.
-            GENERIC = Category.new('GENERIC')
+      # @!attribute [rw] date_time
+      #     @return [Com::Vmware::Vapi::Metadata::Metamodel::Type::BuiltinType]
+      #     The built-in type is a datetime. The value should be in the UTC timezone and the precision is milliseconds.
+      DATE_TIME = BuiltinType.send(:new, 'DATE_TIME')
 
-        end
+      # @!attribute [rw] id
+      #     @return [Com::Vmware::Vapi::Metadata::Metamodel::Type::BuiltinType]
+      #     The built-in type is an ID. The value represents an identifier for a resource.
+      ID = BuiltinType.send(:new, 'ID')
 
+      # @!attribute [rw] uri
+      #     @return [Com::Vmware::Vapi::Metadata::Metamodel::Type::BuiltinType]
+      #     The built-in type is an URI. The value follows the IRI specification in RFC 3987.
+      URI = BuiltinType.send(:new, 'URI')
 
-        # The  ``Com::Vmware::Vapi::Metadata::Metamodel::Type::BuiltinType``   enumerated type  provides  enumeration value  for each of the built-in types present in the interface definition language type system.
-        # @!attribute [rw] void
-        #     @return [Com::Vmware::Vapi::Metadata::Metamodel::Type::BuiltinType]
-        #     The built-in type is a void. The value is  nil .
-        # @!attribute [rw] boolean
-        #     @return [Com::Vmware::Vapi::Metadata::Metamodel::Type::BuiltinType]
-        #     The built-in type is a boolean. The value is true or false.
-        # @!attribute [rw] long
-        #     @return [Com::Vmware::Vapi::Metadata::Metamodel::Type::BuiltinType]
-        #     The built-in type is a long. The value is a 64 bit signed integer.
-        # @!attribute [rw] double
-        #     @return [Com::Vmware::Vapi::Metadata::Metamodel::Type::BuiltinType]
-        #     The built-in type is a double. The value is a 64 bit floating point number.
-        # @!attribute [rw] string
-        #     @return [Com::Vmware::Vapi::Metadata::Metamodel::Type::BuiltinType]
-        #     The built-in type is a string. The value is a variable-length sequence of zero or more unicode characters.
-        # @!attribute [rw] binary
-        #     @return [Com::Vmware::Vapi::Metadata::Metamodel::Type::BuiltinType]
-        #     The built-in type is a binary. The value is a variable-length sequence of zero or more bytes.
-        # @!attribute [rw] secret
-        #     @return [Com::Vmware::Vapi::Metadata::Metamodel::Type::BuiltinType]
-        #     The built-in type is a secret. The value is a variable-length sequence of zero or more unicode characters. The value contains sensitive data that should not be printed or displayed anywhere.
-        # @!attribute [rw] date_time
-        #     @return [Com::Vmware::Vapi::Metadata::Metamodel::Type::BuiltinType]
-        #     The built-in type is a datetime. The value should be in the UTC timezone and the precision is milliseconds.
-        # @!attribute [rw] id
-        #     @return [Com::Vmware::Vapi::Metadata::Metamodel::Type::BuiltinType]
-        #     The built-in type is an ID. The value represents an identifier for a resource.
-        # @!attribute [rw] uri
-        #     @return [Com::Vmware::Vapi::Metadata::Metamodel::Type::BuiltinType]
-        #     The built-in type is an URI. The value follows the IRI specification in RFC 3987.
-        # @!attribute [rw] any_error
-        #     @return [Com::Vmware::Vapi::Metadata::Metamodel::Type::BuiltinType]
-        #     The built-in type is an arbitrary  error  type. This is used if the value of a typed element can be one of any user defined named type which is an  error .
-        # @!attribute [rw] dynamic_structure
-        #     @return [Com::Vmware::Vapi::Metadata::Metamodel::Type::BuiltinType]
-        #     The built-in type is a dynamic structure. This is used if the value of a typed element can be one of any user defined named type.
-        # @!attribute [rw] opaque
-        #     @return [Com::Vmware::Vapi::Metadata::Metamodel::Type::BuiltinType]
-        #     The built-in type is an opaque. This is used if the value of a typed element could be of any type and the actual type will be known only during the execution of the API. This is mostly used in infrastructure  classs .
-        class BuiltinType < VAPI::Bindings::VapiEnum
+      # @!attribute [rw] any_error
+      #     @return [Com::Vmware::Vapi::Metadata::Metamodel::Type::BuiltinType]
+      #     The built-in type is an arbitrary  error  type. This is used if the value of a typed element can be one of any user defined named type which is an  error .
+      ANY_ERROR = BuiltinType.send(:new, 'ANY_ERROR')
 
-            class << self
-                # Holds (gets or creates) the binding type metadata for this enumeration type.
-                # @scope class
-                # @return [VAPI::Bindings::EnumType] the binding type
-                def binding_type
-                    @binding_type ||= VAPI::Bindings::EnumType.new(
-                        'com.vmware.vapi.metadata.metamodel.type.builtin_type',
-                        BuiltinType)
-                end
+      # @!attribute [rw] dynamic_structure
+      #     @return [Com::Vmware::Vapi::Metadata::Metamodel::Type::BuiltinType]
+      #     The built-in type is a dynamic structure. This is used if the value of a typed element can be one of any user defined named type.
+      DYNAMIC_STRUCTURE = BuiltinType.send(:new, 'DYNAMIC_STRUCTURE')
 
-                # Converts from a string value (perhaps off the wire) to an instance
-                # of this enum type.
-                # @param value [String] the actual value of the enum instance
-                # @return [BuiltinType] the instance found for the value, otherwise
-                #         an unknown instance will be built for the value
-                def from_string(value)
-                    begin
-                        const_get(value)
-                    rescue NameError
-                        BuiltinType.new('UNKNOWN', value)
-                    end
-                end
-            end
-
-            private
-
-            # Constructs a new instance.
-            # @param value [String] the actual value of the enum instance
-            # @param unknown [String] the unknown value when value is 'UKNOWN'
-            def initialize(value, unknown=nil)
-                super(self.class.binding_type, value, unknown)
-            end
-
-            public
-
-            # @!attribute [rw] void
-            #     @return [Com::Vmware::Vapi::Metadata::Metamodel::Type::BuiltinType]
-            #     The built-in type is a void. The value is  nil .
-            VOID = BuiltinType.new('VOID')
-
-            # @!attribute [rw] boolean
-            #     @return [Com::Vmware::Vapi::Metadata::Metamodel::Type::BuiltinType]
-            #     The built-in type is a boolean. The value is true or false.
-            BOOLEAN = BuiltinType.new('BOOLEAN')
-
-            # @!attribute [rw] long
-            #     @return [Com::Vmware::Vapi::Metadata::Metamodel::Type::BuiltinType]
-            #     The built-in type is a long. The value is a 64 bit signed integer.
-            LONG = BuiltinType.new('LONG')
-
-            # @!attribute [rw] double
-            #     @return [Com::Vmware::Vapi::Metadata::Metamodel::Type::BuiltinType]
-            #     The built-in type is a double. The value is a 64 bit floating point number.
-            DOUBLE = BuiltinType.new('DOUBLE')
-
-            # @!attribute [rw] string
-            #     @return [Com::Vmware::Vapi::Metadata::Metamodel::Type::BuiltinType]
-            #     The built-in type is a string. The value is a variable-length sequence of zero or more unicode characters.
-            STRING = BuiltinType.new('STRING')
-
-            # @!attribute [rw] binary
-            #     @return [Com::Vmware::Vapi::Metadata::Metamodel::Type::BuiltinType]
-            #     The built-in type is a binary. The value is a variable-length sequence of zero or more bytes.
-            BINARY = BuiltinType.new('BINARY')
-
-            # @!attribute [rw] secret
-            #     @return [Com::Vmware::Vapi::Metadata::Metamodel::Type::BuiltinType]
-            #     The built-in type is a secret. The value is a variable-length sequence of zero or more unicode characters. The value contains sensitive data that should not be printed or displayed anywhere.
-            SECRET = BuiltinType.new('SECRET')
-
-            # @!attribute [rw] date_time
-            #     @return [Com::Vmware::Vapi::Metadata::Metamodel::Type::BuiltinType]
-            #     The built-in type is a datetime. The value should be in the UTC timezone and the precision is milliseconds.
-            DATE_TIME = BuiltinType.new('DATE_TIME')
-
-            # @!attribute [rw] id
-            #     @return [Com::Vmware::Vapi::Metadata::Metamodel::Type::BuiltinType]
-            #     The built-in type is an ID. The value represents an identifier for a resource.
-            ID = BuiltinType.new('ID')
-
-            # @!attribute [rw] uri
-            #     @return [Com::Vmware::Vapi::Metadata::Metamodel::Type::BuiltinType]
-            #     The built-in type is an URI. The value follows the IRI specification in RFC 3987.
-            URI = BuiltinType.new('URI')
-
-            # @!attribute [rw] any_error
-            #     @return [Com::Vmware::Vapi::Metadata::Metamodel::Type::BuiltinType]
-            #     The built-in type is an arbitrary  error  type. This is used if the value of a typed element can be one of any user defined named type which is an  error .
-            ANY_ERROR = BuiltinType.new('ANY_ERROR')
-
-            # @!attribute [rw] dynamic_structure
-            #     @return [Com::Vmware::Vapi::Metadata::Metamodel::Type::BuiltinType]
-            #     The built-in type is a dynamic structure. This is used if the value of a typed element can be one of any user defined named type.
-            DYNAMIC_STRUCTURE = BuiltinType.new('DYNAMIC_STRUCTURE')
-
-            # @!attribute [rw] opaque
-            #     @return [Com::Vmware::Vapi::Metadata::Metamodel::Type::BuiltinType]
-            #     The built-in type is an opaque. This is used if the value of a typed element could be of any type and the actual type will be known only during the execution of the API. This is mostly used in infrastructure  classs .
-            OPAQUE = BuiltinType.new('OPAQUE')
-
-        end
-
-
+      # @!attribute [rw] opaque
+      #     @return [Com::Vmware::Vapi::Metadata::Metamodel::Type::BuiltinType]
+      #     The built-in type is an opaque. This is used if the value of a typed element could be of any type and the actual type will be known only during the execution of the API. This is mostly used in infrastructure  classs .
+      OPAQUE = BuiltinType.send(:new, 'OPAQUE')
+    end
+  end
+  # The  ``Com::Vmware::Vapi::Metadata::Metamodel::UserDefinedType``   class  contains the metamodel type information of a typed element whose type is a user defined named type.
+  # @!attribute [rw] resource_type
+  #     @return [String]
+  #     Category of the user defined named type. The named type could be a structure element or an enumeration element.
+  # @!attribute [rw] resource_id
+  #     @return [String]
+  #     Identifier of the user defined named type.
+  class UserDefinedType < VAPI::Bindings::VapiStruct
+    class << self
+      # Holds (gets or creates) the binding type metadata for this structure type.
+      # @scope class
+      # @return [VAPI::Bindings::StructType] the binding type
+      def binding_type
+        @binding_type ||= VAPI::Bindings::StructType.new(
+          'com.vmware.vapi.metadata.metamodel.user_defined_type',
+          {
+            'resource_type' => VAPI::Bindings::StringType.instance,
+            'resource_id' => VAPI::Bindings::IdType.new(["com.vmware.vapi.structure", "com.vmware.vapi.enumeration"], "resource_type")
+          },
+          UserDefinedType,
+          false,
+          nil
+        )
+      end
     end
 
+    attr_accessor :resource_type,
+                  :resource_id
 
-    # The  ``Com::Vmware::Vapi::Metadata::Metamodel::UserDefinedType``   class  contains the metamodel type information of a typed element whose type is a user defined named type.
-    # @!attribute [rw] resource_type
-    #     @return [String]
-    #     Category of the user defined named type. The named type could be a structure element or an enumeration element.
-    # @!attribute [rw] resource_id
-    #     @return [String]
-    #     Identifier of the user defined named type.
-    class UserDefinedType < VAPI::Bindings::VapiStruct
-
-        class << self
-            # Holds (gets or creates) the binding type metadata for this structure type.
-            # @scope class
-            # @return [VAPI::Bindings::StructType] the binding type
-            def binding_type
-                @binding_type ||= VAPI::Bindings::StructType.new(
-                    'com.vmware.vapi.metadata.metamodel.user_defined_type',
-                    {
-                        'resource_type' => VAPI::Bindings::StringType.instance,
-                        'resource_id' => VAPI::Bindings::IdType.new(resource_types=["com.vmware.vapi.structure", "com.vmware.vapi.enumeration"], resource_type_field_name="resource_type"),
-                    },
-                    UserDefinedType,
-                    false,
-                    nil)
-            end
-        end
-
-        attr_accessor :resource_type,
-                      :resource_id
-
-        # Constructs a new instance.
-        # @param ruby_values [Hash] a map of initial property values (optional)
-        # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
-        def initialize(ruby_values=nil, struct_value=nil)
-            super(self.class.binding_type, ruby_values, struct_value)
-        end
+    # Constructs a new instance.
+    # @param ruby_values [Hash] a map of initial property values (optional)
+    # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
+    def initialize(ruby_values = nil, struct_value = nil)
+      super(self.class.binding_type, ruby_values, struct_value)
     end
-
+  end
 end

--- a/client/sdk/com/vmware/vapi/metadata/metamodel/resource.rb
+++ b/client/sdk/com/vmware/vapi/metadata/metamodel/resource.rb
@@ -1,5 +1,6 @@
 #---------------------------------------------------------------------------
-# Copyright 2016 VMware, Inc.  All rights reserved.
+# Copyright 2017 VMware, Inc.  All rights reserved.
+#
 # AUTO GENERATED FILE -- DO NOT MODIFY!
 #
 # vAPI type descriptors for package com.vmware.vapi.metadata.metamodel.resource.
@@ -8,78 +9,68 @@ require 'vapi'
 
 # declare the module hierarchy before we use the shorthand syntax below
 module Com
-    module Vmware
-        module Vapi
-            module Metadata
-                module Metamodel
-                    module Resource
-                    end
-                end
-            end
+  module Vmware
+    module Vapi
+      module Metadata
+        module Metamodel
+          module Resource
+          end
         end
+      end
     end
+  end
 end
 
 # The  ``com.vmware.vapi.metadata.metamodel.resource``   package  provides  classs  to retrieve metamodel information for resource types.
 module Com::Vmware::Vapi::Metadata::Metamodel::Resource
+  # The  ``Com::Vmware::Vapi::Metadata::Metamodel::Resource::Model``   class  provides  methods  to retrieve information about models.  
+  # 
+  #  A structure is used as a model if it is used for persisting data about an entity. Some of the fields in the model structure are also used for creating indexes for querying.  
+  # 
+  #  One or more services can operate on the same resource type. One or more services can provide the model structure for an entity of this resource type. Using  ``Com::Vmware::Vapi::Metadata::Metamodel::Resource::Model``   class  you can retrieve the list of all the structure elements that are model structures for a given resource type.
+  class Model < VAPI::Bindings::VapiService
+    # static metamodel definitions
+    SERVICE_ID = VAPI::Core::ServiceIdentifier.new('com.vmware.vapi.metadata.metamodel.resource.model')
 
-    # The  ``Com::Vmware::Vapi::Metadata::Metamodel::Resource::Model``   class  provides  methods  to retrieve information about models.  
-    # 
-    #  A structure is used as a model if it is used for persisting data about an entity. Some of the fields in the model structure are also used for creating indexes for querying.  
-    # 
-    #  One or more services can operate on the same resource type. One or more services can provide the model structure for an entity of this resource type. Using  ``Com::Vmware::Vapi::Metadata::Metamodel::Resource::Model``   class  you can retrieve the list of all the structure elements that are model structures for a given resource type.
-    class Model < VAPI::Bindings::VapiService
+    LIST_INFO = VAPI::Bindings::OperationInfo.new(
+      VAPI::Core::OperationIdentifier.new('list', SERVICE_ID),
+      VAPI::Bindings::OperationInputType.new(
+        'resource_id' => VAPI::Bindings::IdType.new('com.vmware.vapi.resource')
+      ),
+      VAPI::Bindings::SetType.new(VAPI::Bindings::IdType.new),
+      {
+        'com.vmware.vapi.std.errors.not_found' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::NotFound')
+      },
+      [],
+      []
+    )
 
-        protected
+    SERVICE_INFO = VAPI::Bindings::ServiceInfo.new(
+      SERVICE_ID,
+      'list' => LIST_INFO
+    )
 
-        # static metamodel definitions
-        @@service_id = VAPI::Core::ServiceIdentifier.new('com.vmware.vapi.metadata.metamodel.resource.model')
-
-        @@list_info = VAPI::Bindings::OperationInfo.new(
-            VAPI::Core::OperationIdentifier.new('list', @@service_id),
-            VAPI::Bindings::OperationInputType.new({
-                'resource_id' => VAPI::Bindings::IdType.new(resource_types='com.vmware.vapi.resource'),
-            }),
-            VAPI::Bindings::SetType.new(VAPI::Bindings::IdType.new),
-            {
-                'com.vmware.vapi.std.errors.not_found' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::NotFound'),
-
-            },
-            [],
-            [])
-
-        @@service_info = VAPI::Bindings::ServiceInfo.new(@@service_id, {
-            'list' => @@list_info,
-        })
-
-        public
-
-        # Constructs a new instance.
-        #
-        # @param config [VAPI::Bindings::StubConfig] A hash with the api provider details.
-        def initialize(config)
-            super(config, @@service_info)
-        end
-
-
-        # Returns the set of identifiers for the structure elements that are models for the resource type corresponding to  ``resource_id`` .  
-        # 
-        #  The   :class:`Com::Vmware::Vapi::Metadata::Metamodel::Structure`    class  provides  methods  to retrieve more details about the structure elements corresponding to the identifiers returned by this  method .
-        #
-        # @param resource_id [String]
-        #     Identifier of the resource type.
-        # @return [Set<String>]
-        #     The set of identifiers for the models that are associated with the resource type in  ``resource_id`` .
-        # @raise [Com::Vmware::Vapi::Std::Errors::NotFound]
-        #     if the resource type associated with  ``resource_id``  does not exist.
-        def list(resource_id)
-            invoke_with_info(@@list_info, {
-                'resource_id' => resource_id,
-            })
-        end
-
-
+    # Constructs a new instance.
+    #
+    # @param config [VAPI::Bindings::StubConfig] A hash with the api provider details.
+    def initialize(config)
+      super(config, SERVICE_INFO)
     end
 
+    # Returns the set of identifiers for the structure elements that are models for the resource type corresponding to  ``resource_id`` .  
+    # 
+    #  The   :class:`Com::Vmware::Vapi::Metadata::Metamodel::Structure`    class  provides  methods  to retrieve more details about the structure elements corresponding to the identifiers returned by this  method .
+    #
+    # @param resource_id [String]
+    #     Identifier of the resource type.
+    # @return [Set<String>]
+    #     The set of identifiers for the models that are associated with the resource type in  ``resource_id`` .
+    # @raise [Com::Vmware::Vapi::Std::Errors::NotFound]
+    #     if the resource type associated with  ``resource_id``  does not exist.
+    def list(resource_id)
+      invoke_with_info(LIST_INFO,
+                       'resource_id' => resource_id)
+    end
 
+  end
 end

--- a/client/sdk/com/vmware/vapi/metadata/metamodel/service.rb
+++ b/client/sdk/com/vmware/vapi/metadata/metamodel/service.rb
@@ -1,5 +1,6 @@
 #---------------------------------------------------------------------------
-# Copyright 2016 VMware, Inc.  All rights reserved.
+# Copyright 2017 VMware, Inc.  All rights reserved.
+#
 # AUTO GENERATED FILE -- DO NOT MODIFY!
 #
 # vAPI type descriptors for package com.vmware.vapi.metadata.metamodel.service.
@@ -8,107 +9,95 @@ require 'vapi'
 
 # declare the module hierarchy before we use the shorthand syntax below
 module Com
-    module Vmware
-        module Vapi
-            module Metadata
-                module Metamodel
-                    module Service
-                    end
-                end
-            end
+  module Vmware
+    module Vapi
+      module Metadata
+        module Metamodel
+          module Service
+          end
         end
+      end
     end
+  end
 end
 
 module Com::Vmware::Vapi::Metadata::Metamodel::Service
+  # The  ``Com::Vmware::Vapi::Metadata::Metamodel::Service::Operation``   class  provides  methods  to retrieve metamodel information of an operation element in the interface definition language.
+  class Operation < VAPI::Bindings::VapiService
+    # static metamodel definitions
+    SERVICE_ID = VAPI::Core::ServiceIdentifier.new('com.vmware.vapi.metadata.metamodel.service.operation')
 
-    # The  ``Com::Vmware::Vapi::Metadata::Metamodel::Service::Operation``   class  provides  methods  to retrieve metamodel information of an operation element in the interface definition language.
-    class Operation < VAPI::Bindings::VapiService
+    LIST_INFO = VAPI::Bindings::OperationInfo.new(
+      VAPI::Core::OperationIdentifier.new('list', SERVICE_ID),
+      VAPI::Bindings::OperationInputType.new(
+        'service_id' => VAPI::Bindings::IdType.new('com.vmware.vapi.service')
+      ),
+      VAPI::Bindings::ListType.new(VAPI::Bindings::IdType.new),
+      {
+        'com.vmware.vapi.std.errors.not_found' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::NotFound')
+      },
+      [],
+      []
+    )
 
-        protected
+    GET_INFO = VAPI::Bindings::OperationInfo.new(
+      VAPI::Core::OperationIdentifier.new('get', SERVICE_ID),
+      VAPI::Bindings::OperationInputType.new(
+        'service_id' => VAPI::Bindings::IdType.new('com.vmware.vapi.service'),
+        'operation_id' => VAPI::Bindings::IdType.new('com.vmware.vapi.operation')
+      ),
+      VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Metadata::Metamodel::OperationInfo'),
+      {
+        'com.vmware.vapi.std.errors.not_found' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::NotFound')
+      },
+      [],
+      []
+    )
 
-        # static metamodel definitions
-        @@service_id = VAPI::Core::ServiceIdentifier.new('com.vmware.vapi.metadata.metamodel.service.operation')
+    SERVICE_INFO = VAPI::Bindings::ServiceInfo.new(
+      SERVICE_ID,
+      'list' => LIST_INFO,
+      'get' => GET_INFO
+    )
 
-        @@list_info = VAPI::Bindings::OperationInfo.new(
-            VAPI::Core::OperationIdentifier.new('list', @@service_id),
-            VAPI::Bindings::OperationInputType.new({
-                'service_id' => VAPI::Bindings::IdType.new(resource_types='com.vmware.vapi.service'),
-            }),
-            VAPI::Bindings::ListType.new(VAPI::Bindings::IdType.new),
-            {
-                'com.vmware.vapi.std.errors.not_found' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::NotFound'),
-
-            },
-            [],
-            [])
-        @@get_info = VAPI::Bindings::OperationInfo.new(
-            VAPI::Core::OperationIdentifier.new('get', @@service_id),
-            VAPI::Bindings::OperationInputType.new({
-                'service_id' => VAPI::Bindings::IdType.new(resource_types='com.vmware.vapi.service'),
-                'operation_id' => VAPI::Bindings::IdType.new(resource_types='com.vmware.vapi.operation'),
-            }),
-            VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Metadata::Metamodel::OperationInfo'),
-            {
-                'com.vmware.vapi.std.errors.not_found' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::NotFound'),
-
-            },
-            [],
-            [])
-
-        @@service_info = VAPI::Bindings::ServiceInfo.new(@@service_id, {
-            'list' => @@list_info,
-            'get' => @@get_info,
-        })
-
-        public
-
-        # Constructs a new instance.
-        #
-        # @param config [VAPI::Bindings::StubConfig] A hash with the api provider details.
-        def initialize(config)
-            super(config, @@service_info)
-        end
-
-        RESOURCE_TYPE = 'com.vmware.vapi.operation'
-
-
-        # Returns the identifiers for the operation elements that are defined in the scope of  ``service_id`` .
-        #
-        # @param service_id [String]
-        #     Identifier of the service element.
-        # @return [Array<String>]
-        #     The list of identifiers for the operation elements that are defined in the scope of  ``service_id`` .
-        # @raise [Com::Vmware::Vapi::Std::Errors::NotFound]
-        #     if the service element associated with  ``service_id``  does not exist in any of the package elements.
-        def list(service_id)
-            invoke_with_info(@@list_info, {
-                'service_id' => service_id,
-            })
-        end
-
-
-        # Retrieves the metamodel information about an operation element corresponding to  ``operation_id``  contained in the service element corresponding to  ``service_id`` .
-        #
-        # @param service_id [String]
-        #     Identifier of the service element.
-        # @param operation_id [String]
-        #     Identifier of the operation element.
-        # @return [Com::Vmware::Vapi::Metadata::Metamodel::OperationInfo]
-        #     The   :class:`Com::Vmware::Vapi::Metadata::Metamodel::OperationInfo`   instance that corresponds to  ``operation_id``  defined in scope  ``service_id`` .
-        # @raise [Com::Vmware::Vapi::Std::Errors::NotFound]
-        #     if the service element associated with  ``service_id``  does not exist in any of the package elements.
-        # @raise [Com::Vmware::Vapi::Std::Errors::NotFound]
-        #     if the operation element associated with  ``operation_id``  does not exist in the service element.
-        def get(service_id, operation_id)
-            invoke_with_info(@@get_info, {
-                'service_id' => service_id,
-                'operation_id' => operation_id,
-            })
-        end
-
-
+    # Constructs a new instance.
+    #
+    # @param config [VAPI::Bindings::StubConfig] A hash with the api provider details.
+    def initialize(config)
+      super(config, SERVICE_INFO)
     end
 
+    RESOURCE_TYPE = 'com.vmware.vapi.operation'
+    # Returns the identifiers for the operation elements that are defined in the scope of  ``service_id`` .
+    #
+    # @param service_id [String]
+    #     Identifier of the service element.
+    # @return [Array<String>]
+    #     The list of identifiers for the operation elements that are defined in the scope of  ``service_id`` .
+    # @raise [Com::Vmware::Vapi::Std::Errors::NotFound]
+    #     if the service element associated with  ``service_id``  does not exist in any of the package elements.
+    def list(service_id)
+      invoke_with_info(LIST_INFO,
+                       'service_id' => service_id)
+    end
 
+    # Retrieves the metamodel information about an operation element corresponding to  ``operation_id``  contained in the service element corresponding to  ``service_id`` .
+    #
+    # @param service_id [String]
+    #     Identifier of the service element.
+    # @param operation_id [String]
+    #     Identifier of the operation element.
+    # @return [Com::Vmware::Vapi::Metadata::Metamodel::OperationInfo]
+    #     The   :class:`Com::Vmware::Vapi::Metadata::Metamodel::OperationInfo`   instance that corresponds to  ``operation_id``  defined in scope  ``service_id`` .
+    # @raise [Com::Vmware::Vapi::Std::Errors::NotFound]
+    #     if the service element associated with  ``service_id``  does not exist in any of the package elements.
+    # @raise [Com::Vmware::Vapi::Std::Errors::NotFound]
+    #     if the operation element associated with  ``operation_id``  does not exist in the service element.
+    def get(service_id, operation_id)
+      invoke_with_info(GET_INFO,
+                       'service_id' => service_id,
+                       'operation_id' => operation_id)
+    end
+
+  end
 end

--- a/client/sdk/com/vmware/vapi/metadata/privilege.rb
+++ b/client/sdk/com/vmware/vapi/metadata/privilege.rb
@@ -1,5 +1,6 @@
 #---------------------------------------------------------------------------
-# Copyright 2016 VMware, Inc.  All rights reserved.
+# Copyright 2017 VMware, Inc.  All rights reserved.
+#
 # AUTO GENERATED FILE -- DO NOT MODIFY!
 #
 # vAPI type descriptors for package com.vmware.vapi.metadata.privilege.
@@ -8,14 +9,14 @@ require 'vapi'
 
 # declare the module hierarchy before we use the shorthand syntax below
 module Com
-    module Vmware
-        module Vapi
-            module Metadata
-                module Privilege
-                end
-            end
+  module Vmware
+    module Vapi
+      module Metadata
+        module Privilege
         end
+      end
     end
+  end
 end
 
 # The  ``com.vmware.vapi.metadata.privilege``   package  provides  classs  that expose privilege information for operation elements across all the service elements.  
@@ -24,787 +25,730 @@ end
 # 
 #  Privileges can be assigned to either operation elements or entities used in the operation element. A list of privileges can also be applied on a package element. This list of privileges would be used as a default for all the operation elements and the entities that do not have any defined privileges.
 module Com::Vmware::Vapi::Metadata::Privilege
+  # The  ``Com::Vmware::Vapi::Metadata::Privilege::Component``   class  provides  methods  to retrieve privilege information of a component element.  
+  # 
+  #  A component element is said to contain privilege information if any one of package elements in it contains privilege information.
+  class Component < VAPI::Bindings::VapiService
+    # static metamodel definitions
+    SERVICE_ID = VAPI::Core::ServiceIdentifier.new('com.vmware.vapi.metadata.privilege.component')
 
-    # The  ``Com::Vmware::Vapi::Metadata::Privilege::Component``   class  provides  methods  to retrieve privilege information of a component element.  
-    # 
-    #  A component element is said to contain privilege information if any one of package elements in it contains privilege information.
-    class Component < VAPI::Bindings::VapiService
+    LIST_INFO = VAPI::Bindings::OperationInfo.new(
+      VAPI::Core::OperationIdentifier.new('list', SERVICE_ID),
+      VAPI::Bindings::OperationInputType.new,
+      VAPI::Bindings::ListType.new(VAPI::Bindings::IdType.new),
+      {},
+      [],
+      []
+    )
 
-        protected
+    GET_INFO = VAPI::Bindings::OperationInfo.new(
+      VAPI::Core::OperationIdentifier.new('get', SERVICE_ID),
+      VAPI::Bindings::OperationInputType.new(
+        'component_id' => VAPI::Bindings::IdType.new('com.vmware.vapi.component')
+      ),
+      VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Metadata::Privilege::ComponentData'),
+      {
+        'com.vmware.vapi.std.errors.not_found' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::NotFound')
+      },
+      [],
+      []
+    )
 
-        # static metamodel definitions
-        @@service_id = VAPI::Core::ServiceIdentifier.new('com.vmware.vapi.metadata.privilege.component')
+    FINGERPRINT_INFO = VAPI::Bindings::OperationInfo.new(
+      VAPI::Core::OperationIdentifier.new('fingerprint', SERVICE_ID),
+      VAPI::Bindings::OperationInputType.new(
+        'component_id' => VAPI::Bindings::IdType.new('com.vmware.vapi.component')
+      ),
+      VAPI::Bindings::StringType.instance,
+      {
+        'com.vmware.vapi.std.errors.not_found' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::NotFound')
+      },
+      [],
+      []
+    )
 
-        @@list_info = VAPI::Bindings::OperationInfo.new(
-            VAPI::Core::OperationIdentifier.new('list', @@service_id),
-            VAPI::Bindings::OperationInputType.new,
-            VAPI::Bindings::ListType.new(VAPI::Bindings::IdType.new),
-            {},
-            [],
-            [])
-        @@get_info = VAPI::Bindings::OperationInfo.new(
-            VAPI::Core::OperationIdentifier.new('get', @@service_id),
-            VAPI::Bindings::OperationInputType.new({
-                'component_id' => VAPI::Bindings::IdType.new(resource_types='com.vmware.vapi.component'),
-            }),
-            VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Metadata::Privilege::ComponentData'),
-            {
-                'com.vmware.vapi.std.errors.not_found' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::NotFound'),
+    SERVICE_INFO = VAPI::Bindings::ServiceInfo.new(
+      SERVICE_ID,
+      'list' => LIST_INFO,
+      'get' => GET_INFO,
+      'fingerprint' => FINGERPRINT_INFO
+    )
 
-            },
-            [],
-            [])
-        @@fingerprint_info = VAPI::Bindings::OperationInfo.new(
-            VAPI::Core::OperationIdentifier.new('fingerprint', @@service_id),
-            VAPI::Bindings::OperationInputType.new({
-                'component_id' => VAPI::Bindings::IdType.new(resource_types='com.vmware.vapi.component'),
-            }),
-            VAPI::Bindings::StringType.instance,
-            {
-                'com.vmware.vapi.std.errors.not_found' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::NotFound'),
-
-            },
-            [],
-            [])
-
-        @@service_info = VAPI::Bindings::ServiceInfo.new(@@service_id, {
-            'list' => @@list_info,
-            'get' => @@get_info,
-            'fingerprint' => @@fingerprint_info,
-        })
-
-        public
-
-        # Constructs a new instance.
-        #
-        # @param config [VAPI::Bindings::StubConfig] A hash with the api provider details.
-        def initialize(config)
-            super(config, @@service_info)
-        end
-
-        RESOURCE_TYPE = 'com.vmware.vapi.component'
-
-
-        # Returns the identifiers for the component elements that have privilege information.
-        #
-        # @return [Array<String>]
-        #     The list of identifiers for the component elements that have privilege information.
-        def list()
-            invoke_with_info(@@list_info)
-        end
-
-
-        # Retrieves privilege information about the component element corresponding to  ``component_id`` .  
-        # 
-        #  The   :class:`Com::Vmware::Vapi::Metadata::Privilege::ComponentData`   contains the privilege information about the component element and its fingerprint. It contains information about all the package elements that belong to this component element.
-        #
-        # @param component_id [String]
-        #     Identifier of the component element.
-        # @return [Com::Vmware::Vapi::Metadata::Privilege::ComponentData]
-        #     The   :class:`Com::Vmware::Vapi::Metadata::Privilege::ComponentData`   instance that corresponds to  ``component_id``
-        # @raise [Com::Vmware::Vapi::Std::Errors::NotFound]
-        #     if the component element associated with  ``component_id``  does not have any privilege information.
-        def get(component_id)
-            invoke_with_info(@@get_info, {
-                'component_id' => component_id,
-            })
-        end
-
-
-        # Retrieves the fingerprint computed from the privilege metadata of the component element corresponding to  ``component_id`` .  
-        # 
-        #  The fingerprint provides clients an efficient way to check if the metadata for a particular component has been modified on the server. The client can do this by comparing the result of this operation with the fingerprint returned in the result of   :func:`Com::Vmware::Vapi::Metadata::Privilege::Component.get`  .
-        #
-        # @param component_id [String]
-        #     Identifier of the component element.
-        # @return [String]
-        #     The fingerprint computed from the privilege metadata of the component.
-        # @raise [Com::Vmware::Vapi::Std::Errors::NotFound]
-        #     if the component element associated with  ``component_id``  does not have any privilege information.
-        def fingerprint(component_id)
-            invoke_with_info(@@fingerprint_info, {
-                'component_id' => component_id,
-            })
-        end
-
-
+    # Constructs a new instance.
+    #
+    # @param config [VAPI::Bindings::StubConfig] A hash with the api provider details.
+    def initialize(config)
+      super(config, SERVICE_INFO)
     end
 
-
-    # The  ``Com::Vmware::Vapi::Metadata::Privilege::Package``   class  provides  methods  to retrieve privilege information of a package element.  
-    # 
-    #  A package element is said to contain privilege information if there is a default privilege assigned to all service elements contained in the package element or if one of the operation elements contained in one of the service elements in this package element has privilege information.
-    class Package < VAPI::Bindings::VapiService
-
-        protected
-
-        # static metamodel definitions
-        @@service_id = VAPI::Core::ServiceIdentifier.new('com.vmware.vapi.metadata.privilege.package')
-
-        @@list_info = VAPI::Bindings::OperationInfo.new(
-            VAPI::Core::OperationIdentifier.new('list', @@service_id),
-            VAPI::Bindings::OperationInputType.new,
-            VAPI::Bindings::ListType.new(VAPI::Bindings::IdType.new),
-            {},
-            [],
-            [])
-        @@get_info = VAPI::Bindings::OperationInfo.new(
-            VAPI::Core::OperationIdentifier.new('get', @@service_id),
-            VAPI::Bindings::OperationInputType.new({
-                'package_id' => VAPI::Bindings::IdType.new(resource_types='com.vmware.vapi.package'),
-            }),
-            VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Metadata::Privilege::PackageInfo'),
-            {
-                'com.vmware.vapi.std.errors.not_found' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::NotFound'),
-
-            },
-            [],
-            [])
-
-        @@service_info = VAPI::Bindings::ServiceInfo.new(@@service_id, {
-            'list' => @@list_info,
-            'get' => @@get_info,
-        })
-
-        public
-
-        # Constructs a new instance.
-        #
-        # @param config [VAPI::Bindings::StubConfig] A hash with the api provider details.
-        def initialize(config)
-            super(config, @@service_info)
-        end
-
-        RESOURCE_TYPE = 'com.vmware.vapi.package'
-
-
-        # Returns the identifiers for the package elements that have privilege information.
-        #
-        # @return [Array<String>]
-        #     The list of identifiers for the package elements that have privilege information.
-        def list()
-            invoke_with_info(@@list_info)
-        end
-
-
-        # Retrieves privilege information about the package element corresponding to  ``package_id`` .
-        #
-        # @param package_id [String]
-        #     Identifier of the package element.
-        # @return [Com::Vmware::Vapi::Metadata::Privilege::PackageInfo]
-        #     The   :class:`Com::Vmware::Vapi::Metadata::Privilege::PackageInfo`   instance that corresponds to  ``package_id``
-        # @raise [Com::Vmware::Vapi::Std::Errors::NotFound]
-        #     if the package element associated with  ``package_id``  does not have any privilege information.
-        def get(package_id)
-            invoke_with_info(@@get_info, {
-                'package_id' => package_id,
-            })
-        end
-
-
+    RESOURCE_TYPE = 'com.vmware.vapi.component'
+    # Returns the identifiers for the component elements that have privilege information.
+    #
+    # @return [Array<String>]
+    #     The list of identifiers for the component elements that have privilege information.
+    def list
+      invoke_with_info(LIST_INFO)
     end
 
-
-    # The  ``Com::Vmware::Vapi::Metadata::Privilege::Service``   class  provides  methods  to retrieve privilege information of a service element.  
+    # Retrieves privilege information about the component element corresponding to  ``component_id`` .  
     # 
-    #  A service element is said to contain privilege information if one of the operation elements contained in this service element has privilege information.
-    class ServiceService < VAPI::Bindings::VapiService
-
-        protected
-
-        # static metamodel definitions
-        @@service_id = VAPI::Core::ServiceIdentifier.new('com.vmware.vapi.metadata.privilege.service')
-
-        @@list_info = VAPI::Bindings::OperationInfo.new(
-            VAPI::Core::OperationIdentifier.new('list', @@service_id),
-            VAPI::Bindings::OperationInputType.new,
-            VAPI::Bindings::ListType.new(VAPI::Bindings::IdType.new),
-            {},
-            [],
-            [])
-        @@get_info = VAPI::Bindings::OperationInfo.new(
-            VAPI::Core::OperationIdentifier.new('get', @@service_id),
-            VAPI::Bindings::OperationInputType.new({
-                'service_id' => VAPI::Bindings::IdType.new(resource_types='com.vmware.vapi.service'),
-            }),
-            VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Metadata::Privilege::ServiceInfo'),
-            {
-                'com.vmware.vapi.std.errors.not_found' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::NotFound'),
-
-            },
-            [],
-            [])
-
-        @@service_info = VAPI::Bindings::ServiceInfo.new(@@service_id, {
-            'list' => @@list_info,
-            'get' => @@get_info,
-        })
-
-        public
-
-        # Constructs a new instance.
-        #
-        # @param config [VAPI::Bindings::StubConfig] A hash with the api provider details.
-        def initialize(config)
-            super(config, @@service_info)
-        end
-
-        RESOURCE_TYPE = 'com.vmware.vapi.service'
-
-
-        # Returns the identifiers for the service elements that have privilege information.
-        #
-        # @return [Array<String>]
-        #     The list of identifiers for the service elements that have privilege information.
-        def list()
-            invoke_with_info(@@list_info)
-        end
-
-
-        # Retrieves privilege information about the service element corresponding to  ``service_id`` .
-        #
-        # @param service_id [String]
-        #     Identifier of the service element.
-        # @return [Com::Vmware::Vapi::Metadata::Privilege::ServiceInfo]
-        #     The   :class:`Com::Vmware::Vapi::Metadata::Privilege::ServiceInfo`   instance that corresponds to  ``service_id``
-        # @raise [Com::Vmware::Vapi::Std::Errors::NotFound]
-        #     if the service element associated with  ``service_id``  does not have any privilege information.
-        def get(service_id)
-            invoke_with_info(@@get_info, {
-                'service_id' => service_id,
-            })
-        end
-
-
+    #  The   :class:`Com::Vmware::Vapi::Metadata::Privilege::ComponentData`   contains the privilege information about the component element and its fingerprint. It contains information about all the package elements that belong to this component element.
+    #
+    # @param component_id [String]
+    #     Identifier of the component element.
+    # @return [Com::Vmware::Vapi::Metadata::Privilege::ComponentData]
+    #     The   :class:`Com::Vmware::Vapi::Metadata::Privilege::ComponentData`   instance that corresponds to  ``component_id``
+    # @raise [Com::Vmware::Vapi::Std::Errors::NotFound]
+    #     if the component element associated with  ``component_id``  does not have any privilege information.
+    def get(component_id)
+      invoke_with_info(GET_INFO,
+                       'component_id' => component_id)
     end
 
-
-    # The  ``Com::Vmware::Vapi::Metadata::Privilege::Source``   class  provides  methods  to manage the sources of privilege metadata information.  
+    # Retrieves the fingerprint computed from the privilege metadata of the component element corresponding to  ``component_id`` .  
     # 
-    #  The interface definition language infrastructure provides tools to generate various kinds of metadata in JSON format from the interface definition files and additional properties files. One of the generated files contains privilege information. The generated file can be registered as a source of metadata.  
-    # 
-    #  The privilege file contains all the data present in the interface definition files. Each privilege file contains data about one component element. When a privilege file is added as a source, each source contributes only one component element's metadata.  
-    # 
-    #  Privilege metadata can also be discovered from a remote server that supports the privilege metadata  classs  (see   :mod:`com.vmware.vapi.metadata.privilege`  ). Since multiple components can be registered with a single metadata server, when a remote server is registered as a source, that source can contribute more than one component.
-    class Source < VAPI::Bindings::VapiService
-
-        protected
-
-        # static metamodel definitions
-        @@service_id = VAPI::Core::ServiceIdentifier.new('com.vmware.vapi.metadata.privilege.source')
-
-        @@create_info = VAPI::Bindings::OperationInfo.new(
-            VAPI::Core::OperationIdentifier.new('create', @@service_id),
-            VAPI::Bindings::OperationInputType.new({
-                'source_id' => VAPI::Bindings::IdType.new(resource_types='com.vmware.vapi.metadata.privilege.source'),
-                'spec' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Metadata::Privilege::Source::CreateSpec'),
-            }),
-            VAPI::Bindings::VoidType.instance,
-            {
-                'com.vmware.vapi.std.errors.already_exists' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::AlreadyExists'),
-                'com.vmware.vapi.std.errors.invalid_argument' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::InvalidArgument'),
-                'com.vmware.vapi.std.errors.not_found' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::NotFound'),
-
-            },
-            [],
-            [])
-        @@delete_info = VAPI::Bindings::OperationInfo.new(
-            VAPI::Core::OperationIdentifier.new('delete', @@service_id),
-            VAPI::Bindings::OperationInputType.new({
-                'source_id' => VAPI::Bindings::IdType.new(resource_types='com.vmware.vapi.metadata.privilege.source'),
-            }),
-            VAPI::Bindings::VoidType.instance,
-            {
-                'com.vmware.vapi.std.errors.not_found' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::NotFound'),
-
-            },
-            [],
-            [])
-        @@get_info = VAPI::Bindings::OperationInfo.new(
-            VAPI::Core::OperationIdentifier.new('get', @@service_id),
-            VAPI::Bindings::OperationInputType.new({
-                'source_id' => VAPI::Bindings::IdType.new(resource_types='com.vmware.vapi.metadata.privilege.source'),
-            }),
-            VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Metadata::Privilege::Source::Info'),
-            {
-                'com.vmware.vapi.std.errors.not_found' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::NotFound'),
-
-            },
-            [],
-            [])
-        @@list_info = VAPI::Bindings::OperationInfo.new(
-            VAPI::Core::OperationIdentifier.new('list', @@service_id),
-            VAPI::Bindings::OperationInputType.new,
-            VAPI::Bindings::ListType.new(VAPI::Bindings::IdType.new),
-            {},
-            [],
-            [])
-        @@reload_info = VAPI::Bindings::OperationInfo.new(
-            VAPI::Core::OperationIdentifier.new('reload', @@service_id),
-            VAPI::Bindings::OperationInputType.new({
-                'source_id' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::IdType.new),
-            }),
-            VAPI::Bindings::VoidType.instance,
-            {
-                'com.vmware.vapi.std.errors.not_found' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::NotFound'),
-
-            },
-            [],
-            [])
-        @@fingerprint_info = VAPI::Bindings::OperationInfo.new(
-            VAPI::Core::OperationIdentifier.new('fingerprint', @@service_id),
-            VAPI::Bindings::OperationInputType.new({
-                'source_id' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::IdType.new),
-            }),
-            VAPI::Bindings::StringType.instance,
-            {
-                'com.vmware.vapi.std.errors.not_found' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::NotFound'),
-
-            },
-            [],
-            [])
-
-        @@service_info = VAPI::Bindings::ServiceInfo.new(@@service_id, {
-            'create' => @@create_info,
-            'delete' => @@delete_info,
-            'get' => @@get_info,
-            'list' => @@list_info,
-            'reload' => @@reload_info,
-            'fingerprint' => @@fingerprint_info,
-        })
-
-        public
-
-        # Constructs a new instance.
-        #
-        # @param config [VAPI::Bindings::StubConfig] A hash with the api provider details.
-        def initialize(config)
-            super(config, @@service_info)
-        end
-
-        RESOURCE_TYPE = 'com.vmware.vapi.metadata.privilege.source'
-
-
-        # Creates a new metadata source. Once the server validates the registration information of the metadata source, the privilege metadata is retrieved from the source. This populates elements in all the  classs  defined in   :mod:`com.vmware.vapi.metadata.privilege`    package .
-        #
-        # @param source_id [String]
-        #     metadata source identifier.
-        # @param spec [Com::Vmware::Vapi::Metadata::Privilege::Source::CreateSpec]
-        #     create specification.
-        # @return [Void]
-        # @raise [Com::Vmware::Vapi::Std::Errors::AlreadyExists]
-        #     if the metadata source identifier is already registered with the infrastructure.
-        # @raise [Com::Vmware::Vapi::Std::Errors::InvalidArgument]
-        #     if the type of the source specified in  null  is invalid.
-        # @raise [Com::Vmware::Vapi::Std::Errors::InvalidArgument]
-        #     if the file specified in  null  is not a valid JSON file or if the format of the privilege metadata in the JSON file is invalid.
-        # @raise [Com::Vmware::Vapi::Std::Errors::InvalidArgument]
-        #     if the URI specified in  null  is unreachable or if there is a transport protocol or message protocol mismatch between the client and the server or if the remote server do not have  classs  present in   :mod:`com.vmware.vapi.metadata.privilege`    package .
-        # @raise [Com::Vmware::Vapi::Std::Errors::NotFound]
-        #     if the file specified in  null  does not exist.
-        def create(source_id, spec)
-            invoke_with_info(@@create_info, {
-                'source_id' => source_id,
-                'spec' => spec,
-            })
-        end
-
-
-        # Deletes an existing privilege metadata source from the infrastructure.
-        #
-        # @param source_id [String]
-        #     Identifier of the metadata source.
-        # @return [Void]
-        # @raise [Com::Vmware::Vapi::Std::Errors::NotFound]
-        #     if the metadata source associated with  ``source_id``  is not found.
-        def delete(source_id)
-            invoke_with_info(@@delete_info, {
-                'source_id' => source_id,
-            })
-        end
-
-
-        # Retrieves information about the metadata source corresponding to  ``source_id`` .
-        #
-        # @param source_id [String]
-        #     Identifier of the metadata source.
-        # @return [Com::Vmware::Vapi::Metadata::Privilege::Source::Info]
-        #     The   :class:`Com::Vmware::Vapi::Metadata::Privilege::Source::Info`   instance that corresponds to  ``source_id``
-        # @raise [Com::Vmware::Vapi::Std::Errors::NotFound]
-        #     if the metadata source associated with  ``source_id``  is not found.
-        def get(source_id)
-            invoke_with_info(@@get_info, {
-                'source_id' => source_id,
-            })
-        end
-
-
-        # Returns the identifiers of the metadata sources currently registered with the infrastructure.
-        #
-        # @return [Array<String>]
-        #     The list of identifiers for metadata sources currently registered.
-        def list()
-            invoke_with_info(@@list_info)
-        end
-
-
-        # Reloads the privilege metadata from all the metadata sources or of a particular metadata source if  ``source_id``  is specified.
-        #
-        # @param source_id [String, nil]
-        #     Identifier of the metadata source.
-        #     If unspecified, all the metadata sources are reloaded.
-        # @return [Void]
-        # @raise [Com::Vmware::Vapi::Std::Errors::NotFound]
-        #     if the metadata source associated with  ``source_id``  is not found.
-        def reload(source_id=nil)
-            invoke_with_info(@@reload_info, {
-                'source_id' => source_id,
-            })
-        end
-
-
-        # Returns the aggregate fingerprint of metadata from all the metadata sources or from a particular metadata source if  ``source_id``  is specified.
-        #
-        # @param source_id [String, nil]
-        #     Identifier of the metadata source.
-        #     If unspecified, the fingerprint of all the metadata sources is returned.
-        # @return [String]
-        #     Aggregate fingerprint of all the metadata sources or of a particular metadata source.
-        # @raise [Com::Vmware::Vapi::Std::Errors::NotFound]
-        #     if the metadata source associated with  ``source_id``  is not found.
-        def fingerprint(source_id=nil)
-            invoke_with_info(@@fingerprint_info, {
-                'source_id' => source_id,
-            })
-        end
-
-
-
-        # The  ``Com::Vmware::Vapi::Metadata::Privilege::Source::Info``   class  contains the metadata source information.
-        # @!attribute [rw] description
-        #     @return [String]
-        #     English language human readable description of the source.
-        # @!attribute [rw] type
-        #     @return [Com::Vmware::Vapi::Metadata::SourceType]
-        #     Type of the metadata source.
-        # @!attribute [rw] filepath
-        #     @return [String]
-        #     Absolute file path of the privilege metadata file that has the privilege information about one component element. The  ``filePath``  is the path to the file in the server's filesystem.
-        #     This  field  is optional and it is only relevant when the value of  ``type``  is  null .
-        # @!attribute [rw] address
-        #     @return [URI]
-        #     Connection information for the remote server. This must be in the format http(s)://IP:port/namespace.  
-        #     
-        #      The remote server must support the  classs  in the   :mod:`com.vmware.vapi.metadata.privilege`    package . It must expose privilege information of one or more components.
-        #     This  field  is optional and it is only relevant when the value of  ``type``  is  null .
-        class Info < VAPI::Bindings::VapiStruct
-
-            class << self
-                # Holds (gets or creates) the binding type metadata for this structure type.
-                # @scope class
-                # @return [VAPI::Bindings::StructType] the binding type
-                def binding_type
-                    @binding_type ||= VAPI::Bindings::StructType.new(
-                        'com.vmware.vapi.metadata.privilege.source.info',
-                        {
-                            'description' => VAPI::Bindings::StringType.instance,
-                            'type' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Metadata::SourceType'),
-                            'filepath' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::StringType.instance),
-                            'address' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::URIType.instance),
-                        },
-                        Info,
-                        false,
-                        nil)
-                end
-            end
-
-            attr_accessor :description,
-                          :type,
-                          :filepath,
-                          :address
-
-            # Constructs a new instance.
-            # @param ruby_values [Hash] a map of initial property values (optional)
-            # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
-            def initialize(ruby_values=nil, struct_value=nil)
-                super(self.class.binding_type, ruby_values, struct_value)
-            end
-        end
-
-
-        # The  ``Com::Vmware::Vapi::Metadata::Privilege::Source::CreateSpec``   class  contains the registration information of a privilege source.
-        class CreateSpec < VAPI::Bindings::VapiStruct
-
-            class << self
-                # Holds (gets or creates) the binding type metadata for this structure type.
-                # @scope class
-                # @return [VAPI::Bindings::StructType] the binding type
-                def binding_type
-                    @binding_type ||= VAPI::Bindings::StructType.new(
-                        'com.vmware.vapi.metadata.privilege.source.create_spec',
-                        {
-                            'description' => VAPI::Bindings::StringType.instance,
-                            'type' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Metadata::SourceType'),
-                            'filepath' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::StringType.instance),
-                            'address' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::URIType.instance),
-                        },
-                        CreateSpec,
-                        false,
-                        nil)
-                end
-            end
-
-            attr_accessor :description,
-                          :type,
-                          :filepath,
-                          :address
-
-            # Constructs a new instance.
-            # @param ruby_values [Hash] a map of initial property values (optional)
-            # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
-            def initialize(ruby_values=nil, struct_value=nil)
-                super(self.class.binding_type, ruby_values, struct_value)
-            end
-        end
-
-
+    #  The fingerprint provides clients an efficient way to check if the metadata for a particular component has been modified on the server. The client can do this by comparing the result of this operation with the fingerprint returned in the result of   :func:`Com::Vmware::Vapi::Metadata::Privilege::Component.get`  .
+    #
+    # @param component_id [String]
+    #     Identifier of the component element.
+    # @return [String]
+    #     The fingerprint computed from the privilege metadata of the component.
+    # @raise [Com::Vmware::Vapi::Std::Errors::NotFound]
+    #     if the component element associated with  ``component_id``  does not have any privilege information.
+    def fingerprint(component_id)
+      invoke_with_info(FINGERPRINT_INFO,
+                       'component_id' => component_id)
     end
 
+  end
+  # The  ``Com::Vmware::Vapi::Metadata::Privilege::Package``   class  provides  methods  to retrieve privilege information of a package element.  
+  # 
+  #  A package element is said to contain privilege information if there is a default privilege assigned to all service elements contained in the package element or if one of the operation elements contained in one of the service elements in this package element has privilege information.
+  class Package < VAPI::Bindings::VapiService
+    # static metamodel definitions
+    SERVICE_ID = VAPI::Core::ServiceIdentifier.new('com.vmware.vapi.metadata.privilege.package')
 
+    LIST_INFO = VAPI::Bindings::OperationInfo.new(
+      VAPI::Core::OperationIdentifier.new('list', SERVICE_ID),
+      VAPI::Bindings::OperationInputType.new,
+      VAPI::Bindings::ListType.new(VAPI::Bindings::IdType.new),
+      {},
+      [],
+      []
+    )
 
-    # The  ``Com::Vmware::Vapi::Metadata::Privilege::ComponentData``   class  contains the privilege information of the component along with its fingerprint.
-    # @!attribute [rw] info
-    #     @return [Com::Vmware::Vapi::Metadata::Privilege::ComponentInfo]
-    #     Privilege information of the component. This includes information about all the  packages  in the component.
-    # @!attribute [rw] fingerprint
+    GET_INFO = VAPI::Bindings::OperationInfo.new(
+      VAPI::Core::OperationIdentifier.new('get', SERVICE_ID),
+      VAPI::Bindings::OperationInputType.new(
+        'package_id' => VAPI::Bindings::IdType.new('com.vmware.vapi.package')
+      ),
+      VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Metadata::Privilege::PackageInfo'),
+      {
+        'com.vmware.vapi.std.errors.not_found' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::NotFound')
+      },
+      [],
+      []
+    )
+
+    SERVICE_INFO = VAPI::Bindings::ServiceInfo.new(
+      SERVICE_ID,
+      'list' => LIST_INFO,
+      'get' => GET_INFO
+    )
+
+    # Constructs a new instance.
+    #
+    # @param config [VAPI::Bindings::StubConfig] A hash with the api provider details.
+    def initialize(config)
+      super(config, SERVICE_INFO)
+    end
+
+    RESOURCE_TYPE = 'com.vmware.vapi.package'
+    # Returns the identifiers for the package elements that have privilege information.
+    #
+    # @return [Array<String>]
+    #     The list of identifiers for the package elements that have privilege information.
+    def list
+      invoke_with_info(LIST_INFO)
+    end
+
+    # Retrieves privilege information about the package element corresponding to  ``package_id`` .
+    #
+    # @param package_id [String]
+    #     Identifier of the package element.
+    # @return [Com::Vmware::Vapi::Metadata::Privilege::PackageInfo]
+    #     The   :class:`Com::Vmware::Vapi::Metadata::Privilege::PackageInfo`   instance that corresponds to  ``package_id``
+    # @raise [Com::Vmware::Vapi::Std::Errors::NotFound]
+    #     if the package element associated with  ``package_id``  does not have any privilege information.
+    def get(package_id)
+      invoke_with_info(GET_INFO,
+                       'package_id' => package_id)
+    end
+
+  end
+  # The  ``Com::Vmware::Vapi::Metadata::Privilege::Service``   class  provides  methods  to retrieve privilege information of a service element.  
+  # 
+  #  A service element is said to contain privilege information if one of the operation elements contained in this service element has privilege information.
+  class ServiceService < VAPI::Bindings::VapiService
+    # static metamodel definitions
+    SERVICE_ID = VAPI::Core::ServiceIdentifier.new('com.vmware.vapi.metadata.privilege.service')
+
+    LIST_INFO = VAPI::Bindings::OperationInfo.new(
+      VAPI::Core::OperationIdentifier.new('list', SERVICE_ID),
+      VAPI::Bindings::OperationInputType.new,
+      VAPI::Bindings::ListType.new(VAPI::Bindings::IdType.new),
+      {},
+      [],
+      []
+    )
+
+    GET_INFO = VAPI::Bindings::OperationInfo.new(
+      VAPI::Core::OperationIdentifier.new('get', SERVICE_ID),
+      VAPI::Bindings::OperationInputType.new(
+        'service_id' => VAPI::Bindings::IdType.new('com.vmware.vapi.service')
+      ),
+      VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Metadata::Privilege::ServiceInfo'),
+      {
+        'com.vmware.vapi.std.errors.not_found' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::NotFound')
+      },
+      [],
+      []
+    )
+
+    SERVICE_INFO = VAPI::Bindings::ServiceInfo.new(
+      SERVICE_ID,
+      'list' => LIST_INFO,
+      'get' => GET_INFO
+    )
+
+    # Constructs a new instance.
+    #
+    # @param config [VAPI::Bindings::StubConfig] A hash with the api provider details.
+    def initialize(config)
+      super(config, SERVICE_INFO)
+    end
+
+    RESOURCE_TYPE = 'com.vmware.vapi.service'
+    # Returns the identifiers for the service elements that have privilege information.
+    #
+    # @return [Array<String>]
+    #     The list of identifiers for the service elements that have privilege information.
+    def list
+      invoke_with_info(LIST_INFO)
+    end
+
+    # Retrieves privilege information about the service element corresponding to  ``service_id`` .
+    #
+    # @param service_id [String]
+    #     Identifier of the service element.
+    # @return [Com::Vmware::Vapi::Metadata::Privilege::ServiceInfo]
+    #     The   :class:`Com::Vmware::Vapi::Metadata::Privilege::ServiceInfo`   instance that corresponds to  ``service_id``
+    # @raise [Com::Vmware::Vapi::Std::Errors::NotFound]
+    #     if the service element associated with  ``service_id``  does not have any privilege information.
+    def get(service_id)
+      invoke_with_info(GET_INFO,
+                       'service_id' => service_id)
+    end
+
+  end
+  # The  ``Com::Vmware::Vapi::Metadata::Privilege::Source``   class  provides  methods  to manage the sources of privilege metadata information.  
+  # 
+  #  The interface definition language infrastructure provides tools to generate various kinds of metadata in JSON format from the interface definition files and additional properties files. One of the generated files contains privilege information. The generated file can be registered as a source of metadata.  
+  # 
+  #  The privilege file contains all the data present in the interface definition files. Each privilege file contains data about one component element. When a privilege file is added as a source, each source contributes only one component element's metadata.  
+  # 
+  #  Privilege metadata can also be discovered from a remote server that supports the privilege metadata  classs  (see   :mod:`com.vmware.vapi.metadata.privilege`  ). Since multiple components can be registered with a single metadata server, when a remote server is registered as a source, that source can contribute more than one component.
+  class Source < VAPI::Bindings::VapiService
+    # static metamodel definitions
+    SERVICE_ID = VAPI::Core::ServiceIdentifier.new('com.vmware.vapi.metadata.privilege.source')
+
+    CREATE_INFO = VAPI::Bindings::OperationInfo.new(
+      VAPI::Core::OperationIdentifier.new('create', SERVICE_ID),
+      VAPI::Bindings::OperationInputType.new(
+        'source_id' => VAPI::Bindings::IdType.new('com.vmware.vapi.metadata.privilege.source'),
+        'spec' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Metadata::Privilege::Source::CreateSpec')
+      ),
+      VAPI::Bindings::VoidType.instance,
+      {
+        'com.vmware.vapi.std.errors.already_exists' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::AlreadyExists'),
+        'com.vmware.vapi.std.errors.invalid_argument' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::InvalidArgument'),
+        'com.vmware.vapi.std.errors.not_found' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::NotFound')
+      },
+      [],
+      []
+    )
+
+    DELETE_INFO = VAPI::Bindings::OperationInfo.new(
+      VAPI::Core::OperationIdentifier.new('delete', SERVICE_ID),
+      VAPI::Bindings::OperationInputType.new(
+        'source_id' => VAPI::Bindings::IdType.new('com.vmware.vapi.metadata.privilege.source')
+      ),
+      VAPI::Bindings::VoidType.instance,
+      {
+        'com.vmware.vapi.std.errors.not_found' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::NotFound')
+      },
+      [],
+      []
+    )
+
+    GET_INFO = VAPI::Bindings::OperationInfo.new(
+      VAPI::Core::OperationIdentifier.new('get', SERVICE_ID),
+      VAPI::Bindings::OperationInputType.new(
+        'source_id' => VAPI::Bindings::IdType.new('com.vmware.vapi.metadata.privilege.source')
+      ),
+      VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Metadata::Privilege::Source::Info'),
+      {
+        'com.vmware.vapi.std.errors.not_found' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::NotFound')
+      },
+      [],
+      []
+    )
+
+    LIST_INFO = VAPI::Bindings::OperationInfo.new(
+      VAPI::Core::OperationIdentifier.new('list', SERVICE_ID),
+      VAPI::Bindings::OperationInputType.new,
+      VAPI::Bindings::ListType.new(VAPI::Bindings::IdType.new),
+      {},
+      [],
+      []
+    )
+
+    RELOAD_INFO = VAPI::Bindings::OperationInfo.new(
+      VAPI::Core::OperationIdentifier.new('reload', SERVICE_ID),
+      VAPI::Bindings::OperationInputType.new(
+        'source_id' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::IdType.new)
+      ),
+      VAPI::Bindings::VoidType.instance,
+      {
+        'com.vmware.vapi.std.errors.not_found' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::NotFound')
+      },
+      [],
+      []
+    )
+
+    FINGERPRINT_INFO = VAPI::Bindings::OperationInfo.new(
+      VAPI::Core::OperationIdentifier.new('fingerprint', SERVICE_ID),
+      VAPI::Bindings::OperationInputType.new(
+        'source_id' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::IdType.new)
+      ),
+      VAPI::Bindings::StringType.instance,
+      {
+        'com.vmware.vapi.std.errors.not_found' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::NotFound')
+      },
+      [],
+      []
+    )
+
+    SERVICE_INFO = VAPI::Bindings::ServiceInfo.new(
+      SERVICE_ID,
+      'create' => CREATE_INFO,
+      'delete' => DELETE_INFO,
+      'get' => GET_INFO,
+      'list' => LIST_INFO,
+      'reload' => RELOAD_INFO,
+      'fingerprint' => FINGERPRINT_INFO
+    )
+
+    # Constructs a new instance.
+    #
+    # @param config [VAPI::Bindings::StubConfig] A hash with the api provider details.
+    def initialize(config)
+      super(config, SERVICE_INFO)
+    end
+
+    RESOURCE_TYPE = 'com.vmware.vapi.metadata.privilege.source'
+    # Creates a new metadata source. Once the server validates the registration information of the metadata source, the privilege metadata is retrieved from the source. This populates elements in all the  classs  defined in   :mod:`com.vmware.vapi.metadata.privilege`    package .
+    #
+    # @param source_id [String]
+    #     metadata source identifier.
+    # @param spec [Com::Vmware::Vapi::Metadata::Privilege::Source::CreateSpec]
+    #     create specification.
+    # @return [Void]
+    # @raise [Com::Vmware::Vapi::Std::Errors::AlreadyExists]
+    #     if the metadata source identifier is already registered with the infrastructure.
+    # @raise [Com::Vmware::Vapi::Std::Errors::InvalidArgument]
+    #     if the type of the source specified in  null  is invalid.
+    # @raise [Com::Vmware::Vapi::Std::Errors::InvalidArgument]
+    #     if the file specified in  null  is not a valid JSON file or if the format of the privilege metadata in the JSON file is invalid.
+    # @raise [Com::Vmware::Vapi::Std::Errors::InvalidArgument]
+    #     if the URI specified in  null  is unreachable or if there is a transport protocol or message protocol mismatch between the client and the server or if the remote server do not have  classs  present in   :mod:`com.vmware.vapi.metadata.privilege`    package .
+    # @raise [Com::Vmware::Vapi::Std::Errors::NotFound]
+    #     if the file specified in  null  does not exist.
+    def create(source_id, spec)
+      invoke_with_info(CREATE_INFO,
+                       'source_id' => source_id,
+                       'spec' => spec)
+    end
+
+    # Deletes an existing privilege metadata source from the infrastructure.
+    #
+    # @param source_id [String]
+    #     Identifier of the metadata source.
+    # @return [Void]
+    # @raise [Com::Vmware::Vapi::Std::Errors::NotFound]
+    #     if the metadata source associated with  ``source_id``  is not found.
+    def delete(source_id)
+      invoke_with_info(DELETE_INFO,
+                       'source_id' => source_id)
+    end
+
+    # Retrieves information about the metadata source corresponding to  ``source_id`` .
+    #
+    # @param source_id [String]
+    #     Identifier of the metadata source.
+    # @return [Com::Vmware::Vapi::Metadata::Privilege::Source::Info]
+    #     The   :class:`Com::Vmware::Vapi::Metadata::Privilege::Source::Info`   instance that corresponds to  ``source_id``
+    # @raise [Com::Vmware::Vapi::Std::Errors::NotFound]
+    #     if the metadata source associated with  ``source_id``  is not found.
+    def get(source_id)
+      invoke_with_info(GET_INFO,
+                       'source_id' => source_id)
+    end
+
+    # Returns the identifiers of the metadata sources currently registered with the infrastructure.
+    #
+    # @return [Array<String>]
+    #     The list of identifiers for metadata sources currently registered.
+    def list
+      invoke_with_info(LIST_INFO)
+    end
+
+    # Reloads the privilege metadata from all the metadata sources or of a particular metadata source if  ``source_id``  is specified.
+    #
+    # @param source_id [String, nil]
+    #     Identifier of the metadata source.
+    #     If unspecified, all the metadata sources are reloaded.
+    # @return [Void]
+    # @raise [Com::Vmware::Vapi::Std::Errors::NotFound]
+    #     if the metadata source associated with  ``source_id``  is not found.
+    def reload(source_id = nil)
+      invoke_with_info(RELOAD_INFO,
+                       'source_id' => source_id)
+    end
+
+    # Returns the aggregate fingerprint of metadata from all the metadata sources or from a particular metadata source if  ``source_id``  is specified.
+    #
+    # @param source_id [String, nil]
+    #     Identifier of the metadata source.
+    #     If unspecified, the fingerprint of all the metadata sources is returned.
+    # @return [String]
+    #     Aggregate fingerprint of all the metadata sources or of a particular metadata source.
+    # @raise [Com::Vmware::Vapi::Std::Errors::NotFound]
+    #     if the metadata source associated with  ``source_id``  is not found.
+    def fingerprint(source_id = nil)
+      invoke_with_info(FINGERPRINT_INFO,
+                       'source_id' => source_id)
+    end
+
+    # The  ``Com::Vmware::Vapi::Metadata::Privilege::Source::Info``   class  contains the metadata source information.
+    # @!attribute [rw] description
     #     @return [String]
-    #     Fingerprint of the metadata of the component.  
-    #     
-    #      Privilege information could change when there is an infrastructure update. Since the data present in   :attr:`Com::Vmware::Vapi::Metadata::Privilege::ComponentData.info`   could be quite large,  ``fingerprint``  provides a convenient way to check if the data for a particular component is updated.  
-    #     
-    #      You should store the fingerprint associated with a component. After an update, by invoking the   :func:`Com::Vmware::Vapi::Metadata::Privilege::Component.fingerprint`    method , you can retrieve the new fingerprint for the component. If the new fingerprint and the previously stored fingerprint do not match, clients can then use the   :func:`Com::Vmware::Vapi::Metadata::Privilege::Component.get`   to retrieve the new privilege information for the component.
-    class ComponentData < VAPI::Bindings::VapiStruct
-
-        class << self
-            # Holds (gets or creates) the binding type metadata for this structure type.
-            # @scope class
-            # @return [VAPI::Bindings::StructType] the binding type
-            def binding_type
-                @binding_type ||= VAPI::Bindings::StructType.new(
-                    'com.vmware.vapi.metadata.privilege.component_data',
-                    {
-                        'info' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Metadata::Privilege::ComponentInfo'),
-                        'fingerprint' => VAPI::Bindings::StringType.instance,
-                    },
-                    ComponentData,
-                    false,
-                    nil)
-            end
-        end
-
-        attr_accessor :info,
-                      :fingerprint
-
-        # Constructs a new instance.
-        # @param ruby_values [Hash] a map of initial property values (optional)
-        # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
-        def initialize(ruby_values=nil, struct_value=nil)
-            super(self.class.binding_type, ruby_values, struct_value)
-        end
-    end
-
-
-    # The  ``Com::Vmware::Vapi::Metadata::Privilege::ComponentInfo``   class  contains the privilege information of a component element.  
-    # 
-    #  For an explanation of privilege information contained within component elements, see   :class:`Com::Vmware::Vapi::Metadata::Privilege::Component`  .
-    # @!attribute [rw] packages
-    #     @return [Hash<String, Com::Vmware::Vapi::Metadata::Privilege::PackageInfo>]
-    #     Privilege information of all the package elements. The key in the  map  is the identifier of the package element and the value in the  map  is the privilege information for the package element.  
-    #     
-    #      For an explanation of privilege information containment within package elements, see   :class:`Com::Vmware::Vapi::Metadata::Privilege::Package`  .
-    class ComponentInfo < VAPI::Bindings::VapiStruct
-
-        class << self
-            # Holds (gets or creates) the binding type metadata for this structure type.
-            # @scope class
-            # @return [VAPI::Bindings::StructType] the binding type
-            def binding_type
-                @binding_type ||= VAPI::Bindings::StructType.new(
-                    'com.vmware.vapi.metadata.privilege.component_info',
-                    {
-                        'packages' => VAPI::Bindings::MapType.new(VAPI::Bindings::IdType.new, VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Metadata::Privilege::PackageInfo')),
-                    },
-                    ComponentInfo,
-                    false,
-                    nil)
-            end
-        end
-
-        attr_accessor :packages
-
-        # Constructs a new instance.
-        # @param ruby_values [Hash] a map of initial property values (optional)
-        # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
-        def initialize(ruby_values=nil, struct_value=nil)
-            super(self.class.binding_type, ruby_values, struct_value)
-        end
-    end
-
-
-    # The  ``Com::Vmware::Vapi::Metadata::Privilege::OperationInfo``   class  contains privilege information of an operation element.  
-    # 
-    #  For an explanation of containment within operation elements, see   :class:`Com::Vmware::Vapi::Metadata::Privilege::Service::Operation`  .
-    # @!attribute [rw] privileges
-    #     @return [Array<String>]
-    #     List of all privileges assigned to the operation element.
-    # @!attribute [rw] privilege_info
-    #     @return [Array<Com::Vmware::Vapi::Metadata::Privilege::PrivilegeInfo>]
-    #     Privilege information of all the parameter elements of the operation element. For an explanation of containment of privilege information within parameter elements, see   :class:`Com::Vmware::Vapi::Metadata::Privilege::PrivilegeInfo`  .
-    class OperationInfo < VAPI::Bindings::VapiStruct
-
-        class << self
-            # Holds (gets or creates) the binding type metadata for this structure type.
-            # @scope class
-            # @return [VAPI::Bindings::StructType] the binding type
-            def binding_type
-                @binding_type ||= VAPI::Bindings::StructType.new(
-                    'com.vmware.vapi.metadata.privilege.operation_info',
-                    {
-                        'privileges' => VAPI::Bindings::ListType.new(VAPI::Bindings::StringType.instance),
-                        'privilege_info' => VAPI::Bindings::ListType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Metadata::Privilege::PrivilegeInfo')),
-                    },
-                    OperationInfo,
-                    false,
-                    nil)
-            end
-        end
-
-        attr_accessor :privileges,
-                      :privilege_info
-
-        # Constructs a new instance.
-        # @param ruby_values [Hash] a map of initial property values (optional)
-        # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
-        def initialize(ruby_values=nil, struct_value=nil)
-            super(self.class.binding_type, ruby_values, struct_value)
-        end
-    end
-
-
-    # The  ``Com::Vmware::Vapi::Metadata::Privilege::PackageInfo``   class  contains the privilege information of a package element.  
-    # 
-    #  For an explanation of privilege information contained within package elements, see   :class:`Com::Vmware::Vapi::Metadata::Privilege::Package`  .
-    # @!attribute [rw] privileges
-    #     @return [Array<String>]
-    #     List of default privileges to be used for all the operations present in this package. If a particular operation element has no explicit privileges defined in the privilege definition file, these privileges are used for enforcing authorization.
-    # @!attribute [rw] services
-    #     @return [Hash<String, Com::Vmware::Vapi::Metadata::Privilege::ServiceInfo>]
-    #     Information about all service elements contained in this package element that contain privilege information. The key in the  map  is the identifier of the service element and the value in the  map  is the privilege information for the service element. For an explanation of privilege information containment within service elements, see   :class:`Com::Vmware::Vapi::Metadata::Privilege::Service`  .
-    class PackageInfo < VAPI::Bindings::VapiStruct
-
-        class << self
-            # Holds (gets or creates) the binding type metadata for this structure type.
-            # @scope class
-            # @return [VAPI::Bindings::StructType] the binding type
-            def binding_type
-                @binding_type ||= VAPI::Bindings::StructType.new(
-                    'com.vmware.vapi.metadata.privilege.package_info',
-                    {
-                        'privileges' => VAPI::Bindings::ListType.new(VAPI::Bindings::StringType.instance),
-                        'services' => VAPI::Bindings::MapType.new(VAPI::Bindings::IdType.new, VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Metadata::Privilege::ServiceInfo')),
-                    },
-                    PackageInfo,
-                    false,
-                    nil)
-            end
-        end
-
-        attr_accessor :privileges,
-                      :services
-
-        # Constructs a new instance.
-        # @param ruby_values [Hash] a map of initial property values (optional)
-        # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
-        def initialize(ruby_values=nil, struct_value=nil)
-            super(self.class.binding_type, ruby_values, struct_value)
-        end
-    end
-
-
-    # The  ``Com::Vmware::Vapi::Metadata::Privilege::PrivilegeInfo``   class  contains the privilege information for a parameter element in an operation element.
-    # @!attribute [rw] property_path
+    #     English language human readable description of the source.
+    # @!attribute [rw] type
+    #     @return [Com::Vmware::Vapi::Metadata::SourceType]
+    #     Type of the metadata source.
+    # @!attribute [rw] filepath
     #     @return [String]
-    #     The  ``propertyPath``  points to an entity that is used in the operation element. An entity can either be present in one of the parameter elements or if a parameter is a structure element, it could also be present in one of the field elements.  
+    #     Absolute file path of the privilege metadata file that has the privilege information about one component element. The  ``filePath``  is the path to the file in the server's filesystem.
+    #     This  field  is optional and it is only relevant when the value of  ``type``  is  null .
+    # @!attribute [rw] address
+    #     @return [URI]
+    #     Connection information for the remote server. This must be in the format http(s)://IP:port/namespace.  
     #     
-    #      If the privilege is assigned to an entity used in the parameter,  ``propertyPath``  will just contain the name of the parameter field. If the privilege is assigned to an entity in one of the field elements of a parameter element that is a structure element, then  ``propertyPath``  will contain a path to the field element starting from the parameter name.
-    # @!attribute [rw] privileges
-    #     @return [Array<String>]
-    #     List of privileges assigned to the entity that is being referred by   :attr:`Com::Vmware::Vapi::Metadata::Privilege::PrivilegeInfo.property_path`  .
-    class PrivilegeInfo < VAPI::Bindings::VapiStruct
-
-        class << self
-            # Holds (gets or creates) the binding type metadata for this structure type.
-            # @scope class
-            # @return [VAPI::Bindings::StructType] the binding type
-            def binding_type
-                @binding_type ||= VAPI::Bindings::StructType.new(
-                    'com.vmware.vapi.metadata.privilege.privilege_info',
-                    {
-                        'property_path' => VAPI::Bindings::StringType.instance,
-                        'privileges' => VAPI::Bindings::ListType.new(VAPI::Bindings::StringType.instance),
-                    },
-                    PrivilegeInfo,
-                    false,
-                    nil)
-            end
+    #      The remote server must support the  classs  in the   :mod:`com.vmware.vapi.metadata.privilege`    package . It must expose privilege information of one or more components.
+    #     This  field  is optional and it is only relevant when the value of  ``type``  is  null .
+    class Info < VAPI::Bindings::VapiStruct
+      class << self
+        # Holds (gets or creates) the binding type metadata for this structure type.
+        # @scope class
+        # @return [VAPI::Bindings::StructType] the binding type
+        def binding_type
+          @binding_type ||= VAPI::Bindings::StructType.new(
+            'com.vmware.vapi.metadata.privilege.source.info',
+            {
+              'description' => VAPI::Bindings::StringType.instance,
+              'type' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Metadata::SourceType'),
+              'filepath' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::StringType.instance),
+              'address' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::URIType.instance)
+            },
+            Info,
+            false,
+            nil
+          )
         end
+      end
 
-        attr_accessor :property_path,
-                      :privileges
+      attr_accessor :description,
+                    :type,
+                    :filepath,
+                    :address
 
-        # Constructs a new instance.
-        # @param ruby_values [Hash] a map of initial property values (optional)
-        # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
-        def initialize(ruby_values=nil, struct_value=nil)
-            super(self.class.binding_type, ruby_values, struct_value)
-        end
+      # Constructs a new instance.
+      # @param ruby_values [Hash] a map of initial property values (optional)
+      # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
+      def initialize(ruby_values = nil, struct_value = nil)
+        super(self.class.binding_type, ruby_values, struct_value)
+      end
     end
 
-
-    # The  ``Com::Vmware::Vapi::Metadata::Privilege::ServiceInfo``   class  contains privilege information of a service element.  
-    # 
-    #  For an explanation of privilege information contained within service elements, see   :class:`Com::Vmware::Vapi::Metadata::Privilege::Service`  .
-    # @!attribute [rw] operations
-    #     @return [Hash<String, Com::Vmware::Vapi::Metadata::Privilege::OperationInfo>]
-    #     Information about all operation elements contained in this service element that contain privilege information. The key in the  map  is the identifier of the operation element and the value in the  map  is the privilege information for the operation element.  
-    #     
-    #      For an explanation of containment of privilege information within operation elements, see   :class:`Com::Vmware::Vapi::Metadata::Privilege::Service::Operation`  .
-    class ServiceInfo < VAPI::Bindings::VapiStruct
-
-        class << self
-            # Holds (gets or creates) the binding type metadata for this structure type.
-            # @scope class
-            # @return [VAPI::Bindings::StructType] the binding type
-            def binding_type
-                @binding_type ||= VAPI::Bindings::StructType.new(
-                    'com.vmware.vapi.metadata.privilege.service_info',
-                    {
-                        'operations' => VAPI::Bindings::MapType.new(VAPI::Bindings::IdType.new, VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Metadata::Privilege::OperationInfo')),
-                    },
-                    ServiceInfo,
-                    false,
-                    nil)
-            end
+    # The  ``Com::Vmware::Vapi::Metadata::Privilege::Source::CreateSpec``   class  contains the registration information of a privilege source.
+    class CreateSpec < VAPI::Bindings::VapiStruct
+      class << self
+        # Holds (gets or creates) the binding type metadata for this structure type.
+        # @scope class
+        # @return [VAPI::Bindings::StructType] the binding type
+        def binding_type
+          @binding_type ||= VAPI::Bindings::StructType.new(
+            'com.vmware.vapi.metadata.privilege.source.create_spec',
+            {
+              'description' => VAPI::Bindings::StringType.instance,
+              'type' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Metadata::SourceType'),
+              'filepath' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::StringType.instance),
+              'address' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::URIType.instance)
+            },
+            CreateSpec,
+            false,
+            nil
+          )
         end
+      end
 
-        attr_accessor :operations
+      attr_accessor :description,
+                    :type,
+                    :filepath,
+                    :address
 
-        # Constructs a new instance.
-        # @param ruby_values [Hash] a map of initial property values (optional)
-        # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
-        def initialize(ruby_values=nil, struct_value=nil)
-            super(self.class.binding_type, ruby_values, struct_value)
-        end
+      # Constructs a new instance.
+      # @param ruby_values [Hash] a map of initial property values (optional)
+      # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
+      def initialize(ruby_values = nil, struct_value = nil)
+        super(self.class.binding_type, ruby_values, struct_value)
+      end
     end
 
+  end
+  # The  ``Com::Vmware::Vapi::Metadata::Privilege::ComponentData``   class  contains the privilege information of the component along with its fingerprint.
+  # @!attribute [rw] info
+  #     @return [Com::Vmware::Vapi::Metadata::Privilege::ComponentInfo]
+  #     Privilege information of the component. This includes information about all the  packages  in the component.
+  # @!attribute [rw] fingerprint
+  #     @return [String]
+  #     Fingerprint of the metadata of the component.  
+  #     
+  #      Privilege information could change when there is an infrastructure update. Since the data present in   :attr:`Com::Vmware::Vapi::Metadata::Privilege::ComponentData.info`   could be quite large,  ``fingerprint``  provides a convenient way to check if the data for a particular component is updated.  
+  #     
+  #      You should store the fingerprint associated with a component. After an update, by invoking the   :func:`Com::Vmware::Vapi::Metadata::Privilege::Component.fingerprint`    method , you can retrieve the new fingerprint for the component. If the new fingerprint and the previously stored fingerprint do not match, clients can then use the   :func:`Com::Vmware::Vapi::Metadata::Privilege::Component.get`   to retrieve the new privilege information for the component.
+  class ComponentData < VAPI::Bindings::VapiStruct
+    class << self
+      # Holds (gets or creates) the binding type metadata for this structure type.
+      # @scope class
+      # @return [VAPI::Bindings::StructType] the binding type
+      def binding_type
+        @binding_type ||= VAPI::Bindings::StructType.new(
+          'com.vmware.vapi.metadata.privilege.component_data',
+          {
+            'info' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Metadata::Privilege::ComponentInfo'),
+            'fingerprint' => VAPI::Bindings::StringType.instance
+          },
+          ComponentData,
+          false,
+          nil
+        )
+      end
+    end
+
+    attr_accessor :info,
+                  :fingerprint
+
+    # Constructs a new instance.
+    # @param ruby_values [Hash] a map of initial property values (optional)
+    # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
+    def initialize(ruby_values = nil, struct_value = nil)
+      super(self.class.binding_type, ruby_values, struct_value)
+    end
+  end
+  # The  ``Com::Vmware::Vapi::Metadata::Privilege::ComponentInfo``   class  contains the privilege information of a component element.  
+  # 
+  #  For an explanation of privilege information contained within component elements, see   :class:`Com::Vmware::Vapi::Metadata::Privilege::Component`  .
+  # @!attribute [rw] packages
+  #     @return [Hash<String, Com::Vmware::Vapi::Metadata::Privilege::PackageInfo>]
+  #     Privilege information of all the package elements. The key in the  map  is the identifier of the package element and the value in the  map  is the privilege information for the package element.  
+  #     
+  #      For an explanation of privilege information containment within package elements, see   :class:`Com::Vmware::Vapi::Metadata::Privilege::Package`  .
+  class ComponentInfo < VAPI::Bindings::VapiStruct
+    class << self
+      # Holds (gets or creates) the binding type metadata for this structure type.
+      # @scope class
+      # @return [VAPI::Bindings::StructType] the binding type
+      def binding_type
+        @binding_type ||= VAPI::Bindings::StructType.new(
+          'com.vmware.vapi.metadata.privilege.component_info',
+          {
+            'packages' => VAPI::Bindings::MapType.new(VAPI::Bindings::IdType.new, VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Metadata::Privilege::PackageInfo'))
+          },
+          ComponentInfo,
+          false,
+          nil
+        )
+      end
+    end
+
+    attr_accessor :packages
+
+    # Constructs a new instance.
+    # @param ruby_values [Hash] a map of initial property values (optional)
+    # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
+    def initialize(ruby_values = nil, struct_value = nil)
+      super(self.class.binding_type, ruby_values, struct_value)
+    end
+  end
+  # The  ``Com::Vmware::Vapi::Metadata::Privilege::OperationInfo``   class  contains privilege information of an operation element.  
+  # 
+  #  For an explanation of containment within operation elements, see   :class:`Com::Vmware::Vapi::Metadata::Privilege::Service::Operation`  .
+  # @!attribute [rw] privileges
+  #     @return [Array<String>]
+  #     List of all privileges assigned to the operation element.
+  # @!attribute [rw] privilege_info
+  #     @return [Array<Com::Vmware::Vapi::Metadata::Privilege::PrivilegeInfo>]
+  #     Privilege information of all the parameter elements of the operation element. For an explanation of containment of privilege information within parameter elements, see   :class:`Com::Vmware::Vapi::Metadata::Privilege::PrivilegeInfo`  .
+  class OperationInfo < VAPI::Bindings::VapiStruct
+    class << self
+      # Holds (gets or creates) the binding type metadata for this structure type.
+      # @scope class
+      # @return [VAPI::Bindings::StructType] the binding type
+      def binding_type
+        @binding_type ||= VAPI::Bindings::StructType.new(
+          'com.vmware.vapi.metadata.privilege.operation_info',
+          {
+            'privileges' => VAPI::Bindings::ListType.new(VAPI::Bindings::StringType.instance),
+            'privilege_info' => VAPI::Bindings::ListType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Metadata::Privilege::PrivilegeInfo'))
+          },
+          OperationInfo,
+          false,
+          nil
+        )
+      end
+    end
+
+    attr_accessor :privileges,
+                  :privilege_info
+
+    # Constructs a new instance.
+    # @param ruby_values [Hash] a map of initial property values (optional)
+    # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
+    def initialize(ruby_values = nil, struct_value = nil)
+      super(self.class.binding_type, ruby_values, struct_value)
+    end
+  end
+  # The  ``Com::Vmware::Vapi::Metadata::Privilege::PackageInfo``   class  contains the privilege information of a package element.  
+  # 
+  #  For an explanation of privilege information contained within package elements, see   :class:`Com::Vmware::Vapi::Metadata::Privilege::Package`  .
+  # @!attribute [rw] privileges
+  #     @return [Array<String>]
+  #     List of default privileges to be used for all the operations present in this package. If a particular operation element has no explicit privileges defined in the privilege definition file, these privileges are used for enforcing authorization.
+  # @!attribute [rw] services
+  #     @return [Hash<String, Com::Vmware::Vapi::Metadata::Privilege::ServiceInfo>]
+  #     Information about all service elements contained in this package element that contain privilege information. The key in the  map  is the identifier of the service element and the value in the  map  is the privilege information for the service element. For an explanation of privilege information containment within service elements, see   :class:`Com::Vmware::Vapi::Metadata::Privilege::Service`  .
+  class PackageInfo < VAPI::Bindings::VapiStruct
+    class << self
+      # Holds (gets or creates) the binding type metadata for this structure type.
+      # @scope class
+      # @return [VAPI::Bindings::StructType] the binding type
+      def binding_type
+        @binding_type ||= VAPI::Bindings::StructType.new(
+          'com.vmware.vapi.metadata.privilege.package_info',
+          {
+            'privileges' => VAPI::Bindings::ListType.new(VAPI::Bindings::StringType.instance),
+            'services' => VAPI::Bindings::MapType.new(VAPI::Bindings::IdType.new, VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Metadata::Privilege::ServiceInfo'))
+          },
+          PackageInfo,
+          false,
+          nil
+        )
+      end
+    end
+
+    attr_accessor :privileges,
+                  :services
+
+    # Constructs a new instance.
+    # @param ruby_values [Hash] a map of initial property values (optional)
+    # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
+    def initialize(ruby_values = nil, struct_value = nil)
+      super(self.class.binding_type, ruby_values, struct_value)
+    end
+  end
+  # The  ``Com::Vmware::Vapi::Metadata::Privilege::PrivilegeInfo``   class  contains the privilege information for a parameter element in an operation element.
+  # @!attribute [rw] property_path
+  #     @return [String]
+  #     The  ``propertyPath``  points to an entity that is used in the operation element. An entity can either be present in one of the parameter elements or if a parameter is a structure element, it could also be present in one of the field elements.  
+  #     
+  #      If the privilege is assigned to an entity used in the parameter,  ``propertyPath``  will just contain the name of the parameter field. If the privilege is assigned to an entity in one of the field elements of a parameter element that is a structure element, then  ``propertyPath``  will contain a path to the field element starting from the parameter name.
+  # @!attribute [rw] privileges
+  #     @return [Array<String>]
+  #     List of privileges assigned to the entity that is being referred by   :attr:`Com::Vmware::Vapi::Metadata::Privilege::PrivilegeInfo.property_path`  .
+  class PrivilegeInfo < VAPI::Bindings::VapiStruct
+    class << self
+      # Holds (gets or creates) the binding type metadata for this structure type.
+      # @scope class
+      # @return [VAPI::Bindings::StructType] the binding type
+      def binding_type
+        @binding_type ||= VAPI::Bindings::StructType.new(
+          'com.vmware.vapi.metadata.privilege.privilege_info',
+          {
+            'property_path' => VAPI::Bindings::StringType.instance,
+            'privileges' => VAPI::Bindings::ListType.new(VAPI::Bindings::StringType.instance)
+          },
+          PrivilegeInfo,
+          false,
+          nil
+        )
+      end
+    end
+
+    attr_accessor :property_path,
+                  :privileges
+
+    # Constructs a new instance.
+    # @param ruby_values [Hash] a map of initial property values (optional)
+    # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
+    def initialize(ruby_values = nil, struct_value = nil)
+      super(self.class.binding_type, ruby_values, struct_value)
+    end
+  end
+  # The  ``Com::Vmware::Vapi::Metadata::Privilege::ServiceInfo``   class  contains privilege information of a service element.  
+  # 
+  #  For an explanation of privilege information contained within service elements, see   :class:`Com::Vmware::Vapi::Metadata::Privilege::Service`  .
+  # @!attribute [rw] operations
+  #     @return [Hash<String, Com::Vmware::Vapi::Metadata::Privilege::OperationInfo>]
+  #     Information about all operation elements contained in this service element that contain privilege information. The key in the  map  is the identifier of the operation element and the value in the  map  is the privilege information for the operation element.  
+  #     
+  #      For an explanation of containment of privilege information within operation elements, see   :class:`Com::Vmware::Vapi::Metadata::Privilege::Service::Operation`  .
+  class ServiceInfo < VAPI::Bindings::VapiStruct
+    class << self
+      # Holds (gets or creates) the binding type metadata for this structure type.
+      # @scope class
+      # @return [VAPI::Bindings::StructType] the binding type
+      def binding_type
+        @binding_type ||= VAPI::Bindings::StructType.new(
+          'com.vmware.vapi.metadata.privilege.service_info',
+          {
+            'operations' => VAPI::Bindings::MapType.new(VAPI::Bindings::IdType.new, VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Metadata::Privilege::OperationInfo'))
+          },
+          ServiceInfo,
+          false,
+          nil
+        )
+      end
+    end
+
+    attr_accessor :operations
+
+    # Constructs a new instance.
+    # @param ruby_values [Hash] a map of initial property values (optional)
+    # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
+    def initialize(ruby_values = nil, struct_value = nil)
+      super(self.class.binding_type, ruby_values, struct_value)
+    end
+  end
 end

--- a/client/sdk/com/vmware/vapi/metadata/privilege/service.rb
+++ b/client/sdk/com/vmware/vapi/metadata/privilege/service.rb
@@ -1,5 +1,6 @@
 #---------------------------------------------------------------------------
-# Copyright 2016 VMware, Inc.  All rights reserved.
+# Copyright 2017 VMware, Inc.  All rights reserved.
+#
 # AUTO GENERATED FILE -- DO NOT MODIFY!
 #
 # vAPI type descriptors for package com.vmware.vapi.metadata.privilege.service.
@@ -8,112 +9,100 @@ require 'vapi'
 
 # declare the module hierarchy before we use the shorthand syntax below
 module Com
-    module Vmware
-        module Vapi
-            module Metadata
-                module Privilege
-                    module Service
-                    end
-                end
-            end
+  module Vmware
+    module Vapi
+      module Metadata
+        module Privilege
+          module Service
+          end
         end
+      end
     end
+  end
 end
 
 # The  ``com.vmware.vapi.metadata.privilege.service``   package  provides  classs  to retrieve privilege information for operation elements.
 module Com::Vmware::Vapi::Metadata::Privilege::Service
+  # The  ``Com::Vmware::Vapi::Metadata::Privilege::Service::Operation``   class  provides  methods  to retrieve privilege information of an operation element.  
+  # 
+  #  An operation element is said to contain privilege information if there are any privileges assigned to the operation element or if one of the parameter elements contained in it has privileges assigned in privilege definition file.
+  class Operation < VAPI::Bindings::VapiService
+    # static metamodel definitions
+    SERVICE_ID = VAPI::Core::ServiceIdentifier.new('com.vmware.vapi.metadata.privilege.service.operation')
 
-    # The  ``Com::Vmware::Vapi::Metadata::Privilege::Service::Operation``   class  provides  methods  to retrieve privilege information of an operation element.  
-    # 
-    #  An operation element is said to contain privilege information if there are any privileges assigned to the operation element or if one of the parameter elements contained in it has privileges assigned in privilege definition file.
-    class Operation < VAPI::Bindings::VapiService
+    LIST_INFO = VAPI::Bindings::OperationInfo.new(
+      VAPI::Core::OperationIdentifier.new('list', SERVICE_ID),
+      VAPI::Bindings::OperationInputType.new(
+        'service_id' => VAPI::Bindings::IdType.new('com.vmware.vapi.service')
+      ),
+      VAPI::Bindings::ListType.new(VAPI::Bindings::IdType.new),
+      {
+        'com.vmware.vapi.std.errors.not_found' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::NotFound')
+      },
+      [],
+      []
+    )
 
-        protected
+    GET_INFO = VAPI::Bindings::OperationInfo.new(
+      VAPI::Core::OperationIdentifier.new('get', SERVICE_ID),
+      VAPI::Bindings::OperationInputType.new(
+        'service_id' => VAPI::Bindings::IdType.new('com.vmware.vapi.service'),
+        'operation_id' => VAPI::Bindings::IdType.new('com.vmware.vapi.operation')
+      ),
+      VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Metadata::Privilege::OperationInfo'),
+      {
+        'com.vmware.vapi.std.errors.not_found' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::NotFound')
+      },
+      [],
+      []
+    )
 
-        # static metamodel definitions
-        @@service_id = VAPI::Core::ServiceIdentifier.new('com.vmware.vapi.metadata.privilege.service.operation')
+    SERVICE_INFO = VAPI::Bindings::ServiceInfo.new(
+      SERVICE_ID,
+      'list' => LIST_INFO,
+      'get' => GET_INFO
+    )
 
-        @@list_info = VAPI::Bindings::OperationInfo.new(
-            VAPI::Core::OperationIdentifier.new('list', @@service_id),
-            VAPI::Bindings::OperationInputType.new({
-                'service_id' => VAPI::Bindings::IdType.new(resource_types='com.vmware.vapi.service'),
-            }),
-            VAPI::Bindings::ListType.new(VAPI::Bindings::IdType.new),
-            {
-                'com.vmware.vapi.std.errors.not_found' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::NotFound'),
-
-            },
-            [],
-            [])
-        @@get_info = VAPI::Bindings::OperationInfo.new(
-            VAPI::Core::OperationIdentifier.new('get', @@service_id),
-            VAPI::Bindings::OperationInputType.new({
-                'service_id' => VAPI::Bindings::IdType.new(resource_types='com.vmware.vapi.service'),
-                'operation_id' => VAPI::Bindings::IdType.new(resource_types='com.vmware.vapi.operation'),
-            }),
-            VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Metadata::Privilege::OperationInfo'),
-            {
-                'com.vmware.vapi.std.errors.not_found' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::NotFound'),
-
-            },
-            [],
-            [])
-
-        @@service_info = VAPI::Bindings::ServiceInfo.new(@@service_id, {
-            'list' => @@list_info,
-            'get' => @@get_info,
-        })
-
-        public
-
-        # Constructs a new instance.
-        #
-        # @param config [VAPI::Bindings::StubConfig] A hash with the api provider details.
-        def initialize(config)
-            super(config, @@service_info)
-        end
-
-        RESOURCE_TYPE = 'com.vmware.vapi.operation'
-
-
-        # Returns the identifiers for the operation elements contained in the service element corresponding to  ``service_id``  that have privilege information.
-        #
-        # @param service_id [String]
-        #     Identifier of the service element.
-        # @return [Array<String>]
-        #     List of identifiers for the operation elements contained in the service element that have privilege information.
-        # @raise [Com::Vmware::Vapi::Std::Errors::NotFound]
-        #     if the service element associated with  ``service_id``  does not have any operation elements that have privilege information.
-        def list(service_id)
-            invoke_with_info(@@list_info, {
-                'service_id' => service_id,
-            })
-        end
-
-
-        # Retrieves the privilege information about an operation element corresponding to  ``operation_id``  contained in the service element corresponding to  ``service_id`` .
-        #
-        # @param service_id [String]
-        #     Identifier of the service element.
-        # @param operation_id [String]
-        #     Identifier of the operation element.
-        # @return [Com::Vmware::Vapi::Metadata::Privilege::OperationInfo]
-        #     The   :class:`Com::Vmware::Vapi::Metadata::Privilege::OperationInfo`   instance that corresponds to  ``operation_id`` .
-        # @raise [Com::Vmware::Vapi::Std::Errors::NotFound]
-        #     if the service element associated with  ``service_id``  does not exist.
-        # @raise [Com::Vmware::Vapi::Std::Errors::NotFound]
-        #     if the operation element associated with  ``operation_id``  does not exist.
-        # @raise [Com::Vmware::Vapi::Std::Errors::NotFound]
-        #     if the operation element associated with  ``operation_id``  does not have any privilege information.
-        def get(service_id, operation_id)
-            invoke_with_info(@@get_info, {
-                'service_id' => service_id,
-                'operation_id' => operation_id,
-            })
-        end
-
-
+    # Constructs a new instance.
+    #
+    # @param config [VAPI::Bindings::StubConfig] A hash with the api provider details.
+    def initialize(config)
+      super(config, SERVICE_INFO)
     end
 
+    RESOURCE_TYPE = 'com.vmware.vapi.operation'
+    # Returns the identifiers for the operation elements contained in the service element corresponding to  ``service_id``  that have privilege information.
+    #
+    # @param service_id [String]
+    #     Identifier of the service element.
+    # @return [Array<String>]
+    #     List of identifiers for the operation elements contained in the service element that have privilege information.
+    # @raise [Com::Vmware::Vapi::Std::Errors::NotFound]
+    #     if the service element associated with  ``service_id``  does not have any operation elements that have privilege information.
+    def list(service_id)
+      invoke_with_info(LIST_INFO,
+                       'service_id' => service_id)
+    end
 
+    # Retrieves the privilege information about an operation element corresponding to  ``operation_id``  contained in the service element corresponding to  ``service_id`` .
+    #
+    # @param service_id [String]
+    #     Identifier of the service element.
+    # @param operation_id [String]
+    #     Identifier of the operation element.
+    # @return [Com::Vmware::Vapi::Metadata::Privilege::OperationInfo]
+    #     The   :class:`Com::Vmware::Vapi::Metadata::Privilege::OperationInfo`   instance that corresponds to  ``operation_id`` .
+    # @raise [Com::Vmware::Vapi::Std::Errors::NotFound]
+    #     if the service element associated with  ``service_id``  does not exist.
+    # @raise [Com::Vmware::Vapi::Std::Errors::NotFound]
+    #     if the operation element associated with  ``operation_id``  does not exist.
+    # @raise [Com::Vmware::Vapi::Std::Errors::NotFound]
+    #     if the operation element associated with  ``operation_id``  does not have any privilege information.
+    def get(service_id, operation_id)
+      invoke_with_info(GET_INFO,
+                       'service_id' => service_id,
+                       'operation_id' => operation_id)
+    end
+
+  end
 end

--- a/client/sdk/com/vmware/vapi/std.rb
+++ b/client/sdk/com/vmware/vapi/std.rb
@@ -1,5 +1,6 @@
 #---------------------------------------------------------------------------
-# Copyright 2016 VMware, Inc.  All rights reserved.
+# Copyright 2017 VMware, Inc.  All rights reserved.
+#
 # AUTO GENERATED FILE -- DO NOT MODIFY!
 #
 # vAPI type descriptors for package com.vmware.vapi.std.
@@ -8,135 +9,129 @@ require 'vapi'
 
 # declare the module hierarchy before we use the shorthand syntax below
 module Com
-    module Vmware
-        module Vapi
-            module Std
-            end
-        end
+  module Vmware
+    module Vapi
+      module Std
+      end
     end
+  end
 end
 
 # The  ``com.vmware.vapi.std``   package  provides standard types that can be used in the interface specification of any  class .
 module Com::Vmware::Vapi::Std
-
-    # The   :class:`Com::Vmware::Vapi::Std::AuthenticationScheme`   class defines constants for authentication scheme identifiers for authentication mechanisms present in the vAPI infrastructure shipped by VMware.  
-    # 
-    #  A third party extension can define and implements it's own authentication mechanism and define a constant in a different IDL file.
-    class AuthenticationScheme < VAPI::Bindings::VapiStruct
-
-        class << self
-            # Holds (gets or creates) the binding type metadata for this structure type.
-            # @scope class
-            # @return [VAPI::Bindings::StructType] the binding type
-            def binding_type
-                @binding_type ||= VAPI::Bindings::StructType.new(
-                    'com.vmware.vapi.std.authentication_scheme',
-                    {
-                    },
-                    AuthenticationScheme,
-                    false,
-                    nil)
-            end
-        end
-
-        NO_AUTHENTICATION = 'com.vmware.vapi.std.security.no_authentication'
-        SAML_BEARER_TOKEN = 'com.vmware.vapi.std.security.saml_bearer_token'
-        SAML_HOK_TOKEN = 'com.vmware.vapi.std.security.saml_hok_token'
-        SESSION_ID = 'com.vmware.vapi.std.security.session_id'
-        USER_PASSWORD = 'com.vmware.vapi.std.security.user_pass'
-        OAUTH_ACCESS_TOKEN = 'com.vmware.vapi.std.security.oauth'
-
-        # Constructs a new instance.
-        # @param ruby_values [Hash] a map of initial property values (optional)
-        # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
-        def initialize(ruby_values=nil, struct_value=nil)
-            super(self.class.binding_type, ruby_values, struct_value)
-        end
+  # The   :class:`Com::Vmware::Vapi::Std::AuthenticationScheme`   class defines constants for authentication scheme identifiers for authentication mechanisms present in the vAPI infrastructure shipped by VMware.  
+  # 
+  #  A third party extension can define and implements it's own authentication mechanism and define a constant in a different IDL file.
+  class AuthenticationScheme < VAPI::Bindings::VapiStruct
+    class << self
+      # Holds (gets or creates) the binding type metadata for this structure type.
+      # @scope class
+      # @return [VAPI::Bindings::StructType] the binding type
+      def binding_type
+        @binding_type ||= VAPI::Bindings::StructType.new(
+          'com.vmware.vapi.std.authentication_scheme',
+          {
+          },
+          AuthenticationScheme,
+          false,
+          nil
+        )
+      end
     end
 
+    NO_AUTHENTICATION = 'com.vmware.vapi.std.security.no_authentication'
+    SAML_BEARER_TOKEN = 'com.vmware.vapi.std.security.saml_bearer_token'
+    SAML_HOK_TOKEN = 'com.vmware.vapi.std.security.saml_hok_token'
+    SESSION_ID = 'com.vmware.vapi.std.security.session_id'
+    USER_PASSWORD = 'com.vmware.vapi.std.security.user_pass'
+    OAUTH_ACCESS_TOKEN = 'com.vmware.vapi.std.security.oauth'
 
-    # The  ``Com::Vmware::Vapi::Std::DynamicID``   class  represents an identifier for a resource of an arbitrary type.
-    # @!attribute [rw] type
-    #     @return [String]
-    #     The type of resource being identified (for example  ``com.acme.Person`` ).  
-    #     
-    #       Classs  that contain  methods  for creating and deleting resources typically contain a  constant  specifying the resource type for the resources being created and deleted. The API metamodel metadata  classs  include a  class  that allows retrieving all the known resource types.
-    # @!attribute [rw] id
-    #     @return [String]
-    #     The identifier for a resource whose type is specified by   :attr:`Com::Vmware::Vapi::Std::DynamicID.type`  .
-    class DynamicID < VAPI::Bindings::VapiStruct
-
-        class << self
-            # Holds (gets or creates) the binding type metadata for this structure type.
-            # @scope class
-            # @return [VAPI::Bindings::StructType] the binding type
-            def binding_type
-                @binding_type ||= VAPI::Bindings::StructType.new(
-                    'com.vmware.vapi.std.dynamic_ID',
-                    {
-                        'type' => VAPI::Bindings::StringType.instance,
-                        'id' => VAPI::Bindings::IdType.new(resource_types=[], resource_type_field_name="type"),
-                    },
-                    DynamicID,
-                    false,
-                    nil)
-            end
-        end
-
-        attr_accessor :type,
-                      :id
-
-        # Constructs a new instance.
-        # @param ruby_values [Hash] a map of initial property values (optional)
-        # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
-        def initialize(ruby_values=nil, struct_value=nil)
-            super(self.class.binding_type, ruby_values, struct_value)
-        end
+    # Constructs a new instance.
+    # @param ruby_values [Hash] a map of initial property values (optional)
+    # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
+    def initialize(ruby_values = nil, struct_value = nil)
+      super(self.class.binding_type, ruby_values, struct_value)
+    end
+  end
+  # The  ``Com::Vmware::Vapi::Std::DynamicID``   class  represents an identifier for a resource of an arbitrary type.
+  # @!attribute [rw] type
+  #     @return [String]
+  #     The type of resource being identified (for example  ``com.acme.Person`` ).  
+  #     
+  #       Classs  that contain  methods  for creating and deleting resources typically contain a  constant  specifying the resource type for the resources being created and deleted. The API metamodel metadata  classs  include a  class  that allows retrieving all the known resource types.
+  # @!attribute [rw] id
+  #     @return [String]
+  #     The identifier for a resource whose type is specified by   :attr:`Com::Vmware::Vapi::Std::DynamicID.type`  .
+  class DynamicID < VAPI::Bindings::VapiStruct
+    class << self
+      # Holds (gets or creates) the binding type metadata for this structure type.
+      # @scope class
+      # @return [VAPI::Bindings::StructType] the binding type
+      def binding_type
+        @binding_type ||= VAPI::Bindings::StructType.new(
+          'com.vmware.vapi.std.dynamic_ID',
+          {
+            'type' => VAPI::Bindings::StringType.instance,
+            'id' => VAPI::Bindings::IdType.new([], "type")
+          },
+          DynamicID,
+          false,
+          nil
+        )
+      end
     end
 
+    attr_accessor :type,
+                  :id
 
-    # The  ``Com::Vmware::Vapi::Std::LocalizableMessage``   class  represents a localizable string or message template.  Classs  include one or more localizable message templates in the  errors  they report so that clients can display diagnostic messages in the native language of the user.  Classs  can include localizable strings in the data returned from  methods  to allow clients to display localized status information in the native language of the user.
-    # @!attribute [rw] id
-    #     @return [String]
-    #     Unique identifier of the localizable string or message template.  
-    #     
-    #      This identifier is typically used to retrieve a locale-specific string or message template from a message catalog.
-    # @!attribute [rw] default_message
-    #     @return [String]
-    #     The value of this localizable string or message template in the  ``en_US``  (English) locale. If   :attr:`Com::Vmware::Vapi::Std::LocalizableMessage.id`   refers to a message template, the default message will contain the substituted arguments. This value can be used by clients that do not need to display strings and messages in the native language of the user. It could also be used as a fallback if a client is unable to access the appropriate message catalog.
-    # @!attribute [rw] args
-    #     @return [Array<String>]
-    #     Arguments to be substituted into a message template.
-    class LocalizableMessage < VAPI::Bindings::VapiStruct
-
-        class << self
-            # Holds (gets or creates) the binding type metadata for this structure type.
-            # @scope class
-            # @return [VAPI::Bindings::StructType] the binding type
-            def binding_type
-                @binding_type ||= VAPI::Bindings::StructType.new(
-                    'com.vmware.vapi.std.localizable_message',
-                    {
-                        'id' => VAPI::Bindings::StringType.instance,
-                        'default_message' => VAPI::Bindings::StringType.instance,
-                        'args' => VAPI::Bindings::ListType.new(VAPI::Bindings::StringType.instance),
-                    },
-                    LocalizableMessage,
-                    false,
-                    nil)
-            end
-        end
-
-        attr_accessor :id,
-                      :default_message,
-                      :args
-
-        # Constructs a new instance.
-        # @param ruby_values [Hash] a map of initial property values (optional)
-        # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
-        def initialize(ruby_values=nil, struct_value=nil)
-            super(self.class.binding_type, ruby_values, struct_value)
-        end
+    # Constructs a new instance.
+    # @param ruby_values [Hash] a map of initial property values (optional)
+    # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
+    def initialize(ruby_values = nil, struct_value = nil)
+      super(self.class.binding_type, ruby_values, struct_value)
+    end
+  end
+  # The  ``Com::Vmware::Vapi::Std::LocalizableMessage``   class  represents a localizable string or message template.  Classs  include one or more localizable message templates in the  errors  they report so that clients can display diagnostic messages in the native language of the user.  Classs  can include localizable strings in the data returned from  methods  to allow clients to display localized status information in the native language of the user.
+  # @!attribute [rw] id
+  #     @return [String]
+  #     Unique identifier of the localizable string or message template.  
+  #     
+  #      This identifier is typically used to retrieve a locale-specific string or message template from a message catalog.
+  # @!attribute [rw] default_message
+  #     @return [String]
+  #     The value of this localizable string or message template in the  ``en_US``  (English) locale. If   :attr:`Com::Vmware::Vapi::Std::LocalizableMessage.id`   refers to a message template, the default message will contain the substituted arguments. This value can be used by clients that do not need to display strings and messages in the native language of the user. It could also be used as a fallback if a client is unable to access the appropriate message catalog.
+  # @!attribute [rw] args
+  #     @return [Array<String>]
+  #     Arguments to be substituted into a message template.
+  class LocalizableMessage < VAPI::Bindings::VapiStruct
+    class << self
+      # Holds (gets or creates) the binding type metadata for this structure type.
+      # @scope class
+      # @return [VAPI::Bindings::StructType] the binding type
+      def binding_type
+        @binding_type ||= VAPI::Bindings::StructType.new(
+          'com.vmware.vapi.std.localizable_message',
+          {
+            'id' => VAPI::Bindings::StringType.instance,
+            'default_message' => VAPI::Bindings::StringType.instance,
+            'args' => VAPI::Bindings::ListType.new(VAPI::Bindings::StringType.instance)
+          },
+          LocalizableMessage,
+          false,
+          nil
+        )
+      end
     end
 
+    attr_accessor :id,
+                  :default_message,
+                  :args
+
+    # Constructs a new instance.
+    # @param ruby_values [Hash] a map of initial property values (optional)
+    # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
+    def initialize(ruby_values = nil, struct_value = nil)
+      super(self.class.binding_type, ruby_values, struct_value)
+    end
+  end
 end

--- a/client/sdk/com/vmware/vapi/std/errors.rb
+++ b/client/sdk/com/vmware/vapi/std/errors.rb
@@ -1,5 +1,6 @@
 #---------------------------------------------------------------------------
-# Copyright 2016 VMware, Inc.  All rights reserved.
+# Copyright 2017 VMware, Inc.  All rights reserved.
+#
 # AUTO GENERATED FILE -- DO NOT MODIFY!
 #
 # vAPI type descriptors for package com.vmware.vapi.std.errors.
@@ -8,1114 +9,1060 @@ require 'vapi'
 
 # declare the module hierarchy before we use the shorthand syntax below
 module Com
-    module Vmware
-        module Vapi
-            module Std
-                module Errors
-                end
-            end
+  module Vmware
+    module Vapi
+      module Std
+        module Errors
         end
+      end
     end
+  end
 end
 
 # The  ``com.vmware.vapi.std.errors``   package  provides the standard  errors  that can be included in the list of  errors  in the specification of  methods  to indicate that the  method  might report those  errors . It also provides some  classes  intended to be used as payload to provide additional information about those  errors .
 module Com::Vmware::Vapi::Std::Errors
-
-    # The  ``Com::Vmware::Vapi::Std::Errors::ArgumentLocations``   class  describes which part(s) of the input to the  method  caused the  error .  
-    # 
-    #  Some types of  errors  are caused by the value of one of the inputs to the  method , possibly due to an interaction with other inputs to the  method . This  class  is intended to be used as the payload to identify those inputs when the  method  reports  errors  like   :class:`Com::Vmware::Vapi::Std::Errors::InvalidArgument`   or   :class:`Com::Vmware::Vapi::Std::Errors::NotFound`  . See   :attr:`Com::Vmware::Vapi::Std::Errors::Error.data`  .
-    # @!attribute [rw] primary
-    #     @return [String]
-    #     String describing the location of the input that triggered the  error .
-    # @!attribute [rw] secondary
-    #     @return [Array<String>]
-    #     List  (possibly empty) of strings describing the locations of other inputs that caused the the primary input to trigger the  error .
-    class ArgumentLocations < VAPI::Bindings::VapiStruct
-
-        class << self
-            # Holds (gets or creates) the binding type metadata for this structure type.
-            # @scope class
-            # @return [VAPI::Bindings::StructType] the binding type
-            def binding_type
-                @binding_type ||= VAPI::Bindings::StructType.new(
-                    'com.vmware.vapi.std.errors.argument_locations',
-                    {
-                        'primary' => VAPI::Bindings::StringType.instance,
-                        'secondary' => VAPI::Bindings::ListType.new(VAPI::Bindings::StringType.instance),
-                    },
-                    ArgumentLocations,
-                    false,
-                    nil)
-            end
-        end
-
-        attr_accessor :primary,
-                      :secondary
-
-        # Constructs a new instance.
-        # @param ruby_values [Hash] a map of initial property values (optional)
-        # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
-        def initialize(ruby_values=nil, struct_value=nil)
-            super(self.class.binding_type, ruby_values, struct_value)
-        end
+  # The  ``Com::Vmware::Vapi::Std::Errors::ArgumentLocations``   class  describes which part(s) of the input to the  method  caused the  error .  
+  # 
+  #  Some types of  errors  are caused by the value of one of the inputs to the  method , possibly due to an interaction with other inputs to the  method . This  class  is intended to be used as the payload to identify those inputs when the  method  reports  errors  like   :class:`Com::Vmware::Vapi::Std::Errors::InvalidArgument`   or   :class:`Com::Vmware::Vapi::Std::Errors::NotFound`  . See   :attr:`Com::Vmware::Vapi::Std::Errors::Error.data`  .
+  # @!attribute [rw] primary
+  #     @return [String]
+  #     String describing the location of the input that triggered the  error .
+  # @!attribute [rw] secondary
+  #     @return [Array<String>]
+  #     List  (possibly empty) of strings describing the locations of other inputs that caused the the primary input to trigger the  error .
+  class ArgumentLocations < VAPI::Bindings::VapiStruct
+    class << self
+      # Holds (gets or creates) the binding type metadata for this structure type.
+      # @scope class
+      # @return [VAPI::Bindings::StructType] the binding type
+      def binding_type
+        @binding_type ||= VAPI::Bindings::StructType.new(
+          'com.vmware.vapi.std.errors.argument_locations',
+          {
+            'primary' => VAPI::Bindings::StringType.instance,
+            'secondary' => VAPI::Bindings::ListType.new(VAPI::Bindings::StringType.instance)
+          },
+          ArgumentLocations,
+          false,
+          nil
+        )
+      end
     end
 
+    attr_accessor :primary,
+                  :secondary
 
-    # The  ``Com::Vmware::Vapi::Std::Errors::FileLocations``   class  identifies the file(s) that caused the  method  to report the  error .  
-    # 
-    #  Some types of  errors  are caused by a problem with one or more files. This  class  is intended to be used as the payload to identify those files when the  method  reports  errors  like   :class:`Com::Vmware::Vapi::Std::Errors::NotFound`  . See   :attr:`Com::Vmware::Vapi::Std::Errors::Error.data`  .
-    # @!attribute [rw] primary
-    #     @return [String]
-    #     String identifying the file that triggered the  error .
-    # @!attribute [rw] secondary
-    #     @return [Array<String>]
-    #     List  (possibly empty) of strings identifying other files that caused the primary file to trigger the  error .
-    class FileLocations < VAPI::Bindings::VapiStruct
-
-        class << self
-            # Holds (gets or creates) the binding type metadata for this structure type.
-            # @scope class
-            # @return [VAPI::Bindings::StructType] the binding type
-            def binding_type
-                @binding_type ||= VAPI::Bindings::StructType.new(
-                    'com.vmware.vapi.std.errors.file_locations',
-                    {
-                        'primary' => VAPI::Bindings::StringType.instance,
-                        'secondary' => VAPI::Bindings::ListType.new(VAPI::Bindings::StringType.instance),
-                    },
-                    FileLocations,
-                    false,
-                    nil)
-            end
-        end
-
-        attr_accessor :primary,
-                      :secondary
-
-        # Constructs a new instance.
-        # @param ruby_values [Hash] a map of initial property values (optional)
-        # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
-        def initialize(ruby_values=nil, struct_value=nil)
-            super(self.class.binding_type, ruby_values, struct_value)
-        end
+    # Constructs a new instance.
+    # @param ruby_values [Hash] a map of initial property values (optional)
+    # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
+    def initialize(ruby_values = nil, struct_value = nil)
+      super(self.class.binding_type, ruby_values, struct_value)
+    end
+  end
+  # The  ``Com::Vmware::Vapi::Std::Errors::FileLocations``   class  identifies the file(s) that caused the  method  to report the  error .  
+  # 
+  #  Some types of  errors  are caused by a problem with one or more files. This  class  is intended to be used as the payload to identify those files when the  method  reports  errors  like   :class:`Com::Vmware::Vapi::Std::Errors::NotFound`  . See   :attr:`Com::Vmware::Vapi::Std::Errors::Error.data`  .
+  # @!attribute [rw] primary
+  #     @return [String]
+  #     String identifying the file that triggered the  error .
+  # @!attribute [rw] secondary
+  #     @return [Array<String>]
+  #     List  (possibly empty) of strings identifying other files that caused the primary file to trigger the  error .
+  class FileLocations < VAPI::Bindings::VapiStruct
+    class << self
+      # Holds (gets or creates) the binding type metadata for this structure type.
+      # @scope class
+      # @return [VAPI::Bindings::StructType] the binding type
+      def binding_type
+        @binding_type ||= VAPI::Bindings::StructType.new(
+          'com.vmware.vapi.std.errors.file_locations',
+          {
+            'primary' => VAPI::Bindings::StringType.instance,
+            'secondary' => VAPI::Bindings::ListType.new(VAPI::Bindings::StringType.instance)
+          },
+          FileLocations,
+          false,
+          nil
+        )
+      end
     end
 
+    attr_accessor :primary,
+                  :secondary
 
-    # The  ``Com::Vmware::Vapi::Std::Errors::TransientIndication``   class  indicates whether or not the  error  is transient.  
-    # 
-    #  Some types of  errors  are transient in certain situtations and not transient in other situtations. This  error  payload can be used to indicate to clients whether a particular  error  is transient. See   :attr:`Com::Vmware::Vapi::Std::Errors::Error.data`  .
-    # @!attribute [rw] is_transient
-    #     @return [Boolean]
-    #     Indicates that the  error  this  class  is attached to is transient.
-    class TransientIndication < VAPI::Bindings::VapiStruct
-
-        class << self
-            # Holds (gets or creates) the binding type metadata for this structure type.
-            # @scope class
-            # @return [VAPI::Bindings::StructType] the binding type
-            def binding_type
-                @binding_type ||= VAPI::Bindings::StructType.new(
-                    'com.vmware.vapi.std.errors.transient_indication',
-                    {
-                        'is_transient' => VAPI::Bindings::BooleanType.instance,
-                    },
-                    TransientIndication,
-                    false,
-                    nil)
-            end
-        end
-
-        attr_accessor :is_transient
-
-        # Constructs a new instance.
-        # @param ruby_values [Hash] a map of initial property values (optional)
-        # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
-        def initialize(ruby_values=nil, struct_value=nil)
-            super(self.class.binding_type, ruby_values, struct_value)
-        end
+    # Constructs a new instance.
+    # @param ruby_values [Hash] a map of initial property values (optional)
+    # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
+    def initialize(ruby_values = nil, struct_value = nil)
+      super(self.class.binding_type, ruby_values, struct_value)
+    end
+  end
+  # The  ``Com::Vmware::Vapi::Std::Errors::TransientIndication``   class  indicates whether or not the  error  is transient.  
+  # 
+  #  Some types of  errors  are transient in certain situtations and not transient in other situtations. This  error  payload can be used to indicate to clients whether a particular  error  is transient. See   :attr:`Com::Vmware::Vapi::Std::Errors::Error.data`  .
+  # @!attribute [rw] is_transient
+  #     @return [Boolean]
+  #     Indicates that the  error  this  class  is attached to is transient.
+  class TransientIndication < VAPI::Bindings::VapiStruct
+    class << self
+      # Holds (gets or creates) the binding type metadata for this structure type.
+      # @scope class
+      # @return [VAPI::Bindings::StructType] the binding type
+      def binding_type
+        @binding_type ||= VAPI::Bindings::StructType.new(
+          'com.vmware.vapi.std.errors.transient_indication',
+          {
+            'is_transient' => VAPI::Bindings::BooleanType.instance
+          },
+          TransientIndication,
+          false,
+          nil
+        )
+      end
     end
 
+    attr_accessor :is_transient
 
-    # The  ``Com::Vmware::Vapi::Std::Errors::Error``   error  describes the fields  common to all standard  errors .  
-    # 
-    #  This  error  serves two purposes:  
-    # 
-    #   # It is the  error  that clients in many programming languages can catch to handle all standard  errors . Typically those clients will display one or more of the localizable messages from   :attr:`Com::Vmware::Vapi::Std::Errors::Error.messages`   to a human. 
-    #    # It is the  error  that  methods  can report when they need to report some  error , but the  error  doesn't fit into any other standard  error , and in fact the only reasonable way for a client to react to the  error  is to display the message(s) to a human. 
-    #   
-    # @!attribute [rw] messages
-    #     @return [Array<Com::Vmware::Vapi::Std::LocalizableMessage>]
-    #     Stack of one or more localizable messages for human  error  consumers.  
-    #     
-    #      The message at the top of the stack (first in the list) describes the  error  from the perspective of the  method  the client invoked. Each subsequent message in the stack describes the "cause" of the prior message.
-    # @!attribute [rw] data
-    #     @return [VAPI::Bindings::VapiStruct, nil]
-    #     Data to facilitate clients responding to the  method  reporting a standard  error  to indicating that it was unable to complete successfully.  
-    #     
-    #       Methods  may provide data that clients can use when responding to  errors . Since the data that clients need may be specific to the context of the  method  reporting the  error , different  methods  that report the same  error  may provide different data in the  error . The documentation for each each  method  will describe what, if any, data it provides for each  error  it reports. The   :class:`Com::Vmware::Vapi::Std::Errors::ArgumentLocations`  ,   :class:`Com::Vmware::Vapi::Std::Errors::FileLocations`  , and   :class:`Com::Vmware::Vapi::Std::Errors::TransientIndication`    classes  are intended as possible values for this  field .   :class:`Com::Vmware::Vapi::Std::DynamicID`   may also be useful as a value for this  field  (although that is not its primary purpose). Some  classs  may provide their own specific  classes  for use as the value of this  field  when reporting  errors  from their  methods .
-    #     Some  methods  will not set this  field  when reporting  errors .
-    class Error < VAPI::Bindings::VapiError
-
-        class << self
-            # Holds (gets or creates) the binding type metadata for this error type.
-            # @scope class
-            # @return [VAPI::Bindings::ErrorType] the binding type
-            def binding_type
-                @binding_type ||= VAPI::Bindings::ErrorType.new(
-                    'com.vmware.vapi.std.errors.error',
-                    {
-                        'messages' => VAPI::Bindings::ListType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::LocalizableMessage')),
-                        'data' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::DynamicStructType.new()),
-                    },
-                    Error)
-            end
-        end
-
-        attr_accessor :messages,
-          :data
-
-        # Constructs a new instance.
-        # @param binding_type [VAPI::Bindings::BindingType] the specific BindingType
-        #        declaration for this concrete VapiError type
-        # @param error_value [VAPI::Data::ErrorValue] the error value (default nil)
-        def initialize(binding_type=self.class.binding_type, error_value=nil)
-            super(binding_type, error_value)
-        end
+    # Constructs a new instance.
+    # @param ruby_values [Hash] a map of initial property values (optional)
+    # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
+    def initialize(ruby_values = nil, struct_value = nil)
+      super(self.class.binding_type, ruby_values, struct_value)
     end
-
-
-    # The  ``Com::Vmware::Vapi::Std::Errors::Unsupported``   error  indicates that the  method  is not supported by the  class .  
-    # 
-    #  Examples:  
-    # 
-    #   * Trying to hot-plug a CPU when the current configuration of the VM does not support hot-plugging of CPUs. 
-    #    * Trying to change the memory size to a value that is not within the acceptable guest memory bounds supported by the virtual machine's host. 
-    #   
-    class Unsupported < Com::Vmware::Vapi::Std::Errors::Error
-
-        class << self
-            # Holds (gets or creates) the binding type metadata for this error type.
-            # @scope class
-            # @return [VAPI::Bindings::ErrorType] the binding type
-            def binding_type
-                @binding_type ||= VAPI::Bindings::ErrorType.new(
-                    'com.vmware.vapi.std.errors.unsupported',
-                    {
-                        'messages' => VAPI::Bindings::ListType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::LocalizableMessage')),
-                        'data' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::DynamicStructType.new()),
-                    },
-                    Unsupported)
-            end
-        end
-
-
-        # Constructs a new instance.
-        # @param binding_type [VAPI::Bindings::BindingType] the specific BindingType
-        #        declaration for this concrete VapiError type
-        # @param error_value [VAPI::Data::ErrorValue] the error value (default nil)
-        def initialize(binding_type=self.class.binding_type, error_value=nil)
-            super(binding_type, error_value)
-        end
-    end
-
-
-    # The  ``Com::Vmware::Vapi::Std::Errors::UnexpectedInput``   error  indicates that the request contained a  parameter  or  field  whose name is not known by the server.  
-    # 
-    #  Every  method  expects  parameters  with known names. Some of those  parameters  may be (or contain)  classes , and the  method  expects those  classes  to contain  fields  with known names. If the  method  receives  parameters  or  fields  with names that is does not expect, this  error  may be reported.  
-    # 
-    #  This  error  can be reported by the API infrastructure for any  method , but it is specific to the API infrastructure, and should never be reported by the implementation of any  method .  
-    # 
-    #  Examples:  
-    # 
-    #   * A client using stubs generated from the interface specification for version2 of a  class  invokes the  method  passing one or more  parameters  that were added in version2, but they are communicating with a server that only supports version1 of the  class . 
-    #    * A client provides an unexpected  parameter  or  field  name when invoking the  method  using a dynamic interface (for example REST). 
-    #   
-    class UnexpectedInput < Com::Vmware::Vapi::Std::Errors::Error
-
-        class << self
-            # Holds (gets or creates) the binding type metadata for this error type.
-            # @scope class
-            # @return [VAPI::Bindings::ErrorType] the binding type
-            def binding_type
-                @binding_type ||= VAPI::Bindings::ErrorType.new(
-                    'com.vmware.vapi.std.errors.unexpected_input',
-                    {
-                        'messages' => VAPI::Bindings::ListType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::LocalizableMessage')),
-                        'data' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::DynamicStructType.new()),
-                    },
-                    UnexpectedInput)
-            end
-        end
-
-
-        # Constructs a new instance.
-        # @param binding_type [VAPI::Bindings::BindingType] the specific BindingType
-        #        declaration for this concrete VapiError type
-        # @param error_value [VAPI::Data::ErrorValue] the error value (default nil)
-        def initialize(binding_type=self.class.binding_type, error_value=nil)
-            super(binding_type, error_value)
-        end
-    end
-
-
-    # The  ``Com::Vmware::Vapi::Std::Errors::Unauthorized``   error  indicates that the user is not authorized to perform the  method .  
-    # 
-    #  API requests may include a security context containing user credentials. For example, the user credentials could be a SAML token, a user name and password, or the session identifier for a previously established session. Invoking the  method  may require that the user identified by those credentials has particular privileges on the  method  or on one or more resource identifiers passed to the  method .  
-    # 
-    #  Examples:  
-    # 
-    #   * The  method  requires that the user have one or more privileges on the  method , but the user identified by the credentials in the security context does not have the required privileges. 
-    #    * The  method  requires that the user have one or more privileges on a resource identifier passed to the  method , but the user identified by the credentials in the security context does not have the required privileges. 
-    #   
-    #    
-    # 
-    #   
-    # 
-    #  Counterexamples:  
-    # 
-    #   * The SAML token in the request's security context has expired. A   :class:`Com::Vmware::Vapi::Std::Errors::Unauthenticated`    error  would be used instead. 
-    #    * The user name and password in the request's security context are invalid. The   :class:`Com::Vmware::Vapi::Std::Errors::Unauthenticated`    error  would be used instead. 
-    #    * The session identifier in the request's security context identifies a session that has expired. The   :class:`Com::Vmware::Vapi::Std::Errors::Unauthenticated`    error  would be used instead. 
-    #   
-    #    
-    # 
-    #  For security reasons, the   :attr:`Com::Vmware::Vapi::Std::Errors::Error.data`    field  in this  error  is  nil , and the   :attr:`Com::Vmware::Vapi::Std::Errors::Error.messages`    field  in this  error  does not disclose why the user is not authorized to perform the  method . For example the messages would not disclose which privilege the user did not have or which resource identifier the user did not have the required privilege to access. The API documentation should indicate what privileges are required.
-    class Unauthorized < Com::Vmware::Vapi::Std::Errors::Error
-
-        class << self
-            # Holds (gets or creates) the binding type metadata for this error type.
-            # @scope class
-            # @return [VAPI::Bindings::ErrorType] the binding type
-            def binding_type
-                @binding_type ||= VAPI::Bindings::ErrorType.new(
-                    'com.vmware.vapi.std.errors.unauthorized',
-                    {
-                        'messages' => VAPI::Bindings::ListType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::LocalizableMessage')),
-                        'data' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::DynamicStructType.new()),
-                    },
-                    Unauthorized)
-            end
-        end
-
-
-        # Constructs a new instance.
-        # @param binding_type [VAPI::Bindings::BindingType] the specific BindingType
-        #        declaration for this concrete VapiError type
-        # @param error_value [VAPI::Data::ErrorValue] the error value (default nil)
-        def initialize(binding_type=self.class.binding_type, error_value=nil)
-            super(binding_type, error_value)
-        end
-    end
-
-
-    # The  ``Com::Vmware::Vapi::Std::Errors::Unauthenticated``   error  indicates that the  method  requires authentication and the user is not authenticated.  
-    # 
-    #  API requests may include a security context containing user credentials. For example, the user credentials could be a SAML token, a user name and password, or the session identifier for a previously established session.  
-    # 
-    #  Examples:  
-    # 
-    #   * The SAML token in the request's security context has expired. 
-    #    * The user name and password in the request's security context are invalid. 
-    #    * The session identifier in the request's security context identifies a session that has expired. 
-    #   
-    #   Counterexamples:  
-    # 
-    #   *  The user is authenticated but isn't authorized to perform the requested  method . The   :class:`Com::Vmware::Vapi::Std::Errors::Unauthorized`    error  would be used instead. 
-    #   
-    #    
-    # 
-    #  For security reasons, the   :attr:`Com::Vmware::Vapi::Std::Errors::Error.data`    field  in this  error  is  nil , and the   :attr:`Com::Vmware::Vapi::Std::Errors::Error.messages`    field  in this  error  does not disclose which part of the security context is correct or incorrect. For example the messages would not disclose whether a username or a password is valid or invalid, but only that a combination of username and password is invalid.
-    class Unauthenticated < Com::Vmware::Vapi::Std::Errors::Error
-
-        class << self
-            # Holds (gets or creates) the binding type metadata for this error type.
-            # @scope class
-            # @return [VAPI::Bindings::ErrorType] the binding type
-            def binding_type
-                @binding_type ||= VAPI::Bindings::ErrorType.new(
-                    'com.vmware.vapi.std.errors.unauthenticated',
-                    {
-                        'messages' => VAPI::Bindings::ListType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::LocalizableMessage')),
-                        'data' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::DynamicStructType.new()),
-                    },
-                    Unauthenticated)
-            end
-        end
-
-
-        # Constructs a new instance.
-        # @param binding_type [VAPI::Bindings::BindingType] the specific BindingType
-        #        declaration for this concrete VapiError type
-        # @param error_value [VAPI::Data::ErrorValue] the error value (default nil)
-        def initialize(binding_type=self.class.binding_type, error_value=nil)
-            super(binding_type, error_value)
-        end
-    end
-
-
-    # The  ``Com::Vmware::Vapi::Std::Errors::UnableToAllocateResource``   error  indicates that the  method  failed because it was unable to allocate or acquire a required resource.  
-    # 
-    #  Examples:  
-    # 
-    #   * Trying to power on a virtual machine when there are not enough licenses to do so. 
-    #    * Trying to power on a virtual machine that would violate a resource usage policy. 
-    #   
-    #    
-    # 
-    #  Counterexamples:  
-    # 
-    #   * Trying to power off a virtual machine that is in the process of being powered on. A   :class:`Com::Vmware::Vapi::Std::Errors::ResourceBusy`    error  would be used instead. 
-    #    * Trying to remove a VMFS datastore when the is a virtual machine registered on any host attached to the datastore. The   :class:`Com::Vmware::Vapi::Std::Errors::ResourceInUse`    error  would be used instead. 
-    #    * Trying to add a virtual switch if the physical network adapter being bridged is already in use. The   :class:`Com::Vmware::Vapi::Std::Errors::ResourceInUse`    error  would be used instead. 
-    #    * Attempt to invoke some  method  on a virtual machine when the virtual machine's configuration file is not accessible (for example due to a storage APD condition). The   :class:`Com::Vmware::Vapi::Std::Errors::ResourceInaccessible`    error  would be used instead. 
-    #   
-    class UnableToAllocateResource < Com::Vmware::Vapi::Std::Errors::Error
-
-        class << self
-            # Holds (gets or creates) the binding type metadata for this error type.
-            # @scope class
-            # @return [VAPI::Bindings::ErrorType] the binding type
-            def binding_type
-                @binding_type ||= VAPI::Bindings::ErrorType.new(
-                    'com.vmware.vapi.std.errors.unable_to_allocate_resource',
-                    {
-                        'messages' => VAPI::Bindings::ListType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::LocalizableMessage')),
-                        'data' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::DynamicStructType.new()),
-                    },
-                    UnableToAllocateResource)
-            end
-        end
-
-
-        # Constructs a new instance.
-        # @param binding_type [VAPI::Bindings::BindingType] the specific BindingType
-        #        declaration for this concrete VapiError type
-        # @param error_value [VAPI::Data::ErrorValue] the error value (default nil)
-        def initialize(binding_type=self.class.binding_type, error_value=nil)
-            super(binding_type, error_value)
-        end
-    end
-
-
-    # The  ``Com::Vmware::Vapi::Std::Errors::TimedOut``   error  indicates that the  method  did not complete within the allowed amount of time. The allowed amount of time might be:  
-    # 
-    #   * provided by the client as an input  parameter . 
-    #    * a fixed limit of the  class  implementation that is a documented part of the contract of the  class . 
-    #    * a configurable limit used by the implementation of the  class . 
-    #    * a dynamic limit computed by the implementation of the  class . 
-    #   
-    #   The  method  may or may not complete after the  ``Com::Vmware::Vapi::Std::Errors::TimedOut``   error  was reported.  
-    # 
-    #  Examples:  
-    # 
-    #   * The  method  was unable to complete within the timeout duration specified by a  parameter  of the  method . 
-    #   
-    #    
-    # 
-    #  Counterexamples:  
-    # 
-    #   * A server implementation that puts requests into a queue before dispatching them might delete a request from the queue if it doesn't get dispatched within  *n*  minutes. The   :class:`Com::Vmware::Vapi::Std::Errors::ServiceUnavailable`    error  would be used instead. 
-    #   
-    class TimedOut < Com::Vmware::Vapi::Std::Errors::Error
-
-        class << self
-            # Holds (gets or creates) the binding type metadata for this error type.
-            # @scope class
-            # @return [VAPI::Bindings::ErrorType] the binding type
-            def binding_type
-                @binding_type ||= VAPI::Bindings::ErrorType.new(
-                    'com.vmware.vapi.std.errors.timed_out',
-                    {
-                        'messages' => VAPI::Bindings::ListType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::LocalizableMessage')),
-                        'data' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::DynamicStructType.new()),
-                    },
-                    TimedOut)
-            end
-        end
-
-
-        # Constructs a new instance.
-        # @param binding_type [VAPI::Bindings::BindingType] the specific BindingType
-        #        declaration for this concrete VapiError type
-        # @param error_value [VAPI::Data::ErrorValue] the error value (default nil)
-        def initialize(binding_type=self.class.binding_type, error_value=nil)
-            super(binding_type, error_value)
-        end
-    end
-
-
-    # The  ``Com::Vmware::Vapi::Std::Errors::ServiceUnavailable``   error  indicates that the  class  is unavailable.  
-    # 
-    #  Examples:  
-    # 
-    #   * Attempt to invoke a  method  when the server is too busy. 
-    #    * Attempt to invoke a  method  when the server is undergoing maintenance. 
-    #    * An  method  fails to contact VMware Tools running inside the virtual machine. 
-    #   
-    #    
-    # 
-    #  Counterexamples:  
-    # 
-    #   * A client provides an invalid service or operation identifier when invoking the  method  using a dynamic interface (for example REST). The   :class:`Com::Vmware::Vapi::Std::Errors::OperationNotFound`    error  would be used instead. 
-    #    * A client invokes the  method  from the  class , but that  class  has not been installed. The   :class:`Com::Vmware::Vapi::Std::Errors::OperationNotFound`    error  would be used instead. 
-    #   
-    class ServiceUnavailable < Com::Vmware::Vapi::Std::Errors::Error
-
-        class << self
-            # Holds (gets or creates) the binding type metadata for this error type.
-            # @scope class
-            # @return [VAPI::Bindings::ErrorType] the binding type
-            def binding_type
-                @binding_type ||= VAPI::Bindings::ErrorType.new(
-                    'com.vmware.vapi.std.errors.service_unavailable',
-                    {
-                        'messages' => VAPI::Bindings::ListType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::LocalizableMessage')),
-                        'data' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::DynamicStructType.new()),
-                    },
-                    ServiceUnavailable)
-            end
-        end
-
-
-        # Constructs a new instance.
-        # @param binding_type [VAPI::Bindings::BindingType] the specific BindingType
-        #        declaration for this concrete VapiError type
-        # @param error_value [VAPI::Data::ErrorValue] the error value (default nil)
-        def initialize(binding_type=self.class.binding_type, error_value=nil)
-            super(binding_type, error_value)
-        end
-    end
-
-
-    # The  ``Com::Vmware::Vapi::Std::Errors::ResourceInaccessible``   error  indicates that the  method  could not be completed because an entity is not accessible.  
-    # 
-    #  Examples:  
-    # 
-    #   * Attempt to invoke some  method  on a virtual machine when the virtual machine's configuration file is not accessible (for example due to a storage APD condition). 
-    #   
-    #    
-    # 
-    #  Counterexamples:  
-    # 
-    #   * Attempt to invoke some  method  when the server is too busy. The   :class:`Com::Vmware::Vapi::Std::Errors::ServiceUnavailable`    error  would be used instead. 
-    #    * Attempt to invoke some  method  when the server is undergoing maintenance. The   :class:`Com::Vmware::Vapi::Std::Errors::ServiceUnavailable`    error  would be used instead. 
-    #    * Some  method  fails to contact VMware Tools running inside the virtual machine. The   :class:`Com::Vmware::Vapi::Std::Errors::ServiceUnavailable`    error  would be used instead. 
-    #   
-    class ResourceInaccessible < Com::Vmware::Vapi::Std::Errors::Error
-
-        class << self
-            # Holds (gets or creates) the binding type metadata for this error type.
-            # @scope class
-            # @return [VAPI::Bindings::ErrorType] the binding type
-            def binding_type
-                @binding_type ||= VAPI::Bindings::ErrorType.new(
-                    'com.vmware.vapi.std.errors.resource_inaccessible',
-                    {
-                        'messages' => VAPI::Bindings::ListType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::LocalizableMessage')),
-                        'data' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::DynamicStructType.new()),
-                    },
-                    ResourceInaccessible)
-            end
-        end
-
-
-        # Constructs a new instance.
-        # @param binding_type [VAPI::Bindings::BindingType] the specific BindingType
-        #        declaration for this concrete VapiError type
-        # @param error_value [VAPI::Data::ErrorValue] the error value (default nil)
-        def initialize(binding_type=self.class.binding_type, error_value=nil)
-            super(binding_type, error_value)
-        end
-    end
-
-
-    # The  ``Com::Vmware::Vapi::Std::Errors::ResourceInUse``   error  indicates that the  method  could not be completed because a resource is in use.  
-    # 
-    #  Examples:  
-    # 
-    #   * Trying to remove a VMFS datastore when the is a virtual machine registered on any host attached to the datastore. 
-    #    * Trying to add a virtual switch if the physical network adapter being bridged is already in use. 
-    #   
-    #    
-    # 
-    #  Counterexamples:  
-    # 
-    #   * Trying to power off a virtual machine that is in the process of being powered on. The   :class:`Com::Vmware::Vapi::Std::Errors::ResourceBusy`    error  would be used instead. 
-    #   
-    class ResourceInUse < Com::Vmware::Vapi::Std::Errors::Error
-
-        class << self
-            # Holds (gets or creates) the binding type metadata for this error type.
-            # @scope class
-            # @return [VAPI::Bindings::ErrorType] the binding type
-            def binding_type
-                @binding_type ||= VAPI::Bindings::ErrorType.new(
-                    'com.vmware.vapi.std.errors.resource_in_use',
-                    {
-                        'messages' => VAPI::Bindings::ListType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::LocalizableMessage')),
-                        'data' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::DynamicStructType.new()),
-                    },
-                    ResourceInUse)
-            end
-        end
-
-
-        # Constructs a new instance.
-        # @param binding_type [VAPI::Bindings::BindingType] the specific BindingType
-        #        declaration for this concrete VapiError type
-        # @param error_value [VAPI::Data::ErrorValue] the error value (default nil)
-        def initialize(binding_type=self.class.binding_type, error_value=nil)
-            super(binding_type, error_value)
-        end
-    end
-
-
-    # The  ``Com::Vmware::Vapi::Std::Errors::ResourceBusy``   error  indicates that the  method  could not be completed because a resource it needs is busy.  
-    # 
-    #  Examples:  
-    # 
-    #   * Trying to power off a virtual machine that is in the process of being powered on. 
-    #   
-    #    
-    # 
-    #  Counterexamples:  
-    # 
-    #   * Trying to remove a VMFS datastore when there is a virtual machine registered on any host attached to the datastore. The   :class:`Com::Vmware::Vapi::Std::Errors::ResourceInUse`    error  would be used instead. 
-    #   
-    class ResourceBusy < Com::Vmware::Vapi::Std::Errors::Error
-
-        class << self
-            # Holds (gets or creates) the binding type metadata for this error type.
-            # @scope class
-            # @return [VAPI::Bindings::ErrorType] the binding type
-            def binding_type
-                @binding_type ||= VAPI::Bindings::ErrorType.new(
-                    'com.vmware.vapi.std.errors.resource_busy',
-                    {
-                        'messages' => VAPI::Bindings::ListType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::LocalizableMessage')),
-                        'data' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::DynamicStructType.new()),
-                    },
-                    ResourceBusy)
-            end
-        end
-
-
-        # Constructs a new instance.
-        # @param binding_type [VAPI::Bindings::BindingType] the specific BindingType
-        #        declaration for this concrete VapiError type
-        # @param error_value [VAPI::Data::ErrorValue] the error value (default nil)
-        def initialize(binding_type=self.class.binding_type, error_value=nil)
-            super(binding_type, error_value)
-        end
-    end
-
-
-    # The  ``Com::Vmware::Vapi::Std::Errors::OperationNotFound``   error  indicates that the  method  specified in the request could not be found.  
-    # 
-    #  Every API request specifies a service identifier and an operation identifier along with the  parameters . If the API infrastructure is unable to find the requested  class  or  method  it reports this  error .  
-    # 
-    #  This  error  can be reported by the API infrastructure for any  method , but it is specific to the API infrastructure, and should never be reported by the implementation of any  method .  
-    # 
-    #  Examples:  
-    # 
-    #   * A client provides an invalid service or operation identifier when invoking the  method  using a dynamic interface (for example REST). 
-    #    * A client invokes the  method  from a  class , but that  class  has not been installed. 
-    #   
-    #    
-    # 
-    #  Counterexamples:  
-    # 
-    #   * A client invokes a task scheduling  method , but provides an invalid service identifier or operation identifier. The   :class:`Com::Vmware::Vapi::Std::Errors::NotFound`    error  would be used instead. 
-    #   
-    class OperationNotFound < Com::Vmware::Vapi::Std::Errors::Error
-
-        class << self
-            # Holds (gets or creates) the binding type metadata for this error type.
-            # @scope class
-            # @return [VAPI::Bindings::ErrorType] the binding type
-            def binding_type
-                @binding_type ||= VAPI::Bindings::ErrorType.new(
-                    'com.vmware.vapi.std.errors.operation_not_found',
-                    {
-                        'messages' => VAPI::Bindings::ListType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::LocalizableMessage')),
-                        'data' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::DynamicStructType.new()),
-                    },
-                    OperationNotFound)
-            end
-        end
-
-
-        # Constructs a new instance.
-        # @param binding_type [VAPI::Bindings::BindingType] the specific BindingType
-        #        declaration for this concrete VapiError type
-        # @param error_value [VAPI::Data::ErrorValue] the error value (default nil)
-        def initialize(binding_type=self.class.binding_type, error_value=nil)
-            super(binding_type, error_value)
-        end
-    end
-
-
-    # The  ``Com::Vmware::Vapi::Std::Errors::NotFound``   error  indicates that a specified element could not be found.  
-    # 
-    #  Examples:  
-    # 
-    #   * Invoke the  method  to retrieve information about a virtual machine, passing an id that does not identify an existing virtual machine. 
-    #    * Invoke the  method  to modify the configuration of a virtual nic, passing an id that does not identify an existing virtual nic in the specified virtual machine. 
-    #    * Invoke the  method  to remove a vswitch, passing an id that does not identify an existing vswitch. 
-    #   
-    class NotFound < Com::Vmware::Vapi::Std::Errors::Error
-
-        class << self
-            # Holds (gets or creates) the binding type metadata for this error type.
-            # @scope class
-            # @return [VAPI::Bindings::ErrorType] the binding type
-            def binding_type
-                @binding_type ||= VAPI::Bindings::ErrorType.new(
-                    'com.vmware.vapi.std.errors.not_found',
-                    {
-                        'messages' => VAPI::Bindings::ListType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::LocalizableMessage')),
-                        'data' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::DynamicStructType.new()),
-                    },
-                    NotFound)
-            end
-        end
-
-
-        # Constructs a new instance.
-        # @param binding_type [VAPI::Bindings::BindingType] the specific BindingType
-        #        declaration for this concrete VapiError type
-        # @param error_value [VAPI::Data::ErrorValue] the error value (default nil)
-        def initialize(binding_type=self.class.binding_type, error_value=nil)
-            super(binding_type, error_value)
-        end
-    end
-
-
-    # The  ``Com::Vmware::Vapi::Std::Errors::NotAllowedInCurrentState``   error  indicates that the requested  method  is not allowed with a resource or service in its current state. This could be because the  method  is performing a configuration change that is not allowed in the current state or because  method  itself is not allowed in the current state.  
-    # 
-    #  Examples:  
-    # 
-    #   * Trying to add a virtual device that cannot be hot plugged to a running virtual machine. 
-    #    * Trying to upgrade the virtual hardware version for a suspended virtual machine. 
-    #    * Trying to power off, reset, or suspend a virtual machine that is not powered on. 
-    #   
-    #    
-    # 
-    #  Counterexamples:  
-    # 
-    #   * Trying to power off a virtual machine that is in the process of being powered on. The   :class:`Com::Vmware::Vapi::Std::Errors::ResourceBusy`    error  would be used instead. 
-    #   
-    class NotAllowedInCurrentState < Com::Vmware::Vapi::Std::Errors::Error
-
-        class << self
-            # Holds (gets or creates) the binding type metadata for this error type.
-            # @scope class
-            # @return [VAPI::Bindings::ErrorType] the binding type
-            def binding_type
-                @binding_type ||= VAPI::Bindings::ErrorType.new(
-                    'com.vmware.vapi.std.errors.not_allowed_in_current_state',
-                    {
-                        'messages' => VAPI::Bindings::ListType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::LocalizableMessage')),
-                        'data' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::DynamicStructType.new()),
-                    },
-                    NotAllowedInCurrentState)
-            end
-        end
-
-
-        # Constructs a new instance.
-        # @param binding_type [VAPI::Bindings::BindingType] the specific BindingType
-        #        declaration for this concrete VapiError type
-        # @param error_value [VAPI::Data::ErrorValue] the error value (default nil)
-        def initialize(binding_type=self.class.binding_type, error_value=nil)
-            super(binding_type, error_value)
-        end
-    end
-
-
-    # The  ``Com::Vmware::Vapi::Std::Errors::InvalidRequest``   error  indicates that the request is malformed in such a way that the server is unable to process it.  
-    # 
-    #  Examples:  
-    # 
-    #   * The XML in a SOAP request is not well-formed so the server cannot parse the request. 
-    #    * The XML in a SOAP request is well-formed but does not match the structure required by the SOAP specification. 
-    #    * A JSON-RPC request is not valid JSON. 
-    #    * The JSON sent in a JSON-RPC request is not a valid JSON-RPC Request object. 
-    #    * The Request object from a JSON-RPC request does not match the structure required by the API infrastructure. 
-    #   
-    #    
-    # 
-    #  Counterexamples:  
-    # 
-    #   * The  parameter  has a value that is not with the required range. The   :class:`Com::Vmware::Vapi::Std::Errors::InvalidArgument`    error  would be used instead. 
-    #    * The name of the  method  specified in the request doesn't not match any known  method . The   :class:`Com::Vmware::Vapi::Std::Errors::NotFound`    error  would be used instead. 
-    #   
-    #    
-    # 
-    #  Some transport protocols (for example JSON-RPC) include their own mechanism for reporting these kinds of errors, and the API infrastructure for a programming language may expose the errors using a language specific mechanism, so this  error  might not be used.
-    class InvalidRequest < Com::Vmware::Vapi::Std::Errors::Error
-
-        class << self
-            # Holds (gets or creates) the binding type metadata for this error type.
-            # @scope class
-            # @return [VAPI::Bindings::ErrorType] the binding type
-            def binding_type
-                @binding_type ||= VAPI::Bindings::ErrorType.new(
-                    'com.vmware.vapi.std.errors.invalid_request',
-                    {
-                        'messages' => VAPI::Bindings::ListType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::LocalizableMessage')),
-                        'data' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::DynamicStructType.new()),
-                    },
-                    InvalidRequest)
-            end
-        end
-
-
-        # Constructs a new instance.
-        # @param binding_type [VAPI::Bindings::BindingType] the specific BindingType
-        #        declaration for this concrete VapiError type
-        # @param error_value [VAPI::Data::ErrorValue] the error value (default nil)
-        def initialize(binding_type=self.class.binding_type, error_value=nil)
-            super(binding_type, error_value)
-        end
-    end
-
-
-    # The  ``Com::Vmware::Vapi::Std::Errors::InvalidElementType``   error  indicates that the server was unable to fulfil the request because an element of a specific type cannot be a member of particular group.  
-    # 
-    #  This  error  could be reported, for example, if an attempt is made to put an element into the wrong type of container.  
-    # 
-    #  Examples:  
-    # 
-    #   * Attempt to put a virtual machine into a folder that can only contain hosts. 
-    #    * Attempt to attach a SCSI virtual disk to an IDE port. 
-    #   
-    #   Counterexamples:  
-    # 
-    #   * A  parameter  has a value that is not of the expected type. The   :class:`Com::Vmware::Vapi::Std::Errors::InvalidArgument`    error  would be used instead. 
-    #   
-    class InvalidElementType < Com::Vmware::Vapi::Std::Errors::Error
-
-        class << self
-            # Holds (gets or creates) the binding type metadata for this error type.
-            # @scope class
-            # @return [VAPI::Bindings::ErrorType] the binding type
-            def binding_type
-                @binding_type ||= VAPI::Bindings::ErrorType.new(
-                    'com.vmware.vapi.std.errors.invalid_element_type',
-                    {
-                        'messages' => VAPI::Bindings::ListType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::LocalizableMessage')),
-                        'data' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::DynamicStructType.new()),
-                    },
-                    InvalidElementType)
-            end
-        end
-
-
-        # Constructs a new instance.
-        # @param binding_type [VAPI::Bindings::BindingType] the specific BindingType
-        #        declaration for this concrete VapiError type
-        # @param error_value [VAPI::Data::ErrorValue] the error value (default nil)
-        def initialize(binding_type=self.class.binding_type, error_value=nil)
-            super(binding_type, error_value)
-        end
-    end
-
-
-    # The  ``Com::Vmware::Vapi::Std::Errors::InvalidElementConfiguration``   error  indicates that an attempt to modify the configuration of an element or a group containing the element failed due to the configuraton of the element. A typical case is when the  method  is am attempt to change the group membership of the element fails, in which case a configuration change on the element may allow the group membership change to succeed.  
-    # 
-    #  Examples:  
-    # 
-    #   * Attempt to move a host with a fault tolerant virtual machine out of a cluster (i.e. make the host a standalone host). 
-    #    * Attempt to remove a host from a DRS cluster without putting the host into maintenance mode. 
-    #   
-    class InvalidElementConfiguration < Com::Vmware::Vapi::Std::Errors::Error
-
-        class << self
-            # Holds (gets or creates) the binding type metadata for this error type.
-            # @scope class
-            # @return [VAPI::Bindings::ErrorType] the binding type
-            def binding_type
-                @binding_type ||= VAPI::Bindings::ErrorType.new(
-                    'com.vmware.vapi.std.errors.invalid_element_configuration',
-                    {
-                        'messages' => VAPI::Bindings::ListType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::LocalizableMessage')),
-                        'data' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::DynamicStructType.new()),
-                    },
-                    InvalidElementConfiguration)
-            end
-        end
-
-
-        # Constructs a new instance.
-        # @param binding_type [VAPI::Bindings::BindingType] the specific BindingType
-        #        declaration for this concrete VapiError type
-        # @param error_value [VAPI::Data::ErrorValue] the error value (default nil)
-        def initialize(binding_type=self.class.binding_type, error_value=nil)
-            super(binding_type, error_value)
-        end
-    end
-
-
-    # The  ``Com::Vmware::Vapi::Std::Errors::InvalidArgument``   error  indicates that the values received for one or more  parameters  are not acceptable.  
-    # 
-    #  This  error  is reported by the API infrastructure, so it could occur in response to the invocation of any  method . It may also be reported as the result of  method -specific validation.  
-    # 
-    #  Examples:  
-    # 
-    #   * A  parameter  has a value that is not of the expected type. 
-    #    * A  parameter  has a value that is not in the required range. 
-    #    * A  parameter  has a value that is not one of the specifically allowed strings. 
-    #    * One  field  of a  class  is the tag for a tagged union, and has a specific value but another  field  of the  class  that is required to be specified when the tag has that value is not specified, or another  field  of the  class  that is required to be unspecified when the tag has that value is specified. 
-    #   
-    #    
-    # 
-    #  Counterexamples:  
-    # 
-    #   * Trying to create a new tag in tag category when a tag with the specified name already exists the tag category. The   :class:`Com::Vmware::Vapi::Std::Errors::AlreadyExists`    error  would be used instead. 
-    #    * Invoke the  method  to retrieve information about a virtual machine, passing an id that does not identify an existing virtual machine. The   :class:`Com::Vmware::Vapi::Std::Errors::NotFound`    error  would be used instead. 
-    #    * Attempt to put a virtual machine into a folder that can only contain hosts. The   :class:`Com::Vmware::Vapi::Std::Errors::InvalidElementType`    error  would be used instead. 
-    #    * Attempt to attach a SCSI virtual disk to an IDE port. The   :class:`Com::Vmware::Vapi::Std::Errors::InvalidElementType`    error  would be used instead. 
-    #   
-    class InvalidArgument < Com::Vmware::Vapi::Std::Errors::Error
-
-        class << self
-            # Holds (gets or creates) the binding type metadata for this error type.
-            # @scope class
-            # @return [VAPI::Bindings::ErrorType] the binding type
-            def binding_type
-                @binding_type ||= VAPI::Bindings::ErrorType.new(
-                    'com.vmware.vapi.std.errors.invalid_argument',
-                    {
-                        'messages' => VAPI::Bindings::ListType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::LocalizableMessage')),
-                        'data' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::DynamicStructType.new()),
-                    },
-                    InvalidArgument)
-            end
-        end
-
-
-        # Constructs a new instance.
-        # @param binding_type [VAPI::Bindings::BindingType] the specific BindingType
-        #        declaration for this concrete VapiError type
-        # @param error_value [VAPI::Data::ErrorValue] the error value (default nil)
-        def initialize(binding_type=self.class.binding_type, error_value=nil)
-            super(binding_type, error_value)
-        end
-    end
-
-
-    # The  ``Com::Vmware::Vapi::Std::Errors::InternalServerError``   error  indicates that the server encounters an unexpected condition that prevented it from fulfilling the request.  
-    # 
-    #  This  error  is reported by the API infrastructure, so it could occur in response to the invocation of any  method .  
-    # 
-    #  Examples:  
-    # 
-    #   * The  method  returns a value whose type doesn't match the type type the  method  says it should return.
-    #    * The  method  reports an  error  that is not included in the list of  errors  the  method  says that it can report.
-    #   
-    class InternalServerError < Com::Vmware::Vapi::Std::Errors::Error
-
-        class << self
-            # Holds (gets or creates) the binding type metadata for this error type.
-            # @scope class
-            # @return [VAPI::Bindings::ErrorType] the binding type
-            def binding_type
-                @binding_type ||= VAPI::Bindings::ErrorType.new(
-                    'com.vmware.vapi.std.errors.internal_server_error',
-                    {
-                        'messages' => VAPI::Bindings::ListType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::LocalizableMessage')),
-                        'data' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::DynamicStructType.new()),
-                    },
-                    InternalServerError)
-            end
-        end
-
-
-        # Constructs a new instance.
-        # @param binding_type [VAPI::Bindings::BindingType] the specific BindingType
-        #        declaration for this concrete VapiError type
-        # @param error_value [VAPI::Data::ErrorValue] the error value (default nil)
-        def initialize(binding_type=self.class.binding_type, error_value=nil)
-            super(binding_type, error_value)
-        end
-    end
-
-
-    # The  ``Com::Vmware::Vapi::Std::Errors::FeatureInUse``   error  indicates that an action cannot be completed because a feature is in use.  
-    # 
-    #  Examples:  
-    # 
-    #   * Trying to disable snapshots on a virtual machine which has a snapshot. 
-    #    * Trying to downgrade a license that has licensed features that are in use. 
-    #   
-    class FeatureInUse < Com::Vmware::Vapi::Std::Errors::Error
-
-        class << self
-            # Holds (gets or creates) the binding type metadata for this error type.
-            # @scope class
-            # @return [VAPI::Bindings::ErrorType] the binding type
-            def binding_type
-                @binding_type ||= VAPI::Bindings::ErrorType.new(
-                    'com.vmware.vapi.std.errors.feature_in_use',
-                    {
-                        'messages' => VAPI::Bindings::ListType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::LocalizableMessage')),
-                        'data' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::DynamicStructType.new()),
-                    },
-                    FeatureInUse)
-            end
-        end
-
-
-        # Constructs a new instance.
-        # @param binding_type [VAPI::Bindings::BindingType] the specific BindingType
-        #        declaration for this concrete VapiError type
-        # @param error_value [VAPI::Data::ErrorValue] the error value (default nil)
-        def initialize(binding_type=self.class.binding_type, error_value=nil)
-            super(binding_type, error_value)
-        end
-    end
-
-
-    # The  ``Com::Vmware::Vapi::Std::Errors::ConcurrentChange``   error  indicates that a data structure, entity, or resource has been modified since some earlier point in time. Typically this happens when the client is doing the  *write*  portion of a read-modify-write sequence and indicates that it wants the server to notify it if the data in the server has changed after it did the  *read* , so that it can avoid overwriting that change inadvertantly.
-    class ConcurrentChange < Com::Vmware::Vapi::Std::Errors::Error
-
-        class << self
-            # Holds (gets or creates) the binding type metadata for this error type.
-            # @scope class
-            # @return [VAPI::Bindings::ErrorType] the binding type
-            def binding_type
-                @binding_type ||= VAPI::Bindings::ErrorType.new(
-                    'com.vmware.vapi.std.errors.concurrent_change',
-                    {
-                        'messages' => VAPI::Bindings::ListType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::LocalizableMessage')),
-                        'data' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::DynamicStructType.new()),
-                    },
-                    ConcurrentChange)
-            end
-        end
-
-
-        # Constructs a new instance.
-        # @param binding_type [VAPI::Bindings::BindingType] the specific BindingType
-        #        declaration for this concrete VapiError type
-        # @param error_value [VAPI::Data::ErrorValue] the error value (default nil)
-        def initialize(binding_type=self.class.binding_type, error_value=nil)
-            super(binding_type, error_value)
-        end
-    end
-
-
-    # The  ``Com::Vmware::Vapi::Std::Errors::Canceled``   error  indicates that the  method  canceled itself in response to an explicit request to do so.  Methods  being "canceled" for other reasons (for example the client connection was closed, a time out occured, or due to excessive resource consumption) should not report this  error .  
-    # 
-    #  Examples:  
-    # 
-    #   * A user is monitoring the progress of the  method  in a GUI and sees that it is likely to take longer than he is willing to wait and clicks the cancel button. 
-    #    * A user invokes the  method  using a command-line tool and decides that she didn't really want to invoke that  method , and presses CTRL-c. 
-    #   
-    #    
-    # 
-    #  Counterexamples:  
-    # 
-    #   * The client's connection to the server was closed. Reporting an  error  is pointless since the client will not receive the error response because the connection has been closed. 
-    #    * The request is taking longer than some amount of time. The   :class:`Com::Vmware::Vapi::Std::Errors::TimedOut`    error  would be reported if the time was specified as part of the input or is documented in the API contract. 
-    #   
-    class Canceled < Com::Vmware::Vapi::Std::Errors::Error
-
-        class << self
-            # Holds (gets or creates) the binding type metadata for this error type.
-            # @scope class
-            # @return [VAPI::Bindings::ErrorType] the binding type
-            def binding_type
-                @binding_type ||= VAPI::Bindings::ErrorType.new(
-                    'com.vmware.vapi.std.errors.canceled',
-                    {
-                        'messages' => VAPI::Bindings::ListType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::LocalizableMessage')),
-                        'data' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::DynamicStructType.new()),
-                    },
-                    Canceled)
-            end
-        end
-
-
-        # Constructs a new instance.
-        # @param binding_type [VAPI::Bindings::BindingType] the specific BindingType
-        #        declaration for this concrete VapiError type
-        # @param error_value [VAPI::Data::ErrorValue] the error value (default nil)
-        def initialize(binding_type=self.class.binding_type, error_value=nil)
-            super(binding_type, error_value)
-        end
-    end
-
-
-    # The  ``Com::Vmware::Vapi::Std::Errors::AlreadyInDesiredState``   error  indicates that an attempt to change the state of a resource or service had no effect because the resource or service is already in the desired state.  
-    # 
-    #  Examples:  
-    # 
-    #   * Trying to power on a virtual machine that is already powered on.
-    #   
-    class AlreadyInDesiredState < Com::Vmware::Vapi::Std::Errors::Error
-
-        class << self
-            # Holds (gets or creates) the binding type metadata for this error type.
-            # @scope class
-            # @return [VAPI::Bindings::ErrorType] the binding type
-            def binding_type
-                @binding_type ||= VAPI::Bindings::ErrorType.new(
-                    'com.vmware.vapi.std.errors.already_in_desired_state',
-                    {
-                        'messages' => VAPI::Bindings::ListType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::LocalizableMessage')),
-                        'data' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::DynamicStructType.new()),
-                    },
-                    AlreadyInDesiredState)
-            end
-        end
-
-
-        # Constructs a new instance.
-        # @param binding_type [VAPI::Bindings::BindingType] the specific BindingType
-        #        declaration for this concrete VapiError type
-        # @param error_value [VAPI::Data::ErrorValue] the error value (default nil)
-        def initialize(binding_type=self.class.binding_type, error_value=nil)
-            super(binding_type, error_value)
-        end
-    end
-
-
-    # The  ``Com::Vmware::Vapi::Std::Errors::AlreadyExists``   error  indicates that an attempt was made to create an entity but the entity already exists. Typically the entity has a name or identifier that is required to be unique in some context, but there is already an entity with that name or identifier in that context.  
-    # 
-    #  Examples:  
-    # 
-    #   * Trying to create a new tag category when a tag category with the specified name already exists.
-    #    * Trying to create a new tag in tag category when a tag with the specified name already exists the tag category.
-    #    * Trying to create a LUN with a specific UUID on a node (for replication purposes) when a LUN with that UUID already exists on the node.
-    #    * Trying to create a file in a directory or move or copy a file to a directory when a file with that name already exists in the directory. 
-    #   
-    class AlreadyExists < Com::Vmware::Vapi::Std::Errors::Error
-
-        class << self
-            # Holds (gets or creates) the binding type metadata for this error type.
-            # @scope class
-            # @return [VAPI::Bindings::ErrorType] the binding type
-            def binding_type
-                @binding_type ||= VAPI::Bindings::ErrorType.new(
-                    'com.vmware.vapi.std.errors.already_exists',
-                    {
-                        'messages' => VAPI::Bindings::ListType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::LocalizableMessage')),
-                        'data' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::DynamicStructType.new()),
-                    },
-                    AlreadyExists)
-            end
-        end
-
-
-        # Constructs a new instance.
-        # @param binding_type [VAPI::Bindings::BindingType] the specific BindingType
-        #        declaration for this concrete VapiError type
-        # @param error_value [VAPI::Data::ErrorValue] the error value (default nil)
-        def initialize(binding_type=self.class.binding_type, error_value=nil)
-            super(binding_type, error_value)
-        end
-    end
-
+  end
+  # The  ``Com::Vmware::Vapi::Std::Errors::Error``   error  describes the fields  common to all standard  errors .  
+  # 
+  #  This  error  serves two purposes:  
+  # 
+  #   # It is the  error  that clients in many programming languages can catch to handle all standard  errors . Typically those clients will display one or more of the localizable messages from   :attr:`Com::Vmware::Vapi::Std::Errors::Error.messages`   to a human. 
+  #    # It is the  error  that  methods  can report when they need to report some  error , but the  error  doesn't fit into any other standard  error , and in fact the only reasonable way for a client to react to the  error  is to display the message(s) to a human. 
+  #   
+  # @!attribute [rw] messages
+  #     @return [Array<Com::Vmware::Vapi::Std::LocalizableMessage>]
+  #     Stack of one or more localizable messages for human  error  consumers.  
+  #     
+  #      The message at the top of the stack (first in the list) describes the  error  from the perspective of the  method  the client invoked. Each subsequent message in the stack describes the "cause" of the prior message.
+  # @!attribute [rw] data
+  #     @return [VAPI::Bindings::VapiStruct, nil]
+  #     Data to facilitate clients responding to the  method  reporting a standard  error  to indicating that it was unable to complete successfully.  
+  #     
+  #       Methods  may provide data that clients can use when responding to  errors . Since the data that clients need may be specific to the context of the  method  reporting the  error , different  methods  that report the same  error  may provide different data in the  error . The documentation for each each  method  will describe what, if any, data it provides for each  error  it reports. The   :class:`Com::Vmware::Vapi::Std::Errors::ArgumentLocations`  ,   :class:`Com::Vmware::Vapi::Std::Errors::FileLocations`  , and   :class:`Com::Vmware::Vapi::Std::Errors::TransientIndication`    classes  are intended as possible values for this  field .   :class:`Com::Vmware::Vapi::Std::DynamicID`   may also be useful as a value for this  field  (although that is not its primary purpose). Some  classs  may provide their own specific  classes  for use as the value of this  field  when reporting  errors  from their  methods .
+  #     Some  methods  will not set this  field  when reporting  errors .
+  class Error < VAPI::Bindings::VapiError
+
+      class << self
+          # Holds (gets or creates) the binding type metadata for this error type.
+          # @scope class
+          # @return [VAPI::Bindings::ErrorType] the binding type
+          def binding_type
+              @binding_type ||= VAPI::Bindings::ErrorType.new(
+                  'com.vmware.vapi.std.errors.error',
+                  {
+                      'messages' => VAPI::Bindings::ListType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::LocalizableMessage')),
+                      'data' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::DynamicStructType.new()),
+                  },
+                  Error)
+          end
+      end
+
+      attr_accessor :messages,
+        :data
+
+      # Constructs a new instance.
+      # @param binding_type [VAPI::Bindings::BindingType] the specific BindingType
+      #        declaration for this concrete VapiError type
+      # @param error_value [VAPI::Data::ErrorValue] the error value (default nil)
+      def initialize(binding_type=self.class.binding_type, error_value=nil)
+          super(binding_type, error_value)
+      end
+  end
+  # The  ``Com::Vmware::Vapi::Std::Errors::Unsupported``   error  indicates that the  method  is not supported by the  class .  
+  # 
+  #  Examples:  
+  # 
+  #   * Trying to hot-plug a CPU when the current configuration of the VM does not support hot-plugging of CPUs. 
+  #    * Trying to change the memory size to a value that is not within the acceptable guest memory bounds supported by the virtual machine's host. 
+  #   
+  class Unsupported < Com::Vmware::Vapi::Std::Errors::Error
+
+      class << self
+          # Holds (gets or creates) the binding type metadata for this error type.
+          # @scope class
+          # @return [VAPI::Bindings::ErrorType] the binding type
+          def binding_type
+              @binding_type ||= VAPI::Bindings::ErrorType.new(
+                  'com.vmware.vapi.std.errors.unsupported',
+                  {
+                      'messages' => VAPI::Bindings::ListType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::LocalizableMessage')),
+                      'data' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::DynamicStructType.new()),
+                  },
+                  Unsupported)
+          end
+      end
+
+
+      # Constructs a new instance.
+      # @param binding_type [VAPI::Bindings::BindingType] the specific BindingType
+      #        declaration for this concrete VapiError type
+      # @param error_value [VAPI::Data::ErrorValue] the error value (default nil)
+      def initialize(binding_type=self.class.binding_type, error_value=nil)
+          super(binding_type, error_value)
+      end
+  end
+  # The  ``Com::Vmware::Vapi::Std::Errors::UnexpectedInput``   error  indicates that the request contained a  parameter  or  field  whose name is not known by the server.  
+  # 
+  #  Every  method  expects  parameters  with known names. Some of those  parameters  may be (or contain)  classes , and the  method  expects those  classes  to contain  fields  with known names. If the  method  receives  parameters  or  fields  with names that is does not expect, this  error  may be reported.  
+  # 
+  #  This  error  can be reported by the API infrastructure for any  method , but it is specific to the API infrastructure, and should never be reported by the implementation of any  method .  
+  # 
+  #  Examples:  
+  # 
+  #   * A client using stubs generated from the interface specification for version2 of a  class  invokes the  method  passing one or more  parameters  that were added in version2, but they are communicating with a server that only supports version1 of the  class . 
+  #    * A client provides an unexpected  parameter  or  field  name when invoking the  method  using a dynamic interface (for example REST). 
+  #   
+  class UnexpectedInput < Com::Vmware::Vapi::Std::Errors::Error
+
+      class << self
+          # Holds (gets or creates) the binding type metadata for this error type.
+          # @scope class
+          # @return [VAPI::Bindings::ErrorType] the binding type
+          def binding_type
+              @binding_type ||= VAPI::Bindings::ErrorType.new(
+                  'com.vmware.vapi.std.errors.unexpected_input',
+                  {
+                      'messages' => VAPI::Bindings::ListType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::LocalizableMessage')),
+                      'data' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::DynamicStructType.new()),
+                  },
+                  UnexpectedInput)
+          end
+      end
+
+
+      # Constructs a new instance.
+      # @param binding_type [VAPI::Bindings::BindingType] the specific BindingType
+      #        declaration for this concrete VapiError type
+      # @param error_value [VAPI::Data::ErrorValue] the error value (default nil)
+      def initialize(binding_type=self.class.binding_type, error_value=nil)
+          super(binding_type, error_value)
+      end
+  end
+  # The  ``Com::Vmware::Vapi::Std::Errors::Unauthorized``   error  indicates that the user is not authorized to perform the  method .  
+  # 
+  #  API requests may include a security context containing user credentials. For example, the user credentials could be a SAML token, a user name and password, or the session identifier for a previously established session. Invoking the  method  may require that the user identified by those credentials has particular privileges on the  method  or on one or more resource identifiers passed to the  method .  
+  # 
+  #  Examples:  
+  # 
+  #   * The  method  requires that the user have one or more privileges on the  method , but the user identified by the credentials in the security context does not have the required privileges. 
+  #    * The  method  requires that the user have one or more privileges on a resource identifier passed to the  method , but the user identified by the credentials in the security context does not have the required privileges. 
+  #   
+  #    
+  # 
+  #   
+  # 
+  #  Counterexamples:  
+  # 
+  #   * The SAML token in the request's security context has expired. A   :class:`Com::Vmware::Vapi::Std::Errors::Unauthenticated`    error  would be used instead. 
+  #    * The user name and password in the request's security context are invalid. The   :class:`Com::Vmware::Vapi::Std::Errors::Unauthenticated`    error  would be used instead. 
+  #    * The session identifier in the request's security context identifies a session that has expired. The   :class:`Com::Vmware::Vapi::Std::Errors::Unauthenticated`    error  would be used instead. 
+  #   
+  #    
+  # 
+  #  For security reasons, the   :attr:`Com::Vmware::Vapi::Std::Errors::Error.data`    field  in this  error  is  nil , and the   :attr:`Com::Vmware::Vapi::Std::Errors::Error.messages`    field  in this  error  does not disclose why the user is not authorized to perform the  method . For example the messages would not disclose which privilege the user did not have or which resource identifier the user did not have the required privilege to access. The API documentation should indicate what privileges are required.
+  class Unauthorized < Com::Vmware::Vapi::Std::Errors::Error
+
+      class << self
+          # Holds (gets or creates) the binding type metadata for this error type.
+          # @scope class
+          # @return [VAPI::Bindings::ErrorType] the binding type
+          def binding_type
+              @binding_type ||= VAPI::Bindings::ErrorType.new(
+                  'com.vmware.vapi.std.errors.unauthorized',
+                  {
+                      'messages' => VAPI::Bindings::ListType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::LocalizableMessage')),
+                      'data' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::DynamicStructType.new()),
+                  },
+                  Unauthorized)
+          end
+      end
+
+
+      # Constructs a new instance.
+      # @param binding_type [VAPI::Bindings::BindingType] the specific BindingType
+      #        declaration for this concrete VapiError type
+      # @param error_value [VAPI::Data::ErrorValue] the error value (default nil)
+      def initialize(binding_type=self.class.binding_type, error_value=nil)
+          super(binding_type, error_value)
+      end
+  end
+  # The  ``Com::Vmware::Vapi::Std::Errors::Unauthenticated``   error  indicates that the  method  requires authentication and the user is not authenticated.  
+  # 
+  #  API requests may include a security context containing user credentials. For example, the user credentials could be a SAML token, a user name and password, or the session identifier for a previously established session.  
+  # 
+  #  Examples:  
+  # 
+  #   * The SAML token in the request's security context has expired. 
+  #    * The user name and password in the request's security context are invalid. 
+  #    * The session identifier in the request's security context identifies a session that has expired. 
+  #   
+  #   Counterexamples:  
+  # 
+  #   *  The user is authenticated but isn't authorized to perform the requested  method . The   :class:`Com::Vmware::Vapi::Std::Errors::Unauthorized`    error  would be used instead. 
+  #   
+  #    
+  # 
+  #  For security reasons, the   :attr:`Com::Vmware::Vapi::Std::Errors::Error.data`    field  in this  error  is  nil , and the   :attr:`Com::Vmware::Vapi::Std::Errors::Error.messages`    field  in this  error  does not disclose which part of the security context is correct or incorrect. For example the messages would not disclose whether a username or a password is valid or invalid, but only that a combination of username and password is invalid.
+  class Unauthenticated < Com::Vmware::Vapi::Std::Errors::Error
+
+      class << self
+          # Holds (gets or creates) the binding type metadata for this error type.
+          # @scope class
+          # @return [VAPI::Bindings::ErrorType] the binding type
+          def binding_type
+              @binding_type ||= VAPI::Bindings::ErrorType.new(
+                  'com.vmware.vapi.std.errors.unauthenticated',
+                  {
+                      'messages' => VAPI::Bindings::ListType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::LocalizableMessage')),
+                      'data' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::DynamicStructType.new()),
+                  },
+                  Unauthenticated)
+          end
+      end
+
+
+      # Constructs a new instance.
+      # @param binding_type [VAPI::Bindings::BindingType] the specific BindingType
+      #        declaration for this concrete VapiError type
+      # @param error_value [VAPI::Data::ErrorValue] the error value (default nil)
+      def initialize(binding_type=self.class.binding_type, error_value=nil)
+          super(binding_type, error_value)
+      end
+  end
+  # The  ``Com::Vmware::Vapi::Std::Errors::UnableToAllocateResource``   error  indicates that the  method  failed because it was unable to allocate or acquire a required resource.  
+  # 
+  #  Examples:  
+  # 
+  #   * Trying to power on a virtual machine when there are not enough licenses to do so. 
+  #    * Trying to power on a virtual machine that would violate a resource usage policy. 
+  #   
+  #    
+  # 
+  #  Counterexamples:  
+  # 
+  #   * Trying to power off a virtual machine that is in the process of being powered on. A   :class:`Com::Vmware::Vapi::Std::Errors::ResourceBusy`    error  would be used instead. 
+  #    * Trying to remove a VMFS datastore when the is a virtual machine registered on any host attached to the datastore. The   :class:`Com::Vmware::Vapi::Std::Errors::ResourceInUse`    error  would be used instead. 
+  #    * Trying to add a virtual switch if the physical network adapter being bridged is already in use. The   :class:`Com::Vmware::Vapi::Std::Errors::ResourceInUse`    error  would be used instead. 
+  #    * Attempt to invoke some  method  on a virtual machine when the virtual machine's configuration file is not accessible (for example due to a storage APD condition). The   :class:`Com::Vmware::Vapi::Std::Errors::ResourceInaccessible`    error  would be used instead. 
+  #   
+  class UnableToAllocateResource < Com::Vmware::Vapi::Std::Errors::Error
+
+      class << self
+          # Holds (gets or creates) the binding type metadata for this error type.
+          # @scope class
+          # @return [VAPI::Bindings::ErrorType] the binding type
+          def binding_type
+              @binding_type ||= VAPI::Bindings::ErrorType.new(
+                  'com.vmware.vapi.std.errors.unable_to_allocate_resource',
+                  {
+                      'messages' => VAPI::Bindings::ListType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::LocalizableMessage')),
+                      'data' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::DynamicStructType.new()),
+                  },
+                  UnableToAllocateResource)
+          end
+      end
+
+
+      # Constructs a new instance.
+      # @param binding_type [VAPI::Bindings::BindingType] the specific BindingType
+      #        declaration for this concrete VapiError type
+      # @param error_value [VAPI::Data::ErrorValue] the error value (default nil)
+      def initialize(binding_type=self.class.binding_type, error_value=nil)
+          super(binding_type, error_value)
+      end
+  end
+  # The  ``Com::Vmware::Vapi::Std::Errors::TimedOut``   error  indicates that the  method  did not complete within the allowed amount of time. The allowed amount of time might be:  
+  # 
+  #   * provided by the client as an input  parameter . 
+  #    * a fixed limit of the  class  implementation that is a documented part of the contract of the  class . 
+  #    * a configurable limit used by the implementation of the  class . 
+  #    * a dynamic limit computed by the implementation of the  class . 
+  #   
+  #   The  method  may or may not complete after the  ``Com::Vmware::Vapi::Std::Errors::TimedOut``   error  was reported.  
+  # 
+  #  Examples:  
+  # 
+  #   * The  method  was unable to complete within the timeout duration specified by a  parameter  of the  method . 
+  #   
+  #    
+  # 
+  #  Counterexamples:  
+  # 
+  #   * A server implementation that puts requests into a queue before dispatching them might delete a request from the queue if it doesn't get dispatched within  *n*  minutes. The   :class:`Com::Vmware::Vapi::Std::Errors::ServiceUnavailable`    error  would be used instead. 
+  #   
+  class TimedOut < Com::Vmware::Vapi::Std::Errors::Error
+
+      class << self
+          # Holds (gets or creates) the binding type metadata for this error type.
+          # @scope class
+          # @return [VAPI::Bindings::ErrorType] the binding type
+          def binding_type
+              @binding_type ||= VAPI::Bindings::ErrorType.new(
+                  'com.vmware.vapi.std.errors.timed_out',
+                  {
+                      'messages' => VAPI::Bindings::ListType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::LocalizableMessage')),
+                      'data' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::DynamicStructType.new()),
+                  },
+                  TimedOut)
+          end
+      end
+
+
+      # Constructs a new instance.
+      # @param binding_type [VAPI::Bindings::BindingType] the specific BindingType
+      #        declaration for this concrete VapiError type
+      # @param error_value [VAPI::Data::ErrorValue] the error value (default nil)
+      def initialize(binding_type=self.class.binding_type, error_value=nil)
+          super(binding_type, error_value)
+      end
+  end
+  # The  ``Com::Vmware::Vapi::Std::Errors::ServiceUnavailable``   error  indicates that the  class  is unavailable.  
+  # 
+  #  Examples:  
+  # 
+  #   * Attempt to invoke a  method  when the server is too busy. 
+  #    * Attempt to invoke a  method  when the server is undergoing maintenance. 
+  #    * An  method  fails to contact VMware Tools running inside the virtual machine. 
+  #   
+  #    
+  # 
+  #  Counterexamples:  
+  # 
+  #   * A client provides an invalid service or operation identifier when invoking the  method  using a dynamic interface (for example REST). The   :class:`Com::Vmware::Vapi::Std::Errors::OperationNotFound`    error  would be used instead. 
+  #    * A client invokes the  method  from the  class , but that  class  has not been installed. The   :class:`Com::Vmware::Vapi::Std::Errors::OperationNotFound`    error  would be used instead. 
+  #   
+  class ServiceUnavailable < Com::Vmware::Vapi::Std::Errors::Error
+
+      class << self
+          # Holds (gets or creates) the binding type metadata for this error type.
+          # @scope class
+          # @return [VAPI::Bindings::ErrorType] the binding type
+          def binding_type
+              @binding_type ||= VAPI::Bindings::ErrorType.new(
+                  'com.vmware.vapi.std.errors.service_unavailable',
+                  {
+                      'messages' => VAPI::Bindings::ListType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::LocalizableMessage')),
+                      'data' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::DynamicStructType.new()),
+                  },
+                  ServiceUnavailable)
+          end
+      end
+
+
+      # Constructs a new instance.
+      # @param binding_type [VAPI::Bindings::BindingType] the specific BindingType
+      #        declaration for this concrete VapiError type
+      # @param error_value [VAPI::Data::ErrorValue] the error value (default nil)
+      def initialize(binding_type=self.class.binding_type, error_value=nil)
+          super(binding_type, error_value)
+      end
+  end
+  # The  ``Com::Vmware::Vapi::Std::Errors::ResourceInaccessible``   error  indicates that the  method  could not be completed because an entity is not accessible.  
+  # 
+  #  Examples:  
+  # 
+  #   * Attempt to invoke some  method  on a virtual machine when the virtual machine's configuration file is not accessible (for example due to a storage APD condition). 
+  #   
+  #    
+  # 
+  #  Counterexamples:  
+  # 
+  #   * Attempt to invoke some  method  when the server is too busy. The   :class:`Com::Vmware::Vapi::Std::Errors::ServiceUnavailable`    error  would be used instead. 
+  #    * Attempt to invoke some  method  when the server is undergoing maintenance. The   :class:`Com::Vmware::Vapi::Std::Errors::ServiceUnavailable`    error  would be used instead. 
+  #    * Some  method  fails to contact VMware Tools running inside the virtual machine. The   :class:`Com::Vmware::Vapi::Std::Errors::ServiceUnavailable`    error  would be used instead. 
+  #   
+  class ResourceInaccessible < Com::Vmware::Vapi::Std::Errors::Error
+
+      class << self
+          # Holds (gets or creates) the binding type metadata for this error type.
+          # @scope class
+          # @return [VAPI::Bindings::ErrorType] the binding type
+          def binding_type
+              @binding_type ||= VAPI::Bindings::ErrorType.new(
+                  'com.vmware.vapi.std.errors.resource_inaccessible',
+                  {
+                      'messages' => VAPI::Bindings::ListType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::LocalizableMessage')),
+                      'data' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::DynamicStructType.new()),
+                  },
+                  ResourceInaccessible)
+          end
+      end
+
+
+      # Constructs a new instance.
+      # @param binding_type [VAPI::Bindings::BindingType] the specific BindingType
+      #        declaration for this concrete VapiError type
+      # @param error_value [VAPI::Data::ErrorValue] the error value (default nil)
+      def initialize(binding_type=self.class.binding_type, error_value=nil)
+          super(binding_type, error_value)
+      end
+  end
+  # The  ``Com::Vmware::Vapi::Std::Errors::ResourceInUse``   error  indicates that the  method  could not be completed because a resource is in use.  
+  # 
+  #  Examples:  
+  # 
+  #   * Trying to remove a VMFS datastore when the is a virtual machine registered on any host attached to the datastore. 
+  #    * Trying to add a virtual switch if the physical network adapter being bridged is already in use. 
+  #   
+  #    
+  # 
+  #  Counterexamples:  
+  # 
+  #   * Trying to power off a virtual machine that is in the process of being powered on. The   :class:`Com::Vmware::Vapi::Std::Errors::ResourceBusy`    error  would be used instead. 
+  #   
+  class ResourceInUse < Com::Vmware::Vapi::Std::Errors::Error
+
+      class << self
+          # Holds (gets or creates) the binding type metadata for this error type.
+          # @scope class
+          # @return [VAPI::Bindings::ErrorType] the binding type
+          def binding_type
+              @binding_type ||= VAPI::Bindings::ErrorType.new(
+                  'com.vmware.vapi.std.errors.resource_in_use',
+                  {
+                      'messages' => VAPI::Bindings::ListType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::LocalizableMessage')),
+                      'data' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::DynamicStructType.new()),
+                  },
+                  ResourceInUse)
+          end
+      end
+
+
+      # Constructs a new instance.
+      # @param binding_type [VAPI::Bindings::BindingType] the specific BindingType
+      #        declaration for this concrete VapiError type
+      # @param error_value [VAPI::Data::ErrorValue] the error value (default nil)
+      def initialize(binding_type=self.class.binding_type, error_value=nil)
+          super(binding_type, error_value)
+      end
+  end
+  # The  ``Com::Vmware::Vapi::Std::Errors::ResourceBusy``   error  indicates that the  method  could not be completed because a resource it needs is busy.  
+  # 
+  #  Examples:  
+  # 
+  #   * Trying to power off a virtual machine that is in the process of being powered on. 
+  #   
+  #    
+  # 
+  #  Counterexamples:  
+  # 
+  #   * Trying to remove a VMFS datastore when there is a virtual machine registered on any host attached to the datastore. The   :class:`Com::Vmware::Vapi::Std::Errors::ResourceInUse`    error  would be used instead. 
+  #   
+  class ResourceBusy < Com::Vmware::Vapi::Std::Errors::Error
+
+      class << self
+          # Holds (gets or creates) the binding type metadata for this error type.
+          # @scope class
+          # @return [VAPI::Bindings::ErrorType] the binding type
+          def binding_type
+              @binding_type ||= VAPI::Bindings::ErrorType.new(
+                  'com.vmware.vapi.std.errors.resource_busy',
+                  {
+                      'messages' => VAPI::Bindings::ListType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::LocalizableMessage')),
+                      'data' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::DynamicStructType.new()),
+                  },
+                  ResourceBusy)
+          end
+      end
+
+
+      # Constructs a new instance.
+      # @param binding_type [VAPI::Bindings::BindingType] the specific BindingType
+      #        declaration for this concrete VapiError type
+      # @param error_value [VAPI::Data::ErrorValue] the error value (default nil)
+      def initialize(binding_type=self.class.binding_type, error_value=nil)
+          super(binding_type, error_value)
+      end
+  end
+  # The  ``Com::Vmware::Vapi::Std::Errors::OperationNotFound``   error  indicates that the  method  specified in the request could not be found.  
+  # 
+  #  Every API request specifies a service identifier and an operation identifier along with the  parameters . If the API infrastructure is unable to find the requested  class  or  method  it reports this  error .  
+  # 
+  #  This  error  can be reported by the API infrastructure for any  method , but it is specific to the API infrastructure, and should never be reported by the implementation of any  method .  
+  # 
+  #  Examples:  
+  # 
+  #   * A client provides an invalid service or operation identifier when invoking the  method  using a dynamic interface (for example REST). 
+  #    * A client invokes the  method  from a  class , but that  class  has not been installed. 
+  #   
+  #    
+  # 
+  #  Counterexamples:  
+  # 
+  #   * A client invokes a task scheduling  method , but provides an invalid service identifier or operation identifier. The   :class:`Com::Vmware::Vapi::Std::Errors::NotFound`    error  would be used instead. 
+  #   
+  class OperationNotFound < Com::Vmware::Vapi::Std::Errors::Error
+
+      class << self
+          # Holds (gets or creates) the binding type metadata for this error type.
+          # @scope class
+          # @return [VAPI::Bindings::ErrorType] the binding type
+          def binding_type
+              @binding_type ||= VAPI::Bindings::ErrorType.new(
+                  'com.vmware.vapi.std.errors.operation_not_found',
+                  {
+                      'messages' => VAPI::Bindings::ListType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::LocalizableMessage')),
+                      'data' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::DynamicStructType.new()),
+                  },
+                  OperationNotFound)
+          end
+      end
+
+
+      # Constructs a new instance.
+      # @param binding_type [VAPI::Bindings::BindingType] the specific BindingType
+      #        declaration for this concrete VapiError type
+      # @param error_value [VAPI::Data::ErrorValue] the error value (default nil)
+      def initialize(binding_type=self.class.binding_type, error_value=nil)
+          super(binding_type, error_value)
+      end
+  end
+  # The  ``Com::Vmware::Vapi::Std::Errors::NotFound``   error  indicates that a specified element could not be found.  
+  # 
+  #  Examples:  
+  # 
+  #   * Invoke the  method  to retrieve information about a virtual machine, passing an id that does not identify an existing virtual machine. 
+  #    * Invoke the  method  to modify the configuration of a virtual nic, passing an id that does not identify an existing virtual nic in the specified virtual machine. 
+  #    * Invoke the  method  to remove a vswitch, passing an id that does not identify an existing vswitch. 
+  #   
+  class NotFound < Com::Vmware::Vapi::Std::Errors::Error
+
+      class << self
+          # Holds (gets or creates) the binding type metadata for this error type.
+          # @scope class
+          # @return [VAPI::Bindings::ErrorType] the binding type
+          def binding_type
+              @binding_type ||= VAPI::Bindings::ErrorType.new(
+                  'com.vmware.vapi.std.errors.not_found',
+                  {
+                      'messages' => VAPI::Bindings::ListType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::LocalizableMessage')),
+                      'data' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::DynamicStructType.new()),
+                  },
+                  NotFound)
+          end
+      end
+
+
+      # Constructs a new instance.
+      # @param binding_type [VAPI::Bindings::BindingType] the specific BindingType
+      #        declaration for this concrete VapiError type
+      # @param error_value [VAPI::Data::ErrorValue] the error value (default nil)
+      def initialize(binding_type=self.class.binding_type, error_value=nil)
+          super(binding_type, error_value)
+      end
+  end
+  # The  ``Com::Vmware::Vapi::Std::Errors::NotAllowedInCurrentState``   error  indicates that the requested  method  is not allowed with a resource or service in its current state. This could be because the  method  is performing a configuration change that is not allowed in the current state or because  method  itself is not allowed in the current state.  
+  # 
+  #  Examples:  
+  # 
+  #   * Trying to add a virtual device that cannot be hot plugged to a running virtual machine. 
+  #    * Trying to upgrade the virtual hardware version for a suspended virtual machine. 
+  #    * Trying to power off, reset, or suspend a virtual machine that is not powered on. 
+  #   
+  #    
+  # 
+  #  Counterexamples:  
+  # 
+  #   * Trying to power off a virtual machine that is in the process of being powered on. The   :class:`Com::Vmware::Vapi::Std::Errors::ResourceBusy`    error  would be used instead. 
+  #   
+  class NotAllowedInCurrentState < Com::Vmware::Vapi::Std::Errors::Error
+
+      class << self
+          # Holds (gets or creates) the binding type metadata for this error type.
+          # @scope class
+          # @return [VAPI::Bindings::ErrorType] the binding type
+          def binding_type
+              @binding_type ||= VAPI::Bindings::ErrorType.new(
+                  'com.vmware.vapi.std.errors.not_allowed_in_current_state',
+                  {
+                      'messages' => VAPI::Bindings::ListType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::LocalizableMessage')),
+                      'data' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::DynamicStructType.new()),
+                  },
+                  NotAllowedInCurrentState)
+          end
+      end
+
+
+      # Constructs a new instance.
+      # @param binding_type [VAPI::Bindings::BindingType] the specific BindingType
+      #        declaration for this concrete VapiError type
+      # @param error_value [VAPI::Data::ErrorValue] the error value (default nil)
+      def initialize(binding_type=self.class.binding_type, error_value=nil)
+          super(binding_type, error_value)
+      end
+  end
+  # The  ``Com::Vmware::Vapi::Std::Errors::InvalidRequest``   error  indicates that the request is malformed in such a way that the server is unable to process it.  
+  # 
+  #  Examples:  
+  # 
+  #   * The XML in a SOAP request is not well-formed so the server cannot parse the request. 
+  #    * The XML in a SOAP request is well-formed but does not match the structure required by the SOAP specification. 
+  #    * A JSON-RPC request is not valid JSON. 
+  #    * The JSON sent in a JSON-RPC request is not a valid JSON-RPC Request object. 
+  #    * The Request object from a JSON-RPC request does not match the structure required by the API infrastructure. 
+  #   
+  #    
+  # 
+  #  Counterexamples:  
+  # 
+  #   * The  parameter  has a value that is not with the required range. The   :class:`Com::Vmware::Vapi::Std::Errors::InvalidArgument`    error  would be used instead. 
+  #    * The name of the  method  specified in the request doesn't not match any known  method . The   :class:`Com::Vmware::Vapi::Std::Errors::NotFound`    error  would be used instead. 
+  #   
+  #    
+  # 
+  #  Some transport protocols (for example JSON-RPC) include their own mechanism for reporting these kinds of errors, and the API infrastructure for a programming language may expose the errors using a language specific mechanism, so this  error  might not be used.
+  class InvalidRequest < Com::Vmware::Vapi::Std::Errors::Error
+
+      class << self
+          # Holds (gets or creates) the binding type metadata for this error type.
+          # @scope class
+          # @return [VAPI::Bindings::ErrorType] the binding type
+          def binding_type
+              @binding_type ||= VAPI::Bindings::ErrorType.new(
+                  'com.vmware.vapi.std.errors.invalid_request',
+                  {
+                      'messages' => VAPI::Bindings::ListType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::LocalizableMessage')),
+                      'data' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::DynamicStructType.new()),
+                  },
+                  InvalidRequest)
+          end
+      end
+
+
+      # Constructs a new instance.
+      # @param binding_type [VAPI::Bindings::BindingType] the specific BindingType
+      #        declaration for this concrete VapiError type
+      # @param error_value [VAPI::Data::ErrorValue] the error value (default nil)
+      def initialize(binding_type=self.class.binding_type, error_value=nil)
+          super(binding_type, error_value)
+      end
+  end
+  # The  ``Com::Vmware::Vapi::Std::Errors::InvalidElementType``   error  indicates that the server was unable to fulfil the request because an element of a specific type cannot be a member of particular group.  
+  # 
+  #  This  error  could be reported, for example, if an attempt is made to put an element into the wrong type of container.  
+  # 
+  #  Examples:  
+  # 
+  #   * Attempt to put a virtual machine into a folder that can only contain hosts. 
+  #    * Attempt to attach a SCSI virtual disk to an IDE port. 
+  #   
+  #   Counterexamples:  
+  # 
+  #   * A  parameter  has a value that is not of the expected type. The   :class:`Com::Vmware::Vapi::Std::Errors::InvalidArgument`    error  would be used instead. 
+  #   
+  class InvalidElementType < Com::Vmware::Vapi::Std::Errors::Error
+
+      class << self
+          # Holds (gets or creates) the binding type metadata for this error type.
+          # @scope class
+          # @return [VAPI::Bindings::ErrorType] the binding type
+          def binding_type
+              @binding_type ||= VAPI::Bindings::ErrorType.new(
+                  'com.vmware.vapi.std.errors.invalid_element_type',
+                  {
+                      'messages' => VAPI::Bindings::ListType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::LocalizableMessage')),
+                      'data' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::DynamicStructType.new()),
+                  },
+                  InvalidElementType)
+          end
+      end
+
+
+      # Constructs a new instance.
+      # @param binding_type [VAPI::Bindings::BindingType] the specific BindingType
+      #        declaration for this concrete VapiError type
+      # @param error_value [VAPI::Data::ErrorValue] the error value (default nil)
+      def initialize(binding_type=self.class.binding_type, error_value=nil)
+          super(binding_type, error_value)
+      end
+  end
+  # The  ``Com::Vmware::Vapi::Std::Errors::InvalidElementConfiguration``   error  indicates that an attempt to modify the configuration of an element or a group containing the element failed due to the configuraton of the element. A typical case is when the  method  is am attempt to change the group membership of the element fails, in which case a configuration change on the element may allow the group membership change to succeed.  
+  # 
+  #  Examples:  
+  # 
+  #   * Attempt to move a host with a fault tolerant virtual machine out of a cluster (i.e. make the host a standalone host). 
+  #    * Attempt to remove a host from a DRS cluster without putting the host into maintenance mode. 
+  #   
+  class InvalidElementConfiguration < Com::Vmware::Vapi::Std::Errors::Error
+
+      class << self
+          # Holds (gets or creates) the binding type metadata for this error type.
+          # @scope class
+          # @return [VAPI::Bindings::ErrorType] the binding type
+          def binding_type
+              @binding_type ||= VAPI::Bindings::ErrorType.new(
+                  'com.vmware.vapi.std.errors.invalid_element_configuration',
+                  {
+                      'messages' => VAPI::Bindings::ListType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::LocalizableMessage')),
+                      'data' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::DynamicStructType.new()),
+                  },
+                  InvalidElementConfiguration)
+          end
+      end
+
+
+      # Constructs a new instance.
+      # @param binding_type [VAPI::Bindings::BindingType] the specific BindingType
+      #        declaration for this concrete VapiError type
+      # @param error_value [VAPI::Data::ErrorValue] the error value (default nil)
+      def initialize(binding_type=self.class.binding_type, error_value=nil)
+          super(binding_type, error_value)
+      end
+  end
+  # The  ``Com::Vmware::Vapi::Std::Errors::InvalidArgument``   error  indicates that the values received for one or more  parameters  are not acceptable.  
+  # 
+  #  This  error  is reported by the API infrastructure, so it could occur in response to the invocation of any  method . It may also be reported as the result of  method -specific validation.  
+  # 
+  #  Examples:  
+  # 
+  #   * A  parameter  has a value that is not of the expected type. 
+  #    * A  parameter  has a value that is not in the required range. 
+  #    * A  parameter  has a value that is not one of the specifically allowed strings. 
+  #    * One  field  of a  class  is the tag for a tagged union, and has a specific value but another  field  of the  class  that is required to be specified when the tag has that value is not specified, or another  field  of the  class  that is required to be unspecified when the tag has that value is specified. 
+  #   
+  #    
+  # 
+  #  Counterexamples:  
+  # 
+  #   * Trying to create a new tag in tag category when a tag with the specified name already exists the tag category. The   :class:`Com::Vmware::Vapi::Std::Errors::AlreadyExists`    error  would be used instead. 
+  #    * Invoke the  method  to retrieve information about a virtual machine, passing an id that does not identify an existing virtual machine. The   :class:`Com::Vmware::Vapi::Std::Errors::NotFound`    error  would be used instead. 
+  #    * Attempt to put a virtual machine into a folder that can only contain hosts. The   :class:`Com::Vmware::Vapi::Std::Errors::InvalidElementType`    error  would be used instead. 
+  #    * Attempt to attach a SCSI virtual disk to an IDE port. The   :class:`Com::Vmware::Vapi::Std::Errors::InvalidElementType`    error  would be used instead. 
+  #   
+  class InvalidArgument < Com::Vmware::Vapi::Std::Errors::Error
+
+      class << self
+          # Holds (gets or creates) the binding type metadata for this error type.
+          # @scope class
+          # @return [VAPI::Bindings::ErrorType] the binding type
+          def binding_type
+              @binding_type ||= VAPI::Bindings::ErrorType.new(
+                  'com.vmware.vapi.std.errors.invalid_argument',
+                  {
+                      'messages' => VAPI::Bindings::ListType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::LocalizableMessage')),
+                      'data' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::DynamicStructType.new()),
+                  },
+                  InvalidArgument)
+          end
+      end
+
+
+      # Constructs a new instance.
+      # @param binding_type [VAPI::Bindings::BindingType] the specific BindingType
+      #        declaration for this concrete VapiError type
+      # @param error_value [VAPI::Data::ErrorValue] the error value (default nil)
+      def initialize(binding_type=self.class.binding_type, error_value=nil)
+          super(binding_type, error_value)
+      end
+  end
+  # The  ``Com::Vmware::Vapi::Std::Errors::InternalServerError``   error  indicates that the server encounters an unexpected condition that prevented it from fulfilling the request.  
+  # 
+  #  This  error  is reported by the API infrastructure, so it could occur in response to the invocation of any  method .  
+  # 
+  #  Examples:  
+  # 
+  #   * The  method  returns a value whose type doesn't match the type type the  method  says it should return.
+  #    * The  method  reports an  error  that is not included in the list of  errors  the  method  says that it can report.
+  #   
+  class InternalServerError < Com::Vmware::Vapi::Std::Errors::Error
+
+      class << self
+          # Holds (gets or creates) the binding type metadata for this error type.
+          # @scope class
+          # @return [VAPI::Bindings::ErrorType] the binding type
+          def binding_type
+              @binding_type ||= VAPI::Bindings::ErrorType.new(
+                  'com.vmware.vapi.std.errors.internal_server_error',
+                  {
+                      'messages' => VAPI::Bindings::ListType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::LocalizableMessage')),
+                      'data' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::DynamicStructType.new()),
+                  },
+                  InternalServerError)
+          end
+      end
+
+
+      # Constructs a new instance.
+      # @param binding_type [VAPI::Bindings::BindingType] the specific BindingType
+      #        declaration for this concrete VapiError type
+      # @param error_value [VAPI::Data::ErrorValue] the error value (default nil)
+      def initialize(binding_type=self.class.binding_type, error_value=nil)
+          super(binding_type, error_value)
+      end
+  end
+  # The  ``Com::Vmware::Vapi::Std::Errors::FeatureInUse``   error  indicates that an action cannot be completed because a feature is in use.  
+  # 
+  #  Examples:  
+  # 
+  #   * Trying to disable snapshots on a virtual machine which has a snapshot. 
+  #    * Trying to downgrade a license that has licensed features that are in use. 
+  #   
+  class FeatureInUse < Com::Vmware::Vapi::Std::Errors::Error
+
+      class << self
+          # Holds (gets or creates) the binding type metadata for this error type.
+          # @scope class
+          # @return [VAPI::Bindings::ErrorType] the binding type
+          def binding_type
+              @binding_type ||= VAPI::Bindings::ErrorType.new(
+                  'com.vmware.vapi.std.errors.feature_in_use',
+                  {
+                      'messages' => VAPI::Bindings::ListType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::LocalizableMessage')),
+                      'data' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::DynamicStructType.new()),
+                  },
+                  FeatureInUse)
+          end
+      end
+
+
+      # Constructs a new instance.
+      # @param binding_type [VAPI::Bindings::BindingType] the specific BindingType
+      #        declaration for this concrete VapiError type
+      # @param error_value [VAPI::Data::ErrorValue] the error value (default nil)
+      def initialize(binding_type=self.class.binding_type, error_value=nil)
+          super(binding_type, error_value)
+      end
+  end
+  # The  ``Com::Vmware::Vapi::Std::Errors::ConcurrentChange``   error  indicates that a data structure, entity, or resource has been modified since some earlier point in time. Typically this happens when the client is doing the  *write*  portion of a read-modify-write sequence and indicates that it wants the server to notify it if the data in the server has changed after it did the  *read* , so that it can avoid overwriting that change inadvertantly.
+  class ConcurrentChange < Com::Vmware::Vapi::Std::Errors::Error
+
+      class << self
+          # Holds (gets or creates) the binding type metadata for this error type.
+          # @scope class
+          # @return [VAPI::Bindings::ErrorType] the binding type
+          def binding_type
+              @binding_type ||= VAPI::Bindings::ErrorType.new(
+                  'com.vmware.vapi.std.errors.concurrent_change',
+                  {
+                      'messages' => VAPI::Bindings::ListType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::LocalizableMessage')),
+                      'data' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::DynamicStructType.new()),
+                  },
+                  ConcurrentChange)
+          end
+      end
+
+
+      # Constructs a new instance.
+      # @param binding_type [VAPI::Bindings::BindingType] the specific BindingType
+      #        declaration for this concrete VapiError type
+      # @param error_value [VAPI::Data::ErrorValue] the error value (default nil)
+      def initialize(binding_type=self.class.binding_type, error_value=nil)
+          super(binding_type, error_value)
+      end
+  end
+  # The  ``Com::Vmware::Vapi::Std::Errors::Canceled``   error  indicates that the  method  canceled itself in response to an explicit request to do so.  Methods  being "canceled" for other reasons (for example the client connection was closed, a time out occured, or due to excessive resource consumption) should not report this  error .  
+  # 
+  #  Examples:  
+  # 
+  #   * A user is monitoring the progress of the  method  in a GUI and sees that it is likely to take longer than he is willing to wait and clicks the cancel button. 
+  #    * A user invokes the  method  using a command-line tool and decides that she didn't really want to invoke that  method , and presses CTRL-c. 
+  #   
+  #    
+  # 
+  #  Counterexamples:  
+  # 
+  #   * The client's connection to the server was closed. Reporting an  error  is pointless since the client will not receive the error response because the connection has been closed. 
+  #    * The request is taking longer than some amount of time. The   :class:`Com::Vmware::Vapi::Std::Errors::TimedOut`    error  would be reported if the time was specified as part of the input or is documented in the API contract. 
+  #   
+  class Canceled < Com::Vmware::Vapi::Std::Errors::Error
+
+      class << self
+          # Holds (gets or creates) the binding type metadata for this error type.
+          # @scope class
+          # @return [VAPI::Bindings::ErrorType] the binding type
+          def binding_type
+              @binding_type ||= VAPI::Bindings::ErrorType.new(
+                  'com.vmware.vapi.std.errors.canceled',
+                  {
+                      'messages' => VAPI::Bindings::ListType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::LocalizableMessage')),
+                      'data' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::DynamicStructType.new()),
+                  },
+                  Canceled)
+          end
+      end
+
+
+      # Constructs a new instance.
+      # @param binding_type [VAPI::Bindings::BindingType] the specific BindingType
+      #        declaration for this concrete VapiError type
+      # @param error_value [VAPI::Data::ErrorValue] the error value (default nil)
+      def initialize(binding_type=self.class.binding_type, error_value=nil)
+          super(binding_type, error_value)
+      end
+  end
+  # The  ``Com::Vmware::Vapi::Std::Errors::AlreadyInDesiredState``   error  indicates that an attempt to change the state of a resource or service had no effect because the resource or service is already in the desired state.  
+  # 
+  #  Examples:  
+  # 
+  #   * Trying to power on a virtual machine that is already powered on.
+  #   
+  class AlreadyInDesiredState < Com::Vmware::Vapi::Std::Errors::Error
+
+      class << self
+          # Holds (gets or creates) the binding type metadata for this error type.
+          # @scope class
+          # @return [VAPI::Bindings::ErrorType] the binding type
+          def binding_type
+              @binding_type ||= VAPI::Bindings::ErrorType.new(
+                  'com.vmware.vapi.std.errors.already_in_desired_state',
+                  {
+                      'messages' => VAPI::Bindings::ListType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::LocalizableMessage')),
+                      'data' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::DynamicStructType.new()),
+                  },
+                  AlreadyInDesiredState)
+          end
+      end
+
+
+      # Constructs a new instance.
+      # @param binding_type [VAPI::Bindings::BindingType] the specific BindingType
+      #        declaration for this concrete VapiError type
+      # @param error_value [VAPI::Data::ErrorValue] the error value (default nil)
+      def initialize(binding_type=self.class.binding_type, error_value=nil)
+          super(binding_type, error_value)
+      end
+  end
+  # The  ``Com::Vmware::Vapi::Std::Errors::AlreadyExists``   error  indicates that an attempt was made to create an entity but the entity already exists. Typically the entity has a name or identifier that is required to be unique in some context, but there is already an entity with that name or identifier in that context.  
+  # 
+  #  Examples:  
+  # 
+  #   * Trying to create a new tag category when a tag category with the specified name already exists.
+  #    * Trying to create a new tag in tag category when a tag with the specified name already exists the tag category.
+  #    * Trying to create a LUN with a specific UUID on a node (for replication purposes) when a LUN with that UUID already exists on the node.
+  #    * Trying to create a file in a directory or move or copy a file to a directory when a file with that name already exists in the directory. 
+  #   
+  class AlreadyExists < Com::Vmware::Vapi::Std::Errors::Error
+
+      class << self
+          # Holds (gets or creates) the binding type metadata for this error type.
+          # @scope class
+          # @return [VAPI::Bindings::ErrorType] the binding type
+          def binding_type
+              @binding_type ||= VAPI::Bindings::ErrorType.new(
+                  'com.vmware.vapi.std.errors.already_exists',
+                  {
+                      'messages' => VAPI::Bindings::ListType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::LocalizableMessage')),
+                      'data' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::DynamicStructType.new()),
+                  },
+                  AlreadyExists)
+          end
+      end
+
+
+      # Constructs a new instance.
+      # @param binding_type [VAPI::Bindings::BindingType] the specific BindingType
+      #        declaration for this concrete VapiError type
+      # @param error_value [VAPI::Data::ErrorValue] the error value (default nil)
+      def initialize(binding_type=self.class.binding_type, error_value=nil)
+          super(binding_type, error_value)
+      end
+  end
 end

--- a/client/sdk/com/vmware/vapi/vapi.rb
+++ b/client/sdk/com/vmware/vapi/vapi.rb
@@ -1,5 +1,6 @@
 #---------------------------------------------------------------------------
-# Copyright 2016 VMware, Inc.  All rights reserved.
+# Copyright 2017 VMware, Inc.  All rights reserved.
+#
 # AUTO GENERATED FILE -- DO NOT MODIFY!
 #---------------------------------------------------------------------------
 require 'vapi'

--- a/client/sdk/com/vmware/vapi/vcenter.rb
+++ b/client/sdk/com/vmware/vapi/vcenter.rb
@@ -1,5 +1,6 @@
 #---------------------------------------------------------------------------
-# Copyright 2016 VMware, Inc.  All rights reserved.
+# Copyright 2017 VMware, Inc.  All rights reserved.
+#
 # AUTO GENERATED FILE -- DO NOT MODIFY!
 #
 # vAPI type descriptors for package com.vmware.vapi.vcenter.
@@ -8,78 +9,68 @@ require 'vapi'
 
 # declare the module hierarchy before we use the shorthand syntax below
 module Com
-    module Vmware
-        module Vapi
-            module Vcenter
-            end
-        end
+  module Vmware
+    module Vapi
+      module Vcenter
+      end
     end
+  end
 end
 
 module Com::Vmware::Vapi::Vcenter
+  # The  ``Com::Vmware::Vapi::Vcenter::Activation``   class  provides  methods  for tasks cancelation.
+  class Activation < VAPI::Bindings::VapiService
+    # static metamodel definitions
+    SERVICE_ID = VAPI::Core::ServiceIdentifier.new('com.vmware.vapi.vcenter.activation')
 
-    # The  ``Com::Vmware::Vapi::Vcenter::Activation``   class  provides  methods  for tasks cancelation.
-    class Activation < VAPI::Bindings::VapiService
+    CANCEL_INFO = VAPI::Bindings::OperationInfo.new(
+      VAPI::Core::OperationIdentifier.new('cancel', SERVICE_ID),
+      VAPI::Bindings::OperationInputType.new(
+        'activation_id' => VAPI::Bindings::IdType.new('com.vmware.Activation')
+      ),
+      VAPI::Bindings::VoidType.instance,
+      {
+        'com.vmware.vapi.std.errors.not_found' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::NotFound'),
+        'com.vmware.vapi.std.errors.not_allowed_in_current_state' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::NotAllowedInCurrentState'),
+        'com.vmware.vapi.std.errors.unauthorized' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Unauthorized'),
+        'com.vmware.vapi.std.errors.unauthenticated' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Unauthenticated'),
+        'com.vmware.vapi.std.errors.service_unavailable' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::ServiceUnavailable')
+      },
+      [],
+      []
+    )
 
-        protected
+    SERVICE_INFO = VAPI::Bindings::ServiceInfo.new(
+      SERVICE_ID,
+      'cancel' => CANCEL_INFO
+    )
 
-        # static metamodel definitions
-        @@service_id = VAPI::Core::ServiceIdentifier.new('com.vmware.vapi.vcenter.activation')
-
-        @@cancel_info = VAPI::Bindings::OperationInfo.new(
-            VAPI::Core::OperationIdentifier.new('cancel', @@service_id),
-            VAPI::Bindings::OperationInputType.new({
-                'activation_id' => VAPI::Bindings::IdType.new(resource_types='com.vmware.Activation'),
-            }),
-            VAPI::Bindings::VoidType.instance,
-            {
-                'com.vmware.vapi.std.errors.not_found' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::NotFound'),
-                'com.vmware.vapi.std.errors.not_allowed_in_current_state' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::NotAllowedInCurrentState'),
-                'com.vmware.vapi.std.errors.unauthorized' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Unauthorized'),
-                'com.vmware.vapi.std.errors.unauthenticated' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Unauthenticated'),
-                'com.vmware.vapi.std.errors.service_unavailable' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::ServiceUnavailable'),
-
-            },
-            [],
-            [])
-
-        @@service_info = VAPI::Bindings::ServiceInfo.new(@@service_id, {
-            'cancel' => @@cancel_info,
-        })
-
-        public
-
-        # Constructs a new instance.
-        #
-        # @param config [VAPI::Bindings::StubConfig] A hash with the api provider details.
-        def initialize(config)
-            super(config, @@service_info)
-        end
-
-
-        # Sends a request to cancel the task associated with the provided  ``activation_id`` .
-        #
-        # @param activation_id [String]
-        #      the  ``activation_id``  associated with a vCenter Server task to be canceled.
-        # @return [Void]
-        # @raise [Com::Vmware::Vapi::Std::Errors::NotFound]
-        #      if a vCenter Server task with the given  ``activation_id``  was not found.
-        # @raise [Com::Vmware::Vapi::Std::Errors::NotAllowedInCurrentState]
-        #      if the vCenter Server task associated with the given  ``activation_id``  is not cancelable.
-        # @raise [Com::Vmware::Vapi::Std::Errors::Unauthorized]
-        #      if the user is not authorized to cancel the task.
-        # @raise [Com::Vmware::Vapi::Std::Errors::Unauthenticated]
-        #      if the user is not authenticated.
-        # @raise [Com::Vmware::Vapi::Std::Errors::ServiceUnavailable]
-        #      if the task cancelation cannot be performed due to vCenter server is unreachable or it is not properly configured.
-        def cancel(activation_id)
-            invoke_with_info(@@cancel_info, {
-                'activation_id' => activation_id,
-            })
-        end
-
-
+    # Constructs a new instance.
+    #
+    # @param config [VAPI::Bindings::StubConfig] A hash with the api provider details.
+    def initialize(config)
+      super(config, SERVICE_INFO)
     end
 
+    # Sends a request to cancel the task associated with the provided  ``activation_id`` .
+    #
+    # @param activation_id [String]
+    #      the  ``activation_id``  associated with a vCenter Server task to be canceled.
+    # @return [Void]
+    # @raise [Com::Vmware::Vapi::Std::Errors::NotFound]
+    #      if a vCenter Server task with the given  ``activation_id``  was not found.
+    # @raise [Com::Vmware::Vapi::Std::Errors::NotAllowedInCurrentState]
+    #      if the vCenter Server task associated with the given  ``activation_id``  is not cancelable.
+    # @raise [Com::Vmware::Vapi::Std::Errors::Unauthorized]
+    #      if the user is not authorized to cancel the task.
+    # @raise [Com::Vmware::Vapi::Std::Errors::Unauthenticated]
+    #      if the user is not authenticated.
+    # @raise [Com::Vmware::Vapi::Std::Errors::ServiceUnavailable]
+    #      if the task cancelation cannot be performed due to vCenter server is unreachable or it is not properly configured.
+    def cancel(activation_id)
+      invoke_with_info(CANCEL_INFO,
+                       'activation_id' => activation_id)
+    end
 
+  end
 end

--- a/client/sdk/com/vmware/vcenter.rb
+++ b/client/sdk/com/vmware/vcenter.rb
@@ -1,5 +1,6 @@
 #---------------------------------------------------------------------------
-# Copyright 2016 VMware, Inc.  All rights reserved.
+# Copyright 2017 VMware, Inc.  All rights reserved.
+#
 # AUTO GENERATED FILE -- DO NOT MODIFY!
 #
 # vAPI type descriptors for package com.vmware.vcenter.
@@ -8,3028 +9,2855 @@ require 'vapi'
 
 # declare the module hierarchy before we use the shorthand syntax below
 module Com
-    module Vmware
-        module Vcenter
-        end
+  module Vmware
+    module Vcenter
     end
+  end
 end
 
 # The  ``com.vmware.vcenter``   package  provides  classs  for managing VMware vSphere environments. The  package  is available starting in vSphere 6.5.
 module Com::Vmware::Vcenter
+  # The  ``Com::Vmware::Vcenter::Cluster``   class  provides  methods  to manage clusters in the vCenter Server.
+  class Cluster < VAPI::Bindings::VapiService
+    # static metamodel definitions
+    SERVICE_ID = VAPI::Core::ServiceIdentifier.new('com.vmware.vcenter.cluster')
 
-    # The  ``Com::Vmware::Vcenter::Cluster``   class  provides  methods  to manage clusters in the vCenter Server.
-    class Cluster < VAPI::Bindings::VapiService
+    LIST_INFO = VAPI::Bindings::OperationInfo.new(
+      VAPI::Core::OperationIdentifier.new('list', SERVICE_ID),
+      VAPI::Bindings::OperationInputType.new(
+        'filter' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::Cluster::FilterSpec'))
+      ),
+      VAPI::Bindings::ListType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::Cluster::Summary')),
+      {
+        'com.vmware.vapi.std.errors.unable_to_allocate_resource' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::UnableToAllocateResource'),
+        'com.vmware.vapi.std.errors.service_unavailable' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::ServiceUnavailable'),
+        'com.vmware.vapi.std.errors.unauthenticated' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Unauthenticated'),
+        'com.vmware.vapi.std.errors.unauthorized' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Unauthorized')
+      },
+      [],
+      []
+    )
 
-        protected
+    GET_INFO = VAPI::Bindings::OperationInfo.new(
+      VAPI::Core::OperationIdentifier.new('get', SERVICE_ID),
+      VAPI::Bindings::OperationInputType.new(
+        'cluster' => VAPI::Bindings::IdType.new('ClusterComputeResource')
+      ),
+      VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::Cluster::Info'),
+      {
+        'com.vmware.vapi.std.errors.not_found' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::NotFound'),
+        'com.vmware.vapi.std.errors.service_unavailable' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::ServiceUnavailable'),
+        'com.vmware.vapi.std.errors.unauthenticated' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Unauthenticated'),
+        'com.vmware.vapi.std.errors.unauthorized' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Unauthorized')
+      },
+      [],
+      []
+    )
 
-        # static metamodel definitions
-        @@service_id = VAPI::Core::ServiceIdentifier.new('com.vmware.vcenter.cluster')
+    SERVICE_INFO = VAPI::Bindings::ServiceInfo.new(
+      SERVICE_ID,
+      'list' => LIST_INFO,
+      'get' => GET_INFO
+    )
 
-        @@list_info = VAPI::Bindings::OperationInfo.new(
-            VAPI::Core::OperationIdentifier.new('list', @@service_id),
-            VAPI::Bindings::OperationInputType.new({
-                'filter' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::Cluster::FilterSpec')),
-            }),
-            VAPI::Bindings::ListType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::Cluster::Summary')),
-            {
-                'com.vmware.vapi.std.errors.unable_to_allocate_resource' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::UnableToAllocateResource'),
-                'com.vmware.vapi.std.errors.service_unavailable' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::ServiceUnavailable'),
-                'com.vmware.vapi.std.errors.unauthenticated' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Unauthenticated'),
-                'com.vmware.vapi.std.errors.unauthorized' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Unauthorized'),
-
-            },
-            [],
-            [])
-        @@get_info = VAPI::Bindings::OperationInfo.new(
-            VAPI::Core::OperationIdentifier.new('get', @@service_id),
-            VAPI::Bindings::OperationInputType.new({
-                'cluster' => VAPI::Bindings::IdType.new(resource_types='ClusterComputeResource'),
-            }),
-            VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::Cluster::Info'),
-            {
-                'com.vmware.vapi.std.errors.not_found' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::NotFound'),
-                'com.vmware.vapi.std.errors.service_unavailable' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::ServiceUnavailable'),
-                'com.vmware.vapi.std.errors.unauthenticated' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Unauthenticated'),
-                'com.vmware.vapi.std.errors.unauthorized' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Unauthorized'),
-
-            },
-            [],
-            [])
-
-        @@service_info = VAPI::Bindings::ServiceInfo.new(@@service_id, {
-            'list' => @@list_info,
-            'get' => @@get_info,
-        })
-
-        public
-
-        # Constructs a new instance.
-        #
-        # @param config [VAPI::Bindings::StubConfig] A hash with the api provider details.
-        def initialize(config)
-            super(config, @@service_info)
-        end
-
-        RESOURCE_TYPE = 'ClusterComputeResource'
-
-
-        # Returns information about at most 1000 visible (subject to permission checks) clusters in vCenter matching the   :class:`Com::Vmware::Vcenter::Cluster::FilterSpec`  .
-        #
-        # @param filter [Com::Vmware::Vcenter::Cluster::FilterSpec, nil]
-        #     Specification of matching clusters for which information should be returned.
-        #     If  nil , the behavior is equivalent to a   :class:`Com::Vmware::Vcenter::Cluster::FilterSpec`   with all  fields   nil  which means all clusters match the filter.
-        # @return [Array<Com::Vmware::Vcenter::Cluster::Summary>]
-        #     Commonly used information about the clusters matching the   :class:`Com::Vmware::Vcenter::Cluster::FilterSpec`  .
-        # @raise [Com::Vmware::Vapi::Std::Errors::UnableToAllocateResource]
-        #     if more than 1000 clusters match the   :class:`Com::Vmware::Vcenter::Cluster::FilterSpec`  .
-        # @raise [Com::Vmware::Vapi::Std::Errors::ServiceUnavailable]
-        #     if the system is unable to communicate with a service to complete the request.
-        # @raise [Com::Vmware::Vapi::Std::Errors::Unauthenticated]
-        #     if the user can not be authenticated.
-        # @raise [Com::Vmware::Vapi::Std::Errors::Unauthorized]
-        #     if the user doesn't have the required privileges.
-        def list(filter=nil)
-            invoke_with_info(@@list_info, {
-                'filter' => filter,
-            })
-        end
-
-
-        # Retrieves information about the cluster corresponding to  ``cluster`` .
-        #
-        # @param cluster [String]
-        #     Identifier of the cluster.
-        # @return [Com::Vmware::Vcenter::Cluster::Info]
-        #     The   :class:`Com::Vmware::Vcenter::Cluster::Info`   instances that corresponds to the  ``cluster`` .
-        # @raise [Com::Vmware::Vapi::Std::Errors::NotFound]
-        #     if there is no cluster associated with  ``cluster``  in the system.
-        # @raise [Com::Vmware::Vapi::Std::Errors::ServiceUnavailable]
-        #     if the system is unable to communicate with a service to complete the request.
-        # @raise [Com::Vmware::Vapi::Std::Errors::Unauthenticated]
-        #     if the session id is missing from the request or the corresponding session object cannot be found.
-        # @raise [Com::Vmware::Vapi::Std::Errors::Unauthorized]
-        #     if the user doesn't not have the required privileges.
-        def get(cluster)
-            invoke_with_info(@@get_info, {
-                'cluster' => cluster,
-            })
-        end
-
-
-
-        # The  ``Com::Vmware::Vcenter::Cluster::FilterSpec``   class  contains  fields  used to filter the results when listing clusters (see   :func:`Com::Vmware::Vcenter::Cluster.list`  ). If multiple  fields  are specified, only clusters matching all of the  fields  match the filter.
-        # @!attribute [rw] clusters
-        #     @return [Set<String>, nil]
-        #     Identifiers of clusters that can match the filter.
-        #     If  nil  or empty, clusters with any identifier match the filter.
-        # @!attribute [rw] names
-        #     @return [Set<String>, nil]
-        #     Names that clusters must have to match the filter (see   :attr:`Com::Vmware::Vcenter::Cluster::Info.name`  ).
-        #     If  nil  or empty, clusters with any name match the filter.
-        # @!attribute [rw] folders
-        #     @return [Set<String>, nil]
-        #     Folders that must contain the cluster for the cluster to match the filter.
-        #     If  nil  or empty, clusters in any folder match the filter.
-        # @!attribute [rw] datacenters
-        #     @return [Set<String>, nil]
-        #     Datacenters that must contain the cluster for the cluster to match the filter.
-        #     If  nil  or empty, clusters in any datacenter match the filter.
-        class FilterSpec < VAPI::Bindings::VapiStruct
-
-            class << self
-                # Holds (gets or creates) the binding type metadata for this structure type.
-                # @scope class
-                # @return [VAPI::Bindings::StructType] the binding type
-                def binding_type
-                    @binding_type ||= VAPI::Bindings::StructType.new(
-                        'com.vmware.vcenter.cluster.filter_spec',
-                        {
-                            'clusters' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::SetType.new(VAPI::Bindings::IdType.new)),
-                            'names' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::SetType.new(VAPI::Bindings::StringType.instance)),
-                            'folders' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::SetType.new(VAPI::Bindings::IdType.new)),
-                            'datacenters' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::SetType.new(VAPI::Bindings::IdType.new)),
-                        },
-                        FilterSpec,
-                        false,
-                        nil)
-                end
-            end
-
-            attr_accessor :clusters,
-                          :names,
-                          :folders,
-                          :datacenters
-
-            # Constructs a new instance.
-            # @param ruby_values [Hash] a map of initial property values (optional)
-            # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
-            def initialize(ruby_values=nil, struct_value=nil)
-                super(self.class.binding_type, ruby_values, struct_value)
-            end
-        end
-
-
-        # The  ``Com::Vmware::Vcenter::Cluster::Summary``   class  contains commonly used information about a cluster in vCenter Server.
-        # @!attribute [rw] cluster
-        #     @return [String]
-        #     Identifier of the cluster.
-        # @!attribute [rw] name
-        #     @return [String]
-        #     Name of the cluster.
-        # @!attribute [rw] ha_enabled
-        #     @return [Boolean]
-        #     Flag indicating whether the vSphere HA feature is enabled for the cluster.
-        # @!attribute [rw] drs_enabled
-        #     @return [Boolean]
-        #     Flag indicating whether the vSphere DRS service is enabled for the cluster.
-        class Summary < VAPI::Bindings::VapiStruct
-
-            class << self
-                # Holds (gets or creates) the binding type metadata for this structure type.
-                # @scope class
-                # @return [VAPI::Bindings::StructType] the binding type
-                def binding_type
-                    @binding_type ||= VAPI::Bindings::StructType.new(
-                        'com.vmware.vcenter.cluster.summary',
-                        {
-                            'cluster' => VAPI::Bindings::IdType.new(resource_types='ClusterComputeResource'),
-                            'name' => VAPI::Bindings::StringType.instance,
-                            'ha_enabled' => VAPI::Bindings::BooleanType.instance,
-                            'drs_enabled' => VAPI::Bindings::BooleanType.instance,
-                        },
-                        Summary,
-                        false,
-                        nil)
-                end
-            end
-
-            attr_accessor :cluster,
-                          :name,
-                          :ha_enabled,
-                          :drs_enabled
-
-            # Constructs a new instance.
-            # @param ruby_values [Hash] a map of initial property values (optional)
-            # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
-            def initialize(ruby_values=nil, struct_value=nil)
-                super(self.class.binding_type, ruby_values, struct_value)
-            end
-        end
-
-
-        # The  ``Com::Vmware::Vcenter::Cluster::Info``   class  contains information about a cluster in vCenter Server.
-        # @!attribute [rw] name
-        #     @return [String]
-        #     The name of the cluster
-        # @!attribute [rw] resource_pool
-        #     @return [String]
-        #     Identifier of the root resource pool of the cluster
-        class Info < VAPI::Bindings::VapiStruct
-
-            class << self
-                # Holds (gets or creates) the binding type metadata for this structure type.
-                # @scope class
-                # @return [VAPI::Bindings::StructType] the binding type
-                def binding_type
-                    @binding_type ||= VAPI::Bindings::StructType.new(
-                        'com.vmware.vcenter.cluster.info',
-                        {
-                            'name' => VAPI::Bindings::StringType.instance,
-                            'resource_pool' => VAPI::Bindings::IdType.new(resource_types='ResourcePool'),
-                        },
-                        Info,
-                        false,
-                        nil)
-                end
-            end
-
-            attr_accessor :name,
-                          :resource_pool
-
-            # Constructs a new instance.
-            # @param ruby_values [Hash] a map of initial property values (optional)
-            # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
-            def initialize(ruby_values=nil, struct_value=nil)
-                super(self.class.binding_type, ruby_values, struct_value)
-            end
-        end
-
-
+    # Constructs a new instance.
+    #
+    # @param config [VAPI::Bindings::StubConfig] A hash with the api provider details.
+    def initialize(config)
+      super(config, SERVICE_INFO)
     end
 
-
-    # The  ``Com::Vmware::Vcenter::Datacenter``   class  provides  methods  to manage datacenters in the vCenter Server.
-    class Datacenter < VAPI::Bindings::VapiService
-
-        protected
-
-        # static metamodel definitions
-        @@service_id = VAPI::Core::ServiceIdentifier.new('com.vmware.vcenter.datacenter')
-
-        @@create_info = VAPI::Bindings::OperationInfo.new(
-            VAPI::Core::OperationIdentifier.new('create', @@service_id),
-            VAPI::Bindings::OperationInputType.new({
-                'spec' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::Datacenter::CreateSpec'),
-            }),
-            VAPI::Bindings::IdType.new(resource_types='Datacenter'),
-            {
-                'com.vmware.vapi.std.errors.error' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Error'),
-                'com.vmware.vapi.std.errors.already_exists' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::AlreadyExists'),
-                'com.vmware.vapi.std.errors.invalid_argument' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::InvalidArgument'),
-                'com.vmware.vapi.std.errors.not_found' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::NotFound'),
-                'com.vmware.vapi.std.errors.service_unavailable' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::ServiceUnavailable'),
-                'com.vmware.vapi.std.errors.unauthenticated' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Unauthenticated'),
-                'com.vmware.vapi.std.errors.unauthorized' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Unauthorized'),
-
-            },
-            [],
-            [])
-        @@delete_info = VAPI::Bindings::OperationInfo.new(
-            VAPI::Core::OperationIdentifier.new('delete', @@service_id),
-            VAPI::Bindings::OperationInputType.new({
-                'datacenter' => VAPI::Bindings::IdType.new(resource_types='Datacenter'),
-                'force' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::BooleanType.instance),
-            }),
-            VAPI::Bindings::VoidType.instance,
-            {
-                'com.vmware.vapi.std.errors.error' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Error'),
-                'com.vmware.vapi.std.errors.not_found' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::NotFound'),
-                'com.vmware.vapi.std.errors.resource_in_use' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::ResourceInUse'),
-                'com.vmware.vapi.std.errors.service_unavailable' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::ServiceUnavailable'),
-                'com.vmware.vapi.std.errors.unauthenticated' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Unauthenticated'),
-                'com.vmware.vapi.std.errors.unauthorized' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Unauthorized'),
-
-            },
-            [],
-            [])
-        @@list_info = VAPI::Bindings::OperationInfo.new(
-            VAPI::Core::OperationIdentifier.new('list', @@service_id),
-            VAPI::Bindings::OperationInputType.new({
-                'filter' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::Datacenter::FilterSpec')),
-            }),
-            VAPI::Bindings::ListType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::Datacenter::Summary')),
-            {
-                'com.vmware.vapi.std.errors.unable_to_allocate_resource' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::UnableToAllocateResource'),
-                'com.vmware.vapi.std.errors.service_unavailable' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::ServiceUnavailable'),
-                'com.vmware.vapi.std.errors.unauthenticated' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Unauthenticated'),
-                'com.vmware.vapi.std.errors.unauthorized' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Unauthorized'),
-
-            },
-            [],
-            [])
-        @@get_info = VAPI::Bindings::OperationInfo.new(
-            VAPI::Core::OperationIdentifier.new('get', @@service_id),
-            VAPI::Bindings::OperationInputType.new({
-                'datacenter' => VAPI::Bindings::IdType.new(resource_types='Datacenter'),
-            }),
-            VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::Datacenter::Info'),
-            {
-                'com.vmware.vapi.std.errors.error' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Error'),
-                'com.vmware.vapi.std.errors.not_found' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::NotFound'),
-                'com.vmware.vapi.std.errors.service_unavailable' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::ServiceUnavailable'),
-                'com.vmware.vapi.std.errors.unauthenticated' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Unauthenticated'),
-                'com.vmware.vapi.std.errors.unauthorized' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Unauthorized'),
-
-            },
-            [],
-            [])
-
-        @@service_info = VAPI::Bindings::ServiceInfo.new(@@service_id, {
-            'create' => @@create_info,
-            'delete' => @@delete_info,
-            'list' => @@list_info,
-            'get' => @@get_info,
-        })
-
-        public
-
-        # Constructs a new instance.
-        #
-        # @param config [VAPI::Bindings::StubConfig] A hash with the api provider details.
-        def initialize(config)
-            super(config, @@service_info)
-        end
-
-        RESOURCE_TYPE = 'Datacenter'
-
-
-        # Create a new datacenter in the vCenter inventory
-        #
-        # @param spec [Com::Vmware::Vcenter::Datacenter::CreateSpec]
-        #     Specification for the new datacenter to be created.
-        # @return [String]
-        #     The identifier of the newly created datacenter
-        # @raise [Com::Vmware::Vapi::Std::Errors::Error]
-        #     if the system reports an error while responding to the request.
-        # @raise [Com::Vmware::Vapi::Std::Errors::AlreadyExists]
-        #     if the datacenter with the same name is already present.
-        # @raise [Com::Vmware::Vapi::Std::Errors::InvalidArgument]
-        #     if the datacenter name is empty or invalid as per the underlying implementation.
-        # @raise [Com::Vmware::Vapi::Std::Errors::InvalidArgument]
-        #     if the folder is not specified and the system cannot choose a suitable one.
-        # @raise [Com::Vmware::Vapi::Std::Errors::NotFound]
-        #     if the datacenter folder cannot be found.
-        # @raise [Com::Vmware::Vapi::Std::Errors::ServiceUnavailable]
-        #     if the system is unable to communicate with a service to complete the request.
-        # @raise [Com::Vmware::Vapi::Std::Errors::Unauthenticated]
-        #     if the user can not be authenticated.
-        # @raise [Com::Vmware::Vapi::Std::Errors::Unauthorized]
-        #     if the user doesn't have the required privileges.
-        def create(spec)
-            invoke_with_info(@@create_info, {
-                'spec' => spec,
-            })
-        end
-
-
-        # Delete an empty datacenter from the vCenter Server
-        #
-        # @param datacenter [String]
-        #     Identifier of the datacenter to be deleted.
-        # @param force [Boolean, nil]
-        #     If true, delete the datacenter even if it is not empty.
-        #     If  nil  a   :class:`Com::Vmware::Vapi::Std::Errors::ResourceInUse`    error  will be reported if the datacenter is not empty. This is the equivalent of passing the value false.
-        # @return [Void]
-        # @raise [Com::Vmware::Vapi::Std::Errors::Error]
-        #     if the system reports an error while responding to the request.
-        # @raise [Com::Vmware::Vapi::Std::Errors::NotFound]
-        #     if there is no datacenter associated with  ``datacenter``  in the system.
-        # @raise [Com::Vmware::Vapi::Std::Errors::ResourceInUse]
-        #     if the datacenter associated with  ``datacenter``  is not empty.
-        # @raise [Com::Vmware::Vapi::Std::Errors::ServiceUnavailable]
-        #     if the system is unable to communicate with a service to complete the request.
-        # @raise [Com::Vmware::Vapi::Std::Errors::Unauthenticated]
-        #     if the user can not be authenticated.
-        # @raise [Com::Vmware::Vapi::Std::Errors::Unauthorized]
-        #     if the user doesn't have the required privileges.
-        def delete(datacenter, force=nil)
-            invoke_with_info(@@delete_info, {
-                'datacenter' => datacenter,
-                'force' => force,
-            })
-        end
-
-
-        # Returns information about at most 1000 visible (subject to permission checks) datacenters in vCenter matching the   :class:`Com::Vmware::Vcenter::Datacenter::FilterSpec`  .
-        #
-        # @param filter [Com::Vmware::Vcenter::Datacenter::FilterSpec, nil]
-        #     Specification of matching datacenters for which information should be returned.
-        #     If  nil , the behavior is equivalent to a   :class:`Com::Vmware::Vcenter::Datacenter::FilterSpec`   with all  fields   nil  which means all datacenters match the filter.
-        # @return [Array<Com::Vmware::Vcenter::Datacenter::Summary>]
-        #     Commonly used information about the datacenters matching the   :class:`Com::Vmware::Vcenter::Datacenter::FilterSpec`  .
-        # @raise [Com::Vmware::Vapi::Std::Errors::UnableToAllocateResource]
-        #     if more than 1000 datacenters match the   :class:`Com::Vmware::Vcenter::Datacenter::FilterSpec`  .
-        # @raise [Com::Vmware::Vapi::Std::Errors::ServiceUnavailable]
-        #     if the system is unable to communicate with a service to complete the request.
-        # @raise [Com::Vmware::Vapi::Std::Errors::Unauthenticated]
-        #     if the user can not be authenticated.
-        # @raise [Com::Vmware::Vapi::Std::Errors::Unauthorized]
-        #     if the user doesn't have the required privileges.
-        def list(filter=nil)
-            invoke_with_info(@@list_info, {
-                'filter' => filter,
-            })
-        end
-
-
-        # Retrieves information about the datacenter corresponding to  ``datacenter`` .
-        #
-        # @param datacenter [String]
-        #     Identifier of the datacenter.
-        # @return [Com::Vmware::Vcenter::Datacenter::Info]
-        #     The   :class:`Com::Vmware::Vcenter::Datacenter::Info`   instances that corresponds to the  ``datacenter`` .
-        # @raise [Com::Vmware::Vapi::Std::Errors::Error]
-        #     if the system reports an error while responding to the request.
-        # @raise [Com::Vmware::Vapi::Std::Errors::NotFound]
-        #     if there is no datacenter associated with  ``datacenter``  in the system.
-        # @raise [Com::Vmware::Vapi::Std::Errors::ServiceUnavailable]
-        #     if the system is unable to communicate with a service to complete the request.
-        # @raise [Com::Vmware::Vapi::Std::Errors::Unauthenticated]
-        #     if the user can not be authenticated.
-        # @raise [Com::Vmware::Vapi::Std::Errors::Unauthorized]
-        #     if the user doesn't have the required privileges.
-        def get(datacenter)
-            invoke_with_info(@@get_info, {
-                'datacenter' => datacenter,
-            })
-        end
-
-
-
-        # The  ``Com::Vmware::Vcenter::Datacenter::CreateSpec``   class  defines the information used to create a datacenter.
-        # @!attribute [rw] name
-        #     @return [String]
-        #     The name of the datacenter to be created.
-        # @!attribute [rw] folder
-        #     @return [String, nil]
-        #     Datacenter folder in which the new datacenter should be created.
-        #     This  field  is currently required. In the future, if this  field  is  nil , the system will attempt to choose a suitable folder for the datacenter; if a folder cannot be chosen, the datacenter creation operation will fail.
-        class CreateSpec < VAPI::Bindings::VapiStruct
-
-            class << self
-                # Holds (gets or creates) the binding type metadata for this structure type.
-                # @scope class
-                # @return [VAPI::Bindings::StructType] the binding type
-                def binding_type
-                    @binding_type ||= VAPI::Bindings::StructType.new(
-                        'com.vmware.vcenter.datacenter.create_spec',
-                        {
-                            'name' => VAPI::Bindings::StringType.instance,
-                            'folder' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::IdType.new),
-                        },
-                        CreateSpec,
-                        false,
-                        nil)
-                end
-            end
-
-            attr_accessor :name,
-                          :folder
-
-            # Constructs a new instance.
-            # @param ruby_values [Hash] a map of initial property values (optional)
-            # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
-            def initialize(ruby_values=nil, struct_value=nil)
-                super(self.class.binding_type, ruby_values, struct_value)
-            end
-        end
-
-
-        # The  ``Com::Vmware::Vcenter::Datacenter::FilterSpec``   class  contains  fields  used to filter the results when listing datacenters (see   :func:`Com::Vmware::Vcenter::Datacenter.list`  ). If multiple  fields  are specified, only datacenters matching all of the  fields  match the filter.
-        # @!attribute [rw] datacenters
-        #     @return [Set<String>, nil]
-        #     Identifiers of datacenters that can match the filter.
-        #     If  nil  or empty, datacenters with any identifier match the filter.
-        # @!attribute [rw] names
-        #     @return [Set<String>, nil]
-        #     Names that datacenters must have to match the filter (see   :attr:`Com::Vmware::Vcenter::Datacenter::Info.name`  ).
-        #     If  nil  or empty, datacenters with any name match the filter.
-        # @!attribute [rw] folders
-        #     @return [Set<String>, nil]
-        #     Folders that must contain the datacenters for the datacenter to match the filter.
-        #     If  nil  or empty, datacenters in any folder match the filter.
-        class FilterSpec < VAPI::Bindings::VapiStruct
-
-            class << self
-                # Holds (gets or creates) the binding type metadata for this structure type.
-                # @scope class
-                # @return [VAPI::Bindings::StructType] the binding type
-                def binding_type
-                    @binding_type ||= VAPI::Bindings::StructType.new(
-                        'com.vmware.vcenter.datacenter.filter_spec',
-                        {
-                            'datacenters' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::SetType.new(VAPI::Bindings::IdType.new)),
-                            'names' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::SetType.new(VAPI::Bindings::StringType.instance)),
-                            'folders' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::SetType.new(VAPI::Bindings::IdType.new)),
-                        },
-                        FilterSpec,
-                        false,
-                        nil)
-                end
-            end
-
-            attr_accessor :datacenters,
-                          :names,
-                          :folders
-
-            # Constructs a new instance.
-            # @param ruby_values [Hash] a map of initial property values (optional)
-            # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
-            def initialize(ruby_values=nil, struct_value=nil)
-                super(self.class.binding_type, ruby_values, struct_value)
-            end
-        end
-
-
-        # The  ``Com::Vmware::Vcenter::Datacenter::Summary``   class  contains commonly used information about a datacenter in vCenter Server.
-        # @!attribute [rw] datacenter
-        #     @return [String]
-        #     Identifier of the datacenter.
-        # @!attribute [rw] name
-        #     @return [String]
-        #     Name of the datacenter.
-        class Summary < VAPI::Bindings::VapiStruct
-
-            class << self
-                # Holds (gets or creates) the binding type metadata for this structure type.
-                # @scope class
-                # @return [VAPI::Bindings::StructType] the binding type
-                def binding_type
-                    @binding_type ||= VAPI::Bindings::StructType.new(
-                        'com.vmware.vcenter.datacenter.summary',
-                        {
-                            'datacenter' => VAPI::Bindings::IdType.new(resource_types='Datacenter'),
-                            'name' => VAPI::Bindings::StringType.instance,
-                        },
-                        Summary,
-                        false,
-                        nil)
-                end
-            end
-
-            attr_accessor :datacenter,
-                          :name
-
-            # Constructs a new instance.
-            # @param ruby_values [Hash] a map of initial property values (optional)
-            # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
-            def initialize(ruby_values=nil, struct_value=nil)
-                super(self.class.binding_type, ruby_values, struct_value)
-            end
-        end
-
-
-        # The  ``Com::Vmware::Vcenter::Datacenter::Info``   class  contains information about a datacenter in vCenter Server.
-        # @!attribute [rw] name
-        #     @return [String]
-        #     The name of the datacenter.
-        # @!attribute [rw] datastore_folder
-        #     @return [String]
-        #     The root datastore folder associated with the datacenter.
-        # @!attribute [rw] host_folder
-        #     @return [String]
-        #     The root host and cluster folder associated with the datacenter.
-        # @!attribute [rw] network_folder
-        #     @return [String]
-        #     The root network folder associated with the datacenter.
-        # @!attribute [rw] vm_folder
-        #     @return [String]
-        #     The root virtual machine folder associated with the datacenter.
-        class Info < VAPI::Bindings::VapiStruct
-
-            class << self
-                # Holds (gets or creates) the binding type metadata for this structure type.
-                # @scope class
-                # @return [VAPI::Bindings::StructType] the binding type
-                def binding_type
-                    @binding_type ||= VAPI::Bindings::StructType.new(
-                        'com.vmware.vcenter.datacenter.info',
-                        {
-                            'name' => VAPI::Bindings::StringType.instance,
-                            'datastore_folder' => VAPI::Bindings::IdType.new(resource_types='Folder'),
-                            'host_folder' => VAPI::Bindings::IdType.new(resource_types='Folder'),
-                            'network_folder' => VAPI::Bindings::IdType.new(resource_types='Folder'),
-                            'vm_folder' => VAPI::Bindings::IdType.new(resource_types='Folder'),
-                        },
-                        Info,
-                        false,
-                        nil)
-                end
-            end
-
-            attr_accessor :name,
-                          :datastore_folder,
-                          :host_folder,
-                          :network_folder,
-                          :vm_folder
-
-            # Constructs a new instance.
-            # @param ruby_values [Hash] a map of initial property values (optional)
-            # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
-            def initialize(ruby_values=nil, struct_value=nil)
-                super(self.class.binding_type, ruby_values, struct_value)
-            end
-        end
-
-
+    RESOURCE_TYPE = 'ClusterComputeResource'
+    # Returns information about at most 1000 visible (subject to permission checks) clusters in vCenter matching the   :class:`Com::Vmware::Vcenter::Cluster::FilterSpec`  .
+    #
+    # @param filter [Com::Vmware::Vcenter::Cluster::FilterSpec, nil]
+    #     Specification of matching clusters for which information should be returned.
+    #     If  nil , the behavior is equivalent to a   :class:`Com::Vmware::Vcenter::Cluster::FilterSpec`   with all  fields   nil  which means all clusters match the filter.
+    # @return [Array<Com::Vmware::Vcenter::Cluster::Summary>]
+    #     Commonly used information about the clusters matching the   :class:`Com::Vmware::Vcenter::Cluster::FilterSpec`  .
+    # @raise [Com::Vmware::Vapi::Std::Errors::UnableToAllocateResource]
+    #     if more than 1000 clusters match the   :class:`Com::Vmware::Vcenter::Cluster::FilterSpec`  .
+    # @raise [Com::Vmware::Vapi::Std::Errors::ServiceUnavailable]
+    #     if the system is unable to communicate with a service to complete the request.
+    # @raise [Com::Vmware::Vapi::Std::Errors::Unauthenticated]
+    #     if the user can not be authenticated.
+    # @raise [Com::Vmware::Vapi::Std::Errors::Unauthorized]
+    #     if the user doesn't have the required privileges.
+    def list(filter = nil)
+      invoke_with_info(LIST_INFO,
+                       'filter' => filter)
     end
 
-
-    # The  Datastore   class  provides  methods  for manipulating a datastore.
-    class Datastore < VAPI::Bindings::VapiService
-
-        protected
-
-        # static metamodel definitions
-        @@service_id = VAPI::Core::ServiceIdentifier.new('com.vmware.vcenter.datastore')
-
-        @@get_info = VAPI::Bindings::OperationInfo.new(
-            VAPI::Core::OperationIdentifier.new('get', @@service_id),
-            VAPI::Bindings::OperationInputType.new({
-                'datastore' => VAPI::Bindings::IdType.new(resource_types='Datastore'),
-            }),
-            VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::Datastore::Info'),
-            {
-                'com.vmware.vapi.std.errors.not_found' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::NotFound'),
-                'com.vmware.vapi.std.errors.service_unavailable' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::ServiceUnavailable'),
-                'com.vmware.vapi.std.errors.unauthenticated' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Unauthenticated'),
-                'com.vmware.vapi.std.errors.unauthorized' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Unauthorized'),
-
-            },
-            [],
-            [])
-        @@list_info = VAPI::Bindings::OperationInfo.new(
-            VAPI::Core::OperationIdentifier.new('list', @@service_id),
-            VAPI::Bindings::OperationInputType.new({
-                'filter' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::Datastore::FilterSpec')),
-            }),
-            VAPI::Bindings::ListType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::Datastore::Summary')),
-            {
-                'com.vmware.vapi.std.errors.invalid_argument' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::InvalidArgument'),
-                'com.vmware.vapi.std.errors.unable_to_allocate_resource' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::UnableToAllocateResource'),
-                'com.vmware.vapi.std.errors.service_unavailable' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::ServiceUnavailable'),
-                'com.vmware.vapi.std.errors.unauthenticated' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Unauthenticated'),
-                'com.vmware.vapi.std.errors.unauthorized' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Unauthorized'),
-
-            },
-            [],
-            [])
-
-        @@service_info = VAPI::Bindings::ServiceInfo.new(@@service_id, {
-            'get' => @@get_info,
-            'list' => @@list_info,
-        })
-
-        public
-
-        # Constructs a new instance.
-        #
-        # @param config [VAPI::Bindings::StubConfig] A hash with the api provider details.
-        def initialize(config)
-            super(config, @@service_info)
-        end
-
-        RESOURCE_TYPE = 'Datastore'
-
-
-        # Retrieves information about the datastore indicated by  ``datastore`` .
-        #
-        # @param datastore [String]
-        #     Identifier of the datastore for which information should be retrieved.
-        # @return [Com::Vmware::Vcenter::Datastore::Info]
-        #     information about the datastore.
-        # @raise [Com::Vmware::Vapi::Std::Errors::NotFound]
-        #     if the datastore indicated by  ``datastore``  does not exist.
-        # @raise [Com::Vmware::Vapi::Std::Errors::ServiceUnavailable]
-        #     if the system is unable to communicate with a service to complete the request.
-        # @raise [Com::Vmware::Vapi::Std::Errors::Unauthenticated]
-        #     if the user can not be authenticated.
-        # @raise [Com::Vmware::Vapi::Std::Errors::Unauthorized]
-        #     if the user doesn't have the required privileges.
-        def get(datastore)
-            invoke_with_info(@@get_info, {
-                'datastore' => datastore,
-            })
-        end
-
-
-        # Returns information about at most 1000 visible (subject to permission checks) datastores in vCenter matching the   :class:`Com::Vmware::Vcenter::Datastore::FilterSpec`  .
-        #
-        # @param filter [Com::Vmware::Vcenter::Datastore::FilterSpec, nil]
-        #     Specification of matching datastores for which information should be returned.
-        #     If  nil , the behavior is equivalent to a   :class:`Com::Vmware::Vcenter::Datastore::FilterSpec`   with all  fields   nil  which means all datastores match the filter.
-        # @return [Array<Com::Vmware::Vcenter::Datastore::Summary>]
-        #     Commonly used information about the datastores matching the   :class:`Com::Vmware::Vcenter::Datastore::FilterSpec`  .
-        # @raise [Com::Vmware::Vapi::Std::Errors::InvalidArgument]
-        #     if the   :attr:`Com::Vmware::Vcenter::Datastore::FilterSpec.types`    field  contains a value that is not supported by the server.
-        # @raise [Com::Vmware::Vapi::Std::Errors::InvalidArgument]
-        #     if the   :attr:`Com::Vmware::Vcenter::Datastore::FilterSpec.types`    field  contains a value that is not supported by the server.
-        # @raise [Com::Vmware::Vapi::Std::Errors::UnableToAllocateResource]
-        #     if more than 1000 datastores match the   :class:`Com::Vmware::Vcenter::Datastore::FilterSpec`  .
-        # @raise [Com::Vmware::Vapi::Std::Errors::ServiceUnavailable]
-        #     if the system is unable to communicate with a service to complete the request.
-        # @raise [Com::Vmware::Vapi::Std::Errors::Unauthenticated]
-        #     if the user can not be authenticated.
-        # @raise [Com::Vmware::Vapi::Std::Errors::Unauthorized]
-        #     if the user doesn't have the required privileges.
-        def list(filter=nil)
-            invoke_with_info(@@list_info, {
-                'filter' => filter,
-            })
-        end
-
-
-
-        # The  ``Com::Vmware::Vcenter::Datastore::Info``   class  contains information about a datastore.
-        # @!attribute [rw] name
-        #     @return [String]
-        #     Name of the datastore.
-        # @!attribute [rw] type
-        #     @return [Com::Vmware::Vcenter::Datastore::Type]
-        #     Type ( ``VMFS``, ``NFS``, ``NFS41``, ``CIFS``, ``VSAN``, ``VFFS``, ``VVOL`` ) of the datastore.
-        # @!attribute [rw] accessible
-        #     @return [Boolean]
-        #     Whether or not this datastore is accessible.
-        # @!attribute [rw] free_space
-        #     @return [Fixnum, nil]
-        #     Available space of this datastore, in bytes.  
-        #     
-        #      The server periodically updates this value.
-        #     This  field  will be  nil  if the available space of this datastore is not known.
-        # @!attribute [rw] multiple_host_access
-        #     @return [Boolean]
-        #     Whether or not ore than one host in the datacenter has been configured with access to the datastore.
-        # @!attribute [rw] thin_provisioning_supported
-        #     @return [Boolean]
-        #     Whether or not the datastore supports thin provisioning on a per file basis. When thin provisioning is used, backing storage is lazily allocated.
-        class Info < VAPI::Bindings::VapiStruct
-
-            class << self
-                # Holds (gets or creates) the binding type metadata for this structure type.
-                # @scope class
-                # @return [VAPI::Bindings::StructType] the binding type
-                def binding_type
-                    @binding_type ||= VAPI::Bindings::StructType.new(
-                        'com.vmware.vcenter.datastore.info',
-                        {
-                            'name' => VAPI::Bindings::StringType.instance,
-                            'type' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::Datastore::Type'),
-                            'accessible' => VAPI::Bindings::BooleanType.instance,
-                            'free_space' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::IntegerType.instance),
-                            'multiple_host_access' => VAPI::Bindings::BooleanType.instance,
-                            'thin_provisioning_supported' => VAPI::Bindings::BooleanType.instance,
-                        },
-                        Info,
-                        false,
-                        nil)
-                end
-            end
-
-            attr_accessor :name,
-                          :type,
-                          :accessible,
-                          :free_space,
-                          :multiple_host_access,
-                          :thin_provisioning_supported
-
-            # Constructs a new instance.
-            # @param ruby_values [Hash] a map of initial property values (optional)
-            # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
-            def initialize(ruby_values=nil, struct_value=nil)
-                super(self.class.binding_type, ruby_values, struct_value)
-            end
-        end
-
-
-        # The  ``Com::Vmware::Vcenter::Datastore::FilterSpec``   class  contains  fields  used to filter the results when listing datastores (see   :func:`Com::Vmware::Vcenter::Datastore.list`  ). If multiple  fields  are specified, only datastores matching all of the  fields  match the filter.
-        # @!attribute [rw] datastores
-        #     @return [Set<String>, nil]
-        #     Identifiers of datastores that can match the filter.
-        #     If  nil  or empty, datastores with any identifier match the filter.
-        # @!attribute [rw] names
-        #     @return [Set<String>, nil]
-        #     Names that datastores must have to match the filter (see   :attr:`Com::Vmware::Vcenter::Datastore::Info.name`  ).
-        #     If  nil  or empty, datastores with any name match the filter.
-        # @!attribute [rw] types
-        #     @return [Set<Com::Vmware::Vcenter::Datastore::Type>, nil]
-        #     Types that datastores must have to match the filter (see   :attr:`Com::Vmware::Vcenter::Datastore::Summary.type`  ).
-        #     If  nil  or empty, datastores with any type match the filter.
-        # @!attribute [rw] folders
-        #     @return [Set<String>, nil]
-        #     Folders that must contain the datastore for the datastore to match the filter.
-        #     If  nil  or empty, datastores in any folder match the filter.
-        # @!attribute [rw] datacenters
-        #     @return [Set<String>, nil]
-        #     Datacenters that must contain the datastore for the datastore to match the filter.
-        #     If  nil  or empty, datastores in any datacenter match the filter.
-        class FilterSpec < VAPI::Bindings::VapiStruct
-
-            class << self
-                # Holds (gets or creates) the binding type metadata for this structure type.
-                # @scope class
-                # @return [VAPI::Bindings::StructType] the binding type
-                def binding_type
-                    @binding_type ||= VAPI::Bindings::StructType.new(
-                        'com.vmware.vcenter.datastore.filter_spec',
-                        {
-                            'datastores' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::SetType.new(VAPI::Bindings::IdType.new)),
-                            'names' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::SetType.new(VAPI::Bindings::StringType.instance)),
-                            'types' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::SetType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::Datastore::Type'))),
-                            'folders' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::SetType.new(VAPI::Bindings::IdType.new)),
-                            'datacenters' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::SetType.new(VAPI::Bindings::IdType.new)),
-                        },
-                        FilterSpec,
-                        false,
-                        nil)
-                end
-            end
-
-            attr_accessor :datastores,
-                          :names,
-                          :types,
-                          :folders,
-                          :datacenters
-
-            # Constructs a new instance.
-            # @param ruby_values [Hash] a map of initial property values (optional)
-            # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
-            def initialize(ruby_values=nil, struct_value=nil)
-                super(self.class.binding_type, ruby_values, struct_value)
-            end
-        end
-
-
-        # The  ``Com::Vmware::Vcenter::Datastore::Summary``   class  contains commonly used information about a datastore.
-        # @!attribute [rw] datastore
-        #     @return [String]
-        #     Identifier of the datastore.
-        # @!attribute [rw] name
-        #     @return [String]
-        #     Name of the datastore.
-        # @!attribute [rw] type
-        #     @return [Com::Vmware::Vcenter::Datastore::Type]
-        #     Type ( ``VMFS``, ``NFS``, ``NFS41``, ``CIFS``, ``VSAN``, ``VFFS``, ``VVOL`` ) of the datatore.
-        # @!attribute [rw] free_space
-        #     @return [Fixnum, nil]
-        #     Available space of this datastore, in bytes.  
-        #     
-        #      The server periodically updates this value.
-        #     This  field  will be  nil  if the available space of this datastore is not known.
-        # @!attribute [rw] capacity
-        #     @return [Fixnum, nil]
-        #     Capacity of this datastore, in bytes.  
-        #     
-        #      The server periodically updates this value.
-        #     This  field  will be  nil  if the capacity of this datastore is not known.
-        class Summary < VAPI::Bindings::VapiStruct
-
-            class << self
-                # Holds (gets or creates) the binding type metadata for this structure type.
-                # @scope class
-                # @return [VAPI::Bindings::StructType] the binding type
-                def binding_type
-                    @binding_type ||= VAPI::Bindings::StructType.new(
-                        'com.vmware.vcenter.datastore.summary',
-                        {
-                            'datastore' => VAPI::Bindings::IdType.new(resource_types='Datastore'),
-                            'name' => VAPI::Bindings::StringType.instance,
-                            'type' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::Datastore::Type'),
-                            'free_space' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::IntegerType.instance),
-                            'capacity' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::IntegerType.instance),
-                        },
-                        Summary,
-                        false,
-                        nil)
-                end
-            end
-
-            attr_accessor :datastore,
-                          :name,
-                          :type,
-                          :free_space,
-                          :capacity
-
-            # Constructs a new instance.
-            # @param ruby_values [Hash] a map of initial property values (optional)
-            # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
-            def initialize(ruby_values=nil, struct_value=nil)
-                super(self.class.binding_type, ruby_values, struct_value)
-            end
-        end
-
-
-
-        # The  ``Com::Vmware::Vcenter::Datastore::Type``   enumerated type  defines the supported types of vCenter datastores.
-        # @!attribute [rw] vmfs
-        #     @return [Com::Vmware::Vcenter::Datastore::Type]
-        #     VMware File System (ESX Server only).
-        # @!attribute [rw] nfs
-        #     @return [Com::Vmware::Vcenter::Datastore::Type]
-        #     Network file system v3 (linux & esx servers only).
-        # @!attribute [rw] nf_s41
-        #     @return [Com::Vmware::Vcenter::Datastore::Type]
-        #     Network file system v4.1 (linux & esx servers only).
-        # @!attribute [rw] cifs
-        #     @return [Com::Vmware::Vcenter::Datastore::Type]
-        #     Common Internet File System.
-        # @!attribute [rw] vsan
-        #     @return [Com::Vmware::Vcenter::Datastore::Type]
-        #     Virtual SAN (ESX Server only).
-        # @!attribute [rw] vffs
-        #     @return [Com::Vmware::Vcenter::Datastore::Type]
-        #     Flash Read Cache (ESX Server only).
-        # @!attribute [rw] vvol
-        #     @return [Com::Vmware::Vcenter::Datastore::Type]
-        #     vSphere Virtual Volume (ESX Server only).
-        class Type < VAPI::Bindings::VapiEnum
-
-            class << self
-                # Holds (gets or creates) the binding type metadata for this enumeration type.
-                # @scope class
-                # @return [VAPI::Bindings::EnumType] the binding type
-                def binding_type
-                    @binding_type ||= VAPI::Bindings::EnumType.new(
-                        'com.vmware.vcenter.datastore.type',
-                        Type)
-                end
-
-                # Converts from a string value (perhaps off the wire) to an instance
-                # of this enum type.
-                # @param value [String] the actual value of the enum instance
-                # @return [Type] the instance found for the value, otherwise
-                #         an unknown instance will be built for the value
-                def from_string(value)
-                    begin
-                        const_get(value)
-                    rescue NameError
-                        Type.new('UNKNOWN', value)
-                    end
-                end
-            end
-
-            private
-
-            # Constructs a new instance.
-            # @param value [String] the actual value of the enum instance
-            # @param unknown [String] the unknown value when value is 'UKNOWN'
-            def initialize(value, unknown=nil)
-                super(self.class.binding_type, value, unknown)
-            end
-
-            public
-
-            # @!attribute [rw] vmfs
-            #     @return [Com::Vmware::Vcenter::Datastore::Type]
-            #     VMware File System (ESX Server only).
-            VMFS = Type.new('VMFS')
-
-            # @!attribute [rw] nfs
-            #     @return [Com::Vmware::Vcenter::Datastore::Type]
-            #     Network file system v3 (linux & esx servers only).
-            NFS = Type.new('NFS')
-
-            # @!attribute [rw] nf_s41
-            #     @return [Com::Vmware::Vcenter::Datastore::Type]
-            #     Network file system v4.1 (linux & esx servers only).
-            NF_S41 = Type.new('NF_S41')
-
-            # @!attribute [rw] cifs
-            #     @return [Com::Vmware::Vcenter::Datastore::Type]
-            #     Common Internet File System.
-            CIFS = Type.new('CIFS')
-
-            # @!attribute [rw] vsan
-            #     @return [Com::Vmware::Vcenter::Datastore::Type]
-            #     Virtual SAN (ESX Server only).
-            VSAN = Type.new('VSAN')
-
-            # @!attribute [rw] vffs
-            #     @return [Com::Vmware::Vcenter::Datastore::Type]
-            #     Flash Read Cache (ESX Server only).
-            VFFS = Type.new('VFFS')
-
-            # @!attribute [rw] vvol
-            #     @return [Com::Vmware::Vcenter::Datastore::Type]
-            #     vSphere Virtual Volume (ESX Server only).
-            VVOL = Type.new('VVOL')
-
-        end
-
-
+    # Retrieves information about the cluster corresponding to  ``cluster`` .
+    #
+    # @param cluster [String]
+    #     Identifier of the cluster.
+    # @return [Com::Vmware::Vcenter::Cluster::Info]
+    #     The   :class:`Com::Vmware::Vcenter::Cluster::Info`   instances that corresponds to the  ``cluster`` .
+    # @raise [Com::Vmware::Vapi::Std::Errors::NotFound]
+    #     if there is no cluster associated with  ``cluster``  in the system.
+    # @raise [Com::Vmware::Vapi::Std::Errors::ServiceUnavailable]
+    #     if the system is unable to communicate with a service to complete the request.
+    # @raise [Com::Vmware::Vapi::Std::Errors::Unauthenticated]
+    #     if the session id is missing from the request or the corresponding session object cannot be found.
+    # @raise [Com::Vmware::Vapi::Std::Errors::Unauthorized]
+    #     if the user doesn't not have the required privileges.
+    def get(cluster)
+      invoke_with_info(GET_INFO,
+                       'cluster' => cluster)
     end
 
-
-    # The  Folder   class  provides  methods  for manipulating a vCenter Server folder.
-    class Folder < VAPI::Bindings::VapiService
-
-        protected
-
-        # static metamodel definitions
-        @@service_id = VAPI::Core::ServiceIdentifier.new('com.vmware.vcenter.folder')
-
-        @@list_info = VAPI::Bindings::OperationInfo.new(
-            VAPI::Core::OperationIdentifier.new('list', @@service_id),
-            VAPI::Bindings::OperationInputType.new({
-                'filter' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::Folder::FilterSpec')),
-            }),
-            VAPI::Bindings::ListType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::Folder::Summary')),
+    # The  ``Com::Vmware::Vcenter::Cluster::FilterSpec``   class  contains  fields  used to filter the results when listing clusters (see   :func:`Com::Vmware::Vcenter::Cluster.list`  ). If multiple  fields  are specified, only clusters matching all of the  fields  match the filter.
+    # @!attribute [rw] clusters
+    #     @return [Set<String>, nil]
+    #     Identifiers of clusters that can match the filter.
+    #     If  nil  or empty, clusters with any identifier match the filter.
+    # @!attribute [rw] names
+    #     @return [Set<String>, nil]
+    #     Names that clusters must have to match the filter (see   :attr:`Com::Vmware::Vcenter::Cluster::Info.name`  ).
+    #     If  nil  or empty, clusters with any name match the filter.
+    # @!attribute [rw] folders
+    #     @return [Set<String>, nil]
+    #     Folders that must contain the cluster for the cluster to match the filter.
+    #     If  nil  or empty, clusters in any folder match the filter.
+    # @!attribute [rw] datacenters
+    #     @return [Set<String>, nil]
+    #     Datacenters that must contain the cluster for the cluster to match the filter.
+    #     If  nil  or empty, clusters in any datacenter match the filter.
+    class FilterSpec < VAPI::Bindings::VapiStruct
+      class << self
+        # Holds (gets or creates) the binding type metadata for this structure type.
+        # @scope class
+        # @return [VAPI::Bindings::StructType] the binding type
+        def binding_type
+          @binding_type ||= VAPI::Bindings::StructType.new(
+            'com.vmware.vcenter.cluster.filter_spec',
             {
-                'com.vmware.vapi.std.errors.invalid_argument' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::InvalidArgument'),
-                'com.vmware.vapi.std.errors.unable_to_allocate_resource' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::UnableToAllocateResource'),
-                'com.vmware.vapi.std.errors.service_unavailable' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::ServiceUnavailable'),
-                'com.vmware.vapi.std.errors.unauthenticated' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Unauthenticated'),
-                'com.vmware.vapi.std.errors.unauthorized' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Unauthorized'),
-
+              'clusters' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::SetType.new(VAPI::Bindings::IdType.new)),
+              'names' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::SetType.new(VAPI::Bindings::StringType.instance)),
+              'folders' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::SetType.new(VAPI::Bindings::IdType.new)),
+              'datacenters' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::SetType.new(VAPI::Bindings::IdType.new))
             },
-            [],
-            [])
-
-        @@service_info = VAPI::Bindings::ServiceInfo.new(@@service_id, {
-            'list' => @@list_info,
-        })
-
-        public
-
-        # Constructs a new instance.
-        #
-        # @param config [VAPI::Bindings::StubConfig] A hash with the api provider details.
-        def initialize(config)
-            super(config, @@service_info)
+            FilterSpec,
+            false,
+            nil
+          )
         end
+      end
 
-        RESOURCE_TYPE = 'Folder'
+      attr_accessor :clusters,
+                    :names,
+                    :folders,
+                    :datacenters
 
-
-        # Returns information about at most 1000 visible (subject to permission checks) folders in vCenter matching the   :class:`Com::Vmware::Vcenter::Folder::FilterSpec`  .
-        #
-        # @param filter [Com::Vmware::Vcenter::Folder::FilterSpec, nil]
-        #     Specification of matching folders for which information should be returned.
-        #     If  nil , the behavior is equivalent to a   :class:`Com::Vmware::Vcenter::Folder::FilterSpec`   with all  fields   nil  which means all folders match the filter.
-        # @return [Array<Com::Vmware::Vcenter::Folder::Summary>]
-        #     Commonly used information about the folders matching the   :class:`Com::Vmware::Vcenter::Folder::FilterSpec`  .
-        # @raise [Com::Vmware::Vapi::Std::Errors::InvalidArgument]
-        #     if the   :attr:`Com::Vmware::Vcenter::Folder::FilterSpec.type`    field  contains a value that is not supported by the server.
-        # @raise [Com::Vmware::Vapi::Std::Errors::UnableToAllocateResource]
-        #     if more than 1000 folders match the   :class:`Com::Vmware::Vcenter::Folder::FilterSpec`  .
-        # @raise [Com::Vmware::Vapi::Std::Errors::ServiceUnavailable]
-        #     if the system is unable to communicate with a service to complete the request.
-        # @raise [Com::Vmware::Vapi::Std::Errors::Unauthenticated]
-        #     if the user can not be authenticated.
-        # @raise [Com::Vmware::Vapi::Std::Errors::Unauthorized]
-        #     if the user doesn't have the required privileges.
-        def list(filter=nil)
-            invoke_with_info(@@list_info, {
-                'filter' => filter,
-            })
-        end
-
-
-
-        # The  ``Com::Vmware::Vcenter::Folder::FilterSpec``   class  contains  fields  used to filter the results when listing folders (see   :func:`Com::Vmware::Vcenter::Folder.list`  ). If multiple  fields  are specified, only folders matching all of the  fields  match the filter.
-        # @!attribute [rw] folders
-        #     @return [Set<String>, nil]
-        #     Identifiers of folders that can match the filter.
-        #     If  nil  or empty, folders with any identifier match the filter.
-        # @!attribute [rw] names
-        #     @return [Set<String>, nil]
-        #     Names that folders must have to match the filter (see   :attr:`Com::Vmware::Vcenter::Folder::Summary.name`  ).
-        #     If  nil  or empty, folders with any name match the filter.
-        # @!attribute [rw] type
-        #     @return [Com::Vmware::Vcenter::Folder::Type, nil]
-        #     Type that folders must have to match the filter (see   :attr:`Com::Vmware::Vcenter::Folder::Summary.type`  ).
-        #     If  nil , folders with any type match the filter.
-        # @!attribute [rw] parent_folders
-        #     @return [Set<String>, nil]
-        #     Folders that must contain the folder for the folder to match the filter.
-        #     If  nil  or empty, folder in any folder match the filter.
-        # @!attribute [rw] datacenters
-        #     @return [Set<String>, nil]
-        #     Datacenters that must contain the folder for the folder to match the filter.
-        #     If  nil  or empty, folder in any datacenter match the filter.
-        class FilterSpec < VAPI::Bindings::VapiStruct
-
-            class << self
-                # Holds (gets or creates) the binding type metadata for this structure type.
-                # @scope class
-                # @return [VAPI::Bindings::StructType] the binding type
-                def binding_type
-                    @binding_type ||= VAPI::Bindings::StructType.new(
-                        'com.vmware.vcenter.folder.filter_spec',
-                        {
-                            'folders' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::SetType.new(VAPI::Bindings::IdType.new)),
-                            'names' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::SetType.new(VAPI::Bindings::StringType.instance)),
-                            'type' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::Folder::Type')),
-                            'parent_folders' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::SetType.new(VAPI::Bindings::IdType.new)),
-                            'datacenters' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::SetType.new(VAPI::Bindings::IdType.new)),
-                        },
-                        FilterSpec,
-                        false,
-                        nil)
-                end
-            end
-
-            attr_accessor :folders,
-                          :names,
-                          :type,
-                          :parent_folders,
-                          :datacenters
-
-            # Constructs a new instance.
-            # @param ruby_values [Hash] a map of initial property values (optional)
-            # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
-            def initialize(ruby_values=nil, struct_value=nil)
-                super(self.class.binding_type, ruby_values, struct_value)
-            end
-        end
-
-
-        # The  ``Com::Vmware::Vcenter::Folder::Summary``   class  contains commonly used information about a folder.
-        # @!attribute [rw] folder
-        #     @return [String]
-        #     Identifier of the folder.
-        # @!attribute [rw] name
-        #     @return [String]
-        #     Name of the vCenter Server folder.
-        # @!attribute [rw] type
-        #     @return [Com::Vmware::Vcenter::Folder::Type]
-        #     Type ( ``DATACENTER``, ``DATASTORE``, ``HOST``, ``NETWORK``, ``VIRTUAL_MACHINE`` ) of the vCenter Server folder.
-        class Summary < VAPI::Bindings::VapiStruct
-
-            class << self
-                # Holds (gets or creates) the binding type metadata for this structure type.
-                # @scope class
-                # @return [VAPI::Bindings::StructType] the binding type
-                def binding_type
-                    @binding_type ||= VAPI::Bindings::StructType.new(
-                        'com.vmware.vcenter.folder.summary',
-                        {
-                            'folder' => VAPI::Bindings::IdType.new(resource_types='Folder'),
-                            'name' => VAPI::Bindings::StringType.instance,
-                            'type' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::Folder::Type'),
-                        },
-                        Summary,
-                        false,
-                        nil)
-                end
-            end
-
-            attr_accessor :folder,
-                          :name,
-                          :type
-
-            # Constructs a new instance.
-            # @param ruby_values [Hash] a map of initial property values (optional)
-            # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
-            def initialize(ruby_values=nil, struct_value=nil)
-                super(self.class.binding_type, ruby_values, struct_value)
-            end
-        end
-
-
-
-        # The  ``Com::Vmware::Vcenter::Folder::Type``   enumerated type  defines the type of a vCenter Server folder. The type of a folder determines what what kinds of children can be contained in the folder.
-        # @!attribute [rw] datacenter
-        #     @return [Com::Vmware::Vcenter::Folder::Type]
-        #     A folder that can contain datacenters.
-        # @!attribute [rw] datastore
-        #     @return [Com::Vmware::Vcenter::Folder::Type]
-        #     A folder that can contain datastores.
-        # @!attribute [rw] host
-        #     @return [Com::Vmware::Vcenter::Folder::Type]
-        #     A folder that can contain compute resources (hosts and clusters).
-        # @!attribute [rw] network
-        #     @return [Com::Vmware::Vcenter::Folder::Type]
-        #     A folder that can contain networkds.
-        # @!attribute [rw] virtual_machine
-        #     @return [Com::Vmware::Vcenter::Folder::Type]
-        #     A folder that can contain virtual machines.
-        class Type < VAPI::Bindings::VapiEnum
-
-            class << self
-                # Holds (gets or creates) the binding type metadata for this enumeration type.
-                # @scope class
-                # @return [VAPI::Bindings::EnumType] the binding type
-                def binding_type
-                    @binding_type ||= VAPI::Bindings::EnumType.new(
-                        'com.vmware.vcenter.folder.type',
-                        Type)
-                end
-
-                # Converts from a string value (perhaps off the wire) to an instance
-                # of this enum type.
-                # @param value [String] the actual value of the enum instance
-                # @return [Type] the instance found for the value, otherwise
-                #         an unknown instance will be built for the value
-                def from_string(value)
-                    begin
-                        const_get(value)
-                    rescue NameError
-                        Type.new('UNKNOWN', value)
-                    end
-                end
-            end
-
-            private
-
-            # Constructs a new instance.
-            # @param value [String] the actual value of the enum instance
-            # @param unknown [String] the unknown value when value is 'UKNOWN'
-            def initialize(value, unknown=nil)
-                super(self.class.binding_type, value, unknown)
-            end
-
-            public
-
-            # @!attribute [rw] datacenter
-            #     @return [Com::Vmware::Vcenter::Folder::Type]
-            #     A folder that can contain datacenters.
-            DATACENTER = Type.new('DATACENTER')
-
-            # @!attribute [rw] datastore
-            #     @return [Com::Vmware::Vcenter::Folder::Type]
-            #     A folder that can contain datastores.
-            DATASTORE = Type.new('DATASTORE')
-
-            # @!attribute [rw] host
-            #     @return [Com::Vmware::Vcenter::Folder::Type]
-            #     A folder that can contain compute resources (hosts and clusters).
-            HOST = Type.new('HOST')
-
-            # @!attribute [rw] network
-            #     @return [Com::Vmware::Vcenter::Folder::Type]
-            #     A folder that can contain networkds.
-            NETWORK = Type.new('NETWORK')
-
-            # @!attribute [rw] virtual_machine
-            #     @return [Com::Vmware::Vcenter::Folder::Type]
-            #     A folder that can contain virtual machines.
-            VIRTUAL_MACHINE = Type.new('VIRTUAL_MACHINE')
-
-        end
-
-
+      # Constructs a new instance.
+      # @param ruby_values [Hash] a map of initial property values (optional)
+      # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
+      def initialize(ruby_values = nil, struct_value = nil)
+        super(self.class.binding_type, ruby_values, struct_value)
+      end
     end
 
-
-    # The  ``Com::Vmware::Vcenter::Host``   class  provides  methods  to manage hosts in the vCenter Server.
-    class Host < VAPI::Bindings::VapiService
-
-        protected
-
-        # static metamodel definitions
-        @@service_id = VAPI::Core::ServiceIdentifier.new('com.vmware.vcenter.host')
-
-        @@create_info = VAPI::Bindings::OperationInfo.new(
-            VAPI::Core::OperationIdentifier.new('create', @@service_id),
-            VAPI::Bindings::OperationInputType.new({
-                'spec' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::Host::CreateSpec'),
-            }),
-            VAPI::Bindings::IdType.new(resource_types='HostSystem'),
+    # The  ``Com::Vmware::Vcenter::Cluster::Summary``   class  contains commonly used information about a cluster in vCenter Server.
+    # @!attribute [rw] cluster
+    #     @return [String]
+    #     Identifier of the cluster.
+    # @!attribute [rw] name
+    #     @return [String]
+    #     Name of the cluster.
+    # @!attribute [rw] ha_enabled
+    #     @return [Boolean]
+    #     Flag indicating whether the vSphere HA feature is enabled for the cluster.
+    # @!attribute [rw] drs_enabled
+    #     @return [Boolean]
+    #     Flag indicating whether the vSphere DRS service is enabled for the cluster.
+    class Summary < VAPI::Bindings::VapiStruct
+      class << self
+        # Holds (gets or creates) the binding type metadata for this structure type.
+        # @scope class
+        # @return [VAPI::Bindings::StructType] the binding type
+        def binding_type
+          @binding_type ||= VAPI::Bindings::StructType.new(
+            'com.vmware.vcenter.cluster.summary',
             {
-                'com.vmware.vapi.std.errors.already_exists' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::AlreadyExists'),
-                'com.vmware.vapi.std.errors.error' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Error'),
-                'com.vmware.vapi.std.errors.invalid_argument' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::InvalidArgument'),
-                'com.vmware.vapi.std.errors.invalid_element_type' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::InvalidElementType'),
-                'com.vmware.vapi.std.errors.resource_in_use' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::ResourceInUse'),
-                'com.vmware.vapi.std.errors.unable_to_allocate_resource' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::UnableToAllocateResource'),
-                'com.vmware.vapi.std.errors.unauthenticated' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Unauthenticated'),
-                'com.vmware.vapi.std.errors.unsupported' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Unsupported'),
-                'com.vmware.vapi.std.errors.service_unavailable' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::ServiceUnavailable'),
-                'com.vmware.vapi.std.errors.unauthorized' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Unauthorized'),
-
+              'cluster' => VAPI::Bindings::IdType.new('ClusterComputeResource'),
+              'name' => VAPI::Bindings::StringType.instance,
+              'ha_enabled' => VAPI::Bindings::BooleanType.instance,
+              'drs_enabled' => VAPI::Bindings::BooleanType.instance
             },
-            [],
-            [])
-        @@delete_info = VAPI::Bindings::OperationInfo.new(
-            VAPI::Core::OperationIdentifier.new('delete', @@service_id),
-            VAPI::Bindings::OperationInputType.new({
-                'host' => VAPI::Bindings::IdType.new(resource_types='HostSystem'),
-            }),
-            VAPI::Bindings::VoidType.instance,
+            Summary,
+            false,
+            nil
+          )
+        end
+      end
+
+      attr_accessor :cluster,
+                    :name,
+                    :ha_enabled,
+                    :drs_enabled
+
+      # Constructs a new instance.
+      # @param ruby_values [Hash] a map of initial property values (optional)
+      # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
+      def initialize(ruby_values = nil, struct_value = nil)
+        super(self.class.binding_type, ruby_values, struct_value)
+      end
+    end
+
+    # The  ``Com::Vmware::Vcenter::Cluster::Info``   class  contains information about a cluster in vCenter Server.
+    # @!attribute [rw] name
+    #     @return [String]
+    #     The name of the cluster
+    # @!attribute [rw] resource_pool
+    #     @return [String]
+    #     Identifier of the root resource pool of the cluster
+    class Info < VAPI::Bindings::VapiStruct
+      class << self
+        # Holds (gets or creates) the binding type metadata for this structure type.
+        # @scope class
+        # @return [VAPI::Bindings::StructType] the binding type
+        def binding_type
+          @binding_type ||= VAPI::Bindings::StructType.new(
+            'com.vmware.vcenter.cluster.info',
             {
-                'com.vmware.vapi.std.errors.error' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Error'),
-                'com.vmware.vapi.std.errors.not_found' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::NotFound'),
-                'com.vmware.vapi.std.errors.resource_in_use' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::ResourceInUse'),
-                'com.vmware.vapi.std.errors.service_unavailable' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::ServiceUnavailable'),
-                'com.vmware.vapi.std.errors.unauthenticated' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Unauthenticated'),
-                'com.vmware.vapi.std.errors.unauthorized' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Unauthorized'),
-
+              'name' => VAPI::Bindings::StringType.instance,
+              'resource_pool' => VAPI::Bindings::IdType.new('ResourcePool')
             },
-            [],
-            [])
-        @@list_info = VAPI::Bindings::OperationInfo.new(
-            VAPI::Core::OperationIdentifier.new('list', @@service_id),
-            VAPI::Bindings::OperationInputType.new({
-                'filter' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::Host::FilterSpec')),
-            }),
-            VAPI::Bindings::ListType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::Host::Summary')),
+            Info,
+            false,
+            nil
+          )
+        end
+      end
+
+      attr_accessor :name,
+                    :resource_pool
+
+      # Constructs a new instance.
+      # @param ruby_values [Hash] a map of initial property values (optional)
+      # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
+      def initialize(ruby_values = nil, struct_value = nil)
+        super(self.class.binding_type, ruby_values, struct_value)
+      end
+    end
+
+  end
+  # The  ``Com::Vmware::Vcenter::Datacenter``   class  provides  methods  to manage datacenters in the vCenter Server.
+  class Datacenter < VAPI::Bindings::VapiService
+    # static metamodel definitions
+    SERVICE_ID = VAPI::Core::ServiceIdentifier.new('com.vmware.vcenter.datacenter')
+
+    CREATE_INFO = VAPI::Bindings::OperationInfo.new(
+      VAPI::Core::OperationIdentifier.new('create', SERVICE_ID),
+      VAPI::Bindings::OperationInputType.new(
+        'spec' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::Datacenter::CreateSpec')
+      ),
+      VAPI::Bindings::IdType.new('Datacenter'),
+      {
+        'com.vmware.vapi.std.errors.error' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Error'),
+        'com.vmware.vapi.std.errors.already_exists' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::AlreadyExists'),
+        'com.vmware.vapi.std.errors.invalid_argument' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::InvalidArgument'),
+        'com.vmware.vapi.std.errors.not_found' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::NotFound'),
+        'com.vmware.vapi.std.errors.service_unavailable' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::ServiceUnavailable'),
+        'com.vmware.vapi.std.errors.unauthenticated' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Unauthenticated'),
+        'com.vmware.vapi.std.errors.unauthorized' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Unauthorized')
+      },
+      [],
+      []
+    )
+
+    DELETE_INFO = VAPI::Bindings::OperationInfo.new(
+      VAPI::Core::OperationIdentifier.new('delete', SERVICE_ID),
+      VAPI::Bindings::OperationInputType.new(
+        'datacenter' => VAPI::Bindings::IdType.new('Datacenter'),
+        'force' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::BooleanType.instance)
+      ),
+      VAPI::Bindings::VoidType.instance,
+      {
+        'com.vmware.vapi.std.errors.error' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Error'),
+        'com.vmware.vapi.std.errors.not_found' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::NotFound'),
+        'com.vmware.vapi.std.errors.resource_in_use' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::ResourceInUse'),
+        'com.vmware.vapi.std.errors.service_unavailable' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::ServiceUnavailable'),
+        'com.vmware.vapi.std.errors.unauthenticated' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Unauthenticated'),
+        'com.vmware.vapi.std.errors.unauthorized' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Unauthorized')
+      },
+      [],
+      []
+    )
+
+    LIST_INFO = VAPI::Bindings::OperationInfo.new(
+      VAPI::Core::OperationIdentifier.new('list', SERVICE_ID),
+      VAPI::Bindings::OperationInputType.new(
+        'filter' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::Datacenter::FilterSpec'))
+      ),
+      VAPI::Bindings::ListType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::Datacenter::Summary')),
+      {
+        'com.vmware.vapi.std.errors.unable_to_allocate_resource' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::UnableToAllocateResource'),
+        'com.vmware.vapi.std.errors.service_unavailable' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::ServiceUnavailable'),
+        'com.vmware.vapi.std.errors.unauthenticated' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Unauthenticated'),
+        'com.vmware.vapi.std.errors.unauthorized' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Unauthorized')
+      },
+      [],
+      []
+    )
+
+    GET_INFO = VAPI::Bindings::OperationInfo.new(
+      VAPI::Core::OperationIdentifier.new('get', SERVICE_ID),
+      VAPI::Bindings::OperationInputType.new(
+        'datacenter' => VAPI::Bindings::IdType.new('Datacenter')
+      ),
+      VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::Datacenter::Info'),
+      {
+        'com.vmware.vapi.std.errors.error' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Error'),
+        'com.vmware.vapi.std.errors.not_found' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::NotFound'),
+        'com.vmware.vapi.std.errors.service_unavailable' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::ServiceUnavailable'),
+        'com.vmware.vapi.std.errors.unauthenticated' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Unauthenticated'),
+        'com.vmware.vapi.std.errors.unauthorized' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Unauthorized')
+      },
+      [],
+      []
+    )
+
+    SERVICE_INFO = VAPI::Bindings::ServiceInfo.new(
+      SERVICE_ID,
+      'create' => CREATE_INFO,
+      'delete' => DELETE_INFO,
+      'list' => LIST_INFO,
+      'get' => GET_INFO
+    )
+
+    # Constructs a new instance.
+    #
+    # @param config [VAPI::Bindings::StubConfig] A hash with the api provider details.
+    def initialize(config)
+      super(config, SERVICE_INFO)
+    end
+
+    RESOURCE_TYPE = 'Datacenter'
+    # Create a new datacenter in the vCenter inventory
+    #
+    # @param spec [Com::Vmware::Vcenter::Datacenter::CreateSpec]
+    #     Specification for the new datacenter to be created.
+    # @return [String]
+    #     The identifier of the newly created datacenter
+    # @raise [Com::Vmware::Vapi::Std::Errors::Error]
+    #     if the system reports an error while responding to the request.
+    # @raise [Com::Vmware::Vapi::Std::Errors::AlreadyExists]
+    #     if the datacenter with the same name is already present.
+    # @raise [Com::Vmware::Vapi::Std::Errors::InvalidArgument]
+    #     if the datacenter name is empty or invalid as per the underlying implementation.
+    # @raise [Com::Vmware::Vapi::Std::Errors::InvalidArgument]
+    #     if the folder is not specified and the system cannot choose a suitable one.
+    # @raise [Com::Vmware::Vapi::Std::Errors::NotFound]
+    #     if the datacenter folder cannot be found.
+    # @raise [Com::Vmware::Vapi::Std::Errors::ServiceUnavailable]
+    #     if the system is unable to communicate with a service to complete the request.
+    # @raise [Com::Vmware::Vapi::Std::Errors::Unauthenticated]
+    #     if the user can not be authenticated.
+    # @raise [Com::Vmware::Vapi::Std::Errors::Unauthorized]
+    #     if the user doesn't have the required privileges.
+    def create(spec)
+      invoke_with_info(CREATE_INFO,
+                       'spec' => spec)
+    end
+
+    # Delete an empty datacenter from the vCenter Server
+    #
+    # @param datacenter [String]
+    #     Identifier of the datacenter to be deleted.
+    # @param force [Boolean, nil]
+    #     If true, delete the datacenter even if it is not empty.
+    #     If  nil  a   :class:`Com::Vmware::Vapi::Std::Errors::ResourceInUse`    error  will be reported if the datacenter is not empty. This is the equivalent of passing the value false.
+    # @return [Void]
+    # @raise [Com::Vmware::Vapi::Std::Errors::Error]
+    #     if the system reports an error while responding to the request.
+    # @raise [Com::Vmware::Vapi::Std::Errors::NotFound]
+    #     if there is no datacenter associated with  ``datacenter``  in the system.
+    # @raise [Com::Vmware::Vapi::Std::Errors::ResourceInUse]
+    #     if the datacenter associated with  ``datacenter``  is not empty.
+    # @raise [Com::Vmware::Vapi::Std::Errors::ServiceUnavailable]
+    #     if the system is unable to communicate with a service to complete the request.
+    # @raise [Com::Vmware::Vapi::Std::Errors::Unauthenticated]
+    #     if the user can not be authenticated.
+    # @raise [Com::Vmware::Vapi::Std::Errors::Unauthorized]
+    #     if the user doesn't have the required privileges.
+    def delete(datacenter, force = nil)
+      invoke_with_info(DELETE_INFO,
+                       'datacenter' => datacenter,
+                       'force' => force)
+    end
+
+    # Returns information about at most 1000 visible (subject to permission checks) datacenters in vCenter matching the   :class:`Com::Vmware::Vcenter::Datacenter::FilterSpec`  .
+    #
+    # @param filter [Com::Vmware::Vcenter::Datacenter::FilterSpec, nil]
+    #     Specification of matching datacenters for which information should be returned.
+    #     If  nil , the behavior is equivalent to a   :class:`Com::Vmware::Vcenter::Datacenter::FilterSpec`   with all  fields   nil  which means all datacenters match the filter.
+    # @return [Array<Com::Vmware::Vcenter::Datacenter::Summary>]
+    #     Commonly used information about the datacenters matching the   :class:`Com::Vmware::Vcenter::Datacenter::FilterSpec`  .
+    # @raise [Com::Vmware::Vapi::Std::Errors::UnableToAllocateResource]
+    #     if more than 1000 datacenters match the   :class:`Com::Vmware::Vcenter::Datacenter::FilterSpec`  .
+    # @raise [Com::Vmware::Vapi::Std::Errors::ServiceUnavailable]
+    #     if the system is unable to communicate with a service to complete the request.
+    # @raise [Com::Vmware::Vapi::Std::Errors::Unauthenticated]
+    #     if the user can not be authenticated.
+    # @raise [Com::Vmware::Vapi::Std::Errors::Unauthorized]
+    #     if the user doesn't have the required privileges.
+    def list(filter = nil)
+      invoke_with_info(LIST_INFO,
+                       'filter' => filter)
+    end
+
+    # Retrieves information about the datacenter corresponding to  ``datacenter`` .
+    #
+    # @param datacenter [String]
+    #     Identifier of the datacenter.
+    # @return [Com::Vmware::Vcenter::Datacenter::Info]
+    #     The   :class:`Com::Vmware::Vcenter::Datacenter::Info`   instances that corresponds to the  ``datacenter`` .
+    # @raise [Com::Vmware::Vapi::Std::Errors::Error]
+    #     if the system reports an error while responding to the request.
+    # @raise [Com::Vmware::Vapi::Std::Errors::NotFound]
+    #     if there is no datacenter associated with  ``datacenter``  in the system.
+    # @raise [Com::Vmware::Vapi::Std::Errors::ServiceUnavailable]
+    #     if the system is unable to communicate with a service to complete the request.
+    # @raise [Com::Vmware::Vapi::Std::Errors::Unauthenticated]
+    #     if the user can not be authenticated.
+    # @raise [Com::Vmware::Vapi::Std::Errors::Unauthorized]
+    #     if the user doesn't have the required privileges.
+    def get(datacenter)
+      invoke_with_info(GET_INFO,
+                       'datacenter' => datacenter)
+    end
+
+    # The  ``Com::Vmware::Vcenter::Datacenter::CreateSpec``   class  defines the information used to create a datacenter.
+    # @!attribute [rw] name
+    #     @return [String]
+    #     The name of the datacenter to be created.
+    # @!attribute [rw] folder
+    #     @return [String, nil]
+    #     Datacenter folder in which the new datacenter should be created.
+    #     This  field  is currently required. In the future, if this  field  is  nil , the system will attempt to choose a suitable folder for the datacenter; if a folder cannot be chosen, the datacenter creation operation will fail.
+    class CreateSpec < VAPI::Bindings::VapiStruct
+      class << self
+        # Holds (gets or creates) the binding type metadata for this structure type.
+        # @scope class
+        # @return [VAPI::Bindings::StructType] the binding type
+        def binding_type
+          @binding_type ||= VAPI::Bindings::StructType.new(
+            'com.vmware.vcenter.datacenter.create_spec',
             {
-                'com.vmware.vapi.std.errors.invalid_argument' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::InvalidArgument'),
-                'com.vmware.vapi.std.errors.unable_to_allocate_resource' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::UnableToAllocateResource'),
-                'com.vmware.vapi.std.errors.service_unavailable' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::ServiceUnavailable'),
-                'com.vmware.vapi.std.errors.unauthenticated' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Unauthenticated'),
-                'com.vmware.vapi.std.errors.unauthorized' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Unauthorized'),
-
+              'name' => VAPI::Bindings::StringType.instance,
+              'folder' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::IdType.new)
             },
-            [],
-            [])
-        @@connect_info = VAPI::Bindings::OperationInfo.new(
-            VAPI::Core::OperationIdentifier.new('connect', @@service_id),
-            VAPI::Bindings::OperationInputType.new({
-                'host' => VAPI::Bindings::IdType.new(resource_types='HostSystem'),
-            }),
-            VAPI::Bindings::VoidType.instance,
+            CreateSpec,
+            false,
+            nil
+          )
+        end
+      end
+
+      attr_accessor :name,
+                    :folder
+
+      # Constructs a new instance.
+      # @param ruby_values [Hash] a map of initial property values (optional)
+      # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
+      def initialize(ruby_values = nil, struct_value = nil)
+        super(self.class.binding_type, ruby_values, struct_value)
+      end
+    end
+
+    # The  ``Com::Vmware::Vcenter::Datacenter::FilterSpec``   class  contains  fields  used to filter the results when listing datacenters (see   :func:`Com::Vmware::Vcenter::Datacenter.list`  ). If multiple  fields  are specified, only datacenters matching all of the  fields  match the filter.
+    # @!attribute [rw] datacenters
+    #     @return [Set<String>, nil]
+    #     Identifiers of datacenters that can match the filter.
+    #     If  nil  or empty, datacenters with any identifier match the filter.
+    # @!attribute [rw] names
+    #     @return [Set<String>, nil]
+    #     Names that datacenters must have to match the filter (see   :attr:`Com::Vmware::Vcenter::Datacenter::Info.name`  ).
+    #     If  nil  or empty, datacenters with any name match the filter.
+    # @!attribute [rw] folders
+    #     @return [Set<String>, nil]
+    #     Folders that must contain the datacenters for the datacenter to match the filter.
+    #     If  nil  or empty, datacenters in any folder match the filter.
+    class FilterSpec < VAPI::Bindings::VapiStruct
+      class << self
+        # Holds (gets or creates) the binding type metadata for this structure type.
+        # @scope class
+        # @return [VAPI::Bindings::StructType] the binding type
+        def binding_type
+          @binding_type ||= VAPI::Bindings::StructType.new(
+            'com.vmware.vcenter.datacenter.filter_spec',
             {
-                'com.vmware.vapi.std.errors.already_in_desired_state' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::AlreadyInDesiredState'),
-                'com.vmware.vapi.std.errors.error' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Error'),
-                'com.vmware.vapi.std.errors.not_found' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::NotFound'),
-                'com.vmware.vapi.std.errors.service_unavailable' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::ServiceUnavailable'),
-                'com.vmware.vapi.std.errors.unauthenticated' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Unauthenticated'),
-                'com.vmware.vapi.std.errors.unauthorized' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Unauthorized'),
-
+              'datacenters' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::SetType.new(VAPI::Bindings::IdType.new)),
+              'names' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::SetType.new(VAPI::Bindings::StringType.instance)),
+              'folders' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::SetType.new(VAPI::Bindings::IdType.new))
             },
-            [],
-            [])
-        @@disconnect_info = VAPI::Bindings::OperationInfo.new(
-            VAPI::Core::OperationIdentifier.new('disconnect', @@service_id),
-            VAPI::Bindings::OperationInputType.new({
-                'host' => VAPI::Bindings::IdType.new(resource_types='HostSystem'),
-            }),
-            VAPI::Bindings::VoidType.instance,
+            FilterSpec,
+            false,
+            nil
+          )
+        end
+      end
+
+      attr_accessor :datacenters,
+                    :names,
+                    :folders
+
+      # Constructs a new instance.
+      # @param ruby_values [Hash] a map of initial property values (optional)
+      # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
+      def initialize(ruby_values = nil, struct_value = nil)
+        super(self.class.binding_type, ruby_values, struct_value)
+      end
+    end
+
+    # The  ``Com::Vmware::Vcenter::Datacenter::Summary``   class  contains commonly used information about a datacenter in vCenter Server.
+    # @!attribute [rw] datacenter
+    #     @return [String]
+    #     Identifier of the datacenter.
+    # @!attribute [rw] name
+    #     @return [String]
+    #     Name of the datacenter.
+    class Summary < VAPI::Bindings::VapiStruct
+      class << self
+        # Holds (gets or creates) the binding type metadata for this structure type.
+        # @scope class
+        # @return [VAPI::Bindings::StructType] the binding type
+        def binding_type
+          @binding_type ||= VAPI::Bindings::StructType.new(
+            'com.vmware.vcenter.datacenter.summary',
             {
-                'com.vmware.vapi.std.errors.already_in_desired_state' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::AlreadyInDesiredState'),
-                'com.vmware.vapi.std.errors.error' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Error'),
-                'com.vmware.vapi.std.errors.not_found' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::NotFound'),
-                'com.vmware.vapi.std.errors.service_unavailable' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::ServiceUnavailable'),
-                'com.vmware.vapi.std.errors.unauthenticated' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Unauthenticated'),
-                'com.vmware.vapi.std.errors.unauthorized' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Unauthorized'),
-
+              'datacenter' => VAPI::Bindings::IdType.new('Datacenter'),
+              'name' => VAPI::Bindings::StringType.instance
             },
-            [],
-            [])
+            Summary,
+            false,
+            nil
+          )
+        end
+      end
 
-        @@service_info = VAPI::Bindings::ServiceInfo.new(@@service_id, {
-            'create' => @@create_info,
-            'delete' => @@delete_info,
-            'list' => @@list_info,
-            'connect' => @@connect_info,
-            'disconnect' => @@disconnect_info,
-        })
+      attr_accessor :datacenter,
+                    :name
 
-        public
+      # Constructs a new instance.
+      # @param ruby_values [Hash] a map of initial property values (optional)
+      # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
+      def initialize(ruby_values = nil, struct_value = nil)
+        super(self.class.binding_type, ruby_values, struct_value)
+      end
+    end
+
+    # The  ``Com::Vmware::Vcenter::Datacenter::Info``   class  contains information about a datacenter in vCenter Server.
+    # @!attribute [rw] name
+    #     @return [String]
+    #     The name of the datacenter.
+    # @!attribute [rw] datastore_folder
+    #     @return [String]
+    #     The root datastore folder associated with the datacenter.
+    # @!attribute [rw] host_folder
+    #     @return [String]
+    #     The root host and cluster folder associated with the datacenter.
+    # @!attribute [rw] network_folder
+    #     @return [String]
+    #     The root network folder associated with the datacenter.
+    # @!attribute [rw] vm_folder
+    #     @return [String]
+    #     The root virtual machine folder associated with the datacenter.
+    class Info < VAPI::Bindings::VapiStruct
+      class << self
+        # Holds (gets or creates) the binding type metadata for this structure type.
+        # @scope class
+        # @return [VAPI::Bindings::StructType] the binding type
+        def binding_type
+          @binding_type ||= VAPI::Bindings::StructType.new(
+            'com.vmware.vcenter.datacenter.info',
+            {
+              'name' => VAPI::Bindings::StringType.instance,
+              'datastore_folder' => VAPI::Bindings::IdType.new('Folder'),
+              'host_folder' => VAPI::Bindings::IdType.new('Folder'),
+              'network_folder' => VAPI::Bindings::IdType.new('Folder'),
+              'vm_folder' => VAPI::Bindings::IdType.new('Folder')
+            },
+            Info,
+            false,
+            nil
+          )
+        end
+      end
+
+      attr_accessor :name,
+                    :datastore_folder,
+                    :host_folder,
+                    :network_folder,
+                    :vm_folder
+
+      # Constructs a new instance.
+      # @param ruby_values [Hash] a map of initial property values (optional)
+      # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
+      def initialize(ruby_values = nil, struct_value = nil)
+        super(self.class.binding_type, ruby_values, struct_value)
+      end
+    end
+
+  end
+  # The  Datastore   class  provides  methods  for manipulating a datastore.
+  class Datastore < VAPI::Bindings::VapiService
+    # static metamodel definitions
+    SERVICE_ID = VAPI::Core::ServiceIdentifier.new('com.vmware.vcenter.datastore')
+
+    GET_INFO = VAPI::Bindings::OperationInfo.new(
+      VAPI::Core::OperationIdentifier.new('get', SERVICE_ID),
+      VAPI::Bindings::OperationInputType.new(
+        'datastore' => VAPI::Bindings::IdType.new('Datastore')
+      ),
+      VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::Datastore::Info'),
+      {
+        'com.vmware.vapi.std.errors.not_found' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::NotFound'),
+        'com.vmware.vapi.std.errors.service_unavailable' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::ServiceUnavailable'),
+        'com.vmware.vapi.std.errors.unauthenticated' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Unauthenticated'),
+        'com.vmware.vapi.std.errors.unauthorized' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Unauthorized')
+      },
+      [],
+      []
+    )
+
+    LIST_INFO = VAPI::Bindings::OperationInfo.new(
+      VAPI::Core::OperationIdentifier.new('list', SERVICE_ID),
+      VAPI::Bindings::OperationInputType.new(
+        'filter' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::Datastore::FilterSpec'))
+      ),
+      VAPI::Bindings::ListType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::Datastore::Summary')),
+      {
+        'com.vmware.vapi.std.errors.invalid_argument' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::InvalidArgument'),
+        'com.vmware.vapi.std.errors.unable_to_allocate_resource' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::UnableToAllocateResource'),
+        'com.vmware.vapi.std.errors.service_unavailable' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::ServiceUnavailable'),
+        'com.vmware.vapi.std.errors.unauthenticated' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Unauthenticated'),
+        'com.vmware.vapi.std.errors.unauthorized' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Unauthorized')
+      },
+      [],
+      []
+    )
+
+    SERVICE_INFO = VAPI::Bindings::ServiceInfo.new(
+      SERVICE_ID,
+      'get' => GET_INFO,
+      'list' => LIST_INFO
+    )
+
+    # Constructs a new instance.
+    #
+    # @param config [VAPI::Bindings::StubConfig] A hash with the api provider details.
+    def initialize(config)
+      super(config, SERVICE_INFO)
+    end
+
+    RESOURCE_TYPE = 'Datastore'
+    # Retrieves information about the datastore indicated by  ``datastore`` .
+    #
+    # @param datastore [String]
+    #     Identifier of the datastore for which information should be retrieved.
+    # @return [Com::Vmware::Vcenter::Datastore::Info]
+    #     information about the datastore.
+    # @raise [Com::Vmware::Vapi::Std::Errors::NotFound]
+    #     if the datastore indicated by  ``datastore``  does not exist.
+    # @raise [Com::Vmware::Vapi::Std::Errors::ServiceUnavailable]
+    #     if the system is unable to communicate with a service to complete the request.
+    # @raise [Com::Vmware::Vapi::Std::Errors::Unauthenticated]
+    #     if the user can not be authenticated.
+    # @raise [Com::Vmware::Vapi::Std::Errors::Unauthorized]
+    #     if the user doesn't have the required privileges.
+    def get(datastore)
+      invoke_with_info(GET_INFO,
+                       'datastore' => datastore)
+    end
+
+    # Returns information about at most 1000 visible (subject to permission checks) datastores in vCenter matching the   :class:`Com::Vmware::Vcenter::Datastore::FilterSpec`  .
+    #
+    # @param filter [Com::Vmware::Vcenter::Datastore::FilterSpec, nil]
+    #     Specification of matching datastores for which information should be returned.
+    #     If  nil , the behavior is equivalent to a   :class:`Com::Vmware::Vcenter::Datastore::FilterSpec`   with all  fields   nil  which means all datastores match the filter.
+    # @return [Array<Com::Vmware::Vcenter::Datastore::Summary>]
+    #     Commonly used information about the datastores matching the   :class:`Com::Vmware::Vcenter::Datastore::FilterSpec`  .
+    # @raise [Com::Vmware::Vapi::Std::Errors::InvalidArgument]
+    #     if the   :attr:`Com::Vmware::Vcenter::Datastore::FilterSpec.types`    field  contains a value that is not supported by the server.
+    # @raise [Com::Vmware::Vapi::Std::Errors::InvalidArgument]
+    #     if the   :attr:`Com::Vmware::Vcenter::Datastore::FilterSpec.types`    field  contains a value that is not supported by the server.
+    # @raise [Com::Vmware::Vapi::Std::Errors::UnableToAllocateResource]
+    #     if more than 1000 datastores match the   :class:`Com::Vmware::Vcenter::Datastore::FilterSpec`  .
+    # @raise [Com::Vmware::Vapi::Std::Errors::ServiceUnavailable]
+    #     if the system is unable to communicate with a service to complete the request.
+    # @raise [Com::Vmware::Vapi::Std::Errors::Unauthenticated]
+    #     if the user can not be authenticated.
+    # @raise [Com::Vmware::Vapi::Std::Errors::Unauthorized]
+    #     if the user doesn't have the required privileges.
+    def list(filter = nil)
+      invoke_with_info(LIST_INFO,
+                       'filter' => filter)
+    end
+
+    # The  ``Com::Vmware::Vcenter::Datastore::Info``   class  contains information about a datastore.
+    # @!attribute [rw] name
+    #     @return [String]
+    #     Name of the datastore.
+    # @!attribute [rw] type
+    #     @return [Com::Vmware::Vcenter::Datastore::Type]
+    #     Type ( ``VMFS``, ``NFS``, ``NFS41``, ``CIFS``, ``VSAN``, ``VFFS``, ``VVOL`` ) of the datastore.
+    # @!attribute [rw] accessible
+    #     @return [Boolean]
+    #     Whether or not this datastore is accessible.
+    # @!attribute [rw] free_space
+    #     @return [Fixnum, nil]
+    #     Available space of this datastore, in bytes.  
+    #     
+    #      The server periodically updates this value.
+    #     This  field  will be  nil  if the available space of this datastore is not known.
+    # @!attribute [rw] multiple_host_access
+    #     @return [Boolean]
+    #     Whether or not ore than one host in the datacenter has been configured with access to the datastore.
+    # @!attribute [rw] thin_provisioning_supported
+    #     @return [Boolean]
+    #     Whether or not the datastore supports thin provisioning on a per file basis. When thin provisioning is used, backing storage is lazily allocated.
+    class Info < VAPI::Bindings::VapiStruct
+      class << self
+        # Holds (gets or creates) the binding type metadata for this structure type.
+        # @scope class
+        # @return [VAPI::Bindings::StructType] the binding type
+        def binding_type
+          @binding_type ||= VAPI::Bindings::StructType.new(
+            'com.vmware.vcenter.datastore.info',
+            {
+              'name' => VAPI::Bindings::StringType.instance,
+              'type' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::Datastore::Type'),
+              'accessible' => VAPI::Bindings::BooleanType.instance,
+              'free_space' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::IntegerType.instance),
+              'multiple_host_access' => VAPI::Bindings::BooleanType.instance,
+              'thin_provisioning_supported' => VAPI::Bindings::BooleanType.instance
+            },
+            Info,
+            false,
+            nil
+          )
+        end
+      end
+
+      attr_accessor :name,
+                    :type,
+                    :accessible,
+                    :free_space,
+                    :multiple_host_access,
+                    :thin_provisioning_supported
+
+      # Constructs a new instance.
+      # @param ruby_values [Hash] a map of initial property values (optional)
+      # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
+      def initialize(ruby_values = nil, struct_value = nil)
+        super(self.class.binding_type, ruby_values, struct_value)
+      end
+    end
+
+    # The  ``Com::Vmware::Vcenter::Datastore::FilterSpec``   class  contains  fields  used to filter the results when listing datastores (see   :func:`Com::Vmware::Vcenter::Datastore.list`  ). If multiple  fields  are specified, only datastores matching all of the  fields  match the filter.
+    # @!attribute [rw] datastores
+    #     @return [Set<String>, nil]
+    #     Identifiers of datastores that can match the filter.
+    #     If  nil  or empty, datastores with any identifier match the filter.
+    # @!attribute [rw] names
+    #     @return [Set<String>, nil]
+    #     Names that datastores must have to match the filter (see   :attr:`Com::Vmware::Vcenter::Datastore::Info.name`  ).
+    #     If  nil  or empty, datastores with any name match the filter.
+    # @!attribute [rw] types
+    #     @return [Set<Com::Vmware::Vcenter::Datastore::Type>, nil]
+    #     Types that datastores must have to match the filter (see   :attr:`Com::Vmware::Vcenter::Datastore::Summary.type`  ).
+    #     If  nil  or empty, datastores with any type match the filter.
+    # @!attribute [rw] folders
+    #     @return [Set<String>, nil]
+    #     Folders that must contain the datastore for the datastore to match the filter.
+    #     If  nil  or empty, datastores in any folder match the filter.
+    # @!attribute [rw] datacenters
+    #     @return [Set<String>, nil]
+    #     Datacenters that must contain the datastore for the datastore to match the filter.
+    #     If  nil  or empty, datastores in any datacenter match the filter.
+    class FilterSpec < VAPI::Bindings::VapiStruct
+      class << self
+        # Holds (gets or creates) the binding type metadata for this structure type.
+        # @scope class
+        # @return [VAPI::Bindings::StructType] the binding type
+        def binding_type
+          @binding_type ||= VAPI::Bindings::StructType.new(
+            'com.vmware.vcenter.datastore.filter_spec',
+            {
+              'datastores' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::SetType.new(VAPI::Bindings::IdType.new)),
+              'names' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::SetType.new(VAPI::Bindings::StringType.instance)),
+              'types' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::SetType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::Datastore::Type'))),
+              'folders' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::SetType.new(VAPI::Bindings::IdType.new)),
+              'datacenters' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::SetType.new(VAPI::Bindings::IdType.new))
+            },
+            FilterSpec,
+            false,
+            nil
+          )
+        end
+      end
+
+      attr_accessor :datastores,
+                    :names,
+                    :types,
+                    :folders,
+                    :datacenters
+
+      # Constructs a new instance.
+      # @param ruby_values [Hash] a map of initial property values (optional)
+      # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
+      def initialize(ruby_values = nil, struct_value = nil)
+        super(self.class.binding_type, ruby_values, struct_value)
+      end
+    end
+
+    # The  ``Com::Vmware::Vcenter::Datastore::Summary``   class  contains commonly used information about a datastore.
+    # @!attribute [rw] datastore
+    #     @return [String]
+    #     Identifier of the datastore.
+    # @!attribute [rw] name
+    #     @return [String]
+    #     Name of the datastore.
+    # @!attribute [rw] type
+    #     @return [Com::Vmware::Vcenter::Datastore::Type]
+    #     Type ( ``VMFS``, ``NFS``, ``NFS41``, ``CIFS``, ``VSAN``, ``VFFS``, ``VVOL`` ) of the datatore.
+    # @!attribute [rw] free_space
+    #     @return [Fixnum, nil]
+    #     Available space of this datastore, in bytes.  
+    #     
+    #      The server periodically updates this value.
+    #     This  field  will be  nil  if the available space of this datastore is not known.
+    # @!attribute [rw] capacity
+    #     @return [Fixnum, nil]
+    #     Capacity of this datastore, in bytes.  
+    #     
+    #      The server periodically updates this value.
+    #     This  field  will be  nil  if the capacity of this datastore is not known.
+    class Summary < VAPI::Bindings::VapiStruct
+      class << self
+        # Holds (gets or creates) the binding type metadata for this structure type.
+        # @scope class
+        # @return [VAPI::Bindings::StructType] the binding type
+        def binding_type
+          @binding_type ||= VAPI::Bindings::StructType.new(
+            'com.vmware.vcenter.datastore.summary',
+            {
+              'datastore' => VAPI::Bindings::IdType.new('Datastore'),
+              'name' => VAPI::Bindings::StringType.instance,
+              'type' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::Datastore::Type'),
+              'free_space' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::IntegerType.instance),
+              'capacity' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::IntegerType.instance)
+            },
+            Summary,
+            false,
+            nil
+          )
+        end
+      end
+
+      attr_accessor :datastore,
+                    :name,
+                    :type,
+                    :free_space,
+                    :capacity
+
+      # Constructs a new instance.
+      # @param ruby_values [Hash] a map of initial property values (optional)
+      # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
+      def initialize(ruby_values = nil, struct_value = nil)
+        super(self.class.binding_type, ruby_values, struct_value)
+      end
+    end
+
+    # The  ``Com::Vmware::Vcenter::Datastore::Type``   enumerated type  defines the supported types of vCenter datastores.
+    # @!attribute [rw] vmfs
+    #     @return [Com::Vmware::Vcenter::Datastore::Type]
+    #     VMware File System (ESX Server only).
+    # @!attribute [rw] nfs
+    #     @return [Com::Vmware::Vcenter::Datastore::Type]
+    #     Network file system v3 (linux & esx servers only).
+    # @!attribute [rw] nf_s41
+    #     @return [Com::Vmware::Vcenter::Datastore::Type]
+    #     Network file system v4.1 (linux & esx servers only).
+    # @!attribute [rw] cifs
+    #     @return [Com::Vmware::Vcenter::Datastore::Type]
+    #     Common Internet File System.
+    # @!attribute [rw] vsan
+    #     @return [Com::Vmware::Vcenter::Datastore::Type]
+    #     Virtual SAN (ESX Server only).
+    # @!attribute [rw] vffs
+    #     @return [Com::Vmware::Vcenter::Datastore::Type]
+    #     Flash Read Cache (ESX Server only).
+    # @!attribute [rw] vvol
+    #     @return [Com::Vmware::Vcenter::Datastore::Type]
+    #     vSphere Virtual Volume (ESX Server only).
+    class Type < VAPI::Bindings::VapiEnum
+      class << self
+        # Holds (gets or creates) the binding type metadata for this enumeration type.
+        # @scope class
+        # @return [VAPI::Bindings::EnumType] the binding type
+        def binding_type
+          @binding_type ||= VAPI::Bindings::EnumType.new(
+            'com.vmware.vcenter.datastore.type',
+            Type
+          )
+        end
+
+        # Converts from a string value (perhaps off the wire) to an instance
+        # of this enum type.
+        # @param value [String] the actual value of the enum instance
+        # @return [Type] the instance found for the value, otherwise
+        #         an unknown instance will be built for the value
+        def from_string(value)
+          const_get(value)
+        rescue NameError
+          Type.send(:new, 'UNKNOWN', value)
+        end
+      end
+
+      # Constructs a new instance.
+      # @param value [String] the actual value of the enum instance
+      # @param unknown [String] the unknown value when value is 'UKNOWN'
+      def initialize(value, unknown = nil)
+        super(self.class.binding_type, value, unknown)
+      end
+
+      private_class_method :new
+
+      # @!attribute [rw] vmfs
+      #     @return [Com::Vmware::Vcenter::Datastore::Type]
+      #     VMware File System (ESX Server only).
+      VMFS = Type.send(:new, 'VMFS')
+
+      # @!attribute [rw] nfs
+      #     @return [Com::Vmware::Vcenter::Datastore::Type]
+      #     Network file system v3 (linux & esx servers only).
+      NFS = Type.send(:new, 'NFS')
+
+      # @!attribute [rw] nf_s41
+      #     @return [Com::Vmware::Vcenter::Datastore::Type]
+      #     Network file system v4.1 (linux & esx servers only).
+      NF_S41 = Type.send(:new, 'NF_S41')
+
+      # @!attribute [rw] cifs
+      #     @return [Com::Vmware::Vcenter::Datastore::Type]
+      #     Common Internet File System.
+      CIFS = Type.send(:new, 'CIFS')
+
+      # @!attribute [rw] vsan
+      #     @return [Com::Vmware::Vcenter::Datastore::Type]
+      #     Virtual SAN (ESX Server only).
+      VSAN = Type.send(:new, 'VSAN')
+
+      # @!attribute [rw] vffs
+      #     @return [Com::Vmware::Vcenter::Datastore::Type]
+      #     Flash Read Cache (ESX Server only).
+      VFFS = Type.send(:new, 'VFFS')
+
+      # @!attribute [rw] vvol
+      #     @return [Com::Vmware::Vcenter::Datastore::Type]
+      #     vSphere Virtual Volume (ESX Server only).
+      VVOL = Type.send(:new, 'VVOL')
+    end
+  end
+  # The  Folder   class  provides  methods  for manipulating a vCenter Server folder.
+  class Folder < VAPI::Bindings::VapiService
+    # static metamodel definitions
+    SERVICE_ID = VAPI::Core::ServiceIdentifier.new('com.vmware.vcenter.folder')
+
+    LIST_INFO = VAPI::Bindings::OperationInfo.new(
+      VAPI::Core::OperationIdentifier.new('list', SERVICE_ID),
+      VAPI::Bindings::OperationInputType.new(
+        'filter' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::Folder::FilterSpec'))
+      ),
+      VAPI::Bindings::ListType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::Folder::Summary')),
+      {
+        'com.vmware.vapi.std.errors.invalid_argument' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::InvalidArgument'),
+        'com.vmware.vapi.std.errors.unable_to_allocate_resource' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::UnableToAllocateResource'),
+        'com.vmware.vapi.std.errors.service_unavailable' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::ServiceUnavailable'),
+        'com.vmware.vapi.std.errors.unauthenticated' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Unauthenticated'),
+        'com.vmware.vapi.std.errors.unauthorized' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Unauthorized')
+      },
+      [],
+      []
+    )
+
+    SERVICE_INFO = VAPI::Bindings::ServiceInfo.new(
+      SERVICE_ID,
+      'list' => LIST_INFO
+    )
+
+    # Constructs a new instance.
+    #
+    # @param config [VAPI::Bindings::StubConfig] A hash with the api provider details.
+    def initialize(config)
+      super(config, SERVICE_INFO)
+    end
+
+    RESOURCE_TYPE = 'Folder'
+    # Returns information about at most 1000 visible (subject to permission checks) folders in vCenter matching the   :class:`Com::Vmware::Vcenter::Folder::FilterSpec`  .
+    #
+    # @param filter [Com::Vmware::Vcenter::Folder::FilterSpec, nil]
+    #     Specification of matching folders for which information should be returned.
+    #     If  nil , the behavior is equivalent to a   :class:`Com::Vmware::Vcenter::Folder::FilterSpec`   with all  fields   nil  which means all folders match the filter.
+    # @return [Array<Com::Vmware::Vcenter::Folder::Summary>]
+    #     Commonly used information about the folders matching the   :class:`Com::Vmware::Vcenter::Folder::FilterSpec`  .
+    # @raise [Com::Vmware::Vapi::Std::Errors::InvalidArgument]
+    #     if the   :attr:`Com::Vmware::Vcenter::Folder::FilterSpec.type`    field  contains a value that is not supported by the server.
+    # @raise [Com::Vmware::Vapi::Std::Errors::UnableToAllocateResource]
+    #     if more than 1000 folders match the   :class:`Com::Vmware::Vcenter::Folder::FilterSpec`  .
+    # @raise [Com::Vmware::Vapi::Std::Errors::ServiceUnavailable]
+    #     if the system is unable to communicate with a service to complete the request.
+    # @raise [Com::Vmware::Vapi::Std::Errors::Unauthenticated]
+    #     if the user can not be authenticated.
+    # @raise [Com::Vmware::Vapi::Std::Errors::Unauthorized]
+    #     if the user doesn't have the required privileges.
+    def list(filter = nil)
+      invoke_with_info(LIST_INFO,
+                       'filter' => filter)
+    end
+
+    # The  ``Com::Vmware::Vcenter::Folder::FilterSpec``   class  contains  fields  used to filter the results when listing folders (see   :func:`Com::Vmware::Vcenter::Folder.list`  ). If multiple  fields  are specified, only folders matching all of the  fields  match the filter.
+    # @!attribute [rw] folders
+    #     @return [Set<String>, nil]
+    #     Identifiers of folders that can match the filter.
+    #     If  nil  or empty, folders with any identifier match the filter.
+    # @!attribute [rw] names
+    #     @return [Set<String>, nil]
+    #     Names that folders must have to match the filter (see   :attr:`Com::Vmware::Vcenter::Folder::Summary.name`  ).
+    #     If  nil  or empty, folders with any name match the filter.
+    # @!attribute [rw] type
+    #     @return [Com::Vmware::Vcenter::Folder::Type, nil]
+    #     Type that folders must have to match the filter (see   :attr:`Com::Vmware::Vcenter::Folder::Summary.type`  ).
+    #     If  nil , folders with any type match the filter.
+    # @!attribute [rw] parent_folders
+    #     @return [Set<String>, nil]
+    #     Folders that must contain the folder for the folder to match the filter.
+    #     If  nil  or empty, folder in any folder match the filter.
+    # @!attribute [rw] datacenters
+    #     @return [Set<String>, nil]
+    #     Datacenters that must contain the folder for the folder to match the filter.
+    #     If  nil  or empty, folder in any datacenter match the filter.
+    class FilterSpec < VAPI::Bindings::VapiStruct
+      class << self
+        # Holds (gets or creates) the binding type metadata for this structure type.
+        # @scope class
+        # @return [VAPI::Bindings::StructType] the binding type
+        def binding_type
+          @binding_type ||= VAPI::Bindings::StructType.new(
+            'com.vmware.vcenter.folder.filter_spec',
+            {
+              'folders' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::SetType.new(VAPI::Bindings::IdType.new)),
+              'names' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::SetType.new(VAPI::Bindings::StringType.instance)),
+              'type' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::Folder::Type')),
+              'parent_folders' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::SetType.new(VAPI::Bindings::IdType.new)),
+              'datacenters' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::SetType.new(VAPI::Bindings::IdType.new))
+            },
+            FilterSpec,
+            false,
+            nil
+          )
+        end
+      end
+
+      attr_accessor :folders,
+                    :names,
+                    :type,
+                    :parent_folders,
+                    :datacenters
+
+      # Constructs a new instance.
+      # @param ruby_values [Hash] a map of initial property values (optional)
+      # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
+      def initialize(ruby_values = nil, struct_value = nil)
+        super(self.class.binding_type, ruby_values, struct_value)
+      end
+    end
+
+    # The  ``Com::Vmware::Vcenter::Folder::Summary``   class  contains commonly used information about a folder.
+    # @!attribute [rw] folder
+    #     @return [String]
+    #     Identifier of the folder.
+    # @!attribute [rw] name
+    #     @return [String]
+    #     Name of the vCenter Server folder.
+    # @!attribute [rw] type
+    #     @return [Com::Vmware::Vcenter::Folder::Type]
+    #     Type ( ``DATACENTER``, ``DATASTORE``, ``HOST``, ``NETWORK``, ``VIRTUAL_MACHINE`` ) of the vCenter Server folder.
+    class Summary < VAPI::Bindings::VapiStruct
+      class << self
+        # Holds (gets or creates) the binding type metadata for this structure type.
+        # @scope class
+        # @return [VAPI::Bindings::StructType] the binding type
+        def binding_type
+          @binding_type ||= VAPI::Bindings::StructType.new(
+            'com.vmware.vcenter.folder.summary',
+            {
+              'folder' => VAPI::Bindings::IdType.new('Folder'),
+              'name' => VAPI::Bindings::StringType.instance,
+              'type' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::Folder::Type')
+            },
+            Summary,
+            false,
+            nil
+          )
+        end
+      end
+
+      attr_accessor :folder,
+                    :name,
+                    :type
+
+      # Constructs a new instance.
+      # @param ruby_values [Hash] a map of initial property values (optional)
+      # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
+      def initialize(ruby_values = nil, struct_value = nil)
+        super(self.class.binding_type, ruby_values, struct_value)
+      end
+    end
+
+    # The  ``Com::Vmware::Vcenter::Folder::Type``   enumerated type  defines the type of a vCenter Server folder. The type of a folder determines what what kinds of children can be contained in the folder.
+    # @!attribute [rw] datacenter
+    #     @return [Com::Vmware::Vcenter::Folder::Type]
+    #     A folder that can contain datacenters.
+    # @!attribute [rw] datastore
+    #     @return [Com::Vmware::Vcenter::Folder::Type]
+    #     A folder that can contain datastores.
+    # @!attribute [rw] host
+    #     @return [Com::Vmware::Vcenter::Folder::Type]
+    #     A folder that can contain compute resources (hosts and clusters).
+    # @!attribute [rw] network
+    #     @return [Com::Vmware::Vcenter::Folder::Type]
+    #     A folder that can contain networkds.
+    # @!attribute [rw] virtual_machine
+    #     @return [Com::Vmware::Vcenter::Folder::Type]
+    #     A folder that can contain virtual machines.
+    class Type < VAPI::Bindings::VapiEnum
+      class << self
+        # Holds (gets or creates) the binding type metadata for this enumeration type.
+        # @scope class
+        # @return [VAPI::Bindings::EnumType] the binding type
+        def binding_type
+          @binding_type ||= VAPI::Bindings::EnumType.new(
+            'com.vmware.vcenter.folder.type',
+            Type
+          )
+        end
+
+        # Converts from a string value (perhaps off the wire) to an instance
+        # of this enum type.
+        # @param value [String] the actual value of the enum instance
+        # @return [Type] the instance found for the value, otherwise
+        #         an unknown instance will be built for the value
+        def from_string(value)
+          const_get(value)
+        rescue NameError
+          Type.send(:new, 'UNKNOWN', value)
+        end
+      end
+
+      # Constructs a new instance.
+      # @param value [String] the actual value of the enum instance
+      # @param unknown [String] the unknown value when value is 'UKNOWN'
+      def initialize(value, unknown = nil)
+        super(self.class.binding_type, value, unknown)
+      end
+
+      private_class_method :new
+
+      # @!attribute [rw] datacenter
+      #     @return [Com::Vmware::Vcenter::Folder::Type]
+      #     A folder that can contain datacenters.
+      DATACENTER = Type.send(:new, 'DATACENTER')
+
+      # @!attribute [rw] datastore
+      #     @return [Com::Vmware::Vcenter::Folder::Type]
+      #     A folder that can contain datastores.
+      DATASTORE = Type.send(:new, 'DATASTORE')
+
+      # @!attribute [rw] host
+      #     @return [Com::Vmware::Vcenter::Folder::Type]
+      #     A folder that can contain compute resources (hosts and clusters).
+      HOST = Type.send(:new, 'HOST')
+
+      # @!attribute [rw] network
+      #     @return [Com::Vmware::Vcenter::Folder::Type]
+      #     A folder that can contain networkds.
+      NETWORK = Type.send(:new, 'NETWORK')
+
+      # @!attribute [rw] virtual_machine
+      #     @return [Com::Vmware::Vcenter::Folder::Type]
+      #     A folder that can contain virtual machines.
+      VIRTUAL_MACHINE = Type.send(:new, 'VIRTUAL_MACHINE')
+    end
+  end
+  # The  ``Com::Vmware::Vcenter::Host``   class  provides  methods  to manage hosts in the vCenter Server.
+  class Host < VAPI::Bindings::VapiService
+    # static metamodel definitions
+    SERVICE_ID = VAPI::Core::ServiceIdentifier.new('com.vmware.vcenter.host')
+
+    CREATE_INFO = VAPI::Bindings::OperationInfo.new(
+      VAPI::Core::OperationIdentifier.new('create', SERVICE_ID),
+      VAPI::Bindings::OperationInputType.new(
+        'spec' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::Host::CreateSpec')
+      ),
+      VAPI::Bindings::IdType.new('HostSystem'),
+      {
+        'com.vmware.vapi.std.errors.already_exists' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::AlreadyExists'),
+        'com.vmware.vapi.std.errors.error' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Error'),
+        'com.vmware.vapi.std.errors.invalid_argument' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::InvalidArgument'),
+        'com.vmware.vapi.std.errors.invalid_element_type' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::InvalidElementType'),
+        'com.vmware.vapi.std.errors.resource_in_use' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::ResourceInUse'),
+        'com.vmware.vapi.std.errors.unable_to_allocate_resource' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::UnableToAllocateResource'),
+        'com.vmware.vapi.std.errors.unauthenticated' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Unauthenticated'),
+        'com.vmware.vapi.std.errors.unsupported' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Unsupported'),
+        'com.vmware.vapi.std.errors.service_unavailable' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::ServiceUnavailable'),
+        'com.vmware.vapi.std.errors.unauthorized' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Unauthorized')
+      },
+      [],
+      []
+    )
+
+    DELETE_INFO = VAPI::Bindings::OperationInfo.new(
+      VAPI::Core::OperationIdentifier.new('delete', SERVICE_ID),
+      VAPI::Bindings::OperationInputType.new(
+        'host' => VAPI::Bindings::IdType.new('HostSystem')
+      ),
+      VAPI::Bindings::VoidType.instance,
+      {
+        'com.vmware.vapi.std.errors.error' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Error'),
+        'com.vmware.vapi.std.errors.not_found' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::NotFound'),
+        'com.vmware.vapi.std.errors.resource_in_use' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::ResourceInUse'),
+        'com.vmware.vapi.std.errors.service_unavailable' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::ServiceUnavailable'),
+        'com.vmware.vapi.std.errors.unauthenticated' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Unauthenticated'),
+        'com.vmware.vapi.std.errors.unauthorized' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Unauthorized')
+      },
+      [],
+      []
+    )
+
+    LIST_INFO = VAPI::Bindings::OperationInfo.new(
+      VAPI::Core::OperationIdentifier.new('list', SERVICE_ID),
+      VAPI::Bindings::OperationInputType.new(
+        'filter' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::Host::FilterSpec'))
+      ),
+      VAPI::Bindings::ListType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::Host::Summary')),
+      {
+        'com.vmware.vapi.std.errors.invalid_argument' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::InvalidArgument'),
+        'com.vmware.vapi.std.errors.unable_to_allocate_resource' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::UnableToAllocateResource'),
+        'com.vmware.vapi.std.errors.service_unavailable' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::ServiceUnavailable'),
+        'com.vmware.vapi.std.errors.unauthenticated' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Unauthenticated'),
+        'com.vmware.vapi.std.errors.unauthorized' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Unauthorized')
+      },
+      [],
+      []
+    )
+
+    CONNECT_INFO = VAPI::Bindings::OperationInfo.new(
+      VAPI::Core::OperationIdentifier.new('connect', SERVICE_ID),
+      VAPI::Bindings::OperationInputType.new(
+        'host' => VAPI::Bindings::IdType.new('HostSystem')
+      ),
+      VAPI::Bindings::VoidType.instance,
+      {
+        'com.vmware.vapi.std.errors.already_in_desired_state' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::AlreadyInDesiredState'),
+        'com.vmware.vapi.std.errors.error' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Error'),
+        'com.vmware.vapi.std.errors.not_found' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::NotFound'),
+        'com.vmware.vapi.std.errors.service_unavailable' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::ServiceUnavailable'),
+        'com.vmware.vapi.std.errors.unauthenticated' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Unauthenticated'),
+        'com.vmware.vapi.std.errors.unauthorized' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Unauthorized')
+      },
+      [],
+      []
+    )
+
+    DISCONNECT_INFO = VAPI::Bindings::OperationInfo.new(
+      VAPI::Core::OperationIdentifier.new('disconnect', SERVICE_ID),
+      VAPI::Bindings::OperationInputType.new(
+        'host' => VAPI::Bindings::IdType.new('HostSystem')
+      ),
+      VAPI::Bindings::VoidType.instance,
+      {
+        'com.vmware.vapi.std.errors.already_in_desired_state' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::AlreadyInDesiredState'),
+        'com.vmware.vapi.std.errors.error' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Error'),
+        'com.vmware.vapi.std.errors.not_found' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::NotFound'),
+        'com.vmware.vapi.std.errors.service_unavailable' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::ServiceUnavailable'),
+        'com.vmware.vapi.std.errors.unauthenticated' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Unauthenticated'),
+        'com.vmware.vapi.std.errors.unauthorized' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Unauthorized')
+      },
+      [],
+      []
+    )
+
+    SERVICE_INFO = VAPI::Bindings::ServiceInfo.new(
+      SERVICE_ID,
+      'create' => CREATE_INFO,
+      'delete' => DELETE_INFO,
+      'list' => LIST_INFO,
+      'connect' => CONNECT_INFO,
+      'disconnect' => DISCONNECT_INFO
+    )
+
+    # Constructs a new instance.
+    #
+    # @param config [VAPI::Bindings::StubConfig] A hash with the api provider details.
+    def initialize(config)
+      super(config, SERVICE_INFO)
+    end
+
+    RESOURCE_TYPE = 'HostSystem'
+    # Add a new standalone host in the vCenter inventory. The newly connected host will be in connected state. The vCenter Server will verify the SSL certificate before adding the host to its inventory. In the case where the SSL certificate cannot be verified because the Certificate Authority is not recognized or the certificate is self signed, the vCenter Server will fall back to thumbprint verification mode as defined by   :class:`Com::Vmware::Vcenter::Host::CreateSpec::ThumbprintVerification`  .
+    #
+    # @param spec [Com::Vmware::Vcenter::Host::CreateSpec]
+    #     Specification for the new host to be created.
+    # @return [String]
+    #     The newly created identifier of the host in vCenter.
+    # @raise [Com::Vmware::Vapi::Std::Errors::AlreadyExists]
+    #     if the host with the same name is already present.
+    # @raise [Com::Vmware::Vapi::Std::Errors::Error]
+    #     if installation of VirtualCenter agent on a host fails.
+    # @raise [Com::Vmware::Vapi::Std::Errors::Error]
+    #     if the system reports an error while responding to the request.
+    # @raise [Com::Vmware::Vapi::Std::Errors::InvalidArgument]
+    #     if the host name is invalid.
+    # @raise [Com::Vmware::Vapi::Std::Errors::InvalidArgument]
+    #     if the host folder is invalid.
+    # @raise [Com::Vmware::Vapi::Std::Errors::InvalidArgument]
+    #     if the SSL thumbprint specified is invalid.
+    # @raise [Com::Vmware::Vapi::Std::Errors::InvalidElementType]
+    #     if the host folder id does not support vSphere compute resource as its children type.
+    # @raise [Com::Vmware::Vapi::Std::Errors::ResourceInUse]
+    #     if the host is already being managed by another vCenter Server
+    # @raise [Com::Vmware::Vapi::Std::Errors::UnableToAllocateResource]
+    #     if there are not enough licenses to add the host.
+    # @raise [Com::Vmware::Vapi::Std::Errors::Unauthenticated]
+    #     if the user name or password for the administration account on the host are invalid.
+    # @raise [Com::Vmware::Vapi::Std::Errors::Unauthenticated]
+    #     if the user can not be authenticated.
+    # @raise [Com::Vmware::Vapi::Std::Errors::Unsupported]
+    #     if the software version on the host is not supported.
+    # @raise [Com::Vmware::Vapi::Std::Errors::ServiceUnavailable]
+    #     if the system is unable to communicate with a service to complete the request.
+    # @raise [Com::Vmware::Vapi::Std::Errors::Unauthorized]
+    #     if the user doesn't have the required privileges.
+    def create(spec)
+      invoke_with_info(CREATE_INFO,
+                       'spec' => spec)
+    end
+
+    # Remove a standalone host from the vCenter Server.
+    #
+    # @param host [String]
+    #     Identifier of the host to be deleted.
+    # @return [Void]
+    # @raise [Com::Vmware::Vapi::Std::Errors::Error]
+    #     if the system reports an error while responding to the request.
+    # @raise [Com::Vmware::Vapi::Std::Errors::NotFound]
+    #     if there is no host associated with  ``host``  in the system.
+    # @raise [Com::Vmware::Vapi::Std::Errors::ResourceInUse]
+    #     if the host associated with  ``host``  is in a vCenter cluster
+    # @raise [Com::Vmware::Vapi::Std::Errors::ServiceUnavailable]
+    #     if the system is unable to communicate with a service to complete the request.
+    # @raise [Com::Vmware::Vapi::Std::Errors::Unauthenticated]
+    #     if the user can not be authenticated.
+    # @raise [Com::Vmware::Vapi::Std::Errors::Unauthorized]
+    #     if the user doesn't have the required privileges.
+    def delete(host)
+      invoke_with_info(DELETE_INFO,
+                       'host' => host)
+    end
+
+    # Returns information about at most 1000 visible (subject to permission checks) hosts in vCenter matching the   :class:`Com::Vmware::Vcenter::Host::FilterSpec`  .
+    #
+    # @param filter [Com::Vmware::Vcenter::Host::FilterSpec, nil]
+    #     Specification of matching hosts for which information should be returned.
+    #     If  nil , the behavior is equivalent to a   :class:`Com::Vmware::Vcenter::Host::FilterSpec`   with all  fields   nil  which means all hosts match the filter.
+    # @return [Array<Com::Vmware::Vcenter::Host::Summary>]
+    #     Commonly used information about the hosts matching the   :class:`Com::Vmware::Vcenter::Host::FilterSpec`  .
+    # @raise [Com::Vmware::Vapi::Std::Errors::InvalidArgument]
+    #     if the   :attr:`Com::Vmware::Vcenter::Host::FilterSpec.connection_states`    field  contains a value that is not supported by the server.
+    # @raise [Com::Vmware::Vapi::Std::Errors::UnableToAllocateResource]
+    #     if more than 1000 hosts match the   :class:`Com::Vmware::Vcenter::Host::FilterSpec`  .
+    # @raise [Com::Vmware::Vapi::Std::Errors::ServiceUnavailable]
+    #     if the system is unable to communicate with a service to complete the request.
+    # @raise [Com::Vmware::Vapi::Std::Errors::Unauthenticated]
+    #     if the user can not be authenticated.
+    # @raise [Com::Vmware::Vapi::Std::Errors::Unauthorized]
+    #     if the user doesn't have the required privileges.
+    def list(filter = nil)
+      invoke_with_info(LIST_INFO,
+                       'filter' => filter)
+    end
+
+    # Connect to the host corresponding to  ``host``  previously added to the vCenter server.
+    #
+    # @param host [String]
+    #     Identifier of the host to be reconnected.
+    # @return [Void]
+    # @raise [Com::Vmware::Vapi::Std::Errors::AlreadyInDesiredState]
+    #     if the host associated with  ``host``  is already connected.
+    # @raise [Com::Vmware::Vapi::Std::Errors::Error]
+    #     if the system reports an error while responding to the request.
+    # @raise [Com::Vmware::Vapi::Std::Errors::NotFound]
+    #     if there is no host associated with  ``host``  in the system.
+    # @raise [Com::Vmware::Vapi::Std::Errors::ServiceUnavailable]
+    #     if the system is unable to communicate with a service to complete the request.
+    # @raise [Com::Vmware::Vapi::Std::Errors::Unauthenticated]
+    #     if the user can not be authenticated.
+    # @raise [Com::Vmware::Vapi::Std::Errors::Unauthorized]
+    #     if the user doesn't have the required privileges.
+    def connect(host)
+      invoke_with_info(CONNECT_INFO,
+                       'host' => host)
+    end
+
+    # Disconnect the host corresponding to  ``host``  from the vCenter server
+    #
+    # @param host [String]
+    #     Identifier of the host to be disconnected.
+    # @return [Void]
+    # @raise [Com::Vmware::Vapi::Std::Errors::AlreadyInDesiredState]
+    #     if the host associated with  ``host``  is already disconnected.
+    # @raise [Com::Vmware::Vapi::Std::Errors::Error]
+    #     if the system reports an error while responding to the request.
+    # @raise [Com::Vmware::Vapi::Std::Errors::NotFound]
+    #     if there is no host associated with  ``host``  in the system.
+    # @raise [Com::Vmware::Vapi::Std::Errors::ServiceUnavailable]
+    #     if the system is unable to communicate with a service to complete the request.
+    # @raise [Com::Vmware::Vapi::Std::Errors::Unauthenticated]
+    #     if the user can not be authenticated.
+    # @raise [Com::Vmware::Vapi::Std::Errors::Unauthorized]
+    #     if the user doesn't have the required privileges.
+    def disconnect(host)
+      invoke_with_info(DISCONNECT_INFO,
+                       'host' => host)
+    end
+
+    # The  ``Com::Vmware::Vcenter::Host::CreateSpec``   class  defines the information used to create a host.
+    # @!attribute [rw] hostname
+    #     @return [String]
+    #     The IP address or DNS resolvable name of the host.
+    # @!attribute [rw] port
+    #     @return [Fixnum, nil]
+    #     The port of the host.
+    #     If  nil , port 443 will be used.
+    # @!attribute [rw] user_name
+    #     @return [String]
+    #     The administrator account on the host.
+    # @!attribute [rw] password
+    #     @return [String]
+    #     The password for the administrator account on the host.
+    # @!attribute [rw] folder
+    #     @return [String, nil]
+    #     Host and cluster folder in which the new standalone host should be created.
+    #     This  field  is currently required. In the future, if this  field  is  nil , the system will attempt to choose a suitable folder for the host; if a folder cannot be chosen, the host creation operation will fail.
+    # @!attribute [rw] thumbprint_verification
+    #     @return [Com::Vmware::Vcenter::Host::CreateSpec::ThumbprintVerification]
+    #     Type of host's SSL certificate verification to be done.
+    # @!attribute [rw] thumbprint
+    #     @return [String]
+    #     The thumbprint of the SSL certificate, which the host is expected to have. The thumbprint is always computed using the SHA1 hash and is the string representation of that hash in the format: xx:xx:xx:xx:xx:xx:xx:xx:xx:xx:xx:xx:xx:xx:xx:xx:xx:xx:xx:xx where, 'x' represents a hexadecimal digit.
+    #     This  field  is optional and it is only relevant when the value of  ``thumbprintVerification``  is   :attr:`Com::Vmware::Vcenter::Host::CreateSpec::ThumbprintVerification.THUMBPRINT`  .
+    # @!attribute [rw] force_add
+    #     @return [Boolean, nil]
+    #     Whether host should be added to the vCenter Server even if it is being managed by another vCenter Server. The original vCenterServer loses connection to the host.
+    #     If  nil , forceAdd is default to false.
+    class CreateSpec < VAPI::Bindings::VapiStruct
+      class << self
+        # Holds (gets or creates) the binding type metadata for this structure type.
+        # @scope class
+        # @return [VAPI::Bindings::StructType] the binding type
+        def binding_type
+          @binding_type ||= VAPI::Bindings::StructType.new(
+            'com.vmware.vcenter.host.create_spec',
+            {
+              'hostname' => VAPI::Bindings::StringType.instance,
+              'port' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::IntegerType.instance),
+              'user_name' => VAPI::Bindings::StringType.instance,
+              'password' => VAPI::Bindings::SecretType.instance,
+              'folder' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::IdType.new),
+              'thumbprint_verification' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::Host::CreateSpec::ThumbprintVerification'),
+              'thumbprint' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::StringType.instance),
+              'force_add' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::BooleanType.instance)
+            },
+            CreateSpec,
+            false,
+            nil
+          )
+        end
+      end
+
+      attr_accessor :hostname,
+                    :port,
+                    :user_name,
+                    :password,
+                    :folder,
+                    :thumbprint_verification,
+                    :thumbprint,
+                    :force_add
+
+      # Constructs a new instance.
+      # @param ruby_values [Hash] a map of initial property values (optional)
+      # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
+      def initialize(ruby_values = nil, struct_value = nil)
+        super(self.class.binding_type, ruby_values, struct_value)
+      end
+
+      # The  ``Com::Vmware::Vcenter::Host::CreateSpec::ThumbprintVerification``   enumerated type  defines the thumbprint verification schemes for a host's SSL certificate.
+      # @!attribute [rw] none
+      #     @return [Com::Vmware::Vcenter::Host::CreateSpec::ThumbprintVerification]
+      #     Accept the host's thumbprint without verifying it.
+      # @!attribute [rw] thumbprint
+      #     @return [Com::Vmware::Vcenter::Host::CreateSpec::ThumbprintVerification]
+      #     Host's SSL certificate verified by checking its thumbprint against the specified thumbprint.
+      class ThumbprintVerification < VAPI::Bindings::VapiEnum
+        class << self
+          # Holds (gets or creates) the binding type metadata for this enumeration type.
+          # @scope class
+          # @return [VAPI::Bindings::EnumType] the binding type
+          def binding_type
+            @binding_type ||= VAPI::Bindings::EnumType.new(
+              'com.vmware.vcenter.host.create_spec.thumbprint_verification',
+              ThumbprintVerification
+            )
+          end
+
+          # Converts from a string value (perhaps off the wire) to an instance
+          # of this enum type.
+          # @param value [String] the actual value of the enum instance
+          # @return [ThumbprintVerification] the instance found for the value, otherwise
+          #         an unknown instance will be built for the value
+          def from_string(value)
+            const_get(value)
+          rescue NameError
+            ThumbprintVerification.send(:new, 'UNKNOWN', value)
+          end
+        end
 
         # Constructs a new instance.
-        #
-        # @param config [VAPI::Bindings::StubConfig] A hash with the api provider details.
-        def initialize(config)
-            super(config, @@service_info)
+        # @param value [String] the actual value of the enum instance
+        # @param unknown [String] the unknown value when value is 'UKNOWN'
+        def initialize(value, unknown = nil)
+          super(self.class.binding_type, value, unknown)
         end
 
-        RESOURCE_TYPE = 'HostSystem'
+        private_class_method :new
 
-
-        # Add a new standalone host in the vCenter inventory. The newly connected host will be in connected state. The vCenter Server will verify the SSL certificate before adding the host to its inventory. In the case where the SSL certificate cannot be verified because the Certificate Authority is not recognized or the certificate is self signed, the vCenter Server will fall back to thumbprint verification mode as defined by   :class:`Com::Vmware::Vcenter::Host::CreateSpec::ThumbprintVerification`  .
-        #
-        # @param spec [Com::Vmware::Vcenter::Host::CreateSpec]
-        #     Specification for the new host to be created.
-        # @return [String]
-        #     The newly created identifier of the host in vCenter.
-        # @raise [Com::Vmware::Vapi::Std::Errors::AlreadyExists]
-        #     if the host with the same name is already present.
-        # @raise [Com::Vmware::Vapi::Std::Errors::Error]
-        #     if installation of VirtualCenter agent on a host fails.
-        # @raise [Com::Vmware::Vapi::Std::Errors::Error]
-        #     if the system reports an error while responding to the request.
-        # @raise [Com::Vmware::Vapi::Std::Errors::InvalidArgument]
-        #     if the host name is invalid.
-        # @raise [Com::Vmware::Vapi::Std::Errors::InvalidArgument]
-        #     if the host folder is invalid.
-        # @raise [Com::Vmware::Vapi::Std::Errors::InvalidArgument]
-        #     if the SSL thumbprint specified is invalid.
-        # @raise [Com::Vmware::Vapi::Std::Errors::InvalidElementType]
-        #     if the host folder id does not support vSphere compute resource as its children type.
-        # @raise [Com::Vmware::Vapi::Std::Errors::ResourceInUse]
-        #     if the host is already being managed by another vCenter Server
-        # @raise [Com::Vmware::Vapi::Std::Errors::UnableToAllocateResource]
-        #     if there are not enough licenses to add the host.
-        # @raise [Com::Vmware::Vapi::Std::Errors::Unauthenticated]
-        #     if the user name or password for the administration account on the host are invalid.
-        # @raise [Com::Vmware::Vapi::Std::Errors::Unauthenticated]
-        #     if the user can not be authenticated.
-        # @raise [Com::Vmware::Vapi::Std::Errors::Unsupported]
-        #     if the software version on the host is not supported.
-        # @raise [Com::Vmware::Vapi::Std::Errors::ServiceUnavailable]
-        #     if the system is unable to communicate with a service to complete the request.
-        # @raise [Com::Vmware::Vapi::Std::Errors::Unauthorized]
-        #     if the user doesn't have the required privileges.
-        def create(spec)
-            invoke_with_info(@@create_info, {
-                'spec' => spec,
-            })
-        end
-
-
-        # Remove a standalone host from the vCenter Server.
-        #
-        # @param host [String]
-        #     Identifier of the host to be deleted.
-        # @return [Void]
-        # @raise [Com::Vmware::Vapi::Std::Errors::Error]
-        #     if the system reports an error while responding to the request.
-        # @raise [Com::Vmware::Vapi::Std::Errors::NotFound]
-        #     if there is no host associated with  ``host``  in the system.
-        # @raise [Com::Vmware::Vapi::Std::Errors::ResourceInUse]
-        #     if the host associated with  ``host``  is in a vCenter cluster
-        # @raise [Com::Vmware::Vapi::Std::Errors::ServiceUnavailable]
-        #     if the system is unable to communicate with a service to complete the request.
-        # @raise [Com::Vmware::Vapi::Std::Errors::Unauthenticated]
-        #     if the user can not be authenticated.
-        # @raise [Com::Vmware::Vapi::Std::Errors::Unauthorized]
-        #     if the user doesn't have the required privileges.
-        def delete(host)
-            invoke_with_info(@@delete_info, {
-                'host' => host,
-            })
-        end
-
-
-        # Returns information about at most 1000 visible (subject to permission checks) hosts in vCenter matching the   :class:`Com::Vmware::Vcenter::Host::FilterSpec`  .
-        #
-        # @param filter [Com::Vmware::Vcenter::Host::FilterSpec, nil]
-        #     Specification of matching hosts for which information should be returned.
-        #     If  nil , the behavior is equivalent to a   :class:`Com::Vmware::Vcenter::Host::FilterSpec`   with all  fields   nil  which means all hosts match the filter.
-        # @return [Array<Com::Vmware::Vcenter::Host::Summary>]
-        #     Commonly used information about the hosts matching the   :class:`Com::Vmware::Vcenter::Host::FilterSpec`  .
-        # @raise [Com::Vmware::Vapi::Std::Errors::InvalidArgument]
-        #     if the   :attr:`Com::Vmware::Vcenter::Host::FilterSpec.connection_states`    field  contains a value that is not supported by the server.
-        # @raise [Com::Vmware::Vapi::Std::Errors::UnableToAllocateResource]
-        #     if more than 1000 hosts match the   :class:`Com::Vmware::Vcenter::Host::FilterSpec`  .
-        # @raise [Com::Vmware::Vapi::Std::Errors::ServiceUnavailable]
-        #     if the system is unable to communicate with a service to complete the request.
-        # @raise [Com::Vmware::Vapi::Std::Errors::Unauthenticated]
-        #     if the user can not be authenticated.
-        # @raise [Com::Vmware::Vapi::Std::Errors::Unauthorized]
-        #     if the user doesn't have the required privileges.
-        def list(filter=nil)
-            invoke_with_info(@@list_info, {
-                'filter' => filter,
-            })
-        end
-
-
-        # Connect to the host corresponding to  ``host``  previously added to the vCenter server.
-        #
-        # @param host [String]
-        #     Identifier of the host to be reconnected.
-        # @return [Void]
-        # @raise [Com::Vmware::Vapi::Std::Errors::AlreadyInDesiredState]
-        #     if the host associated with  ``host``  is already connected.
-        # @raise [Com::Vmware::Vapi::Std::Errors::Error]
-        #     if the system reports an error while responding to the request.
-        # @raise [Com::Vmware::Vapi::Std::Errors::NotFound]
-        #     if there is no host associated with  ``host``  in the system.
-        # @raise [Com::Vmware::Vapi::Std::Errors::ServiceUnavailable]
-        #     if the system is unable to communicate with a service to complete the request.
-        # @raise [Com::Vmware::Vapi::Std::Errors::Unauthenticated]
-        #     if the user can not be authenticated.
-        # @raise [Com::Vmware::Vapi::Std::Errors::Unauthorized]
-        #     if the user doesn't have the required privileges.
-        def connect(host)
-            invoke_with_info(@@connect_info, {
-                'host' => host,
-            })
-        end
-
-
-        # Disconnect the host corresponding to  ``host``  from the vCenter server
-        #
-        # @param host [String]
-        #     Identifier of the host to be disconnected.
-        # @return [Void]
-        # @raise [Com::Vmware::Vapi::Std::Errors::AlreadyInDesiredState]
-        #     if the host associated with  ``host``  is already disconnected.
-        # @raise [Com::Vmware::Vapi::Std::Errors::Error]
-        #     if the system reports an error while responding to the request.
-        # @raise [Com::Vmware::Vapi::Std::Errors::NotFound]
-        #     if there is no host associated with  ``host``  in the system.
-        # @raise [Com::Vmware::Vapi::Std::Errors::ServiceUnavailable]
-        #     if the system is unable to communicate with a service to complete the request.
-        # @raise [Com::Vmware::Vapi::Std::Errors::Unauthenticated]
-        #     if the user can not be authenticated.
-        # @raise [Com::Vmware::Vapi::Std::Errors::Unauthorized]
-        #     if the user doesn't have the required privileges.
-        def disconnect(host)
-            invoke_with_info(@@disconnect_info, {
-                'host' => host,
-            })
-        end
-
-
-
-        # The  ``Com::Vmware::Vcenter::Host::CreateSpec``   class  defines the information used to create a host.
-        # @!attribute [rw] hostname
-        #     @return [String]
-        #     The IP address or DNS resolvable name of the host.
-        # @!attribute [rw] port
-        #     @return [Fixnum, nil]
-        #     The port of the host.
-        #     If  nil , port 443 will be used.
-        # @!attribute [rw] user_name
-        #     @return [String]
-        #     The administrator account on the host.
-        # @!attribute [rw] password
-        #     @return [String]
-        #     The password for the administrator account on the host.
-        # @!attribute [rw] folder
-        #     @return [String, nil]
-        #     Host and cluster folder in which the new standalone host should be created.
-        #     This  field  is currently required. In the future, if this  field  is  nil , the system will attempt to choose a suitable folder for the host; if a folder cannot be chosen, the host creation operation will fail.
-        # @!attribute [rw] thumbprint_verification
+        # @!attribute [rw] none
         #     @return [Com::Vmware::Vcenter::Host::CreateSpec::ThumbprintVerification]
-        #     Type of host's SSL certificate verification to be done.
+        #     Accept the host's thumbprint without verifying it.
+        NONE = ThumbprintVerification.send(:new, 'NONE')
+
         # @!attribute [rw] thumbprint
-        #     @return [String]
-        #     The thumbprint of the SSL certificate, which the host is expected to have. The thumbprint is always computed using the SHA1 hash and is the string representation of that hash in the format: xx:xx:xx:xx:xx:xx:xx:xx:xx:xx:xx:xx:xx:xx:xx:xx:xx:xx:xx:xx where, 'x' represents a hexadecimal digit.
-        #     This  field  is optional and it is only relevant when the value of  ``thumbprintVerification``  is   :attr:`Com::Vmware::Vcenter::Host::CreateSpec::ThumbprintVerification.THUMBPRINT`  .
-        # @!attribute [rw] force_add
-        #     @return [Boolean, nil]
-        #     Whether host should be added to the vCenter Server even if it is being managed by another vCenter Server. The original vCenterServer loses connection to the host.
-        #     If  nil , forceAdd is default to false.
-        class CreateSpec < VAPI::Bindings::VapiStruct
-
-            class << self
-                # Holds (gets or creates) the binding type metadata for this structure type.
-                # @scope class
-                # @return [VAPI::Bindings::StructType] the binding type
-                def binding_type
-                    @binding_type ||= VAPI::Bindings::StructType.new(
-                        'com.vmware.vcenter.host.create_spec',
-                        {
-                            'hostname' => VAPI::Bindings::StringType.instance,
-                            'port' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::IntegerType.instance),
-                            'user_name' => VAPI::Bindings::StringType.instance,
-                            'password' => VAPI::Bindings::SecretType.instance,
-                            'folder' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::IdType.new),
-                            'thumbprint_verification' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::Host::CreateSpec::ThumbprintVerification'),
-                            'thumbprint' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::StringType.instance),
-                            'force_add' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::BooleanType.instance),
-                        },
-                        CreateSpec,
-                        false,
-                        nil)
-                end
-            end
-
-            attr_accessor :hostname,
-                          :port,
-                          :user_name,
-                          :password,
-                          :folder,
-                          :thumbprint_verification,
-                          :thumbprint,
-                          :force_add
-
-            # Constructs a new instance.
-            # @param ruby_values [Hash] a map of initial property values (optional)
-            # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
-            def initialize(ruby_values=nil, struct_value=nil)
-                super(self.class.binding_type, ruby_values, struct_value)
-            end
-
-
-            # The  ``Com::Vmware::Vcenter::Host::CreateSpec::ThumbprintVerification``   enumerated type  defines the thumbprint verification schemes for a host's SSL certificate.
-            # @!attribute [rw] none
-            #     @return [Com::Vmware::Vcenter::Host::CreateSpec::ThumbprintVerification]
-            #     Accept the host's thumbprint without verifying it.
-            # @!attribute [rw] thumbprint
-            #     @return [Com::Vmware::Vcenter::Host::CreateSpec::ThumbprintVerification]
-            #     Host's SSL certificate verified by checking its thumbprint against the specified thumbprint.
-            class ThumbprintVerification < VAPI::Bindings::VapiEnum
-
-                class << self
-                    # Holds (gets or creates) the binding type metadata for this enumeration type.
-                    # @scope class
-                    # @return [VAPI::Bindings::EnumType] the binding type
-                    def binding_type
-                        @binding_type ||= VAPI::Bindings::EnumType.new(
-                            'com.vmware.vcenter.host.create_spec.thumbprint_verification',
-                            ThumbprintVerification)
-                    end
-
-                    # Converts from a string value (perhaps off the wire) to an instance
-                    # of this enum type.
-                    # @param value [String] the actual value of the enum instance
-                    # @return [ThumbprintVerification] the instance found for the value, otherwise
-                    #         an unknown instance will be built for the value
-                    def from_string(value)
-                        begin
-                            const_get(value)
-                        rescue NameError
-                            ThumbprintVerification.new('UNKNOWN', value)
-                        end
-                    end
-                end
-
-                private
-
-                # Constructs a new instance.
-                # @param value [String] the actual value of the enum instance
-                # @param unknown [String] the unknown value when value is 'UKNOWN'
-                def initialize(value, unknown=nil)
-                    super(self.class.binding_type, value, unknown)
-                end
-
-                public
-
-                # @!attribute [rw] none
-                #     @return [Com::Vmware::Vcenter::Host::CreateSpec::ThumbprintVerification]
-                #     Accept the host's thumbprint without verifying it.
-                NONE = ThumbprintVerification.new('NONE')
-
-                # @!attribute [rw] thumbprint
-                #     @return [Com::Vmware::Vcenter::Host::CreateSpec::ThumbprintVerification]
-                #     Host's SSL certificate verified by checking its thumbprint against the specified thumbprint.
-                THUMBPRINT = ThumbprintVerification.new('THUMBPRINT')
-
-            end
-
-
-        end
-
-
-        # The  ``Com::Vmware::Vcenter::Host::FilterSpec``   class  contains  fields  used to filter the results when listing hosts (see   :func:`Com::Vmware::Vcenter::Host.list`  ). If multiple  fields  are specified, only hosts matching all of the  fields  match the filter.
-        # @!attribute [rw] hosts
-        #     @return [Set<String>, nil]
-        #     Identifiers of hosts that can match the filter.
-        #     If  nil  or empty, hosts with any identifier match the filter.
-        # @!attribute [rw] names
-        #     @return [Set<String>, nil]
-        #     Names that hosts must have to match the filter (see   :attr:`Com::Vmware::Vcenter::Host::Summary.name`  ).
-        #     If  nil  or empty, hosts with any name match the filter.
-        # @!attribute [rw] folders
-        #     @return [Set<String>, nil]
-        #     Folders that must contain the hosts for the hosts to match the filter.
-        #     If  nil  or empty, hosts in any folder match the filter.
-        # @!attribute [rw] datacenters
-        #     @return [Set<String>, nil]
-        #     Datacenters that must contain the hosts for the hosts to match the filter.
-        #     If  nil  or empty, hosts in any datacenter match the filter.
-        # @!attribute [rw] standalone
-        #     @return [Boolean, nil]
-        #     If true, only hosts that are not part of a cluster can match the filter, and if false, only hosts that are are part of a cluster can match the filter.
-        #     If  nil  Hosts can match filter independent of whether they are part of a cluster or not. If this field is true and   :attr:`Com::Vmware::Vcenter::Host::FilterSpec.clusters`   os not empty, no hosts will match the filter.
-        # @!attribute [rw] clusters
-        #     @return [Set<String>, nil]
-        #     Clusters that must contain the hosts for the hosts to match the filter.
-        #     If  nil  or empty, hosts in any cluster and hosts that are not in a cluster match the filter. If this  field  is not empty and   :attr:`Com::Vmware::Vcenter::Host::FilterSpec.standalone`   is true, no hosts will match the filter.
-        # @!attribute [rw] connection_states
-        #     @return [Set<Com::Vmware::Vcenter::Host::ConnectionState>, nil]
-        #     Connection states that a host must be in to match the filter (see   :attr:`Com::Vmware::Vcenter::Host::Summary.connection_state`  .
-        #     If  nil  or empty, hosts in any connection state match the filter.
-        class FilterSpec < VAPI::Bindings::VapiStruct
-
-            class << self
-                # Holds (gets or creates) the binding type metadata for this structure type.
-                # @scope class
-                # @return [VAPI::Bindings::StructType] the binding type
-                def binding_type
-                    @binding_type ||= VAPI::Bindings::StructType.new(
-                        'com.vmware.vcenter.host.filter_spec',
-                        {
-                            'hosts' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::SetType.new(VAPI::Bindings::IdType.new)),
-                            'names' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::SetType.new(VAPI::Bindings::StringType.instance)),
-                            'folders' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::SetType.new(VAPI::Bindings::IdType.new)),
-                            'datacenters' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::SetType.new(VAPI::Bindings::IdType.new)),
-                            'standalone' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::BooleanType.instance),
-                            'clusters' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::SetType.new(VAPI::Bindings::IdType.new)),
-                            'connection_states' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::SetType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::Host::ConnectionState'))),
-                        },
-                        FilterSpec,
-                        false,
-                        nil)
-                end
-            end
-
-            attr_accessor :hosts,
-                          :names,
-                          :folders,
-                          :datacenters,
-                          :standalone,
-                          :clusters,
-                          :connection_states
-
-            # Constructs a new instance.
-            # @param ruby_values [Hash] a map of initial property values (optional)
-            # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
-            def initialize(ruby_values=nil, struct_value=nil)
-                super(self.class.binding_type, ruby_values, struct_value)
-            end
-        end
-
-
-        # The  ``Com::Vmware::Vcenter::Host::Summary``   class  contains commonly used information about a host in vCenter Server.
-        # @!attribute [rw] host
-        #     @return [String]
-        #     Identifier of the host.
-        # @!attribute [rw] name
-        #     @return [String]
-        #     Name of the host.
-        # @!attribute [rw] connection_state
-        #     @return [Com::Vmware::Vcenter::Host::ConnectionState]
-        #     Connection status of the host
-        # @!attribute [rw] power_state
-        #     @return [Com::Vmware::Vcenter::Host::PowerState]
-        #     Power state of the host
-        #     This  field  is optional and it is only relevant when the value of  ``connectionState``  is   :attr:`Com::Vmware::Vcenter::Host::ConnectionState.CONNECTED`  .
-        class Summary < VAPI::Bindings::VapiStruct
-
-            class << self
-                # Holds (gets or creates) the binding type metadata for this structure type.
-                # @scope class
-                # @return [VAPI::Bindings::StructType] the binding type
-                def binding_type
-                    @binding_type ||= VAPI::Bindings::StructType.new(
-                        'com.vmware.vcenter.host.summary',
-                        {
-                            'host' => VAPI::Bindings::IdType.new(resource_types='HostSystem'),
-                            'name' => VAPI::Bindings::StringType.instance,
-                            'connection_state' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::Host::ConnectionState'),
-                            'power_state' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::Host::PowerState')),
-                        },
-                        Summary,
-                        false,
-                        nil)
-                end
-            end
-
-            attr_accessor :host,
-                          :name,
-                          :connection_state,
-                          :power_state
-
-            # Constructs a new instance.
-            # @param ruby_values [Hash] a map of initial property values (optional)
-            # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
-            def initialize(ruby_values=nil, struct_value=nil)
-                super(self.class.binding_type, ruby_values, struct_value)
-            end
-        end
-
-
-
-        # The  ``Com::Vmware::Vcenter::Host::ConnectionState``   enumerated type  defines the connection status of a host.
-        # @!attribute [rw] connected
-        #     @return [Com::Vmware::Vcenter::Host::ConnectionState]
-        #     Host is connected to the vCenter Server
-        # @!attribute [rw] disconnected
-        #     @return [Com::Vmware::Vcenter::Host::ConnectionState]
-        #     Host is disconnected from the vCenter Server
-        # @!attribute [rw] not_responding
-        #     @return [Com::Vmware::Vcenter::Host::ConnectionState]
-        #     VirtualCenter is not receiving heartbeats from the server. The state automatically changes to connected once heartbeats are received again.
-        class ConnectionState < VAPI::Bindings::VapiEnum
-
-            class << self
-                # Holds (gets or creates) the binding type metadata for this enumeration type.
-                # @scope class
-                # @return [VAPI::Bindings::EnumType] the binding type
-                def binding_type
-                    @binding_type ||= VAPI::Bindings::EnumType.new(
-                        'com.vmware.vcenter.host.connection_state',
-                        ConnectionState)
-                end
-
-                # Converts from a string value (perhaps off the wire) to an instance
-                # of this enum type.
-                # @param value [String] the actual value of the enum instance
-                # @return [ConnectionState] the instance found for the value, otherwise
-                #         an unknown instance will be built for the value
-                def from_string(value)
-                    begin
-                        const_get(value)
-                    rescue NameError
-                        ConnectionState.new('UNKNOWN', value)
-                    end
-                end
-            end
-
-            private
-
-            # Constructs a new instance.
-            # @param value [String] the actual value of the enum instance
-            # @param unknown [String] the unknown value when value is 'UKNOWN'
-            def initialize(value, unknown=nil)
-                super(self.class.binding_type, value, unknown)
-            end
-
-            public
-
-            # @!attribute [rw] connected
-            #     @return [Com::Vmware::Vcenter::Host::ConnectionState]
-            #     Host is connected to the vCenter Server
-            CONNECTED = ConnectionState.new('CONNECTED')
-
-            # @!attribute [rw] disconnected
-            #     @return [Com::Vmware::Vcenter::Host::ConnectionState]
-            #     Host is disconnected from the vCenter Server
-            DISCONNECTED = ConnectionState.new('DISCONNECTED')
-
-            # @!attribute [rw] not_responding
-            #     @return [Com::Vmware::Vcenter::Host::ConnectionState]
-            #     VirtualCenter is not receiving heartbeats from the server. The state automatically changes to connected once heartbeats are received again.
-            NOT_RESPONDING = ConnectionState.new('NOT_RESPONDING')
-
-        end
-
-
-        # The  ``Com::Vmware::Vcenter::Host::PowerState``   enumerated type  defines the power states of a host.
-        # @!attribute [rw] powered_on
-        #     @return [Com::Vmware::Vcenter::Host::PowerState]
-        #     The host is powered on. A host that is entering standby mode is also in this state.
-        # @!attribute [rw] powered_off
-        #     @return [Com::Vmware::Vcenter::Host::PowerState]
-        #     The host was specifically powered off by the user through vCenter server. This state is not a cetain state, because after vCenter server issues the command to power off the host, the host might crash, or kill all the processes but fail to power off.
-        # @!attribute [rw] standby
-        #     @return [Com::Vmware::Vcenter::Host::PowerState]
-        #     The host was specifically put in standby mode, either explicitly by the user, or automatically by DPM. This state is not a cetain state, because after VirtualCenter issues the command to put the host in standby state, the host might crash, or kill all the processes but fail to enter standby mode. A host that is exiting standby mode is also in this state.
-        class PowerState < VAPI::Bindings::VapiEnum
-
-            class << self
-                # Holds (gets or creates) the binding type metadata for this enumeration type.
-                # @scope class
-                # @return [VAPI::Bindings::EnumType] the binding type
-                def binding_type
-                    @binding_type ||= VAPI::Bindings::EnumType.new(
-                        'com.vmware.vcenter.host.power_state',
-                        PowerState)
-                end
-
-                # Converts from a string value (perhaps off the wire) to an instance
-                # of this enum type.
-                # @param value [String] the actual value of the enum instance
-                # @return [PowerState] the instance found for the value, otherwise
-                #         an unknown instance will be built for the value
-                def from_string(value)
-                    begin
-                        const_get(value)
-                    rescue NameError
-                        PowerState.new('UNKNOWN', value)
-                    end
-                end
-            end
-
-            private
-
-            # Constructs a new instance.
-            # @param value [String] the actual value of the enum instance
-            # @param unknown [String] the unknown value when value is 'UKNOWN'
-            def initialize(value, unknown=nil)
-                super(self.class.binding_type, value, unknown)
-            end
-
-            public
-
-            # @!attribute [rw] powered_on
-            #     @return [Com::Vmware::Vcenter::Host::PowerState]
-            #     The host is powered on. A host that is entering standby mode is also in this state.
-            POWERED_ON = PowerState.new('POWERED_ON')
-
-            # @!attribute [rw] powered_off
-            #     @return [Com::Vmware::Vcenter::Host::PowerState]
-            #     The host was specifically powered off by the user through vCenter server. This state is not a cetain state, because after vCenter server issues the command to power off the host, the host might crash, or kill all the processes but fail to power off.
-            POWERED_OFF = PowerState.new('POWERED_OFF')
-
-            # @!attribute [rw] standby
-            #     @return [Com::Vmware::Vcenter::Host::PowerState]
-            #     The host was specifically put in standby mode, either explicitly by the user, or automatically by DPM. This state is not a cetain state, because after VirtualCenter issues the command to put the host in standby state, the host might crash, or kill all the processes but fail to enter standby mode. A host that is exiting standby mode is also in this state.
-            STANDBY = PowerState.new('STANDBY')
-
-        end
-
-
+        #     @return [Com::Vmware::Vcenter::Host::CreateSpec::ThumbprintVerification]
+        #     Host's SSL certificate verified by checking its thumbprint against the specified thumbprint.
+        THUMBPRINT = ThumbprintVerification.send(:new, 'THUMBPRINT')
+      end
     end
 
-
-    # The  Network   class  provides  methods  for manipulating a vCenter Server network.
-    class Network < VAPI::Bindings::VapiService
-
-        protected
-
-        # static metamodel definitions
-        @@service_id = VAPI::Core::ServiceIdentifier.new('com.vmware.vcenter.network')
-
-        @@list_info = VAPI::Bindings::OperationInfo.new(
-            VAPI::Core::OperationIdentifier.new('list', @@service_id),
-            VAPI::Bindings::OperationInputType.new({
-                'filter' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::Network::FilterSpec')),
-            }),
-            VAPI::Bindings::ListType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::Network::Summary')),
+    # The  ``Com::Vmware::Vcenter::Host::FilterSpec``   class  contains  fields  used to filter the results when listing hosts (see   :func:`Com::Vmware::Vcenter::Host.list`  ). If multiple  fields  are specified, only hosts matching all of the  fields  match the filter.
+    # @!attribute [rw] hosts
+    #     @return [Set<String>, nil]
+    #     Identifiers of hosts that can match the filter.
+    #     If  nil  or empty, hosts with any identifier match the filter.
+    # @!attribute [rw] names
+    #     @return [Set<String>, nil]
+    #     Names that hosts must have to match the filter (see   :attr:`Com::Vmware::Vcenter::Host::Summary.name`  ).
+    #     If  nil  or empty, hosts with any name match the filter.
+    # @!attribute [rw] folders
+    #     @return [Set<String>, nil]
+    #     Folders that must contain the hosts for the hosts to match the filter.
+    #     If  nil  or empty, hosts in any folder match the filter.
+    # @!attribute [rw] datacenters
+    #     @return [Set<String>, nil]
+    #     Datacenters that must contain the hosts for the hosts to match the filter.
+    #     If  nil  or empty, hosts in any datacenter match the filter.
+    # @!attribute [rw] standalone
+    #     @return [Boolean, nil]
+    #     If true, only hosts that are not part of a cluster can match the filter, and if false, only hosts that are are part of a cluster can match the filter.
+    #     If  nil  Hosts can match filter independent of whether they are part of a cluster or not. If this field is true and   :attr:`Com::Vmware::Vcenter::Host::FilterSpec.clusters`   os not empty, no hosts will match the filter.
+    # @!attribute [rw] clusters
+    #     @return [Set<String>, nil]
+    #     Clusters that must contain the hosts for the hosts to match the filter.
+    #     If  nil  or empty, hosts in any cluster and hosts that are not in a cluster match the filter. If this  field  is not empty and   :attr:`Com::Vmware::Vcenter::Host::FilterSpec.standalone`   is true, no hosts will match the filter.
+    # @!attribute [rw] connection_states
+    #     @return [Set<Com::Vmware::Vcenter::Host::ConnectionState>, nil]
+    #     Connection states that a host must be in to match the filter (see   :attr:`Com::Vmware::Vcenter::Host::Summary.connection_state`  .
+    #     If  nil  or empty, hosts in any connection state match the filter.
+    class FilterSpec < VAPI::Bindings::VapiStruct
+      class << self
+        # Holds (gets or creates) the binding type metadata for this structure type.
+        # @scope class
+        # @return [VAPI::Bindings::StructType] the binding type
+        def binding_type
+          @binding_type ||= VAPI::Bindings::StructType.new(
+            'com.vmware.vcenter.host.filter_spec',
             {
-                'com.vmware.vapi.std.errors.invalid_argument' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::InvalidArgument'),
-                'com.vmware.vapi.std.errors.unable_to_allocate_resource' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::UnableToAllocateResource'),
-                'com.vmware.vapi.std.errors.service_unavailable' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::ServiceUnavailable'),
-                'com.vmware.vapi.std.errors.unauthenticated' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Unauthenticated'),
-                'com.vmware.vapi.std.errors.unauthorized' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Unauthorized'),
-
+              'hosts' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::SetType.new(VAPI::Bindings::IdType.new)),
+              'names' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::SetType.new(VAPI::Bindings::StringType.instance)),
+              'folders' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::SetType.new(VAPI::Bindings::IdType.new)),
+              'datacenters' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::SetType.new(VAPI::Bindings::IdType.new)),
+              'standalone' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::BooleanType.instance),
+              'clusters' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::SetType.new(VAPI::Bindings::IdType.new)),
+              'connection_states' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::SetType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::Host::ConnectionState')))
             },
-            [],
-            [])
-
-        @@service_info = VAPI::Bindings::ServiceInfo.new(@@service_id, {
-            'list' => @@list_info,
-        })
-
-        public
-
-        # Constructs a new instance.
-        #
-        # @param config [VAPI::Bindings::StubConfig] A hash with the api provider details.
-        def initialize(config)
-            super(config, @@service_info)
+            FilterSpec,
+            false,
+            nil
+          )
         end
+      end
 
-        RESOURCE_TYPE = 'Network'
+      attr_accessor :hosts,
+                    :names,
+                    :folders,
+                    :datacenters,
+                    :standalone,
+                    :clusters,
+                    :connection_states
 
-
-        # Returns information about at most 1000 visible (subject to permission checks) networks in vCenter matching the   :class:`Com::Vmware::Vcenter::Network::FilterSpec`  .
-        #
-        # @param filter [Com::Vmware::Vcenter::Network::FilterSpec, nil]
-        #     Specification of matching networks for which information should be returned.
-        #     If  nil , the behavior is equivalent to a   :class:`Com::Vmware::Vcenter::Network::FilterSpec`   with all  fields   nil  which means all networks match the filter.
-        # @return [Array<Com::Vmware::Vcenter::Network::Summary>]
-        #     Commonly used information about the networks matching the   :class:`Com::Vmware::Vcenter::Network::FilterSpec`  .
-        # @raise [Com::Vmware::Vapi::Std::Errors::InvalidArgument]
-        #     if the   :attr:`Com::Vmware::Vcenter::Network::FilterSpec.types`    field  contains a value that is not supported by the server.
-        # @raise [Com::Vmware::Vapi::Std::Errors::UnableToAllocateResource]
-        #     if more than 1000 networks match the   :class:`Com::Vmware::Vcenter::Network::FilterSpec`  .
-        # @raise [Com::Vmware::Vapi::Std::Errors::ServiceUnavailable]
-        #     if the system is unable to communicate with a service to complete the request.
-        # @raise [Com::Vmware::Vapi::Std::Errors::Unauthenticated]
-        #     if the user can not be authenticated.
-        # @raise [Com::Vmware::Vapi::Std::Errors::Unauthorized]
-        #     if the user doesn't have the required privileges.
-        def list(filter=nil)
-            invoke_with_info(@@list_info, {
-                'filter' => filter,
-            })
-        end
-
-
-
-        # The  ``Com::Vmware::Vcenter::Network::FilterSpec``   class  contains  fields  used to filter the results when listing networks (see   :func:`Com::Vmware::Vcenter::Network.list`  ). If multiple  fields  are specified, only networks matching all of the  fields  match the filter.
-        # @!attribute [rw] networks
-        #     @return [Set<String>, nil]
-        #     Identifiers of networks that can match the filter.
-        #     If  nil  or empty, networks with any identifier match the filter.
-        # @!attribute [rw] names
-        #     @return [Set<String>, nil]
-        #     Names that networks must have to match the filter (see   :attr:`Com::Vmware::Vcenter::Network::Summary.name`  ).
-        #     If  nil  or empty, networks with any name match the filter.
-        # @!attribute [rw] types
-        #     @return [Set<Com::Vmware::Vcenter::Network::Type>, nil]
-        #     Types that networks must have to match the filter (see   :attr:`Com::Vmware::Vcenter::Network::Summary.type`  ).
-        #     If  nil , networks with any type match the filter.
-        # @!attribute [rw] folders
-        #     @return [Set<String>, nil]
-        #     Folders that must contain the network for the network to match the filter.
-        #     If  nil  or empty, networks in any folder match the filter.
-        # @!attribute [rw] datacenters
-        #     @return [Set<String>, nil]
-        #     Datacenters that must contain the network for the network to match the filter.
-        #     If  nil  or empty, networks in any datacenter match the filter.
-        class FilterSpec < VAPI::Bindings::VapiStruct
-
-            class << self
-                # Holds (gets or creates) the binding type metadata for this structure type.
-                # @scope class
-                # @return [VAPI::Bindings::StructType] the binding type
-                def binding_type
-                    @binding_type ||= VAPI::Bindings::StructType.new(
-                        'com.vmware.vcenter.network.filter_spec',
-                        {
-                            'networks' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::SetType.new(VAPI::Bindings::IdType.new)),
-                            'names' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::SetType.new(VAPI::Bindings::StringType.instance)),
-                            'types' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::SetType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::Network::Type'))),
-                            'folders' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::SetType.new(VAPI::Bindings::IdType.new)),
-                            'datacenters' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::SetType.new(VAPI::Bindings::IdType.new)),
-                        },
-                        FilterSpec,
-                        false,
-                        nil)
-                end
-            end
-
-            attr_accessor :networks,
-                          :names,
-                          :types,
-                          :folders,
-                          :datacenters
-
-            # Constructs a new instance.
-            # @param ruby_values [Hash] a map of initial property values (optional)
-            # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
-            def initialize(ruby_values=nil, struct_value=nil)
-                super(self.class.binding_type, ruby_values, struct_value)
-            end
-        end
-
-
-        # The  ``Com::Vmware::Vcenter::Network::Summary``   class  contains commonly used information about a network.
-        # @!attribute [rw] network
-        #     @return [String]
-        #     Identifier of the network.
-        # @!attribute [rw] name
-        #     @return [String]
-        #     Name of the network.
-        # @!attribute [rw] type
-        #     @return [Com::Vmware::Vcenter::Network::Type]
-        #     Type ( ``STANDARD_PORTGROUP``, ``DISTRIBUTED_PORTGROUP``, ``OPAQUE_NETWORK`` ) of the vCenter Server network.
-        class Summary < VAPI::Bindings::VapiStruct
-
-            class << self
-                # Holds (gets or creates) the binding type metadata for this structure type.
-                # @scope class
-                # @return [VAPI::Bindings::StructType] the binding type
-                def binding_type
-                    @binding_type ||= VAPI::Bindings::StructType.new(
-                        'com.vmware.vcenter.network.summary',
-                        {
-                            'network' => VAPI::Bindings::IdType.new(resource_types='Network'),
-                            'name' => VAPI::Bindings::StringType.instance,
-                            'type' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::Network::Type'),
-                        },
-                        Summary,
-                        false,
-                        nil)
-                end
-            end
-
-            attr_accessor :network,
-                          :name,
-                          :type
-
-            # Constructs a new instance.
-            # @param ruby_values [Hash] a map of initial property values (optional)
-            # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
-            def initialize(ruby_values=nil, struct_value=nil)
-                super(self.class.binding_type, ruby_values, struct_value)
-            end
-        end
-
-
-
-        # The  ``Com::Vmware::Vcenter::Network::Type``   enumerated type  defines the type of a vCenter Server network. The type of a network can be used to determine what features it supports and which APIs can be used to find more information about the network or change its configuration.
-        # @!attribute [rw] standard_portgroup
-        #     @return [Com::Vmware::Vcenter::Network::Type]
-        #     XXX: ESX based (created and managed on ESX)
-        # @!attribute [rw] distributed_portgroup
-        #     @return [Com::Vmware::Vcenter::Network::Type]
-        #     XXX: vCenter based (create and managed through vCenter)
-        # @!attribute [rw] opaque_network
-        #     @return [Com::Vmware::Vcenter::Network::Type]
-        #     A network for whose configuration is managed outside of vSphere. The identifer and name of the network is made available through vSphere so that host and virtual machine virtual ethernet devices can connect to them.
-        class Type < VAPI::Bindings::VapiEnum
-
-            class << self
-                # Holds (gets or creates) the binding type metadata for this enumeration type.
-                # @scope class
-                # @return [VAPI::Bindings::EnumType] the binding type
-                def binding_type
-                    @binding_type ||= VAPI::Bindings::EnumType.new(
-                        'com.vmware.vcenter.network.type',
-                        Type)
-                end
-
-                # Converts from a string value (perhaps off the wire) to an instance
-                # of this enum type.
-                # @param value [String] the actual value of the enum instance
-                # @return [Type] the instance found for the value, otherwise
-                #         an unknown instance will be built for the value
-                def from_string(value)
-                    begin
-                        const_get(value)
-                    rescue NameError
-                        Type.new('UNKNOWN', value)
-                    end
-                end
-            end
-
-            private
-
-            # Constructs a new instance.
-            # @param value [String] the actual value of the enum instance
-            # @param unknown [String] the unknown value when value is 'UKNOWN'
-            def initialize(value, unknown=nil)
-                super(self.class.binding_type, value, unknown)
-            end
-
-            public
-
-            # @!attribute [rw] standard_portgroup
-            #     @return [Com::Vmware::Vcenter::Network::Type]
-            #     XXX: ESX based (created and managed on ESX)
-            STANDARD_PORTGROUP = Type.new('STANDARD_PORTGROUP')
-
-            # @!attribute [rw] distributed_portgroup
-            #     @return [Com::Vmware::Vcenter::Network::Type]
-            #     XXX: vCenter based (create and managed through vCenter)
-            DISTRIBUTED_PORTGROUP = Type.new('DISTRIBUTED_PORTGROUP')
-
-            # @!attribute [rw] opaque_network
-            #     @return [Com::Vmware::Vcenter::Network::Type]
-            #     A network for whose configuration is managed outside of vSphere. The identifer and name of the network is made available through vSphere so that host and virtual machine virtual ethernet devices can connect to them.
-            OPAQUE_NETWORK = Type.new('OPAQUE_NETWORK')
-
-        end
-
-
+      # Constructs a new instance.
+      # @param ruby_values [Hash] a map of initial property values (optional)
+      # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
+      def initialize(ruby_values = nil, struct_value = nil)
+        super(self.class.binding_type, ruby_values, struct_value)
+      end
     end
 
-
-    # The  ResourcePool   class  provides  methods  for manipulating a vCenter Server resource pool.  
-    # 
-    #  This  class  does not include virtual appliances in the inventory of resource pools even though part of the behavior of a virtual appliance is to act like a resource pool.
-    class ResourcePool < VAPI::Bindings::VapiService
-
-        protected
-
-        # static metamodel definitions
-        @@service_id = VAPI::Core::ServiceIdentifier.new('com.vmware.vcenter.resource_pool')
-
-        @@get_info = VAPI::Bindings::OperationInfo.new(
-            VAPI::Core::OperationIdentifier.new('get', @@service_id),
-            VAPI::Bindings::OperationInputType.new({
-                'resource_pool' => VAPI::Bindings::IdType.new(resource_types='ResourcePool'),
-            }),
-            VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::ResourcePool::Info'),
+    # The  ``Com::Vmware::Vcenter::Host::Summary``   class  contains commonly used information about a host in vCenter Server.
+    # @!attribute [rw] host
+    #     @return [String]
+    #     Identifier of the host.
+    # @!attribute [rw] name
+    #     @return [String]
+    #     Name of the host.
+    # @!attribute [rw] connection_state
+    #     @return [Com::Vmware::Vcenter::Host::ConnectionState]
+    #     Connection status of the host
+    # @!attribute [rw] power_state
+    #     @return [Com::Vmware::Vcenter::Host::PowerState]
+    #     Power state of the host
+    #     This  field  is optional and it is only relevant when the value of  ``connectionState``  is   :attr:`Com::Vmware::Vcenter::Host::ConnectionState.CONNECTED`  .
+    class Summary < VAPI::Bindings::VapiStruct
+      class << self
+        # Holds (gets or creates) the binding type metadata for this structure type.
+        # @scope class
+        # @return [VAPI::Bindings::StructType] the binding type
+        def binding_type
+          @binding_type ||= VAPI::Bindings::StructType.new(
+            'com.vmware.vcenter.host.summary',
             {
-                'com.vmware.vapi.std.errors.not_found' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::NotFound'),
-                'com.vmware.vapi.std.errors.service_unavailable' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::ServiceUnavailable'),
-                'com.vmware.vapi.std.errors.unauthenticated' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Unauthenticated'),
-                'com.vmware.vapi.std.errors.unauthorized' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Unauthorized'),
-
+              'host' => VAPI::Bindings::IdType.new('HostSystem'),
+              'name' => VAPI::Bindings::StringType.instance,
+              'connection_state' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::Host::ConnectionState'),
+              'power_state' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::Host::PowerState'))
             },
-            [],
-            [])
-        @@list_info = VAPI::Bindings::OperationInfo.new(
-            VAPI::Core::OperationIdentifier.new('list', @@service_id),
-            VAPI::Bindings::OperationInputType.new({
-                'filter' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::ResourcePool::FilterSpec')),
-            }),
-            VAPI::Bindings::ListType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::ResourcePool::Summary')),
-            {
-                'com.vmware.vapi.std.errors.unable_to_allocate_resource' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::UnableToAllocateResource'),
-                'com.vmware.vapi.std.errors.service_unavailable' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::ServiceUnavailable'),
-                'com.vmware.vapi.std.errors.unauthenticated' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Unauthenticated'),
-                'com.vmware.vapi.std.errors.unauthorized' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Unauthorized'),
-
-            },
-            [],
-            [])
-
-        @@service_info = VAPI::Bindings::ServiceInfo.new(@@service_id, {
-            'get' => @@get_info,
-            'list' => @@list_info,
-        })
-
-        public
-
-        # Constructs a new instance.
-        #
-        # @param config [VAPI::Bindings::StubConfig] A hash with the api provider details.
-        def initialize(config)
-            super(config, @@service_info)
+            Summary,
+            false,
+            nil
+          )
         end
+      end
 
-        RESOURCE_TYPE = 'ResourcePool'
+      attr_accessor :host,
+                    :name,
+                    :connection_state,
+                    :power_state
 
-
-        # Retrieves information about the resource pool indicated by  ``resource_pool`` .
-        #
-        # @param resource_pool [String]
-        #     Identifier of the resource pool for which information should be retrieved.
-        # @return [Com::Vmware::Vcenter::ResourcePool::Info]
-        #     information about the resource pool.
-        # @raise [Com::Vmware::Vapi::Std::Errors::NotFound]
-        #     if the resource pool indicated by  ``resource_pool``  does not exist.
-        # @raise [Com::Vmware::Vapi::Std::Errors::ServiceUnavailable]
-        #     if the system is unable to communicate with a service to complete the request.
-        # @raise [Com::Vmware::Vapi::Std::Errors::Unauthenticated]
-        #     if the user can not be authenticated.
-        # @raise [Com::Vmware::Vapi::Std::Errors::Unauthorized]
-        #     if the user doesn't have the required privileges.
-        def get(resource_pool)
-            invoke_with_info(@@get_info, {
-                'resource_pool' => resource_pool,
-            })
-        end
-
-
-        # Returns information about at most 1000 visible (subject to permission checks) resource pools in vCenter matching the   :class:`Com::Vmware::Vcenter::ResourcePool::FilterSpec`  .
-        #
-        # @param filter [Com::Vmware::Vcenter::ResourcePool::FilterSpec, nil]
-        #     Specification of matching resource pools for which information should be returned.
-        #     If  nil , the behavior is equivalent to a   :class:`Com::Vmware::Vcenter::ResourcePool::FilterSpec`   with all  fields   nil  which means all resource pools match the filter.
-        # @return [Array<Com::Vmware::Vcenter::ResourcePool::Summary>]
-        #     Commonly used information about the resource pools matching the   :class:`Com::Vmware::Vcenter::ResourcePool::FilterSpec`  .
-        # @raise [Com::Vmware::Vapi::Std::Errors::UnableToAllocateResource]
-        #     if more than 1000 resource pools match the   :class:`Com::Vmware::Vcenter::ResourcePool::FilterSpec`  .
-        # @raise [Com::Vmware::Vapi::Std::Errors::ServiceUnavailable]
-        #     if the system is unable to communicate with a service to complete the request.
-        # @raise [Com::Vmware::Vapi::Std::Errors::Unauthenticated]
-        #     if the user can not be authenticated.
-        # @raise [Com::Vmware::Vapi::Std::Errors::Unauthorized]
-        #     if the user doesn't have the required privileges.
-        def list(filter=nil)
-            invoke_with_info(@@list_info, {
-                'filter' => filter,
-            })
-        end
-
-
-
-        # The  ``Com::Vmware::Vcenter::ResourcePool::Info``   class  contains information about a resource pool.
-        # @!attribute [rw] name
-        #     @return [String]
-        #     Name of the vCenter Server resource pool.
-        # @!attribute [rw] resource_pools
-        #     @return [Set<String>]
-        #     Identifiers of the child resource pools contained in this resource pool.
-        class Info < VAPI::Bindings::VapiStruct
-
-            class << self
-                # Holds (gets or creates) the binding type metadata for this structure type.
-                # @scope class
-                # @return [VAPI::Bindings::StructType] the binding type
-                def binding_type
-                    @binding_type ||= VAPI::Bindings::StructType.new(
-                        'com.vmware.vcenter.resource_pool.info',
-                        {
-                            'name' => VAPI::Bindings::StringType.instance,
-                            'resource_pools' => VAPI::Bindings::SetType.new(VAPI::Bindings::IdType.new),
-                        },
-                        Info,
-                        false,
-                        nil)
-                end
-            end
-
-            attr_accessor :name,
-                          :resource_pools
-
-            # Constructs a new instance.
-            # @param ruby_values [Hash] a map of initial property values (optional)
-            # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
-            def initialize(ruby_values=nil, struct_value=nil)
-                super(self.class.binding_type, ruby_values, struct_value)
-            end
-        end
-
-
-        # The  ``Com::Vmware::Vcenter::ResourcePool::FilterSpec``   class  contains  fields  used to filter the results when listing resource pools (see   :func:`Com::Vmware::Vcenter::ResourcePool.list`  ). If multiple  fields  are specified, only resource pools matching all of the  fields  match the filter.
-        # @!attribute [rw] resource_pools
-        #     @return [Set<String>, nil]
-        #     Identifiers of resource pools that can match the filter.
-        #     If  nil  or empty, resource pools with any identifier match the filter.
-        # @!attribute [rw] names
-        #     @return [Set<String>, nil]
-        #     Names that resource pools must have to match the filter (see   :attr:`Com::Vmware::Vcenter::ResourcePool::Info.name`  ).
-        #     If  nil  or empty, resource pools with any name match the filter.
-        # @!attribute [rw] parent_resource_pools
-        #     @return [Set<String>, nil]
-        #     Resource pools that must contain the resource pool for the resource pool to match the filter.
-        #     If  nil  or empty, resource pools in any resource pool match the filter.
-        # @!attribute [rw] datacenters
-        #     @return [Set<String>, nil]
-        #     Datacenters that must contain the resource pool for the resource pool to match the filter.
-        #     If  nil  or empty, resource pools in any datacenter match the filter.
-        # @!attribute [rw] hosts
-        #     @return [Set<String>, nil]
-        #     Hosts that must contain the resource pool for the resource pool to match the filter.
-        #     If  nil  or empty, resource pools in any host match the filter.
-        # @!attribute [rw] clusters
-        #     @return [Set<String>, nil]
-        #     Clusters that must contain the resource pool for the resource pool to match the filter.
-        #     If  nil  or empty, resource pools in any cluster match the filter.
-        class FilterSpec < VAPI::Bindings::VapiStruct
-
-            class << self
-                # Holds (gets or creates) the binding type metadata for this structure type.
-                # @scope class
-                # @return [VAPI::Bindings::StructType] the binding type
-                def binding_type
-                    @binding_type ||= VAPI::Bindings::StructType.new(
-                        'com.vmware.vcenter.resource_pool.filter_spec',
-                        {
-                            'resource_pools' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::SetType.new(VAPI::Bindings::IdType.new)),
-                            'names' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::SetType.new(VAPI::Bindings::StringType.instance)),
-                            'parent_resource_pools' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::SetType.new(VAPI::Bindings::IdType.new)),
-                            'datacenters' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::SetType.new(VAPI::Bindings::IdType.new)),
-                            'hosts' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::SetType.new(VAPI::Bindings::IdType.new)),
-                            'clusters' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::SetType.new(VAPI::Bindings::IdType.new)),
-                        },
-                        FilterSpec,
-                        false,
-                        nil)
-                end
-            end
-
-            attr_accessor :resource_pools,
-                          :names,
-                          :parent_resource_pools,
-                          :datacenters,
-                          :hosts,
-                          :clusters
-
-            # Constructs a new instance.
-            # @param ruby_values [Hash] a map of initial property values (optional)
-            # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
-            def initialize(ruby_values=nil, struct_value=nil)
-                super(self.class.binding_type, ruby_values, struct_value)
-            end
-        end
-
-
-        # The  ``Com::Vmware::Vcenter::ResourcePool::Summary``   class  contains commonly used information about a resource pool in vCenter Server.
-        # @!attribute [rw] resource_pool
-        #     @return [String]
-        #     Identifier of the resource pool.
-        # @!attribute [rw] name
-        #     @return [String]
-        #     Name of the resource pool.
-        class Summary < VAPI::Bindings::VapiStruct
-
-            class << self
-                # Holds (gets or creates) the binding type metadata for this structure type.
-                # @scope class
-                # @return [VAPI::Bindings::StructType] the binding type
-                def binding_type
-                    @binding_type ||= VAPI::Bindings::StructType.new(
-                        'com.vmware.vcenter.resource_pool.summary',
-                        {
-                            'resource_pool' => VAPI::Bindings::IdType.new(resource_types='ResourcePool'),
-                            'name' => VAPI::Bindings::StringType.instance,
-                        },
-                        Summary,
-                        false,
-                        nil)
-                end
-            end
-
-            attr_accessor :resource_pool,
-                          :name
-
-            # Constructs a new instance.
-            # @param ruby_values [Hash] a map of initial property values (optional)
-            # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
-            def initialize(ruby_values=nil, struct_value=nil)
-                super(self.class.binding_type, ruby_values, struct_value)
-            end
-        end
-
-
+      # Constructs a new instance.
+      # @param ruby_values [Hash] a map of initial property values (optional)
+      # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
+      def initialize(ruby_values = nil, struct_value = nil)
+        super(self.class.binding_type, ruby_values, struct_value)
+      end
     end
 
-
-    # The  ``Com::Vmware::Vcenter::VM``   class  provides  methods  for managing the lifecycle of a virtual machine.
-    class VM < VAPI::Bindings::VapiService
-
-        protected
-
-        # static metamodel definitions
-        @@service_id = VAPI::Core::ServiceIdentifier.new('com.vmware.vcenter.VM')
-
-        @@create_info = VAPI::Bindings::OperationInfo.new(
-            VAPI::Core::OperationIdentifier.new('create', @@service_id),
-            VAPI::Bindings::OperationInputType.new({
-                'spec' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::VM::CreateSpec'),
-            }),
-            VAPI::Bindings::IdType.new(resource_types='VirtualMachine'),
-            {
-                'com.vmware.vapi.std.errors.already_exists' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::AlreadyExists'),
-                'com.vmware.vapi.std.errors.error' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Error'),
-                'com.vmware.vapi.std.errors.invalid_argument' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::InvalidArgument'),
-                'com.vmware.vapi.std.errors.not_found' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::NotFound'),
-                'com.vmware.vapi.std.errors.resource_inaccessible' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::ResourceInaccessible'),
-                'com.vmware.vapi.std.errors.resource_in_use' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::ResourceInUse'),
-                'com.vmware.vapi.std.errors.service_unavailable' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::ServiceUnavailable'),
-                'com.vmware.vapi.std.errors.unable_to_allocate_resource' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::UnableToAllocateResource'),
-                'com.vmware.vapi.std.errors.unauthenticated' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Unauthenticated'),
-                'com.vmware.vapi.std.errors.unauthorized' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Unauthorized'),
-                'com.vmware.vapi.std.errors.unsupported' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Unsupported'),
-
-            },
-            [],
-            [])
-        @@get_info = VAPI::Bindings::OperationInfo.new(
-            VAPI::Core::OperationIdentifier.new('get', @@service_id),
-            VAPI::Bindings::OperationInputType.new({
-                'vm' => VAPI::Bindings::IdType.new(resource_types='VirtualMachine'),
-            }),
-            VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::VM::Info'),
-            {
-                'com.vmware.vapi.std.errors.error' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Error'),
-                'com.vmware.vapi.std.errors.not_found' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::NotFound'),
-                'com.vmware.vapi.std.errors.resource_inaccessible' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::ResourceInaccessible'),
-                'com.vmware.vapi.std.errors.service_unavailable' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::ServiceUnavailable'),
-                'com.vmware.vapi.std.errors.unauthenticated' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Unauthenticated'),
-                'com.vmware.vapi.std.errors.unauthorized' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Unauthorized'),
-
-            },
-            [],
-            [])
-        @@delete_info = VAPI::Bindings::OperationInfo.new(
-            VAPI::Core::OperationIdentifier.new('delete', @@service_id),
-            VAPI::Bindings::OperationInputType.new({
-                'vm' => VAPI::Bindings::IdType.new(resource_types='VirtualMachine'),
-            }),
-            VAPI::Bindings::VoidType.instance,
-            {
-                'com.vmware.vapi.std.errors.error' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Error'),
-                'com.vmware.vapi.std.errors.not_found' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::NotFound'),
-                'com.vmware.vapi.std.errors.resource_busy' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::ResourceBusy'),
-                'com.vmware.vapi.std.errors.resource_inaccessible' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::ResourceInaccessible'),
-                'com.vmware.vapi.std.errors.service_unavailable' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::ServiceUnavailable'),
-                'com.vmware.vapi.std.errors.unauthenticated' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Unauthenticated'),
-                'com.vmware.vapi.std.errors.unauthorized' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Unauthorized'),
-
-            },
-            [],
-            [])
-        @@list_info = VAPI::Bindings::OperationInfo.new(
-            VAPI::Core::OperationIdentifier.new('list', @@service_id),
-            VAPI::Bindings::OperationInputType.new({
-                'filter' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::VM::FilterSpec')),
-            }),
-            VAPI::Bindings::ListType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::VM::Summary')),
-            {
-                'com.vmware.vapi.std.errors.invalid_argument' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::InvalidArgument'),
-                'com.vmware.vapi.std.errors.unable_to_allocate_resource' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::UnableToAllocateResource'),
-                'com.vmware.vapi.std.errors.service_unavailable' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::ServiceUnavailable'),
-                'com.vmware.vapi.std.errors.unauthenticated' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Unauthenticated'),
-                'com.vmware.vapi.std.errors.unauthorized' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Unauthorized'),
-
-            },
-            [],
-            [])
-
-        @@service_info = VAPI::Bindings::ServiceInfo.new(@@service_id, {
-            'create' => @@create_info,
-            'get' => @@get_info,
-            'delete' => @@delete_info,
-            'list' => @@list_info,
-        })
-
-        public
-
-        # Constructs a new instance.
-        #
-        # @param config [VAPI::Bindings::StubConfig] A hash with the api provider details.
-        def initialize(config)
-            super(config, @@service_info)
+    # The  ``Com::Vmware::Vcenter::Host::ConnectionState``   enumerated type  defines the connection status of a host.
+    # @!attribute [rw] connected
+    #     @return [Com::Vmware::Vcenter::Host::ConnectionState]
+    #     Host is connected to the vCenter Server
+    # @!attribute [rw] disconnected
+    #     @return [Com::Vmware::Vcenter::Host::ConnectionState]
+    #     Host is disconnected from the vCenter Server
+    # @!attribute [rw] not_responding
+    #     @return [Com::Vmware::Vcenter::Host::ConnectionState]
+    #     VirtualCenter is not receiving heartbeats from the server. The state automatically changes to connected once heartbeats are received again.
+    class ConnectionState < VAPI::Bindings::VapiEnum
+      class << self
+        # Holds (gets or creates) the binding type metadata for this enumeration type.
+        # @scope class
+        # @return [VAPI::Bindings::EnumType] the binding type
+        def binding_type
+          @binding_type ||= VAPI::Bindings::EnumType.new(
+            'com.vmware.vcenter.host.connection_state',
+            ConnectionState
+          )
         end
 
+        # Converts from a string value (perhaps off the wire) to an instance
+        # of this enum type.
+        # @param value [String] the actual value of the enum instance
+        # @return [ConnectionState] the instance found for the value, otherwise
+        #         an unknown instance will be built for the value
+        def from_string(value)
+          const_get(value)
+        rescue NameError
+          ConnectionState.send(:new, 'UNKNOWN', value)
+        end
+      end
 
-        # Creates a virtual machine.
-        #
-        # @param spec [Com::Vmware::Vcenter::VM::CreateSpec]
-        #     Virtual machine specification.
-        # @return [String]
-        #     ID of newly-created virtual machine.
-        # @raise [Com::Vmware::Vapi::Std::Errors::AlreadyExists]
-        #     if a virtual machine with the specified name already exists.
-        # @raise [Com::Vmware::Vapi::Std::Errors::Error]
-        #     if the system reports an error while responding to the request.
-        # @raise [Com::Vmware::Vapi::Std::Errors::InvalidArgument]
-        #     if any of the specified parameters are invalid.
-        # @raise [Com::Vmware::Vapi::Std::Errors::NotFound]
-        #     if any of the resources specified in  spec  could not be found
-        # @raise [Com::Vmware::Vapi::Std::Errors::ResourceInaccessible]
-        #     if a specified resource (eg. host) is not accessible.
-        # @raise [Com::Vmware::Vapi::Std::Errors::ResourceInUse]
-        #     if any of the specified storage addresses (eg. IDE, SATA, SCSI) result in a storage address conflict.
-        # @raise [Com::Vmware::Vapi::Std::Errors::ServiceUnavailable]
-        #     if the system is unable to communicate with a service to complete the request.
-        # @raise [Com::Vmware::Vapi::Std::Errors::UnableToAllocateResource]
-        #     if any of the resources needed to create the virtual machine could not be allocated.
-        # @raise [Com::Vmware::Vapi::Std::Errors::Unauthenticated]
-        #     if the user can not be authenticated.
-        # @raise [Com::Vmware::Vapi::Std::Errors::Unauthorized]
-        #     if the user doesn't have the required privileges.
-        # @raise [Com::Vmware::Vapi::Std::Errors::Unsupported]
-        #     if  ``guestOS``  is not supported for the requested virtual hardware version and  spec  includes  nil   fields  that default to guest-specific values.
-        def create(spec)
-            invoke_with_info(@@create_info, {
-                'spec' => spec,
-            })
+      # Constructs a new instance.
+      # @param value [String] the actual value of the enum instance
+      # @param unknown [String] the unknown value when value is 'UKNOWN'
+      def initialize(value, unknown = nil)
+        super(self.class.binding_type, value, unknown)
+      end
+
+      private_class_method :new
+
+      # @!attribute [rw] connected
+      #     @return [Com::Vmware::Vcenter::Host::ConnectionState]
+      #     Host is connected to the vCenter Server
+      CONNECTED = ConnectionState.send(:new, 'CONNECTED')
+
+      # @!attribute [rw] disconnected
+      #     @return [Com::Vmware::Vcenter::Host::ConnectionState]
+      #     Host is disconnected from the vCenter Server
+      DISCONNECTED = ConnectionState.send(:new, 'DISCONNECTED')
+
+      # @!attribute [rw] not_responding
+      #     @return [Com::Vmware::Vcenter::Host::ConnectionState]
+      #     VirtualCenter is not receiving heartbeats from the server. The state automatically changes to connected once heartbeats are received again.
+      NOT_RESPONDING = ConnectionState.send(:new, 'NOT_RESPONDING')
+    end
+    # The  ``Com::Vmware::Vcenter::Host::PowerState``   enumerated type  defines the power states of a host.
+    # @!attribute [rw] powered_on
+    #     @return [Com::Vmware::Vcenter::Host::PowerState]
+    #     The host is powered on. A host that is entering standby mode is also in this state.
+    # @!attribute [rw] powered_off
+    #     @return [Com::Vmware::Vcenter::Host::PowerState]
+    #     The host was specifically powered off by the user through vCenter server. This state is not a cetain state, because after vCenter server issues the command to power off the host, the host might crash, or kill all the processes but fail to power off.
+    # @!attribute [rw] standby
+    #     @return [Com::Vmware::Vcenter::Host::PowerState]
+    #     The host was specifically put in standby mode, either explicitly by the user, or automatically by DPM. This state is not a cetain state, because after VirtualCenter issues the command to put the host in standby state, the host might crash, or kill all the processes but fail to enter standby mode. A host that is exiting standby mode is also in this state.
+    class PowerState < VAPI::Bindings::VapiEnum
+      class << self
+        # Holds (gets or creates) the binding type metadata for this enumeration type.
+        # @scope class
+        # @return [VAPI::Bindings::EnumType] the binding type
+        def binding_type
+          @binding_type ||= VAPI::Bindings::EnumType.new(
+            'com.vmware.vcenter.host.power_state',
+            PowerState
+          )
         end
 
-
-        # Returns information about a virtual machine.
-        #
-        # @param vm [String]
-        #     Virtual machine identifier.
-        # @return [Com::Vmware::Vcenter::VM::Info]
-        #     Information about the specified virtual machine.
-        # @raise [Com::Vmware::Vapi::Std::Errors::Error]
-        #     if the system reports an error while responding to the request.
-        # @raise [Com::Vmware::Vapi::Std::Errors::NotFound]
-        #     if the virtual machine is not found.
-        # @raise [Com::Vmware::Vapi::Std::Errors::ResourceInaccessible]
-        #     if the virtual machine's configuration state cannot be accessed.
-        # @raise [Com::Vmware::Vapi::Std::Errors::ServiceUnavailable]
-        #     if the system is unable to communicate with a service to complete the request.
-        # @raise [Com::Vmware::Vapi::Std::Errors::Unauthenticated]
-        #     if the user can not be authenticated.
-        # @raise [Com::Vmware::Vapi::Std::Errors::Unauthorized]
-        #     if the user doesn't have the required privileges.
-        def get(vm)
-            invoke_with_info(@@get_info, {
-                'vm' => vm,
-            })
+        # Converts from a string value (perhaps off the wire) to an instance
+        # of this enum type.
+        # @param value [String] the actual value of the enum instance
+        # @return [PowerState] the instance found for the value, otherwise
+        #         an unknown instance will be built for the value
+        def from_string(value)
+          const_get(value)
+        rescue NameError
+          PowerState.send(:new, 'UNKNOWN', value)
         end
+      end
 
+      # Constructs a new instance.
+      # @param value [String] the actual value of the enum instance
+      # @param unknown [String] the unknown value when value is 'UKNOWN'
+      def initialize(value, unknown = nil)
+        super(self.class.binding_type, value, unknown)
+      end
 
-        # Deletes a virtual machine.
-        #
-        # @param vm [String]
-        #     Virtual machine identifier.
-        # @return [Void]
-        # @raise [Com::Vmware::Vapi::Std::Errors::Error]
-        #     if the system reports an error while responding to the request.
-        # @raise [Com::Vmware::Vapi::Std::Errors::NotFound]
-        #     if the virtual machine is not found.
-        # @raise [Com::Vmware::Vapi::Std::Errors::ResourceBusy]
-        #     if the virtual machine is busy performing another operation.
-        # @raise [Com::Vmware::Vapi::Std::Errors::ResourceInaccessible]
-        #     if the virtual machine's configuration state cannot be accessed.
-        # @raise [Com::Vmware::Vapi::Std::Errors::ServiceUnavailable]
-        #     if the system is unable to communicate with a service to complete the request.
-        # @raise [Com::Vmware::Vapi::Std::Errors::Unauthenticated]
-        #     if the user can not be authenticated.
-        # @raise [Com::Vmware::Vapi::Std::Errors::Unauthorized]
-        #     if the user doesn't have the required privileges.
-        def delete(vm)
-            invoke_with_info(@@delete_info, {
-                'vm' => vm,
-            })
-        end
+      private_class_method :new
 
+      # @!attribute [rw] powered_on
+      #     @return [Com::Vmware::Vcenter::Host::PowerState]
+      #     The host is powered on. A host that is entering standby mode is also in this state.
+      POWERED_ON = PowerState.send(:new, 'POWERED_ON')
 
-        # Returns information about at most 1000 visible (subject to permission checks) virtual machines in vCenter matching the   :class:`Com::Vmware::Vcenter::VM::FilterSpec`  .
-        #
-        # @param filter [Com::Vmware::Vcenter::VM::FilterSpec, nil]
-        #     Specification of matching virtual machines for which information should be returned.
-        #     If  nil , the behavior is equivalent to a   :class:`Com::Vmware::Vcenter::VM::FilterSpec`   with all  fields   nil  which means all virtual machines match the filter.
-        # @return [Array<Com::Vmware::Vcenter::VM::Summary>]
-        #     Commonly used information about the virtual machines matching the   :class:`Com::Vmware::Vcenter::VM::FilterSpec`  .
-        # @raise [Com::Vmware::Vapi::Std::Errors::InvalidArgument]
-        #     if the   :attr:`Com::Vmware::Vcenter::VM::FilterSpec.power_states`    field  contains a value that is not supported by the server.
-        # @raise [Com::Vmware::Vapi::Std::Errors::UnableToAllocateResource]
-        #     if more than 1000 virtual machines match the   :class:`Com::Vmware::Vcenter::VM::FilterSpec`  .
-        # @raise [Com::Vmware::Vapi::Std::Errors::ServiceUnavailable]
-        #     if the system is unable to communicate with a service to complete the request.
-        # @raise [Com::Vmware::Vapi::Std::Errors::Unauthenticated]
-        #     if the user can not be authenticated.
-        # @raise [Com::Vmware::Vapi::Std::Errors::Unauthorized]
-        #     if the user doesn't have the required privileges.
-        def list(filter=nil)
-            invoke_with_info(@@list_info, {
-                'filter' => filter,
-            })
-        end
+      # @!attribute [rw] powered_off
+      #     @return [Com::Vmware::Vcenter::Host::PowerState]
+      #     The host was specifically powered off by the user through vCenter server. This state is not a cetain state, because after vCenter server issues the command to power off the host, the host might crash, or kill all the processes but fail to power off.
+      POWERED_OFF = PowerState.send(:new, 'POWERED_OFF')
 
+      # @!attribute [rw] standby
+      #     @return [Com::Vmware::Vcenter::Host::PowerState]
+      #     The host was specifically put in standby mode, either explicitly by the user, or automatically by DPM. This state is not a cetain state, because after VirtualCenter issues the command to put the host in standby state, the host might crash, or kill all the processes but fail to enter standby mode. A host that is exiting standby mode is also in this state.
+      STANDBY = PowerState.send(:new, 'STANDBY')
+    end
+  end
+  # The  Network   class  provides  methods  for manipulating a vCenter Server network.
+  class Network < VAPI::Bindings::VapiService
+    # static metamodel definitions
+    SERVICE_ID = VAPI::Core::ServiceIdentifier.new('com.vmware.vcenter.network')
 
+    LIST_INFO = VAPI::Bindings::OperationInfo.new(
+      VAPI::Core::OperationIdentifier.new('list', SERVICE_ID),
+      VAPI::Bindings::OperationInputType.new(
+        'filter' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::Network::FilterSpec'))
+      ),
+      VAPI::Bindings::ListType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::Network::Summary')),
+      {
+        'com.vmware.vapi.std.errors.invalid_argument' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::InvalidArgument'),
+        'com.vmware.vapi.std.errors.unable_to_allocate_resource' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::UnableToAllocateResource'),
+        'com.vmware.vapi.std.errors.service_unavailable' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::ServiceUnavailable'),
+        'com.vmware.vapi.std.errors.unauthenticated' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Unauthenticated'),
+        'com.vmware.vapi.std.errors.unauthorized' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Unauthorized')
+      },
+      [],
+      []
+    )
 
-        # The  ``Com::Vmware::Vcenter::VM::PlacementSpec``   class  contains information used to place a virtual machine onto resources within the vCenter inventory.
-        # @!attribute [rw] folder
-        #     @return [String, nil]
-        #     Virtual machine folder into which the virtual machine should be placed.
-        #     This  field  is currently required. In the future, if this  field  is  nil , the system will attempt to choose a suitable folder for the virtual machine; if a folder cannot be chosen, the virtual machine creation operation will fail.
-        # @!attribute [rw] resource_pool
-        #     @return [String, nil]
-        #     Resource pool into which the virtual machine should be placed.
-        #     This  field  is currently required if both  ``host``  and  ``cluster``  are  nil . In the future, if this  field  is  nil , the system will attempt to choose a suitable resource pool for the virtual machine; if a resource pool cannot be chosen, the virtual machine creation operation will fail.
-        # @!attribute [rw] host
-        #     @return [String, nil]
-        #     Host onto which the virtual machine should be placed.  
-        #     
-        #      If  ``host``  and  ``resourcePool``  are both specified,  ``resourcePool``  must belong to  ``host`` .  
-        #     
-        #      If  ``host``  and  ``cluster``  are both specified,  ``host``  must be a member of  ``cluster`` .
-        #     This  field  may be  nil  if  ``resourcePool``  or  ``cluster``  is specified. If  nil , the system will attempt to choose a suitable host for the virtual machine; if a host cannot be chosen, the virtual machine creation operation will fail.
-        # @!attribute [rw] cluster
-        #     @return [String, nil]
-        #     Cluster onto which the virtual machine should be placed.  
-        #     
-        #      If  ``cluster``  and  ``resourcePool``  are both specified,  ``resourcePool``  must belong to  ``cluster`` .  
-        #     
-        #      If  ``cluster``  and  ``host``  are both specified,  ``host``  must be a member of  ``cluster`` .
-        #     If  ``resourcePool``  or  ``host``  is specified, it is recommended that this  field  be  nil .
-        # @!attribute [rw] datastore
-        #     @return [String, nil]
-        #     Datastore on which the virtual machine's configuration state should be stored. This datastore will also be used for any virtual disks that are created as part of the virtual machine creation operation.
-        #     This  field  is currently required. In the future, if this  field  is  nil , the system will attempt to choose suitable storage for the virtual machine; if storage cannot be chosen, the virtual machine creation operation will fail.
-        class PlacementSpec < VAPI::Bindings::VapiStruct
+    SERVICE_INFO = VAPI::Bindings::ServiceInfo.new(
+      SERVICE_ID,
+      'list' => LIST_INFO
+    )
 
-            class << self
-                # Holds (gets or creates) the binding type metadata for this structure type.
-                # @scope class
-                # @return [VAPI::Bindings::StructType] the binding type
-                def binding_type
-                    @binding_type ||= VAPI::Bindings::StructType.new(
-                        'com.vmware.vcenter.VM.placement_spec',
-                        {
-                            'folder' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::IdType.new),
-                            'resource_pool' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::IdType.new),
-                            'host' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::IdType.new),
-                            'cluster' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::IdType.new),
-                            'datastore' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::IdType.new),
-                        },
-                        PlacementSpec,
-                        false,
-                        nil)
-                end
-            end
-
-            attr_accessor :folder,
-                          :resource_pool,
-                          :host,
-                          :cluster,
-                          :datastore
-
-            # Constructs a new instance.
-            # @param ruby_values [Hash] a map of initial property values (optional)
-            # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
-            def initialize(ruby_values=nil, struct_value=nil)
-                super(self.class.binding_type, ruby_values, struct_value)
-            end
-        end
-
-
-        # Document-based creation spec.
-        # @!attribute [rw] guest_OS
-        #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
-        #     Guest OS.
-        # @!attribute [rw] name
-        #     @return [String, nil]
-        #     Virtual machine name.
-        #     If  nil , a default name will be generated by the server.
-        # @!attribute [rw] placement
-        #     @return [Com::Vmware::Vcenter::VM::PlacementSpec, nil]
-        #     Virtual machine placement information.
-        #     This  field  is currently required. In the future, if this  field  is  nil , the system will attempt to choose suitable resources on which to place the virtual machine.
-        # @!attribute [rw] hardware_version
-        #     @return [Com::Vmware::Vcenter::Vm::Hardware::Version, nil]
-        #     Virtual hardware version.
-        #     If  nil , defaults to the most recent version supported by the server.
-        # @!attribute [rw] boot
-        #     @return [Com::Vmware::Vcenter::Vm::Hardware::Boot::CreateSpec, nil]
-        #     Boot configuration.
-        #     If  nil , guest-specific default values will be used.
-        # @!attribute [rw] boot_devices
-        #     @return [Array<Com::Vmware::Vcenter::Vm::Hardware::Boot::Device::EntryCreateSpec>, nil]
-        #     Boot device configuration.
-        #     If  nil , a server-specific boot sequence will be used.
-        # @!attribute [rw] cpu
-        #     @return [Com::Vmware::Vcenter::Vm::Hardware::Cpu::UpdateSpec, nil]
-        #     CPU configuration.
-        #     If  nil , guest-specific default values will be used.
-        # @!attribute [rw] memory
-        #     @return [Com::Vmware::Vcenter::Vm::Hardware::Memory::UpdateSpec, nil]
-        #     Memory configuration.
-        #     If  nil , guest-specific default values will be used.
-        # @!attribute [rw] disks
-        #     @return [Array<Com::Vmware::Vcenter::Vm::Hardware::Disk::CreateSpec>, nil]
-        #     List of disks.
-        #     If  nil , a single blank virtual disk of a guest-specific size will be created on the same storage as the virtual machine configuration, and will use a guest-specific host bus adapter type. If the guest-specific size is 0, no virtual disk will be created.
-        # @!attribute [rw] nics
-        #     @return [Array<Com::Vmware::Vcenter::Vm::Hardware::Ethernet::CreateSpec>, nil]
-        #     List of Ethernet adapters.
-        #     If  nil , no Ethernet adapters will be created.
-        # @!attribute [rw] cdroms
-        #     @return [Array<Com::Vmware::Vcenter::Vm::Hardware::Cdrom::CreateSpec>, nil]
-        #     List of CD-ROMs.
-        #     If  nil , no CD-ROM devices will be created.
-        # @!attribute [rw] floppies
-        #     @return [Array<Com::Vmware::Vcenter::Vm::Hardware::Floppy::CreateSpec>, nil]
-        #     List of floppy drives.
-        #     If  nil , no floppy drives will be created.
-        # @!attribute [rw] parallel_ports
-        #     @return [Array<Com::Vmware::Vcenter::Vm::Hardware::Parallel::CreateSpec>, nil]
-        #     List of parallel ports.
-        #     If  nil , no parallel ports will be created.
-        # @!attribute [rw] serial_ports
-        #     @return [Array<Com::Vmware::Vcenter::Vm::Hardware::Serial::CreateSpec>, nil]
-        #     List of serial ports.
-        #     If  nil , no serial ports will be created.
-        # @!attribute [rw] sata_adapters
-        #     @return [Array<Com::Vmware::Vcenter::Vm::Hardware::Adapter::Sata::CreateSpec>, nil]
-        #     List of SATA adapters.
-        #     If  nil , any adapters necessary to connect the virtual machine's storage devices will be created; this includes any devices that explicitly specify a SATA host bus adapter, as well as any devices that do not specify a host bus adapter if the guest's preferred adapter type is SATA.
-        # @!attribute [rw] scsi_adapters
-        #     @return [Array<Com::Vmware::Vcenter::Vm::Hardware::Adapter::Scsi::CreateSpec>, nil]
-        #     List of SCSI adapters.
-        #     If  nil , any adapters necessary to connect the virtual machine's storage devices will be created; this includes any devices that explicitly specify a SCSI host bus adapter, as well as any devices that do not specify a host bus adapter if the guest's preferred adapter type is SCSI. The type of the SCSI adapter will be a guest-specific default type.
-        class CreateSpec < VAPI::Bindings::VapiStruct
-
-            class << self
-                # Holds (gets or creates) the binding type metadata for this structure type.
-                # @scope class
-                # @return [VAPI::Bindings::StructType] the binding type
-                def binding_type
-                    @binding_type ||= VAPI::Bindings::StructType.new(
-                        'com.vmware.vcenter.VM.create_spec',
-                        {
-                            'guest_OS' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::Vm::GuestOS'),
-                            'name' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::StringType.instance),
-                            'placement' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::VM::PlacementSpec')),
-                            'hardware_version' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::Vm::Hardware::Version')),
-                            'boot' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::Vm::Hardware::Boot::CreateSpec')),
-                            'boot_devices' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::ListType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::Vm::Hardware::Boot::Device::EntryCreateSpec'))),
-                            'cpu' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::Vm::Hardware::Cpu::UpdateSpec')),
-                            'memory' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::Vm::Hardware::Memory::UpdateSpec')),
-                            'disks' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::ListType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::Vm::Hardware::Disk::CreateSpec'))),
-                            'nics' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::ListType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::Vm::Hardware::Ethernet::CreateSpec'))),
-                            'cdroms' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::ListType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::Vm::Hardware::Cdrom::CreateSpec'))),
-                            'floppies' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::ListType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::Vm::Hardware::Floppy::CreateSpec'))),
-                            'parallel_ports' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::ListType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::Vm::Hardware::Parallel::CreateSpec'))),
-                            'serial_ports' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::ListType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::Vm::Hardware::Serial::CreateSpec'))),
-                            'sata_adapters' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::ListType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::Vm::Hardware::Adapter::Sata::CreateSpec'))),
-                            'scsi_adapters' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::ListType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::Vm::Hardware::Adapter::Scsi::CreateSpec'))),
-                        },
-                        CreateSpec,
-                        false,
-                        nil)
-                end
-            end
-
-            attr_accessor :guest_OS,
-                          :name,
-                          :placement,
-                          :hardware_version,
-                          :boot,
-                          :boot_devices,
-                          :cpu,
-                          :memory,
-                          :disks,
-                          :nics,
-                          :cdroms,
-                          :floppies,
-                          :parallel_ports,
-                          :serial_ports,
-                          :sata_adapters,
-                          :scsi_adapters
-
-            # Constructs a new instance.
-            # @param ruby_values [Hash] a map of initial property values (optional)
-            # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
-            def initialize(ruby_values=nil, struct_value=nil)
-                super(self.class.binding_type, ruby_values, struct_value)
-            end
-        end
-
-
-        # Document-based info.
-        # @!attribute [rw] guest_OS
-        #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
-        #     Guest OS.
-        # @!attribute [rw] name
-        #     @return [String]
-        #     Virtual machine name.
-        # @!attribute [rw] power_state
-        #     @return [Com::Vmware::Vcenter::Vm::Power::State]
-        #     Power state of the virtual machine.
-        # @!attribute [rw] hardware
-        #     @return [Com::Vmware::Vcenter::Vm::Hardware::Info]
-        #     Virtual hardware version information.
-        # @!attribute [rw] boot
-        #     @return [Com::Vmware::Vcenter::Vm::Hardware::Boot::Info]
-        #     Boot configuration.
-        # @!attribute [rw] boot_devices
-        #     @return [Array<Com::Vmware::Vcenter::Vm::Hardware::Boot::Device::Entry>]
-        #     Boot device configuration. If the  list  has no entries, a server-specific default boot sequence is used.
-        # @!attribute [rw] cpu
-        #     @return [Com::Vmware::Vcenter::Vm::Hardware::Cpu::Info]
-        #     CPU configuration.
-        # @!attribute [rw] memory
-        #     @return [Com::Vmware::Vcenter::Vm::Hardware::Memory::Info]
-        #     Memory configuration.
-        # @!attribute [rw] disks
-        #     @return [Hash<String, Com::Vmware::Vcenter::Vm::Hardware::Disk::Info>]
-        #     List of disks.
-        # @!attribute [rw] nics
-        #     @return [Hash<String, Com::Vmware::Vcenter::Vm::Hardware::Ethernet::Info>]
-        #     List of Ethernet adapters.
-        # @!attribute [rw] cdroms
-        #     @return [Hash<String, Com::Vmware::Vcenter::Vm::Hardware::Cdrom::Info>]
-        #     List of CD-ROMs.
-        # @!attribute [rw] floppies
-        #     @return [Hash<String, Com::Vmware::Vcenter::Vm::Hardware::Floppy::Info>]
-        #     List of floppy drives.
-        # @!attribute [rw] parallel_ports
-        #     @return [Hash<String, Com::Vmware::Vcenter::Vm::Hardware::Parallel::Info>]
-        #     List of parallel ports.
-        # @!attribute [rw] serial_ports
-        #     @return [Hash<String, Com::Vmware::Vcenter::Vm::Hardware::Serial::Info>]
-        #     List of serial ports.
-        # @!attribute [rw] sata_adapters
-        #     @return [Hash<String, Com::Vmware::Vcenter::Vm::Hardware::Adapter::Sata::Info>]
-        #     List of SATA adapters.
-        # @!attribute [rw] scsi_adapters
-        #     @return [Hash<String, Com::Vmware::Vcenter::Vm::Hardware::Adapter::Scsi::Info>]
-        #     List of SCSI adapters.
-        class Info < VAPI::Bindings::VapiStruct
-
-            class << self
-                # Holds (gets or creates) the binding type metadata for this structure type.
-                # @scope class
-                # @return [VAPI::Bindings::StructType] the binding type
-                def binding_type
-                    @binding_type ||= VAPI::Bindings::StructType.new(
-                        'com.vmware.vcenter.VM.info',
-                        {
-                            'guest_OS' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::Vm::GuestOS'),
-                            'name' => VAPI::Bindings::StringType.instance,
-                            'power_state' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::Vm::Power::State'),
-                            'hardware' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::Vm::Hardware::Info'),
-                            'boot' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::Vm::Hardware::Boot::Info'),
-                            'boot_devices' => VAPI::Bindings::ListType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::Vm::Hardware::Boot::Device::Entry')),
-                            'cpu' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::Vm::Hardware::Cpu::Info'),
-                            'memory' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::Vm::Hardware::Memory::Info'),
-                            'disks' => VAPI::Bindings::MapType.new(VAPI::Bindings::IdType.new, VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::Vm::Hardware::Disk::Info')),
-                            'nics' => VAPI::Bindings::MapType.new(VAPI::Bindings::IdType.new, VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::Vm::Hardware::Ethernet::Info')),
-                            'cdroms' => VAPI::Bindings::MapType.new(VAPI::Bindings::IdType.new, VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::Vm::Hardware::Cdrom::Info')),
-                            'floppies' => VAPI::Bindings::MapType.new(VAPI::Bindings::IdType.new, VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::Vm::Hardware::Floppy::Info')),
-                            'parallel_ports' => VAPI::Bindings::MapType.new(VAPI::Bindings::IdType.new, VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::Vm::Hardware::Parallel::Info')),
-                            'serial_ports' => VAPI::Bindings::MapType.new(VAPI::Bindings::IdType.new, VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::Vm::Hardware::Serial::Info')),
-                            'sata_adapters' => VAPI::Bindings::MapType.new(VAPI::Bindings::IdType.new, VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::Vm::Hardware::Adapter::Sata::Info')),
-                            'scsi_adapters' => VAPI::Bindings::MapType.new(VAPI::Bindings::IdType.new, VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::Vm::Hardware::Adapter::Scsi::Info')),
-                        },
-                        Info,
-                        false,
-                        nil)
-                end
-            end
-
-            attr_accessor :guest_OS,
-                          :name,
-                          :power_state,
-                          :hardware,
-                          :boot,
-                          :boot_devices,
-                          :cpu,
-                          :memory,
-                          :disks,
-                          :nics,
-                          :cdroms,
-                          :floppies,
-                          :parallel_ports,
-                          :serial_ports,
-                          :sata_adapters,
-                          :scsi_adapters
-
-            # Constructs a new instance.
-            # @param ruby_values [Hash] a map of initial property values (optional)
-            # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
-            def initialize(ruby_values=nil, struct_value=nil)
-                super(self.class.binding_type, ruby_values, struct_value)
-            end
-        end
-
-
-        # The  ``Com::Vmware::Vcenter::VM::FilterSpec``   class  contains  fields  used to filter the results when listing virtual machines (see   :func:`Com::Vmware::Vcenter::VM.list`  ). If multiple  fields  are specified, only virtual machines matching all of the  fields  match the filter.
-        # @!attribute [rw] vms
-        #     @return [Set<String>, nil]
-        #     Identifiers of virtual machines that can match the filter.
-        #     If  nil  or empty, virtual machines with any identifier match the filter.
-        # @!attribute [rw] names
-        #     @return [Set<String>, nil]
-        #     Names that virtual machines must have to match the filter (see   :attr:`Com::Vmware::Vcenter::VM::Info.name`  ).
-        #     If  nil  or empty, virtual machines with any name match the filter.
-        # @!attribute [rw] folders
-        #     @return [Set<String>, nil]
-        #     Folders that must contain the virtual machine for the virtual machine to match the filter.
-        #     If  nil  or empty, virtual machines in any folder match the filter.
-        # @!attribute [rw] datacenters
-        #     @return [Set<String>, nil]
-        #     Datacenters that must contain the virtual machine for the virtual machine to match the filter.
-        #     If  nil  or empty, virtual machines in any datacenter match the filter.
-        # @!attribute [rw] hosts
-        #     @return [Set<String>, nil]
-        #     Hosts that must contain the virtual machine for the virtual machine to match the filter.
-        #     If  nil  or empty, virtual machines on any host match the filter.
-        # @!attribute [rw] clusters
-        #     @return [Set<String>, nil]
-        #     Clusters that must contain the virtual machine for the virtual machine to match the filter.
-        #     If  nil  or empty, virtual machines in any cluster match the filter.
-        # @!attribute [rw] resource_pools
-        #     @return [Set<String>, nil]
-        #     Resource pools that must contain the virtual machine for the virtual machine to match the filter.
-        #     If  nil  or empty, virtual machines in any resource pool match the filter.
-        # @!attribute [rw] power_states
-        #     @return [Set<Com::Vmware::Vcenter::Vm::Power::State>, nil]
-        #     Power states that a virtual machine must be in to match the filter (see   :attr:`Com::Vmware::Vcenter::Vm::Power::Info.state`  .
-        #     If  nil  or empty, virtual machines in any power state match the filter.
-        class FilterSpec < VAPI::Bindings::VapiStruct
-
-            class << self
-                # Holds (gets or creates) the binding type metadata for this structure type.
-                # @scope class
-                # @return [VAPI::Bindings::StructType] the binding type
-                def binding_type
-                    @binding_type ||= VAPI::Bindings::StructType.new(
-                        'com.vmware.vcenter.VM.filter_spec',
-                        {
-                            'vms' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::SetType.new(VAPI::Bindings::IdType.new)),
-                            'names' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::SetType.new(VAPI::Bindings::StringType.instance)),
-                            'folders' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::SetType.new(VAPI::Bindings::IdType.new)),
-                            'datacenters' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::SetType.new(VAPI::Bindings::IdType.new)),
-                            'hosts' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::SetType.new(VAPI::Bindings::IdType.new)),
-                            'clusters' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::SetType.new(VAPI::Bindings::IdType.new)),
-                            'resource_pools' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::SetType.new(VAPI::Bindings::IdType.new)),
-                            'power_states' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::SetType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::Vm::Power::State'))),
-                        },
-                        FilterSpec,
-                        false,
-                        nil)
-                end
-            end
-
-            attr_accessor :vms,
-                          :names,
-                          :folders,
-                          :datacenters,
-                          :hosts,
-                          :clusters,
-                          :resource_pools,
-                          :power_states
-
-            # Constructs a new instance.
-            # @param ruby_values [Hash] a map of initial property values (optional)
-            # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
-            def initialize(ruby_values=nil, struct_value=nil)
-                super(self.class.binding_type, ruby_values, struct_value)
-            end
-        end
-
-
-        # The  ``Com::Vmware::Vcenter::VM::Summary``   class  contains commonly used information about a virtual machine.
-        # @!attribute [rw] vm
-        #     @return [String]
-        #     Identifier of the virtual machine.
-        # @!attribute [rw] name
-        #     @return [String]
-        #     Name of the Virtual machine.
-        # @!attribute [rw] power_state
-        #     @return [Com::Vmware::Vcenter::Vm::Power::State]
-        #     Power state of the virtual machine.
-        # @!attribute [rw] cpu_count
-        #     @return [Fixnum, nil]
-        #     Number of CPU cores.
-        #     This  field  will be  nil  if the virtual machine configuration is not available. For example, the configuration information would be unavailable if the server is unable to access the virtual machine files on disk, and is often also unavailable during the intial phases of virtual machine creation.
-        # @!attribute [rw] memory_size_MiB
-        #     @return [Fixnum, nil]
-        #     Memory size in mebibytes.
-        #     This  field  will be  nil  if the virtual machine configuration is not available. For example, the configuration information would be unavailable if the server is unable to access the virtual machine files on disk, and is often also unavailable during the intial phases of virtual machine creation.
-        class Summary < VAPI::Bindings::VapiStruct
-
-            class << self
-                # Holds (gets or creates) the binding type metadata for this structure type.
-                # @scope class
-                # @return [VAPI::Bindings::StructType] the binding type
-                def binding_type
-                    @binding_type ||= VAPI::Bindings::StructType.new(
-                        'com.vmware.vcenter.VM.summary',
-                        {
-                            'vm' => VAPI::Bindings::IdType.new(resource_types='VirtualMachine'),
-                            'name' => VAPI::Bindings::StringType.instance,
-                            'power_state' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::Vm::Power::State'),
-                            'cpu_count' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::IntegerType.instance),
-                            'memory_size_MiB' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::IntegerType.instance),
-                        },
-                        Summary,
-                        false,
-                        nil)
-                end
-            end
-
-            attr_accessor :vm,
-                          :name,
-                          :power_state,
-                          :cpu_count,
-                          :memory_size_MiB
-
-            # Constructs a new instance.
-            # @param ruby_values [Hash] a map of initial property values (optional)
-            # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
-            def initialize(ruby_values=nil, struct_value=nil)
-                super(self.class.binding_type, ruby_values, struct_value)
-            end
-        end
-
-
+    # Constructs a new instance.
+    #
+    # @param config [VAPI::Bindings::StubConfig] A hash with the api provider details.
+    def initialize(config)
+      super(config, SERVICE_INFO)
     end
 
+    RESOURCE_TYPE = 'Network'
+    # Returns information about at most 1000 visible (subject to permission checks) networks in vCenter matching the   :class:`Com::Vmware::Vcenter::Network::FilterSpec`  .
+    #
+    # @param filter [Com::Vmware::Vcenter::Network::FilterSpec, nil]
+    #     Specification of matching networks for which information should be returned.
+    #     If  nil , the behavior is equivalent to a   :class:`Com::Vmware::Vcenter::Network::FilterSpec`   with all  fields   nil  which means all networks match the filter.
+    # @return [Array<Com::Vmware::Vcenter::Network::Summary>]
+    #     Commonly used information about the networks matching the   :class:`Com::Vmware::Vcenter::Network::FilterSpec`  .
+    # @raise [Com::Vmware::Vapi::Std::Errors::InvalidArgument]
+    #     if the   :attr:`Com::Vmware::Vcenter::Network::FilterSpec.types`    field  contains a value that is not supported by the server.
+    # @raise [Com::Vmware::Vapi::Std::Errors::UnableToAllocateResource]
+    #     if more than 1000 networks match the   :class:`Com::Vmware::Vcenter::Network::FilterSpec`  .
+    # @raise [Com::Vmware::Vapi::Std::Errors::ServiceUnavailable]
+    #     if the system is unable to communicate with a service to complete the request.
+    # @raise [Com::Vmware::Vapi::Std::Errors::Unauthenticated]
+    #     if the user can not be authenticated.
+    # @raise [Com::Vmware::Vapi::Std::Errors::Unauthorized]
+    #     if the user doesn't have the required privileges.
+    def list(filter = nil)
+      invoke_with_info(LIST_INFO,
+                       'filter' => filter)
+    end
 
+    # The  ``Com::Vmware::Vcenter::Network::FilterSpec``   class  contains  fields  used to filter the results when listing networks (see   :func:`Com::Vmware::Vcenter::Network.list`  ). If multiple  fields  are specified, only networks matching all of the  fields  match the filter.
+    # @!attribute [rw] networks
+    #     @return [Set<String>, nil]
+    #     Identifiers of networks that can match the filter.
+    #     If  nil  or empty, networks with any identifier match the filter.
+    # @!attribute [rw] names
+    #     @return [Set<String>, nil]
+    #     Names that networks must have to match the filter (see   :attr:`Com::Vmware::Vcenter::Network::Summary.name`  ).
+    #     If  nil  or empty, networks with any name match the filter.
+    # @!attribute [rw] types
+    #     @return [Set<Com::Vmware::Vcenter::Network::Type>, nil]
+    #     Types that networks must have to match the filter (see   :attr:`Com::Vmware::Vcenter::Network::Summary.type`  ).
+    #     If  nil , networks with any type match the filter.
+    # @!attribute [rw] folders
+    #     @return [Set<String>, nil]
+    #     Folders that must contain the network for the network to match the filter.
+    #     If  nil  or empty, networks in any folder match the filter.
+    # @!attribute [rw] datacenters
+    #     @return [Set<String>, nil]
+    #     Datacenters that must contain the network for the network to match the filter.
+    #     If  nil  or empty, networks in any datacenter match the filter.
+    class FilterSpec < VAPI::Bindings::VapiStruct
+      class << self
+        # Holds (gets or creates) the binding type metadata for this structure type.
+        # @scope class
+        # @return [VAPI::Bindings::StructType] the binding type
+        def binding_type
+          @binding_type ||= VAPI::Bindings::StructType.new(
+            'com.vmware.vcenter.network.filter_spec',
+            {
+              'networks' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::SetType.new(VAPI::Bindings::IdType.new)),
+              'names' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::SetType.new(VAPI::Bindings::StringType.instance)),
+              'types' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::SetType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::Network::Type'))),
+              'folders' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::SetType.new(VAPI::Bindings::IdType.new)),
+              'datacenters' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::SetType.new(VAPI::Bindings::IdType.new))
+            },
+            FilterSpec,
+            false,
+            nil
+          )
+        end
+      end
+
+      attr_accessor :networks,
+                    :names,
+                    :types,
+                    :folders,
+                    :datacenters
+
+      # Constructs a new instance.
+      # @param ruby_values [Hash] a map of initial property values (optional)
+      # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
+      def initialize(ruby_values = nil, struct_value = nil)
+        super(self.class.binding_type, ruby_values, struct_value)
+      end
+    end
+
+    # The  ``Com::Vmware::Vcenter::Network::Summary``   class  contains commonly used information about a network.
+    # @!attribute [rw] network
+    #     @return [String]
+    #     Identifier of the network.
+    # @!attribute [rw] name
+    #     @return [String]
+    #     Name of the network.
+    # @!attribute [rw] type
+    #     @return [Com::Vmware::Vcenter::Network::Type]
+    #     Type ( ``STANDARD_PORTGROUP``, ``DISTRIBUTED_PORTGROUP``, ``OPAQUE_NETWORK`` ) of the vCenter Server network.
+    class Summary < VAPI::Bindings::VapiStruct
+      class << self
+        # Holds (gets or creates) the binding type metadata for this structure type.
+        # @scope class
+        # @return [VAPI::Bindings::StructType] the binding type
+        def binding_type
+          @binding_type ||= VAPI::Bindings::StructType.new(
+            'com.vmware.vcenter.network.summary',
+            {
+              'network' => VAPI::Bindings::IdType.new('Network'),
+              'name' => VAPI::Bindings::StringType.instance,
+              'type' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::Network::Type')
+            },
+            Summary,
+            false,
+            nil
+          )
+        end
+      end
+
+      attr_accessor :network,
+                    :name,
+                    :type
+
+      # Constructs a new instance.
+      # @param ruby_values [Hash] a map of initial property values (optional)
+      # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
+      def initialize(ruby_values = nil, struct_value = nil)
+        super(self.class.binding_type, ruby_values, struct_value)
+      end
+    end
+
+    # The  ``Com::Vmware::Vcenter::Network::Type``   enumerated type  defines the type of a vCenter Server network. The type of a network can be used to determine what features it supports and which APIs can be used to find more information about the network or change its configuration.
+    # @!attribute [rw] standard_portgroup
+    #     @return [Com::Vmware::Vcenter::Network::Type]
+    #     XXX: ESX based (created and managed on ESX)
+    # @!attribute [rw] distributed_portgroup
+    #     @return [Com::Vmware::Vcenter::Network::Type]
+    #     XXX: vCenter based (create and managed through vCenter)
+    # @!attribute [rw] opaque_network
+    #     @return [Com::Vmware::Vcenter::Network::Type]
+    #     A network for whose configuration is managed outside of vSphere. The identifer and name of the network is made available through vSphere so that host and virtual machine virtual ethernet devices can connect to them.
+    class Type < VAPI::Bindings::VapiEnum
+      class << self
+        # Holds (gets or creates) the binding type metadata for this enumeration type.
+        # @scope class
+        # @return [VAPI::Bindings::EnumType] the binding type
+        def binding_type
+          @binding_type ||= VAPI::Bindings::EnumType.new(
+            'com.vmware.vcenter.network.type',
+            Type
+          )
+        end
+
+        # Converts from a string value (perhaps off the wire) to an instance
+        # of this enum type.
+        # @param value [String] the actual value of the enum instance
+        # @return [Type] the instance found for the value, otherwise
+        #         an unknown instance will be built for the value
+        def from_string(value)
+          const_get(value)
+        rescue NameError
+          Type.send(:new, 'UNKNOWN', value)
+        end
+      end
+
+      # Constructs a new instance.
+      # @param value [String] the actual value of the enum instance
+      # @param unknown [String] the unknown value when value is 'UKNOWN'
+      def initialize(value, unknown = nil)
+        super(self.class.binding_type, value, unknown)
+      end
+
+      private_class_method :new
+
+      # @!attribute [rw] standard_portgroup
+      #     @return [Com::Vmware::Vcenter::Network::Type]
+      #     XXX: ESX based (created and managed on ESX)
+      STANDARD_PORTGROUP = Type.send(:new, 'STANDARD_PORTGROUP')
+
+      # @!attribute [rw] distributed_portgroup
+      #     @return [Com::Vmware::Vcenter::Network::Type]
+      #     XXX: vCenter based (create and managed through vCenter)
+      DISTRIBUTED_PORTGROUP = Type.send(:new, 'DISTRIBUTED_PORTGROUP')
+
+      # @!attribute [rw] opaque_network
+      #     @return [Com::Vmware::Vcenter::Network::Type]
+      #     A network for whose configuration is managed outside of vSphere. The identifer and name of the network is made available through vSphere so that host and virtual machine virtual ethernet devices can connect to them.
+      OPAQUE_NETWORK = Type.send(:new, 'OPAQUE_NETWORK')
+    end
+  end
+  # The  ResourcePool   class  provides  methods  for manipulating a vCenter Server resource pool.  
+  # 
+  #  This  class  does not include virtual appliances in the inventory of resource pools even though part of the behavior of a virtual appliance is to act like a resource pool.
+  class ResourcePool < VAPI::Bindings::VapiService
+    # static metamodel definitions
+    SERVICE_ID = VAPI::Core::ServiceIdentifier.new('com.vmware.vcenter.resource_pool')
+
+    GET_INFO = VAPI::Bindings::OperationInfo.new(
+      VAPI::Core::OperationIdentifier.new('get', SERVICE_ID),
+      VAPI::Bindings::OperationInputType.new(
+        'resource_pool' => VAPI::Bindings::IdType.new('ResourcePool')
+      ),
+      VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::ResourcePool::Info'),
+      {
+        'com.vmware.vapi.std.errors.not_found' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::NotFound'),
+        'com.vmware.vapi.std.errors.service_unavailable' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::ServiceUnavailable'),
+        'com.vmware.vapi.std.errors.unauthenticated' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Unauthenticated'),
+        'com.vmware.vapi.std.errors.unauthorized' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Unauthorized')
+      },
+      [],
+      []
+    )
+
+    LIST_INFO = VAPI::Bindings::OperationInfo.new(
+      VAPI::Core::OperationIdentifier.new('list', SERVICE_ID),
+      VAPI::Bindings::OperationInputType.new(
+        'filter' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::ResourcePool::FilterSpec'))
+      ),
+      VAPI::Bindings::ListType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::ResourcePool::Summary')),
+      {
+        'com.vmware.vapi.std.errors.unable_to_allocate_resource' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::UnableToAllocateResource'),
+        'com.vmware.vapi.std.errors.service_unavailable' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::ServiceUnavailable'),
+        'com.vmware.vapi.std.errors.unauthenticated' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Unauthenticated'),
+        'com.vmware.vapi.std.errors.unauthorized' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Unauthorized')
+      },
+      [],
+      []
+    )
+
+    SERVICE_INFO = VAPI::Bindings::ServiceInfo.new(
+      SERVICE_ID,
+      'get' => GET_INFO,
+      'list' => LIST_INFO
+    )
+
+    # Constructs a new instance.
+    #
+    # @param config [VAPI::Bindings::StubConfig] A hash with the api provider details.
+    def initialize(config)
+      super(config, SERVICE_INFO)
+    end
+
+    RESOURCE_TYPE = 'ResourcePool'
+    # Retrieves information about the resource pool indicated by  ``resource_pool`` .
+    #
+    # @param resource_pool [String]
+    #     Identifier of the resource pool for which information should be retrieved.
+    # @return [Com::Vmware::Vcenter::ResourcePool::Info]
+    #     information about the resource pool.
+    # @raise [Com::Vmware::Vapi::Std::Errors::NotFound]
+    #     if the resource pool indicated by  ``resource_pool``  does not exist.
+    # @raise [Com::Vmware::Vapi::Std::Errors::ServiceUnavailable]
+    #     if the system is unable to communicate with a service to complete the request.
+    # @raise [Com::Vmware::Vapi::Std::Errors::Unauthenticated]
+    #     if the user can not be authenticated.
+    # @raise [Com::Vmware::Vapi::Std::Errors::Unauthorized]
+    #     if the user doesn't have the required privileges.
+    def get(resource_pool)
+      invoke_with_info(GET_INFO,
+                       'resource_pool' => resource_pool)
+    end
+
+    # Returns information about at most 1000 visible (subject to permission checks) resource pools in vCenter matching the   :class:`Com::Vmware::Vcenter::ResourcePool::FilterSpec`  .
+    #
+    # @param filter [Com::Vmware::Vcenter::ResourcePool::FilterSpec, nil]
+    #     Specification of matching resource pools for which information should be returned.
+    #     If  nil , the behavior is equivalent to a   :class:`Com::Vmware::Vcenter::ResourcePool::FilterSpec`   with all  fields   nil  which means all resource pools match the filter.
+    # @return [Array<Com::Vmware::Vcenter::ResourcePool::Summary>]
+    #     Commonly used information about the resource pools matching the   :class:`Com::Vmware::Vcenter::ResourcePool::FilterSpec`  .
+    # @raise [Com::Vmware::Vapi::Std::Errors::UnableToAllocateResource]
+    #     if more than 1000 resource pools match the   :class:`Com::Vmware::Vcenter::ResourcePool::FilterSpec`  .
+    # @raise [Com::Vmware::Vapi::Std::Errors::ServiceUnavailable]
+    #     if the system is unable to communicate with a service to complete the request.
+    # @raise [Com::Vmware::Vapi::Std::Errors::Unauthenticated]
+    #     if the user can not be authenticated.
+    # @raise [Com::Vmware::Vapi::Std::Errors::Unauthorized]
+    #     if the user doesn't have the required privileges.
+    def list(filter = nil)
+      invoke_with_info(LIST_INFO,
+                       'filter' => filter)
+    end
+
+    # The  ``Com::Vmware::Vcenter::ResourcePool::Info``   class  contains information about a resource pool.
+    # @!attribute [rw] name
+    #     @return [String]
+    #     Name of the vCenter Server resource pool.
+    # @!attribute [rw] resource_pools
+    #     @return [Set<String>]
+    #     Identifiers of the child resource pools contained in this resource pool.
+    class Info < VAPI::Bindings::VapiStruct
+      class << self
+        # Holds (gets or creates) the binding type metadata for this structure type.
+        # @scope class
+        # @return [VAPI::Bindings::StructType] the binding type
+        def binding_type
+          @binding_type ||= VAPI::Bindings::StructType.new(
+            'com.vmware.vcenter.resource_pool.info',
+            {
+              'name' => VAPI::Bindings::StringType.instance,
+              'resource_pools' => VAPI::Bindings::SetType.new(VAPI::Bindings::IdType.new)
+            },
+            Info,
+            false,
+            nil
+          )
+        end
+      end
+
+      attr_accessor :name,
+                    :resource_pools
+
+      # Constructs a new instance.
+      # @param ruby_values [Hash] a map of initial property values (optional)
+      # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
+      def initialize(ruby_values = nil, struct_value = nil)
+        super(self.class.binding_type, ruby_values, struct_value)
+      end
+    end
+
+    # The  ``Com::Vmware::Vcenter::ResourcePool::FilterSpec``   class  contains  fields  used to filter the results when listing resource pools (see   :func:`Com::Vmware::Vcenter::ResourcePool.list`  ). If multiple  fields  are specified, only resource pools matching all of the  fields  match the filter.
+    # @!attribute [rw] resource_pools
+    #     @return [Set<String>, nil]
+    #     Identifiers of resource pools that can match the filter.
+    #     If  nil  or empty, resource pools with any identifier match the filter.
+    # @!attribute [rw] names
+    #     @return [Set<String>, nil]
+    #     Names that resource pools must have to match the filter (see   :attr:`Com::Vmware::Vcenter::ResourcePool::Info.name`  ).
+    #     If  nil  or empty, resource pools with any name match the filter.
+    # @!attribute [rw] parent_resource_pools
+    #     @return [Set<String>, nil]
+    #     Resource pools that must contain the resource pool for the resource pool to match the filter.
+    #     If  nil  or empty, resource pools in any resource pool match the filter.
+    # @!attribute [rw] datacenters
+    #     @return [Set<String>, nil]
+    #     Datacenters that must contain the resource pool for the resource pool to match the filter.
+    #     If  nil  or empty, resource pools in any datacenter match the filter.
+    # @!attribute [rw] hosts
+    #     @return [Set<String>, nil]
+    #     Hosts that must contain the resource pool for the resource pool to match the filter.
+    #     If  nil  or empty, resource pools in any host match the filter.
+    # @!attribute [rw] clusters
+    #     @return [Set<String>, nil]
+    #     Clusters that must contain the resource pool for the resource pool to match the filter.
+    #     If  nil  or empty, resource pools in any cluster match the filter.
+    class FilterSpec < VAPI::Bindings::VapiStruct
+      class << self
+        # Holds (gets or creates) the binding type metadata for this structure type.
+        # @scope class
+        # @return [VAPI::Bindings::StructType] the binding type
+        def binding_type
+          @binding_type ||= VAPI::Bindings::StructType.new(
+            'com.vmware.vcenter.resource_pool.filter_spec',
+            {
+              'resource_pools' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::SetType.new(VAPI::Bindings::IdType.new)),
+              'names' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::SetType.new(VAPI::Bindings::StringType.instance)),
+              'parent_resource_pools' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::SetType.new(VAPI::Bindings::IdType.new)),
+              'datacenters' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::SetType.new(VAPI::Bindings::IdType.new)),
+              'hosts' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::SetType.new(VAPI::Bindings::IdType.new)),
+              'clusters' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::SetType.new(VAPI::Bindings::IdType.new))
+            },
+            FilterSpec,
+            false,
+            nil
+          )
+        end
+      end
+
+      attr_accessor :resource_pools,
+                    :names,
+                    :parent_resource_pools,
+                    :datacenters,
+                    :hosts,
+                    :clusters
+
+      # Constructs a new instance.
+      # @param ruby_values [Hash] a map of initial property values (optional)
+      # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
+      def initialize(ruby_values = nil, struct_value = nil)
+        super(self.class.binding_type, ruby_values, struct_value)
+      end
+    end
+
+    # The  ``Com::Vmware::Vcenter::ResourcePool::Summary``   class  contains commonly used information about a resource pool in vCenter Server.
+    # @!attribute [rw] resource_pool
+    #     @return [String]
+    #     Identifier of the resource pool.
+    # @!attribute [rw] name
+    #     @return [String]
+    #     Name of the resource pool.
+    class Summary < VAPI::Bindings::VapiStruct
+      class << self
+        # Holds (gets or creates) the binding type metadata for this structure type.
+        # @scope class
+        # @return [VAPI::Bindings::StructType] the binding type
+        def binding_type
+          @binding_type ||= VAPI::Bindings::StructType.new(
+            'com.vmware.vcenter.resource_pool.summary',
+            {
+              'resource_pool' => VAPI::Bindings::IdType.new('ResourcePool'),
+              'name' => VAPI::Bindings::StringType.instance
+            },
+            Summary,
+            false,
+            nil
+          )
+        end
+      end
+
+      attr_accessor :resource_pool,
+                    :name
+
+      # Constructs a new instance.
+      # @param ruby_values [Hash] a map of initial property values (optional)
+      # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
+      def initialize(ruby_values = nil, struct_value = nil)
+        super(self.class.binding_type, ruby_values, struct_value)
+      end
+    end
+
+  end
+  # The  ``Com::Vmware::Vcenter::VM``   class  provides  methods  for managing the lifecycle of a virtual machine.
+  class VM < VAPI::Bindings::VapiService
+    # static metamodel definitions
+    SERVICE_ID = VAPI::Core::ServiceIdentifier.new('com.vmware.vcenter.VM')
+
+    CREATE_INFO = VAPI::Bindings::OperationInfo.new(
+      VAPI::Core::OperationIdentifier.new('create', SERVICE_ID),
+      VAPI::Bindings::OperationInputType.new(
+        'spec' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::VM::CreateSpec')
+      ),
+      VAPI::Bindings::IdType.new('VirtualMachine'),
+      {
+        'com.vmware.vapi.std.errors.already_exists' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::AlreadyExists'),
+        'com.vmware.vapi.std.errors.error' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Error'),
+        'com.vmware.vapi.std.errors.invalid_argument' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::InvalidArgument'),
+        'com.vmware.vapi.std.errors.not_found' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::NotFound'),
+        'com.vmware.vapi.std.errors.resource_inaccessible' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::ResourceInaccessible'),
+        'com.vmware.vapi.std.errors.resource_in_use' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::ResourceInUse'),
+        'com.vmware.vapi.std.errors.service_unavailable' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::ServiceUnavailable'),
+        'com.vmware.vapi.std.errors.unable_to_allocate_resource' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::UnableToAllocateResource'),
+        'com.vmware.vapi.std.errors.unauthenticated' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Unauthenticated'),
+        'com.vmware.vapi.std.errors.unauthorized' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Unauthorized'),
+        'com.vmware.vapi.std.errors.unsupported' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Unsupported')
+      },
+      [],
+      []
+    )
+
+    GET_INFO = VAPI::Bindings::OperationInfo.new(
+      VAPI::Core::OperationIdentifier.new('get', SERVICE_ID),
+      VAPI::Bindings::OperationInputType.new(
+        'vm' => VAPI::Bindings::IdType.new('VirtualMachine')
+      ),
+      VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::VM::Info'),
+      {
+        'com.vmware.vapi.std.errors.error' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Error'),
+        'com.vmware.vapi.std.errors.not_found' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::NotFound'),
+        'com.vmware.vapi.std.errors.resource_inaccessible' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::ResourceInaccessible'),
+        'com.vmware.vapi.std.errors.service_unavailable' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::ServiceUnavailable'),
+        'com.vmware.vapi.std.errors.unauthenticated' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Unauthenticated'),
+        'com.vmware.vapi.std.errors.unauthorized' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Unauthorized')
+      },
+      [],
+      []
+    )
+
+    DELETE_INFO = VAPI::Bindings::OperationInfo.new(
+      VAPI::Core::OperationIdentifier.new('delete', SERVICE_ID),
+      VAPI::Bindings::OperationInputType.new(
+        'vm' => VAPI::Bindings::IdType.new('VirtualMachine')
+      ),
+      VAPI::Bindings::VoidType.instance,
+      {
+        'com.vmware.vapi.std.errors.error' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Error'),
+        'com.vmware.vapi.std.errors.not_found' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::NotFound'),
+        'com.vmware.vapi.std.errors.resource_busy' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::ResourceBusy'),
+        'com.vmware.vapi.std.errors.resource_inaccessible' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::ResourceInaccessible'),
+        'com.vmware.vapi.std.errors.service_unavailable' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::ServiceUnavailable'),
+        'com.vmware.vapi.std.errors.unauthenticated' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Unauthenticated'),
+        'com.vmware.vapi.std.errors.unauthorized' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Unauthorized')
+      },
+      [],
+      []
+    )
+
+    LIST_INFO = VAPI::Bindings::OperationInfo.new(
+      VAPI::Core::OperationIdentifier.new('list', SERVICE_ID),
+      VAPI::Bindings::OperationInputType.new(
+        'filter' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::VM::FilterSpec'))
+      ),
+      VAPI::Bindings::ListType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::VM::Summary')),
+      {
+        'com.vmware.vapi.std.errors.invalid_argument' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::InvalidArgument'),
+        'com.vmware.vapi.std.errors.unable_to_allocate_resource' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::UnableToAllocateResource'),
+        'com.vmware.vapi.std.errors.service_unavailable' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::ServiceUnavailable'),
+        'com.vmware.vapi.std.errors.unauthenticated' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Unauthenticated'),
+        'com.vmware.vapi.std.errors.unauthorized' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Unauthorized')
+      },
+      [],
+      []
+    )
+
+    SERVICE_INFO = VAPI::Bindings::ServiceInfo.new(
+      SERVICE_ID,
+      'create' => CREATE_INFO,
+      'get' => GET_INFO,
+      'delete' => DELETE_INFO,
+      'list' => LIST_INFO
+    )
+
+    # Constructs a new instance.
+    #
+    # @param config [VAPI::Bindings::StubConfig] A hash with the api provider details.
+    def initialize(config)
+      super(config, SERVICE_INFO)
+    end
+
+    # Creates a virtual machine.
+    #
+    # @param spec [Com::Vmware::Vcenter::VM::CreateSpec]
+    #     Virtual machine specification.
+    # @return [String]
+    #     ID of newly-created virtual machine.
+    # @raise [Com::Vmware::Vapi::Std::Errors::AlreadyExists]
+    #     if a virtual machine with the specified name already exists.
+    # @raise [Com::Vmware::Vapi::Std::Errors::Error]
+    #     if the system reports an error while responding to the request.
+    # @raise [Com::Vmware::Vapi::Std::Errors::InvalidArgument]
+    #     if any of the specified parameters are invalid.
+    # @raise [Com::Vmware::Vapi::Std::Errors::NotFound]
+    #     if any of the resources specified in  spec  could not be found
+    # @raise [Com::Vmware::Vapi::Std::Errors::ResourceInaccessible]
+    #     if a specified resource (eg. host) is not accessible.
+    # @raise [Com::Vmware::Vapi::Std::Errors::ResourceInUse]
+    #     if any of the specified storage addresses (eg. IDE, SATA, SCSI) result in a storage address conflict.
+    # @raise [Com::Vmware::Vapi::Std::Errors::ServiceUnavailable]
+    #     if the system is unable to communicate with a service to complete the request.
+    # @raise [Com::Vmware::Vapi::Std::Errors::UnableToAllocateResource]
+    #     if any of the resources needed to create the virtual machine could not be allocated.
+    # @raise [Com::Vmware::Vapi::Std::Errors::Unauthenticated]
+    #     if the user can not be authenticated.
+    # @raise [Com::Vmware::Vapi::Std::Errors::Unauthorized]
+    #     if the user doesn't have the required privileges.
+    # @raise [Com::Vmware::Vapi::Std::Errors::Unsupported]
+    #     if  ``guestOS``  is not supported for the requested virtual hardware version and  spec  includes  nil   fields  that default to guest-specific values.
+    def create(spec)
+      invoke_with_info(CREATE_INFO,
+                       'spec' => spec)
+    end
+
+    # Returns information about a virtual machine.
+    #
+    # @param vm [String]
+    #     Virtual machine identifier.
+    # @return [Com::Vmware::Vcenter::VM::Info]
+    #     Information about the specified virtual machine.
+    # @raise [Com::Vmware::Vapi::Std::Errors::Error]
+    #     if the system reports an error while responding to the request.
+    # @raise [Com::Vmware::Vapi::Std::Errors::NotFound]
+    #     if the virtual machine is not found.
+    # @raise [Com::Vmware::Vapi::Std::Errors::ResourceInaccessible]
+    #     if the virtual machine's configuration state cannot be accessed.
+    # @raise [Com::Vmware::Vapi::Std::Errors::ServiceUnavailable]
+    #     if the system is unable to communicate with a service to complete the request.
+    # @raise [Com::Vmware::Vapi::Std::Errors::Unauthenticated]
+    #     if the user can not be authenticated.
+    # @raise [Com::Vmware::Vapi::Std::Errors::Unauthorized]
+    #     if the user doesn't have the required privileges.
+    def get(vm)
+      invoke_with_info(GET_INFO,
+                       'vm' => vm)
+    end
+
+    # Deletes a virtual machine.
+    #
+    # @param vm [String]
+    #     Virtual machine identifier.
+    # @return [Void]
+    # @raise [Com::Vmware::Vapi::Std::Errors::Error]
+    #     if the system reports an error while responding to the request.
+    # @raise [Com::Vmware::Vapi::Std::Errors::NotFound]
+    #     if the virtual machine is not found.
+    # @raise [Com::Vmware::Vapi::Std::Errors::ResourceBusy]
+    #     if the virtual machine is busy performing another operation.
+    # @raise [Com::Vmware::Vapi::Std::Errors::ResourceInaccessible]
+    #     if the virtual machine's configuration state cannot be accessed.
+    # @raise [Com::Vmware::Vapi::Std::Errors::ServiceUnavailable]
+    #     if the system is unable to communicate with a service to complete the request.
+    # @raise [Com::Vmware::Vapi::Std::Errors::Unauthenticated]
+    #     if the user can not be authenticated.
+    # @raise [Com::Vmware::Vapi::Std::Errors::Unauthorized]
+    #     if the user doesn't have the required privileges.
+    def delete(vm)
+      invoke_with_info(DELETE_INFO,
+                       'vm' => vm)
+    end
+
+    # Returns information about at most 1000 visible (subject to permission checks) virtual machines in vCenter matching the   :class:`Com::Vmware::Vcenter::VM::FilterSpec`  .
+    #
+    # @param filter [Com::Vmware::Vcenter::VM::FilterSpec, nil]
+    #     Specification of matching virtual machines for which information should be returned.
+    #     If  nil , the behavior is equivalent to a   :class:`Com::Vmware::Vcenter::VM::FilterSpec`   with all  fields   nil  which means all virtual machines match the filter.
+    # @return [Array<Com::Vmware::Vcenter::VM::Summary>]
+    #     Commonly used information about the virtual machines matching the   :class:`Com::Vmware::Vcenter::VM::FilterSpec`  .
+    # @raise [Com::Vmware::Vapi::Std::Errors::InvalidArgument]
+    #     if the   :attr:`Com::Vmware::Vcenter::VM::FilterSpec.power_states`    field  contains a value that is not supported by the server.
+    # @raise [Com::Vmware::Vapi::Std::Errors::UnableToAllocateResource]
+    #     if more than 1000 virtual machines match the   :class:`Com::Vmware::Vcenter::VM::FilterSpec`  .
+    # @raise [Com::Vmware::Vapi::Std::Errors::ServiceUnavailable]
+    #     if the system is unable to communicate with a service to complete the request.
+    # @raise [Com::Vmware::Vapi::Std::Errors::Unauthenticated]
+    #     if the user can not be authenticated.
+    # @raise [Com::Vmware::Vapi::Std::Errors::Unauthorized]
+    #     if the user doesn't have the required privileges.
+    def list(filter = nil)
+      invoke_with_info(LIST_INFO,
+                       'filter' => filter)
+    end
+
+    # The  ``Com::Vmware::Vcenter::VM::PlacementSpec``   class  contains information used to place a virtual machine onto resources within the vCenter inventory.
+    # @!attribute [rw] folder
+    #     @return [String, nil]
+    #     Virtual machine folder into which the virtual machine should be placed.
+    #     This  field  is currently required. In the future, if this  field  is  nil , the system will attempt to choose a suitable folder for the virtual machine; if a folder cannot be chosen, the virtual machine creation operation will fail.
+    # @!attribute [rw] resource_pool
+    #     @return [String, nil]
+    #     Resource pool into which the virtual machine should be placed.
+    #     This  field  is currently required if both  ``host``  and  ``cluster``  are  nil . In the future, if this  field  is  nil , the system will attempt to choose a suitable resource pool for the virtual machine; if a resource pool cannot be chosen, the virtual machine creation operation will fail.
+    # @!attribute [rw] host
+    #     @return [String, nil]
+    #     Host onto which the virtual machine should be placed.  
+    #     
+    #      If  ``host``  and  ``resourcePool``  are both specified,  ``resourcePool``  must belong to  ``host`` .  
+    #     
+    #      If  ``host``  and  ``cluster``  are both specified,  ``host``  must be a member of  ``cluster`` .
+    #     This  field  may be  nil  if  ``resourcePool``  or  ``cluster``  is specified. If  nil , the system will attempt to choose a suitable host for the virtual machine; if a host cannot be chosen, the virtual machine creation operation will fail.
+    # @!attribute [rw] cluster
+    #     @return [String, nil]
+    #     Cluster onto which the virtual machine should be placed.  
+    #     
+    #      If  ``cluster``  and  ``resourcePool``  are both specified,  ``resourcePool``  must belong to  ``cluster`` .  
+    #     
+    #      If  ``cluster``  and  ``host``  are both specified,  ``host``  must be a member of  ``cluster`` .
+    #     If  ``resourcePool``  or  ``host``  is specified, it is recommended that this  field  be  nil .
+    # @!attribute [rw] datastore
+    #     @return [String, nil]
+    #     Datastore on which the virtual machine's configuration state should be stored. This datastore will also be used for any virtual disks that are created as part of the virtual machine creation operation.
+    #     This  field  is currently required. In the future, if this  field  is  nil , the system will attempt to choose suitable storage for the virtual machine; if storage cannot be chosen, the virtual machine creation operation will fail.
+    class PlacementSpec < VAPI::Bindings::VapiStruct
+      class << self
+        # Holds (gets or creates) the binding type metadata for this structure type.
+        # @scope class
+        # @return [VAPI::Bindings::StructType] the binding type
+        def binding_type
+          @binding_type ||= VAPI::Bindings::StructType.new(
+            'com.vmware.vcenter.VM.placement_spec',
+            {
+              'folder' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::IdType.new),
+              'resource_pool' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::IdType.new),
+              'host' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::IdType.new),
+              'cluster' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::IdType.new),
+              'datastore' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::IdType.new)
+            },
+            PlacementSpec,
+            false,
+            nil
+          )
+        end
+      end
+
+      attr_accessor :folder,
+                    :resource_pool,
+                    :host,
+                    :cluster,
+                    :datastore
+
+      # Constructs a new instance.
+      # @param ruby_values [Hash] a map of initial property values (optional)
+      # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
+      def initialize(ruby_values = nil, struct_value = nil)
+        super(self.class.binding_type, ruby_values, struct_value)
+      end
+    end
+
+    # Document-based creation spec.
+    # @!attribute [rw] guest_OS
+    #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+    #     Guest OS.
+    # @!attribute [rw] name
+    #     @return [String, nil]
+    #     Virtual machine name.
+    #     If  nil , a default name will be generated by the server.
+    # @!attribute [rw] placement
+    #     @return [Com::Vmware::Vcenter::VM::PlacementSpec, nil]
+    #     Virtual machine placement information.
+    #     This  field  is currently required. In the future, if this  field  is  nil , the system will attempt to choose suitable resources on which to place the virtual machine.
+    # @!attribute [rw] hardware_version
+    #     @return [Com::Vmware::Vcenter::VM::Hardware::Version, nil]
+    #     Virtual hardware version.
+    #     If  nil , defaults to the most recent version supported by the server.
+    # @!attribute [rw] boot
+    #     @return [Com::Vmware::Vcenter::VM::Hardware::Boot::CreateSpec, nil]
+    #     Boot configuration.
+    #     If  nil , guest-specific default values will be used.
+    # @!attribute [rw] boot_devices
+    #     @return [Array<Com::Vmware::Vcenter::VM::Hardware::Boot::Device::EntryCreateSpec>, nil]
+    #     Boot device configuration.
+    #     If  nil , a server-specific boot sequence will be used.
+    # @!attribute [rw] cpu
+    #     @return [Com::Vmware::Vcenter::VM::Hardware::Cpu::UpdateSpec, nil]
+    #     CPU configuration.
+    #     If  nil , guest-specific default values will be used.
+    # @!attribute [rw] memory
+    #     @return [Com::Vmware::Vcenter::VM::Hardware::Memory::UpdateSpec, nil]
+    #     Memory configuration.
+    #     If  nil , guest-specific default values will be used.
+    # @!attribute [rw] disks
+    #     @return [Array<Com::Vmware::Vcenter::VM::Hardware::Disk::CreateSpec>, nil]
+    #     List of disks.
+    #     If  nil , a single blank virtual disk of a guest-specific size will be created on the same storage as the virtual machine configuration, and will use a guest-specific host bus adapter type. If the guest-specific size is 0, no virtual disk will be created.
+    # @!attribute [rw] nics
+    #     @return [Array<Com::Vmware::Vcenter::VM::Hardware::Ethernet::CreateSpec>, nil]
+    #     List of Ethernet adapters.
+    #     If  nil , no Ethernet adapters will be created.
+    # @!attribute [rw] cdroms
+    #     @return [Array<Com::Vmware::Vcenter::VM::Hardware::Cdrom::CreateSpec>, nil]
+    #     List of CD-ROMs.
+    #     If  nil , no CD-ROM devices will be created.
+    # @!attribute [rw] floppies
+    #     @return [Array<Com::Vmware::Vcenter::VM::Hardware::Floppy::CreateSpec>, nil]
+    #     List of floppy drives.
+    #     If  nil , no floppy drives will be created.
+    # @!attribute [rw] parallel_ports
+    #     @return [Array<Com::Vmware::Vcenter::VM::Hardware::Parallel::CreateSpec>, nil]
+    #     List of parallel ports.
+    #     If  nil , no parallel ports will be created.
+    # @!attribute [rw] serial_ports
+    #     @return [Array<Com::Vmware::Vcenter::VM::Hardware::Serial::CreateSpec>, nil]
+    #     List of serial ports.
+    #     If  nil , no serial ports will be created.
+    # @!attribute [rw] sata_adapters
+    #     @return [Array<Com::Vmware::Vcenter::VM::Hardware::Adapter::Sata::CreateSpec>, nil]
+    #     List of SATA adapters.
+    #     If  nil , any adapters necessary to connect the virtual machine's storage devices will be created; this includes any devices that explicitly specify a SATA host bus adapter, as well as any devices that do not specify a host bus adapter if the guest's preferred adapter type is SATA.
+    # @!attribute [rw] scsi_adapters
+    #     @return [Array<Com::Vmware::Vcenter::VM::Hardware::Adapter::Scsi::CreateSpec>, nil]
+    #     List of SCSI adapters.
+    #     If  nil , any adapters necessary to connect the virtual machine's storage devices will be created; this includes any devices that explicitly specify a SCSI host bus adapter, as well as any devices that do not specify a host bus adapter if the guest's preferred adapter type is SCSI. The type of the SCSI adapter will be a guest-specific default type.
+    class CreateSpec < VAPI::Bindings::VapiStruct
+      class << self
+        # Holds (gets or creates) the binding type metadata for this structure type.
+        # @scope class
+        # @return [VAPI::Bindings::StructType] the binding type
+        def binding_type
+          @binding_type ||= VAPI::Bindings::StructType.new(
+            'com.vmware.vcenter.VM.create_spec',
+            {
+              'guest_OS' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::VM::GuestOS'),
+              'name' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::StringType.instance),
+              'placement' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::VM::PlacementSpec')),
+              'hardware_version' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::VM::Hardware::Version')),
+              'boot' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::VM::Hardware::Boot::CreateSpec')),
+              'boot_devices' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::ListType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::VM::Hardware::Boot::Device::EntryCreateSpec'))),
+              'cpu' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::VM::Hardware::Cpu::UpdateSpec')),
+              'memory' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::VM::Hardware::Memory::UpdateSpec')),
+              'disks' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::ListType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::VM::Hardware::Disk::CreateSpec'))),
+              'nics' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::ListType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::VM::Hardware::Ethernet::CreateSpec'))),
+              'cdroms' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::ListType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::VM::Hardware::Cdrom::CreateSpec'))),
+              'floppies' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::ListType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::VM::Hardware::Floppy::CreateSpec'))),
+              'parallel_ports' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::ListType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::VM::Hardware::Parallel::CreateSpec'))),
+              'serial_ports' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::ListType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::VM::Hardware::Serial::CreateSpec'))),
+              'sata_adapters' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::ListType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::VM::Hardware::Adapter::Sata::CreateSpec'))),
+              'scsi_adapters' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::ListType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::VM::Hardware::Adapter::Scsi::CreateSpec')))
+            },
+            CreateSpec,
+            false,
+            nil
+          )
+        end
+      end
+
+      attr_accessor :guest_OS,
+                    :name,
+                    :placement,
+                    :hardware_version,
+                    :boot,
+                    :boot_devices,
+                    :cpu,
+                    :memory,
+                    :disks,
+                    :nics,
+                    :cdroms,
+                    :floppies,
+                    :parallel_ports,
+                    :serial_ports,
+                    :sata_adapters,
+                    :scsi_adapters
+
+      # Constructs a new instance.
+      # @param ruby_values [Hash] a map of initial property values (optional)
+      # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
+      def initialize(ruby_values = nil, struct_value = nil)
+        super(self.class.binding_type, ruby_values, struct_value)
+      end
+    end
+
+    # Document-based info.
+    # @!attribute [rw] guest_OS
+    #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+    #     Guest OS.
+    # @!attribute [rw] name
+    #     @return [String]
+    #     Virtual machine name.
+    # @!attribute [rw] power_state
+    #     @return [Com::Vmware::Vcenter::Vm::Power::State]
+    #     Power state of the virtual machine.
+    # @!attribute [rw] hardware
+    #     @return [Com::Vmware::Vcenter::VM::Hardware::Info]
+    #     Virtual hardware version information.
+    # @!attribute [rw] boot
+    #     @return [Com::Vmware::Vcenter::VM::Hardware::Boot::Info]
+    #     Boot configuration.
+    # @!attribute [rw] boot_devices
+    #     @return [Array<Com::Vmware::Vcenter::VM::Hardware::Boot::Device::Entry>]
+    #     Boot device configuration. If the  list  has no entries, a server-specific default boot sequence is used.
+    # @!attribute [rw] cpu
+    #     @return [Com::Vmware::Vcenter::VM::Hardware::Cpu::Info]
+    #     CPU configuration.
+    # @!attribute [rw] memory
+    #     @return [Com::Vmware::Vcenter::VM::Hardware::Memory::Info]
+    #     Memory configuration.
+    # @!attribute [rw] disks
+    #     @return [Hash<String, Com::Vmware::Vcenter::VM::Hardware::Disk::Info>]
+    #     List of disks.
+    # @!attribute [rw] nics
+    #     @return [Hash<String, Com::Vmware::Vcenter::VM::Hardware::Ethernet::Info>]
+    #     List of Ethernet adapters.
+    # @!attribute [rw] cdroms
+    #     @return [Hash<String, Com::Vmware::Vcenter::VM::Hardware::Cdrom::Info>]
+    #     List of CD-ROMs.
+    # @!attribute [rw] floppies
+    #     @return [Hash<String, Com::Vmware::Vcenter::VM::Hardware::Floppy::Info>]
+    #     List of floppy drives.
+    # @!attribute [rw] parallel_ports
+    #     @return [Hash<String, Com::Vmware::Vcenter::VM::Hardware::Parallel::Info>]
+    #     List of parallel ports.
+    # @!attribute [rw] serial_ports
+    #     @return [Hash<String, Com::Vmware::Vcenter::VM::Hardware::Serial::Info>]
+    #     List of serial ports.
+    # @!attribute [rw] sata_adapters
+    #     @return [Hash<String, Com::Vmware::Vcenter::VM::Hardware::Adapter::Sata::Info>]
+    #     List of SATA adapters.
+    # @!attribute [rw] scsi_adapters
+    #     @return [Hash<String, Com::Vmware::Vcenter::VM::Hardware::Adapter::Scsi::Info>]
+    #     List of SCSI adapters.
+    class Info < VAPI::Bindings::VapiStruct
+      class << self
+        # Holds (gets or creates) the binding type metadata for this structure type.
+        # @scope class
+        # @return [VAPI::Bindings::StructType] the binding type
+        def binding_type
+          @binding_type ||= VAPI::Bindings::StructType.new(
+            'com.vmware.vcenter.VM.info',
+            {
+              'guest_OS' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::VM::GuestOS'),
+              'name' => VAPI::Bindings::StringType.instance,
+              'power_state' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::Vm::Power::State'),
+              'hardware' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::VM::Hardware::Info'),
+              'boot' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::VM::Hardware::Boot::Info'),
+              'boot_devices' => VAPI::Bindings::ListType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::VM::Hardware::Boot::Device::Entry')),
+              'cpu' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::VM::Hardware::Cpu::Info'),
+              'memory' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::VM::Hardware::Memory::Info'),
+              'disks' => VAPI::Bindings::MapType.new(VAPI::Bindings::IdType.new, VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::VM::Hardware::Disk::Info')),
+              'nics' => VAPI::Bindings::MapType.new(VAPI::Bindings::IdType.new, VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::VM::Hardware::Ethernet::Info')),
+              'cdroms' => VAPI::Bindings::MapType.new(VAPI::Bindings::IdType.new, VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::VM::Hardware::Cdrom::Info')),
+              'floppies' => VAPI::Bindings::MapType.new(VAPI::Bindings::IdType.new, VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::VM::Hardware::Floppy::Info')),
+              'parallel_ports' => VAPI::Bindings::MapType.new(VAPI::Bindings::IdType.new, VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::VM::Hardware::Parallel::Info')),
+              'serial_ports' => VAPI::Bindings::MapType.new(VAPI::Bindings::IdType.new, VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::VM::Hardware::Serial::Info')),
+              'sata_adapters' => VAPI::Bindings::MapType.new(VAPI::Bindings::IdType.new, VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::VM::Hardware::Adapter::Sata::Info')),
+              'scsi_adapters' => VAPI::Bindings::MapType.new(VAPI::Bindings::IdType.new, VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::VM::Hardware::Adapter::Scsi::Info'))
+            },
+            Info,
+            false,
+            nil
+          )
+        end
+      end
+
+      attr_accessor :guest_OS,
+                    :name,
+                    :power_state,
+                    :hardware,
+                    :boot,
+                    :boot_devices,
+                    :cpu,
+                    :memory,
+                    :disks,
+                    :nics,
+                    :cdroms,
+                    :floppies,
+                    :parallel_ports,
+                    :serial_ports,
+                    :sata_adapters,
+                    :scsi_adapters
+
+      # Constructs a new instance.
+      # @param ruby_values [Hash] a map of initial property values (optional)
+      # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
+      def initialize(ruby_values = nil, struct_value = nil)
+        super(self.class.binding_type, ruby_values, struct_value)
+      end
+    end
+
+    # The  ``Com::Vmware::Vcenter::VM::FilterSpec``   class  contains  fields  used to filter the results when listing virtual machines (see   :func:`Com::Vmware::Vcenter::VM.list`  ). If multiple  fields  are specified, only virtual machines matching all of the  fields  match the filter.
+    # @!attribute [rw] vms
+    #     @return [Set<String>, nil]
+    #     Identifiers of virtual machines that can match the filter.
+    #     If  nil  or empty, virtual machines with any identifier match the filter.
+    # @!attribute [rw] names
+    #     @return [Set<String>, nil]
+    #     Names that virtual machines must have to match the filter (see   :attr:`Com::Vmware::Vcenter::VM::Info.name`  ).
+    #     If  nil  or empty, virtual machines with any name match the filter.
+    # @!attribute [rw] folders
+    #     @return [Set<String>, nil]
+    #     Folders that must contain the virtual machine for the virtual machine to match the filter.
+    #     If  nil  or empty, virtual machines in any folder match the filter.
+    # @!attribute [rw] datacenters
+    #     @return [Set<String>, nil]
+    #     Datacenters that must contain the virtual machine for the virtual machine to match the filter.
+    #     If  nil  or empty, virtual machines in any datacenter match the filter.
+    # @!attribute [rw] hosts
+    #     @return [Set<String>, nil]
+    #     Hosts that must contain the virtual machine for the virtual machine to match the filter.
+    #     If  nil  or empty, virtual machines on any host match the filter.
+    # @!attribute [rw] clusters
+    #     @return [Set<String>, nil]
+    #     Clusters that must contain the virtual machine for the virtual machine to match the filter.
+    #     If  nil  or empty, virtual machines in any cluster match the filter.
+    # @!attribute [rw] resource_pools
+    #     @return [Set<String>, nil]
+    #     Resource pools that must contain the virtual machine for the virtual machine to match the filter.
+    #     If  nil  or empty, virtual machines in any resource pool match the filter.
+    # @!attribute [rw] power_states
+    #     @return [Set<Com::Vmware::Vcenter::Vm::Power::State>, nil]
+    #     Power states that a virtual machine must be in to match the filter (see   :attr:`Com::Vmware::Vcenter::Vm::Power::Info.state`  .
+    #     If  nil  or empty, virtual machines in any power state match the filter.
+    class FilterSpec < VAPI::Bindings::VapiStruct
+      class << self
+        # Holds (gets or creates) the binding type metadata for this structure type.
+        # @scope class
+        # @return [VAPI::Bindings::StructType] the binding type
+        def binding_type
+          @binding_type ||= VAPI::Bindings::StructType.new(
+            'com.vmware.vcenter.VM.filter_spec',
+            {
+              'vms' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::SetType.new(VAPI::Bindings::IdType.new)),
+              'names' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::SetType.new(VAPI::Bindings::StringType.instance)),
+              'folders' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::SetType.new(VAPI::Bindings::IdType.new)),
+              'datacenters' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::SetType.new(VAPI::Bindings::IdType.new)),
+              'hosts' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::SetType.new(VAPI::Bindings::IdType.new)),
+              'clusters' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::SetType.new(VAPI::Bindings::IdType.new)),
+              'resource_pools' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::SetType.new(VAPI::Bindings::IdType.new)),
+              'power_states' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::SetType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::Vm::Power::State')))
+            },
+            FilterSpec,
+            false,
+            nil
+          )
+        end
+      end
+
+      attr_accessor :vms,
+                    :names,
+                    :folders,
+                    :datacenters,
+                    :hosts,
+                    :clusters,
+                    :resource_pools,
+                    :power_states
+
+      # Constructs a new instance.
+      # @param ruby_values [Hash] a map of initial property values (optional)
+      # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
+      def initialize(ruby_values = nil, struct_value = nil)
+        super(self.class.binding_type, ruby_values, struct_value)
+      end
+    end
+
+    # The  ``Com::Vmware::Vcenter::VM::Summary``   class  contains commonly used information about a virtual machine.
+    # @!attribute [rw] vm
+    #     @return [String]
+    #     Identifier of the virtual machine.
+    # @!attribute [rw] name
+    #     @return [String]
+    #     Name of the Virtual machine.
+    # @!attribute [rw] power_state
+    #     @return [Com::Vmware::Vcenter::Vm::Power::State]
+    #     Power state of the virtual machine.
+    # @!attribute [rw] cpu_count
+    #     @return [Fixnum, nil]
+    #     Number of CPU cores.
+    #     This  field  will be  nil  if the virtual machine configuration is not available. For example, the configuration information would be unavailable if the server is unable to access the virtual machine files on disk, and is often also unavailable during the intial phases of virtual machine creation.
+    # @!attribute [rw] memory_size_MiB
+    #     @return [Fixnum, nil]
+    #     Memory size in mebibytes.
+    #     This  field  will be  nil  if the virtual machine configuration is not available. For example, the configuration information would be unavailable if the server is unable to access the virtual machine files on disk, and is often also unavailable during the intial phases of virtual machine creation.
+    class Summary < VAPI::Bindings::VapiStruct
+      class << self
+        # Holds (gets or creates) the binding type metadata for this structure type.
+        # @scope class
+        # @return [VAPI::Bindings::StructType] the binding type
+        def binding_type
+          @binding_type ||= VAPI::Bindings::StructType.new(
+            'com.vmware.vcenter.VM.summary',
+            {
+              'vm' => VAPI::Bindings::IdType.new('VirtualMachine'),
+              'name' => VAPI::Bindings::StringType.instance,
+              'power_state' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::Vm::Power::State'),
+              'cpu_count' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::IntegerType.instance),
+              'memory_size_MiB' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::IntegerType.instance)
+            },
+            Summary,
+            false,
+            nil
+          )
+        end
+      end
+
+      attr_accessor :vm,
+                    :name,
+                    :power_state,
+                    :cpu_count,
+                    :memory_size_MiB
+
+      # Constructs a new instance.
+      # @param ruby_values [Hash] a map of initial property values (optional)
+      # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
+      def initialize(ruby_values = nil, struct_value = nil)
+        super(self.class.binding_type, ruby_values, struct_value)
+      end
+    end
+
+  end
 end

--- a/client/sdk/com/vmware/vcenter/inventory.rb
+++ b/client/sdk/com/vmware/vcenter/inventory.rb
@@ -1,5 +1,6 @@
 #---------------------------------------------------------------------------
-# Copyright 2016 VMware, Inc.  All rights reserved.
+# Copyright 2017 VMware, Inc.  All rights reserved.
+#
 # AUTO GENERATED FILE -- DO NOT MODIFY!
 #
 # vAPI type descriptors for package com.vmware.vcenter.inventory.
@@ -8,197 +9,174 @@ require 'vapi'
 
 # declare the module hierarchy before we use the shorthand syntax below
 module Com
-    module Vmware
-        module Vcenter
-            module Inventory
-            end
-        end
+  module Vmware
+    module Vcenter
+      module Inventory
+      end
     end
+  end
 end
 
 # The  ``com.vmware.vcenter.inventory``   component  provides  methods  and  classes  for retrieving vCenter datastore and network information for a given  list  of identifiers.
 module Com::Vmware::Vcenter::Inventory
+  # The  ``Com::Vmware::Vcenter::Inventory::Datastore``   class  provides  methods  to retrieve information about datastores.
+  class Datastore < VAPI::Bindings::VapiService
+    # static metamodel definitions
+    SERVICE_ID = VAPI::Core::ServiceIdentifier.new('com.vmware.vcenter.inventory.datastore')
 
-    # The  ``Com::Vmware::Vcenter::Inventory::Datastore``   class  provides  methods  to retrieve information about datastores.
-    class Datastore < VAPI::Bindings::VapiService
+    FIND_INFO = VAPI::Bindings::OperationInfo.new(
+      VAPI::Core::OperationIdentifier.new('find', SERVICE_ID),
+      VAPI::Bindings::OperationInputType.new(
+        'datastores' => VAPI::Bindings::ListType.new(VAPI::Bindings::IdType.new)
+      ),
+      VAPI::Bindings::MapType.new(VAPI::Bindings::IdType.new, VAPI::Bindings::OptionalType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::Inventory::Datastore::Info'))),
+      {
+        'com.vmware.vapi.std.errors.not_found' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::NotFound')
+      },
+      [],
+      []
+    )
 
-        protected
+    SERVICE_INFO = VAPI::Bindings::ServiceInfo.new(
+      SERVICE_ID,
+      'find' => FIND_INFO
+    )
 
-        # static metamodel definitions
-        @@service_id = VAPI::Core::ServiceIdentifier.new('com.vmware.vcenter.inventory.datastore')
-
-        @@find_info = VAPI::Bindings::OperationInfo.new(
-            VAPI::Core::OperationIdentifier.new('find', @@service_id),
-            VAPI::Bindings::OperationInputType.new({
-                'datastores' => VAPI::Bindings::ListType.new(VAPI::Bindings::IdType.new),
-            }),
-            VAPI::Bindings::MapType.new(VAPI::Bindings::IdType.new, VAPI::Bindings::OptionalType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::Inventory::Datastore::Info'))),
-            {
-                'com.vmware.vapi.std.errors.not_found' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::NotFound'),
-
-            },
-            [],
-            [])
-
-        @@service_info = VAPI::Bindings::ServiceInfo.new(@@service_id, {
-            'find' => @@find_info,
-        })
-
-        public
-
-        # Constructs a new instance.
-        #
-        # @param config [VAPI::Bindings::StubConfig] A hash with the api provider details.
-        def initialize(config)
-            super(config, @@service_info)
-        end
-
-
-        # Returns datastore information for the specified datastores. The key in the  result   map  is the datastore identifier and the value in the  map  is the datastore information.
-        #
-        # @param datastores [Array<String>]
-        #      Identifiers of the datastores for which information will be returned.
-        # @return [Hash<String, Com::Vmware::Vcenter::Inventory::Datastore::Info, nil>]
-        #     Datastore information for the specified datastores. The key in the  result   map  is the datastore identifier and the value in the  map  is the datastore information.
-        # @raise [Com::Vmware::Vapi::Std::Errors::NotFound]
-        #      if no datastore can be found for one or more of the datastore identifiers in  ``datastores``
-        # @raise [Com::Vmware::Vapi::Std::Errors::Unauthorized]
-        #     If you do not have all of the privileges described in the following list:
-        #
-        #     System.Read
-        def find(datastores)
-            invoke_with_info(@@find_info, {
-                'datastores' => datastores,
-            })
-        end
-
-
-
-        # The  ``Com::Vmware::Vcenter::Inventory::Datastore::Info``   class  contains information about a datastore.
-        # @!attribute [rw] type
-        #     @return [String]
-        #     Type of the datastore.
-        class Info < VAPI::Bindings::VapiStruct
-
-            class << self
-                # Holds (gets or creates) the binding type metadata for this structure type.
-                # @scope class
-                # @return [VAPI::Bindings::StructType] the binding type
-                def binding_type
-                    @binding_type ||= VAPI::Bindings::StructType.new(
-                        'com.vmware.vcenter.inventory.datastore.info',
-                        {
-                            'type' => VAPI::Bindings::StringType.instance,
-                        },
-                        Info,
-                        false,
-                        nil)
-                end
-            end
-
-            attr_accessor :type
-
-            # Constructs a new instance.
-            # @param ruby_values [Hash] a map of initial property values (optional)
-            # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
-            def initialize(ruby_values=nil, struct_value=nil)
-                super(self.class.binding_type, ruby_values, struct_value)
-            end
-        end
-
-
+    # Constructs a new instance.
+    #
+    # @param config [VAPI::Bindings::StubConfig] A hash with the api provider details.
+    def initialize(config)
+      super(config, SERVICE_INFO)
     end
 
-
-    # The  ``Com::Vmware::Vcenter::Inventory::Network``   class  provides  methods  to retrieve information about vCenter Server networks.
-    class Network < VAPI::Bindings::VapiService
-
-        protected
-
-        # static metamodel definitions
-        @@service_id = VAPI::Core::ServiceIdentifier.new('com.vmware.vcenter.inventory.network')
-
-        @@find_info = VAPI::Bindings::OperationInfo.new(
-            VAPI::Core::OperationIdentifier.new('find', @@service_id),
-            VAPI::Bindings::OperationInputType.new({
-                'networks' => VAPI::Bindings::ListType.new(VAPI::Bindings::IdType.new),
-            }),
-            VAPI::Bindings::MapType.new(VAPI::Bindings::IdType.new, VAPI::Bindings::OptionalType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::Inventory::Network::Info'))),
-            {
-                'com.vmware.vapi.std.errors.not_found' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::NotFound'),
-
-            },
-            [],
-            [])
-
-        @@service_info = VAPI::Bindings::ServiceInfo.new(@@service_id, {
-            'find' => @@find_info,
-        })
-
-        public
-
-        # Constructs a new instance.
-        #
-        # @param config [VAPI::Bindings::StubConfig] A hash with the api provider details.
-        def initialize(config)
-            super(config, @@service_info)
-        end
-
-
-        # Returns network information for the specified vCenter Server networks. The key in the  result   map  is the network identifier and the value in the  map  is the network information.
-        #
-        # @param networks [Array<String>]
-        #      Identifiers of the vCenter Server networks for which information will be returned.
-        # @return [Hash<String, Com::Vmware::Vcenter::Inventory::Network::Info, nil>]
-        #     Network information for the specified vCenter Server networks. The key in the  result   map  is the network identifier and the value in the  map  is the network information.
-        # @raise [Com::Vmware::Vapi::Std::Errors::NotFound]
-        #      if no datastore can be found for one or more of the vCenter Server network identifiers in  ``networks``
-        # @raise [Com::Vmware::Vapi::Std::Errors::Unauthorized]
-        #     If you do not have all of the privileges described in the following list:
-        #
-        #     System.Read
-        def find(networks)
-            invoke_with_info(@@find_info, {
-                'networks' => networks,
-            })
-        end
-
-
-
-        # The  ``Com::Vmware::Vcenter::Inventory::Network::Info``   class  contains information about a vCenter Server network.
-        # @!attribute [rw] type
-        #     @return [String]
-        #     Type of the vCenter Server network.
-        class Info < VAPI::Bindings::VapiStruct
-
-            class << self
-                # Holds (gets or creates) the binding type metadata for this structure type.
-                # @scope class
-                # @return [VAPI::Bindings::StructType] the binding type
-                def binding_type
-                    @binding_type ||= VAPI::Bindings::StructType.new(
-                        'com.vmware.vcenter.inventory.network.info',
-                        {
-                            'type' => VAPI::Bindings::StringType.instance,
-                        },
-                        Info,
-                        false,
-                        nil)
-                end
-            end
-
-            attr_accessor :type
-
-            # Constructs a new instance.
-            # @param ruby_values [Hash] a map of initial property values (optional)
-            # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
-            def initialize(ruby_values=nil, struct_value=nil)
-                super(self.class.binding_type, ruby_values, struct_value)
-            end
-        end
-
-
+    # Returns datastore information for the specified datastores. The key in the  result   map  is the datastore identifier and the value in the  map  is the datastore information.
+    #
+    # @param datastores [Array<String>]
+    #      Identifiers of the datastores for which information will be returned.
+    # @return [Hash<String, Com::Vmware::Vcenter::Inventory::Datastore::Info, nil>]
+    #     Datastore information for the specified datastores. The key in the  result   map  is the datastore identifier and the value in the  map  is the datastore information.
+    # @raise [Com::Vmware::Vapi::Std::Errors::NotFound]
+    #      if no datastore can be found for one or more of the datastore identifiers in  ``datastores``
+    # @raise [Com::Vmware::Vapi::Std::Errors::Unauthorized]
+    #     If you do not have all of the privileges described in the following list:
+    #
+    #     System.Read
+    def find(datastores)
+      invoke_with_info(FIND_INFO,
+                       'datastores' => datastores)
     end
 
+    # The  ``Com::Vmware::Vcenter::Inventory::Datastore::Info``   class  contains information about a datastore.
+    # @!attribute [rw] type
+    #     @return [String]
+    #     Type of the datastore.
+    class Info < VAPI::Bindings::VapiStruct
+      class << self
+        # Holds (gets or creates) the binding type metadata for this structure type.
+        # @scope class
+        # @return [VAPI::Bindings::StructType] the binding type
+        def binding_type
+          @binding_type ||= VAPI::Bindings::StructType.new(
+            'com.vmware.vcenter.inventory.datastore.info',
+            {
+              'type' => VAPI::Bindings::StringType.instance
+            },
+            Info,
+            false,
+            nil
+          )
+        end
+      end
 
+      attr_accessor :type
+
+      # Constructs a new instance.
+      # @param ruby_values [Hash] a map of initial property values (optional)
+      # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
+      def initialize(ruby_values = nil, struct_value = nil)
+        super(self.class.binding_type, ruby_values, struct_value)
+      end
+    end
+
+  end
+  # The  ``Com::Vmware::Vcenter::Inventory::Network``   class  provides  methods  to retrieve information about vCenter Server networks.
+  class Network < VAPI::Bindings::VapiService
+    # static metamodel definitions
+    SERVICE_ID = VAPI::Core::ServiceIdentifier.new('com.vmware.vcenter.inventory.network')
+
+    FIND_INFO = VAPI::Bindings::OperationInfo.new(
+      VAPI::Core::OperationIdentifier.new('find', SERVICE_ID),
+      VAPI::Bindings::OperationInputType.new(
+        'networks' => VAPI::Bindings::ListType.new(VAPI::Bindings::IdType.new)
+      ),
+      VAPI::Bindings::MapType.new(VAPI::Bindings::IdType.new, VAPI::Bindings::OptionalType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::Inventory::Network::Info'))),
+      {
+        'com.vmware.vapi.std.errors.not_found' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::NotFound')
+      },
+      [],
+      []
+    )
+
+    SERVICE_INFO = VAPI::Bindings::ServiceInfo.new(
+      SERVICE_ID,
+      'find' => FIND_INFO
+    )
+
+    # Constructs a new instance.
+    #
+    # @param config [VAPI::Bindings::StubConfig] A hash with the api provider details.
+    def initialize(config)
+      super(config, SERVICE_INFO)
+    end
+
+    # Returns network information for the specified vCenter Server networks. The key in the  result   map  is the network identifier and the value in the  map  is the network information.
+    #
+    # @param networks [Array<String>]
+    #      Identifiers of the vCenter Server networks for which information will be returned.
+    # @return [Hash<String, Com::Vmware::Vcenter::Inventory::Network::Info, nil>]
+    #     Network information for the specified vCenter Server networks. The key in the  result   map  is the network identifier and the value in the  map  is the network information.
+    # @raise [Com::Vmware::Vapi::Std::Errors::NotFound]
+    #      if no datastore can be found for one or more of the vCenter Server network identifiers in  ``networks``
+    # @raise [Com::Vmware::Vapi::Std::Errors::Unauthorized]
+    #     If you do not have all of the privileges described in the following list:
+    #
+    #     System.Read
+    def find(networks)
+      invoke_with_info(FIND_INFO,
+                       'networks' => networks)
+    end
+
+    # The  ``Com::Vmware::Vcenter::Inventory::Network::Info``   class  contains information about a vCenter Server network.
+    # @!attribute [rw] type
+    #     @return [String]
+    #     Type of the vCenter Server network.
+    class Info < VAPI::Bindings::VapiStruct
+      class << self
+        # Holds (gets or creates) the binding type metadata for this structure type.
+        # @scope class
+        # @return [VAPI::Bindings::StructType] the binding type
+        def binding_type
+          @binding_type ||= VAPI::Bindings::StructType.new(
+            'com.vmware.vcenter.inventory.network.info',
+            {
+              'type' => VAPI::Bindings::StringType.instance
+            },
+            Info,
+            false,
+            nil
+          )
+        end
+      end
+
+      attr_accessor :type
+
+      # Constructs a new instance.
+      # @param ruby_values [Hash] a map of initial property values (optional)
+      # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
+      def initialize(ruby_values = nil, struct_value = nil)
+        super(self.class.binding_type, ruby_values, struct_value)
+      end
+    end
+
+  end
 end

--- a/client/sdk/com/vmware/vcenter/inventory/vapi.rb
+++ b/client/sdk/com/vmware/vcenter/inventory/vapi.rb
@@ -1,5 +1,6 @@
 #---------------------------------------------------------------------------
-# Copyright 2016 VMware, Inc.  All rights reserved.
+# Copyright 2017 VMware, Inc.  All rights reserved.
+#
 # AUTO GENERATED FILE -- DO NOT MODIFY!
 #---------------------------------------------------------------------------
 require 'vapi'

--- a/client/sdk/com/vmware/vcenter/iso.rb
+++ b/client/sdk/com/vmware/vcenter/iso.rb
@@ -1,5 +1,6 @@
 #---------------------------------------------------------------------------
-# Copyright 2016 VMware, Inc.  All rights reserved.
+# Copyright 2017 VMware, Inc.  All rights reserved.
+#
 # AUTO GENERATED FILE -- DO NOT MODIFY!
 #
 # vAPI type descriptors for package com.vmware.vcenter.iso.
@@ -8,115 +9,104 @@ require 'vapi'
 
 # declare the module hierarchy before we use the shorthand syntax below
 module Com
-    module Vmware
-        module Vcenter
-            module Iso
-            end
-        end
+  module Vmware
+    module Vcenter
+      module Iso
+      end
     end
+  end
 end
 
 # The  ``com.vmware.vcenter.iso``   package  provides  classes  and  classs  that will let its client mount or unmount an ISO image on a virtual machine as a CD-ROM.
 module Com::Vmware::Vcenter::Iso
+  # Provides an interface to mount and unmount an ISO image on a virtual machine.  
+  # 
+  #  This is an API that will let its client mount or unmount an ISO image on a virtual machine as a CD-ROM. 
+  class Image < VAPI::Bindings::VapiService
+    # static metamodel definitions
+    SERVICE_ID = VAPI::Core::ServiceIdentifier.new('com.vmware.vcenter.iso.image')
 
-    # Provides an interface to mount and unmount an ISO image on a virtual machine.  
-    # 
-    #  This is an API that will let its client mount or unmount an ISO image on a virtual machine as a CD-ROM. 
-    class Image < VAPI::Bindings::VapiService
+    MOUNT_INFO = VAPI::Bindings::OperationInfo.new(
+      VAPI::Core::OperationIdentifier.new('mount', SERVICE_ID),
+      VAPI::Bindings::OperationInputType.new(
+        'library_item' => VAPI::Bindings::IdType.new('com.vmware.content.library.Item'),
+        'vm' => VAPI::Bindings::IdType.new('VirtualMachine')
+      ),
+      VAPI::Bindings::IdType.new('com.vmware.vcenter.vm.hardware.Cdrom'),
+      {
+        'com.vmware.vapi.std.errors.not_found' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::NotFound'),
+        'com.vmware.vapi.std.errors.invalid_argument' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::InvalidArgument'),
+        'com.vmware.vapi.std.errors.not_allowed_in_current_state' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::NotAllowedInCurrentState'),
+        'com.vmware.vapi.std.errors.resource_inaccessible' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::ResourceInaccessible')
+      },
+      [],
+      []
+    )
 
-        protected
+    UNMOUNT_INFO = VAPI::Bindings::OperationInfo.new(
+      VAPI::Core::OperationIdentifier.new('unmount', SERVICE_ID),
+      VAPI::Bindings::OperationInputType.new(
+        'vm' => VAPI::Bindings::IdType.new('VirtualMachine'),
+        'cdrom' => VAPI::Bindings::IdType.new('com.vmware.vcenter.vm.hardware.Cdrom')
+      ),
+      VAPI::Bindings::VoidType.instance,
+      {
+        'com.vmware.vapi.std.errors.not_found' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::NotFound'),
+        'com.vmware.vapi.std.errors.not_allowed_in_current_state' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::NotAllowedInCurrentState')
+      },
+      [],
+      []
+    )
 
-        # static metamodel definitions
-        @@service_id = VAPI::Core::ServiceIdentifier.new('com.vmware.vcenter.iso.image')
+    SERVICE_INFO = VAPI::Bindings::ServiceInfo.new(
+      SERVICE_ID,
+      'mount' => MOUNT_INFO,
+      'unmount' => UNMOUNT_INFO
+    )
 
-        @@mount_info = VAPI::Bindings::OperationInfo.new(
-            VAPI::Core::OperationIdentifier.new('mount', @@service_id),
-            VAPI::Bindings::OperationInputType.new({
-                'library_item' => VAPI::Bindings::IdType.new(resource_types='com.vmware.content.library.Item'),
-                'vm' => VAPI::Bindings::IdType.new(resource_types='VirtualMachine'),
-            }),
-            VAPI::Bindings::IdType.new(resource_types='com.vmware.vcenter.vm.hardware.Cdrom'),
-            {
-                'com.vmware.vapi.std.errors.not_found' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::NotFound'),
-                'com.vmware.vapi.std.errors.invalid_argument' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::InvalidArgument'),
-                'com.vmware.vapi.std.errors.not_allowed_in_current_state' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::NotAllowedInCurrentState'),
-                'com.vmware.vapi.std.errors.resource_inaccessible' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::ResourceInaccessible'),
-
-            },
-            [],
-            [])
-        @@unmount_info = VAPI::Bindings::OperationInfo.new(
-            VAPI::Core::OperationIdentifier.new('unmount', @@service_id),
-            VAPI::Bindings::OperationInputType.new({
-                'vm' => VAPI::Bindings::IdType.new(resource_types='VirtualMachine'),
-                'cdrom' => VAPI::Bindings::IdType.new(resource_types='com.vmware.vcenter.vm.hardware.Cdrom'),
-            }),
-            VAPI::Bindings::VoidType.instance,
-            {
-                'com.vmware.vapi.std.errors.not_found' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::NotFound'),
-                'com.vmware.vapi.std.errors.not_allowed_in_current_state' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::NotAllowedInCurrentState'),
-
-            },
-            [],
-            [])
-
-        @@service_info = VAPI::Bindings::ServiceInfo.new(@@service_id, {
-            'mount' => @@mount_info,
-            'unmount' => @@unmount_info,
-        })
-
-        public
-
-        # Constructs a new instance.
-        #
-        # @param config [VAPI::Bindings::StubConfig] A hash with the api provider details.
-        def initialize(config)
-            super(config, @@service_info)
-        end
-
-
-        # Mounts an ISO image from a content library on a virtual machine.
-        #
-        # @param library_item [String]
-        #     The identifier of the library item having the ISO image to mount on the virtual machine.
-        # @param vm [String]
-        #     The identifier of the virtual machine where the specified ISO image will be mounted.
-        # @return [String]
-        #     The identifier of the newly created virtual CD-ROM backed by the specified ISO image.
-        # @raise [Com::Vmware::Vapi::Std::Errors::NotFound]
-        #     If either  ``vm``  or the  ``library_item``  is not found.
-        # @raise [Com::Vmware::Vapi::Std::Errors::InvalidArgument]
-        #     If no .iso file is present on the library item.
-        # @raise [Com::Vmware::Vapi::Std::Errors::NotAllowedInCurrentState]
-        #     When the operation is not allowed on the virtual machine in its current state.
-        def mount(library_item, vm)
-            invoke_with_info(@@mount_info, {
-                'library_item' => library_item,
-                'vm' => vm,
-            })
-        end
-
-
-        # Unmounts a previously mounted CD-ROM using an ISO image as a backing.
-        #
-        # @param vm [String]
-        #     The identifier of the virtual machine from which to unmount the virtual CD-ROM.
-        # @param cdrom [String]
-        #     The device identifier of the CD-ROM.
-        # @return [Void]
-        # @raise [Com::Vmware::Vapi::Std::Errors::NotFound]
-        #     If the virtual machine identified by  ``vm``  is not found or the  ``cdrom``  does not identify a virtual CD-ROM in the virtual machine.
-        # @raise [Com::Vmware::Vapi::Std::Errors::NotAllowedInCurrentState]
-        #     When the operation is not allowed on the virtual machine in its current state.
-        def unmount(vm, cdrom)
-            invoke_with_info(@@unmount_info, {
-                'vm' => vm,
-                'cdrom' => cdrom,
-            })
-        end
-
-
+    # Constructs a new instance.
+    #
+    # @param config [VAPI::Bindings::StubConfig] A hash with the api provider details.
+    def initialize(config)
+      super(config, SERVICE_INFO)
     end
 
+    # Mounts an ISO image from a content library on a virtual machine.
+    #
+    # @param library_item [String]
+    #     The identifier of the library item having the ISO image to mount on the virtual machine.
+    # @param vm [String]
+    #     The identifier of the virtual machine where the specified ISO image will be mounted.
+    # @return [String]
+    #     The identifier of the newly created virtual CD-ROM backed by the specified ISO image.
+    # @raise [Com::Vmware::Vapi::Std::Errors::NotFound]
+    #     If either  ``vm``  or the  ``library_item``  is not found.
+    # @raise [Com::Vmware::Vapi::Std::Errors::InvalidArgument]
+    #     If no .iso file is present on the library item.
+    # @raise [Com::Vmware::Vapi::Std::Errors::NotAllowedInCurrentState]
+    #     When the operation is not allowed on the virtual machine in its current state.
+    def mount(library_item, vm)
+      invoke_with_info(MOUNT_INFO,
+                       'library_item' => library_item,
+                       'vm' => vm)
+    end
 
+    # Unmounts a previously mounted CD-ROM using an ISO image as a backing.
+    #
+    # @param vm [String]
+    #     The identifier of the virtual machine from which to unmount the virtual CD-ROM.
+    # @param cdrom [String]
+    #     The device identifier of the CD-ROM.
+    # @return [Void]
+    # @raise [Com::Vmware::Vapi::Std::Errors::NotFound]
+    #     If the virtual machine identified by  ``vm``  is not found or the  ``cdrom``  does not identify a virtual CD-ROM in the virtual machine.
+    # @raise [Com::Vmware::Vapi::Std::Errors::NotAllowedInCurrentState]
+    #     When the operation is not allowed on the virtual machine in its current state.
+    def unmount(vm, cdrom)
+      invoke_with_info(UNMOUNT_INFO,
+                       'vm' => vm,
+                       'cdrom' => cdrom)
+    end
+
+  end
 end

--- a/client/sdk/com/vmware/vcenter/iso/vapi.rb
+++ b/client/sdk/com/vmware/vcenter/iso/vapi.rb
@@ -1,5 +1,6 @@
 #---------------------------------------------------------------------------
-# Copyright 2016 VMware, Inc.  All rights reserved.
+# Copyright 2017 VMware, Inc.  All rights reserved.
+#
 # AUTO GENERATED FILE -- DO NOT MODIFY!
 #---------------------------------------------------------------------------
 require 'vapi'

--- a/client/sdk/com/vmware/vcenter/ovf.rb
+++ b/client/sdk/com/vmware/vcenter/ovf.rb
@@ -1,5 +1,6 @@
 #---------------------------------------------------------------------------
-# Copyright 2016 VMware, Inc.  All rights reserved.
+# Copyright 2017 VMware, Inc.  All rights reserved.
+#
 # AUTO GENERATED FILE -- DO NOT MODIFY!
 #
 # vAPI type descriptors for package com.vmware.vcenter.ovf.
@@ -8,2532 +9,2396 @@ require 'vapi'
 
 # declare the module hierarchy before we use the shorthand syntax below
 module Com
-    module Vmware
-        module Vcenter
-            module Ovf
-            end
-        end
+  module Vmware
+    module Vcenter
+      module Ovf
+      end
     end
+  end
 end
 
 # The  ``com.vmware.vcenter.ovf``   package  provides services to capture and deploy Open Virtualization Format (OVF) packages to and from the content library.  
 # 
 #  It provides the ability to deploy OVF packages from the content library with support for advanced network topologies, network services, creating virtual appliances and virtual machines in hosts, resource pools or clusters. It also provides the ability to export virtual appliances and virtual machines from hosts, resource pools or clusters as OVF packages to the content library.
 module Com::Vmware::Vcenter::Ovf
+  # The  ``Com::Vmware::Vcenter::Ovf::ExportFlag``   class  provides  methods  for retrieving information about the export flags supported by the server. Export flags can be specified in a   :class:`Com::Vmware::Vcenter::Ovf::LibraryItem::CreateSpec`   to customize an OVF export.
+  class ExportFlag < VAPI::Bindings::VapiService
+    # static metamodel definitions
+    SERVICE_ID = VAPI::Core::ServiceIdentifier.new('com.vmware.vcenter.ovf.export_flag')
 
-    # The  ``Com::Vmware::Vcenter::Ovf::ExportFlag``   class  provides  methods  for retrieving information about the export flags supported by the server. Export flags can be specified in a   :class:`Com::Vmware::Vcenter::Ovf::LibraryItem::CreateSpec`   to customize an OVF export.
-    class ExportFlag < VAPI::Bindings::VapiService
+    LIST_INFO = VAPI::Bindings::OperationInfo.new(
+      VAPI::Core::OperationIdentifier.new('list', SERVICE_ID),
+      VAPI::Bindings::OperationInputType.new,
+      VAPI::Bindings::ListType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::Ovf::ExportFlag::Info')),
+      {},
+      [],
+      []
+    )
 
-        protected
+    SERVICE_INFO = VAPI::Bindings::ServiceInfo.new(
+      SERVICE_ID,
+      'list' => LIST_INFO
+    )
 
-        # static metamodel definitions
-        @@service_id = VAPI::Core::ServiceIdentifier.new('com.vmware.vcenter.ovf.export_flag')
-
-        @@list_info = VAPI::Bindings::OperationInfo.new(
-            VAPI::Core::OperationIdentifier.new('list', @@service_id),
-            VAPI::Bindings::OperationInputType.new,
-            VAPI::Bindings::ListType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::Ovf::ExportFlag::Info')),
-            {},
-            [],
-            [])
-
-        @@service_info = VAPI::Bindings::ServiceInfo.new(@@service_id, {
-            'list' => @@list_info,
-        })
-
-        public
-
-        # Constructs a new instance.
-        #
-        # @param config [VAPI::Bindings::StubConfig] A hash with the api provider details.
-        def initialize(config)
-            super(config, @@service_info)
-        end
-
-
-        # Returns information about the supported export flags by the server.  
-        # 
-        #  The supported flags are:  
-        #   PRESERVE_MAC
-        #        Include MAC addresses for network adapters.
-        #    EXTRA_CONFIG
-        #        Include extra configuration in OVF export.
-        #      
-        # 
-        #  Future server versions might support additional flags.
-        #
-        # @return [Array<Com::Vmware::Vcenter::Ovf::ExportFlag::Info>]
-        #     A  list  of supported export flags.
-        # @raise [Com::Vmware::Vapi::Std::Errors::Unauthorized]
-        #     If you do not have all of the privileges described in the following list:
-        #
-        #     System.Read
-        def list()
-            invoke_with_info(@@list_info)
-        end
-
-
-
-        # The  ``Com::Vmware::Vcenter::Ovf::ExportFlag::Info``   class  describes an export flag supported by the server.
-        # @!attribute [rw] option
-        #     @return [String]
-        #     The name of the export flag that is supported by the server.
-        # @!attribute [rw] description
-        #     @return [Com::Vmware::Vapi::Std::LocalizableMessage]
-        #     Localizable description of the export flag.
-        class Info < VAPI::Bindings::VapiStruct
-
-            class << self
-                # Holds (gets or creates) the binding type metadata for this structure type.
-                # @scope class
-                # @return [VAPI::Bindings::StructType] the binding type
-                def binding_type
-                    @binding_type ||= VAPI::Bindings::StructType.new(
-                        'com.vmware.vcenter.ovf.export_flag.info',
-                        {
-                            'option' => VAPI::Bindings::StringType.instance,
-                            'description' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::LocalizableMessage'),
-                        },
-                        Info,
-                        false,
-                        nil)
-                end
-            end
-
-            attr_accessor :option,
-                          :description
-
-            # Constructs a new instance.
-            # @param ruby_values [Hash] a map of initial property values (optional)
-            # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
-            def initialize(ruby_values=nil, struct_value=nil)
-                super(self.class.binding_type, ruby_values, struct_value)
-            end
-        end
-
-
+    # Constructs a new instance.
+    #
+    # @param config [VAPI::Bindings::StubConfig] A hash with the api provider details.
+    def initialize(config)
+      super(config, SERVICE_INFO)
     end
 
-
-    # The  ``Com::Vmware::Vcenter::Ovf::ImportFlag``   class  provides  methods  for retrieving information about the import flags supported by the deployment platform. Import flags can be specified in a   :class:`Com::Vmware::Vcenter::Ovf::LibraryItem::ResourcePoolDeploymentSpec`   to customize an OVF deployment.
-    class ImportFlag < VAPI::Bindings::VapiService
-
-        protected
-
-        # static metamodel definitions
-        @@service_id = VAPI::Core::ServiceIdentifier.new('com.vmware.vcenter.ovf.import_flag')
-
-        @@list_info = VAPI::Bindings::OperationInfo.new(
-            VAPI::Core::OperationIdentifier.new('list', @@service_id),
-            VAPI::Bindings::OperationInputType.new({
-                'rp' => VAPI::Bindings::IdType.new(resource_types='ResourcePool'),
-            }),
-            VAPI::Bindings::ListType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::Ovf::ImportFlag::Info')),
-            {
-                'com.vmware.vapi.std.errors.not_found' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::NotFound'),
-
-            },
-            [],
-            [])
-
-        @@service_info = VAPI::Bindings::ServiceInfo.new(@@service_id, {
-            'list' => @@list_info,
-        })
-
-        public
-
-        # Constructs a new instance.
-        #
-        # @param config [VAPI::Bindings::StubConfig] A hash with the api provider details.
-        def initialize(config)
-            super(config, @@service_info)
-        end
-
-
-        # Returns information about the import flags supported by the deployment platform.  
-        # 
-        #  The supported flags are:  
-        #   LAX
-        #        Lax mode parsing of the OVF descriptor.
-        #      
-        # 
-        #  Future server versions might support additional flags.
-        #
-        # @param rp [String]
-        #      The identifier of resource pool target for retrieving the import flag(s).
-        # @return [Array<Com::Vmware::Vcenter::Ovf::ImportFlag::Info>]
-        #     A  list  of supported import flags.
-        # @raise [Com::Vmware::Vapi::Std::Errors::NotFound]
-        #      If the resource pool associated with  ``rp``  does not exist.
-        # @raise [Com::Vmware::Vapi::Std::Errors::Unauthorized]
-        #     If you do not have all of the privileges described in the following list:
-        #
-        #     System.Read
-        def list(rp)
-            invoke_with_info(@@list_info, {
-                'rp' => rp,
-            })
-        end
-
-
-
-        # The  ``Com::Vmware::Vcenter::Ovf::ImportFlag::Info``   class  describes an import flag supported by the deployment platform.
-        # @!attribute [rw] option
-        #     @return [String]
-        #     The name of the import flag that is supported by the deployment platform.
-        # @!attribute [rw] description
-        #     @return [Com::Vmware::Vapi::Std::LocalizableMessage]
-        #     Localizable description of the import flag.
-        class Info < VAPI::Bindings::VapiStruct
-
-            class << self
-                # Holds (gets or creates) the binding type metadata for this structure type.
-                # @scope class
-                # @return [VAPI::Bindings::StructType] the binding type
-                def binding_type
-                    @binding_type ||= VAPI::Bindings::StructType.new(
-                        'com.vmware.vcenter.ovf.import_flag.info',
-                        {
-                            'option' => VAPI::Bindings::StringType.instance,
-                            'description' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::LocalizableMessage'),
-                        },
-                        Info,
-                        false,
-                        nil)
-                end
-            end
-
-            attr_accessor :option,
-                          :description
-
-            # Constructs a new instance.
-            # @param ruby_values [Hash] a map of initial property values (optional)
-            # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
-            def initialize(ruby_values=nil, struct_value=nil)
-                super(self.class.binding_type, ruby_values, struct_value)
-            end
-        end
-
-
+    # Returns information about the supported export flags by the server.  
+    # 
+    #  The supported flags are:  
+    #   PRESERVE_MAC
+    #        Include MAC addresses for network adapters.
+    #    EXTRA_CONFIG
+    #        Include extra configuration in OVF export.
+    #      
+    # 
+    #  Future server versions might support additional flags.
+    #
+    # @return [Array<Com::Vmware::Vcenter::Ovf::ExportFlag::Info>]
+    #     A  list  of supported export flags.
+    # @raise [Com::Vmware::Vapi::Std::Errors::Unauthorized]
+    #     If you do not have all of the privileges described in the following list:
+    #
+    #     System.Read
+    def list
+      invoke_with_info(LIST_INFO)
     end
 
-
-    # The  ``Com::Vmware::Vcenter::Ovf::LibraryItem``   class  provides  methods  to deploy virtual machines and virtual appliances from library items containing Open Virtualization Format (OVF) packages in content library, as well as  methods  to create library items in content library from virtual machines and virtual appliances.  
-    # 
-    #  To deploy a virtual machine or a virtual appliance from a library item:  
-    # 
-    #   #  Create a   :class:`Com::Vmware::Vcenter::Ovf::LibraryItem::DeploymentTarget`   to specify the target deployment type and target deployment designation. 
-    #    #  Create a   :class:`Com::Vmware::Vcenter::Ovf::LibraryItem::ResourcePoolDeploymentSpec`   to specify the parameters for the target deployment. 
-    #    #  Use the  ``deploy``   method  with the created target and parameter specifications, along with the identifier of the specified source content library item. See   :func:`Com::Vmware::Vcenter::Ovf::LibraryItem.deploy`  . 
-    #   
-    #    
-    # 
-    #    
-    # 
-    #  To create a library item in content library from a virtual machine or virtual appliance:  
-    # 
-    #   #  Create a   :class:`Com::Vmware::Vcenter::Ovf::LibraryItem::DeployableIdentity`   to specify the source virtual machine or virtual appliance to be used as the OVF template source. 
-    #    #  Create a   :class:`Com::Vmware::Vcenter::Ovf::LibraryItem::CreateTarget`   to specify the target library and library item. 
-    #    #  Create a   :class:`Com::Vmware::Vcenter::Ovf::LibraryItem::CreateSpec`   to specify the settings for the OVF package to be created.
-    #    #  Use the  ``create``   method  with the created target and parameter specifications, along with the specified source entity. See   :func:`Com::Vmware::Vcenter::Ovf::LibraryItem.create`  . 
-    #   
-    #    
-    class LibraryItem < VAPI::Bindings::VapiService
-
-        protected
-
-        # static metamodel definitions
-        @@service_id = VAPI::Core::ServiceIdentifier.new('com.vmware.vcenter.ovf.library_item')
-
-        @@deploy_info = VAPI::Bindings::OperationInfo.new(
-            VAPI::Core::OperationIdentifier.new('deploy', @@service_id),
-            VAPI::Bindings::OperationInputType.new({
-                'client_token' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::StringType.instance),
-                'ovf_library_item_id' => VAPI::Bindings::IdType.new(resource_types='com.vmware.content.library.Item'),
-                'target' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::Ovf::LibraryItem::DeploymentTarget'),
-                'deployment_spec' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::Ovf::LibraryItem::ResourcePoolDeploymentSpec'),
-            }),
-            VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::Ovf::LibraryItem::DeploymentResult'),
-            {
-                'com.vmware.vapi.std.errors.invalid_argument' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::InvalidArgument'),
-                'com.vmware.vapi.std.errors.not_found' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::NotFound'),
-                'com.vmware.vapi.std.errors.resource_inaccessible' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::ResourceInaccessible'),
-                'com.vmware.vapi.std.errors.unauthorized' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Unauthorized'),
-
-            },
-            [],
-            [])
-        @@filter_info = VAPI::Bindings::OperationInfo.new(
-            VAPI::Core::OperationIdentifier.new('filter', @@service_id),
-            VAPI::Bindings::OperationInputType.new({
-                'ovf_library_item_id' => VAPI::Bindings::IdType.new(resource_types='com.vmware.content.library.Item'),
-                'target' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::Ovf::LibraryItem::DeploymentTarget'),
-            }),
-            VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::Ovf::LibraryItem::OvfSummary'),
-            {
-                'com.vmware.vapi.std.errors.invalid_argument' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::InvalidArgument'),
-                'com.vmware.vapi.std.errors.not_found' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::NotFound'),
-                'com.vmware.vapi.std.errors.resource_inaccessible' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::ResourceInaccessible'),
-
-            },
-            [],
-            [])
-        @@create_info = VAPI::Bindings::OperationInfo.new(
-            VAPI::Core::OperationIdentifier.new('create', @@service_id),
-            VAPI::Bindings::OperationInputType.new({
-                'client_token' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::StringType.instance),
-                'source' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::Ovf::LibraryItem::DeployableIdentity'),
-                'target' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::Ovf::LibraryItem::CreateTarget'),
-                'create_spec' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::Ovf::LibraryItem::CreateSpec'),
-            }),
-            VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::Ovf::LibraryItem::CreateResult'),
-            {
-                'com.vmware.vapi.std.errors.invalid_argument' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::InvalidArgument'),
-                'com.vmware.vapi.std.errors.not_found' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::NotFound'),
-                'com.vmware.vapi.std.errors.not_allowed_in_current_state' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::NotAllowedInCurrentState'),
-                'com.vmware.vapi.std.errors.resource_inaccessible' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::ResourceInaccessible'),
-                'com.vmware.vapi.std.errors.resource_busy' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::ResourceBusy'),
-
-            },
-            [],
-            [])
-
-        @@service_info = VAPI::Bindings::ServiceInfo.new(@@service_id, {
-            'deploy' => @@deploy_info,
-            'filter' => @@filter_info,
-            'create' => @@create_info,
-        })
-
-        public
-
-        # Constructs a new instance.
-        #
-        # @param config [VAPI::Bindings::StubConfig] A hash with the api provider details.
-        def initialize(config)
-            super(config, @@service_info)
-        end
-
-        DEPLOYABLE = ['VirtualMachine', 'VirtualApp']
-
-
-        # Deploys an OVF package stored in content library to a newly created virtual machine or virtual appliance.  
-        # 
-        #  This  method  deploys an OVF package which is stored in the library item specified by  ``ovf_library_item_id`` . It uses the deployment specification in  ``deployment_spec``  to deploy the OVF package to the location specified by  ``target`` . 
-        #
-        # @param client_token [String, nil]
-        #      Client-generated token used to retry a request if the client fails to get a response from the server. If the original request succeeded, the result of that request will be returned, otherwise the operation will be retried.
-        #     If  nil , the server will create a token.
-        # @param ovf_library_item_id [String]
-        #      Identifier of the content library item containing the OVF package to be deployed.
-        # @param target [Com::Vmware::Vcenter::Ovf::LibraryItem::DeploymentTarget]
-        #      Specification of the deployment target.
-        # @param deployment_spec [Com::Vmware::Vcenter::Ovf::LibraryItem::ResourcePoolDeploymentSpec]
-        #      Specification of how the OVF package should be deployed to the target.
-        # @return [Com::Vmware::Vcenter::Ovf::LibraryItem::DeploymentResult]
-        #     Information about the success or failure of the  method , along with the details of the result or failure.
-        # @raise [Com::Vmware::Vapi::Std::Errors::InvalidArgument]
-        #      if  ``target``  contains invalid arguments.
-        # @raise [Com::Vmware::Vapi::Std::Errors::InvalidArgument]
-        #      if  ``deployment_spec``  contains invalid arguments or has  fields  that are inconsistent with  ``target`` .
-        # @raise [Com::Vmware::Vapi::Std::Errors::NotFound]
-        #      if the library item specified by  ``ovf_library_item_id``  does not exist.
-        # @raise [Com::Vmware::Vapi::Std::Errors::NotFound]
-        #      if any resource specified by a  field  of the   :class:`Com::Vmware::Vcenter::Ovf::LibraryItem::DeploymentTarget`    class , specified by  ``target`` , does not exist.
-        # @raise [Com::Vmware::Vapi::Std::Errors::ResourceInaccessible]
-        #      if there was an error accessing the OVF package stored in the library item specified by  ``ovf_library_item_id`` .
-        # @raise [Com::Vmware::Vapi::Std::Errors::Unauthorized]
-        #      if you do not have all of the privileges described as follows :  
-        #     
-        #       * Method  execution requires VirtualMachine.Config.AddNewDisk if the OVF descriptor has a disk drive (type 17) section. 
-        #        * Method  execution requires VirtualMachine.Config.AdvancedConfig if the OVF descriptor has an ExtraConfig section. 
-        #        * Method  execution requires Extension.Register for specified resource group if the OVF descriptor has a vServiceDependency section. 
-        #        * Method  execution requires Network.Assign for target network if specified. 
-        #        * Method  execution requires Datastore.AllocateSpace for target datastore if specified. 
-        #       
-        # @raise [Com::Vmware::Vapi::Std::Errors::Unauthorized]
-        #     If you do not have all of the privileges described in the following list:
-        #
-        #     System.Read
-        def deploy(ovf_library_item_id, target, deployment_spec, client_token=nil)
-            invoke_with_info(@@deploy_info, {
-                'client_token' => client_token,
-                'ovf_library_item_id' => ovf_library_item_id,
-                'target' => target,
-                'deployment_spec' => deployment_spec,
-            })
-        end
-
-
-        # Queries an OVF package stored in content library to retrieve information to use when deploying the package. See   :func:`Com::Vmware::Vcenter::Ovf::LibraryItem.deploy`  .  
-        # 
-        #  This  method  retrieves information from the descriptor of the OVF package stored in the library item specified by  ``ovf_library_item_id`` . The information returned by the  method  can be used to populate the deployment specification (see   :class:`Com::Vmware::Vcenter::Ovf::LibraryItem::ResourcePoolDeploymentSpec`   when deploying the OVF package to the deployment target specified by  ``target`` . 
-        #
-        # @param ovf_library_item_id [String]
-        #      Identifier of the content library item containing the OVF package to query.
-        # @param target [Com::Vmware::Vcenter::Ovf::LibraryItem::DeploymentTarget]
-        #      Specification of the deployment target.
-        # @return [Com::Vmware::Vcenter::Ovf::LibraryItem::OvfSummary]
-        #     Information that can be used to populate the deployment specification (see   :class:`Com::Vmware::Vcenter::Ovf::LibraryItem::ResourcePoolDeploymentSpec`  ) when deploying the OVF package to the deployment target specified by  ``target`` .
-        # @raise [Com::Vmware::Vapi::Std::Errors::InvalidArgument]
-        #      if  ``target``  contains invalid arguments.
-        # @raise [Com::Vmware::Vapi::Std::Errors::NotFound]
-        #      if the library item specified by  ``ovf_library_item_id``  does not exist.
-        # @raise [Com::Vmware::Vapi::Std::Errors::NotFound]
-        #      if any resource specified by a  field  of the   :class:`Com::Vmware::Vcenter::Ovf::LibraryItem::DeploymentTarget`    class , specified by  ``target`` , does not exist.
-        # @raise [Com::Vmware::Vapi::Std::Errors::ResourceInaccessible]
-        #      if there was an error accessing the OVF package at the specified  ``ovf_library_item_id`` .
-        # @raise [Com::Vmware::Vapi::Std::Errors::Unauthorized]
-        #     If you do not have all of the privileges described in the following list:
-        #
-        #     System.Read
-        def filter(ovf_library_item_id, target)
-            invoke_with_info(@@filter_info, {
-                'ovf_library_item_id' => ovf_library_item_id,
-                'target' => target,
-            })
-        end
-
-
-        # Creates a library item in content library from a virtual machine or virtual appliance.  
-        # 
-        #  This  method  creates a library item in content library whose content is an OVF package derived from a source virtual machine or virtual appliance, using the supplied create specification. The OVF package may be stored as in a newly created library item or in an in an existing library item. For an existing library item whose content is updated by this  method , the original content is overwritten. 
-        #
-        # @param client_token [String, nil]
-        #      Client-generated token used to retry a request if the client fails to get a response from the server. If the original request succeeded, the result of that request will be returned, otherwise the operation will be retried.
-        #     If  nil , the server will create a token.
-        # @param source [Com::Vmware::Vcenter::Ovf::LibraryItem::DeployableIdentity]
-        #      Identifier of the virtual machine or virtual appliance to use as the source.
-        # @param target [Com::Vmware::Vcenter::Ovf::LibraryItem::CreateTarget]
-        #      Specification of the target content library and library item.
-        # @param create_spec [Com::Vmware::Vcenter::Ovf::LibraryItem::CreateSpec]
-        #      Information used to create the OVF package from the source virtual machine or virtual appliance.
-        # @return [Com::Vmware::Vcenter::Ovf::LibraryItem::CreateResult]
-        #     Information about the success or failure of the  method , along with the details of the result or failure.
-        # @raise [Com::Vmware::Vapi::Std::Errors::InvalidArgument]
-        #      if  ``create_spec``  contains invalid arguments.
-        # @raise [Com::Vmware::Vapi::Std::Errors::InvalidArgument]
-        #      if  ``source``  describes an unexpected resource type.
-        # @raise [Com::Vmware::Vapi::Std::Errors::NotFound]
-        #      if the virtual machine or virtual appliance specified by  ``source``  does not exist.
-        # @raise [Com::Vmware::Vapi::Std::Errors::NotFound]
-        #      if the library or library item specified by  ``target``  does not exist.
-        # @raise [Com::Vmware::Vapi::Std::Errors::NotAllowedInCurrentState]
-        #      if the operation cannot be performed because of the specified virtual machine or virtual appliance's current state. For example, if the virtual machine configuration information is not available, or if the virtual appliance is running.
-        # @raise [Com::Vmware::Vapi::Std::Errors::ResourceInaccessible]
-        #      if there was an error accessing a file from the source virtual machine or virtual appliance.
-        # @raise [Com::Vmware::Vapi::Std::Errors::ResourceBusy]
-        #      if the specified virtual machine or virtual appliance is busy.
-        # @raise [Com::Vmware::Vapi::Std::Errors::Unauthorized]
-        #     If you do not have all of the privileges described in the following list:
-        #
-        #     System.Read
-        def create(source, target, create_spec, client_token=nil)
-            invoke_with_info(@@create_info, {
-                'client_token' => client_token,
-                'source' => source,
-                'target' => target,
-                'create_spec' => create_spec,
-            })
-        end
-
-
-
-        # The  ``Com::Vmware::Vcenter::Ovf::LibraryItem::DeployableIdentity``   class  describes the resource created by a deployment, or the source resource from which library item can be created, by specifying its resource type and resource identifier.
-        # @!attribute [rw] type
-        #     @return [String]
-        #     Type of the deployable resource.
-        # @!attribute [rw] id
-        #     @return [String]
-        #     Identifier of the deployable resource.
-        class DeployableIdentity < VAPI::Bindings::VapiStruct
-
-            class << self
-                # Holds (gets or creates) the binding type metadata for this structure type.
-                # @scope class
-                # @return [VAPI::Bindings::StructType] the binding type
-                def binding_type
-                    @binding_type ||= VAPI::Bindings::StructType.new(
-                        'com.vmware.vcenter.ovf.library_item.deployable_identity',
-                        {
-                            'type' => VAPI::Bindings::StringType.instance,
-                            'id' => VAPI::Bindings::IdType.new(resource_types=[], resource_type_field_name="type"),
-                        },
-                        DeployableIdentity,
-                        false,
-                        nil)
-                end
-            end
-
-            attr_accessor :type,
-                          :id
-
-            # Constructs a new instance.
-            # @param ruby_values [Hash] a map of initial property values (optional)
-            # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
-            def initialize(ruby_values=nil, struct_value=nil)
-                super(self.class.binding_type, ruby_values, struct_value)
-            end
-        end
-
-
-        # The  ``Com::Vmware::Vcenter::Ovf::LibraryItem::ResourcePoolDeploymentSpec``   class  defines the deployment parameters that can be specified for the  ``deploy``   method  where the deployment target is a resource pool. See   :func:`Com::Vmware::Vcenter::Ovf::LibraryItem.deploy`  .
-        # @!attribute [rw] name
-        #     @return [String, nil]
-        #     Name assigned to the deployed target virtual machine or virtual appliance.
-        #     If  nil , the server will use the name from the OVF package.
-        # @!attribute [rw] annotation
-        #     @return [String, nil]
-        #     Annotation assigned to the deployed target virtual machine or virtual appliance.
-        #     If  nil , the server will use the annotation from the OVF package.
-        # @!attribute [rw] accept_all_eula
-        #     @return [Boolean]
-        #     Whether to accept all End User License Agreements. See   :attr:`Com::Vmware::Vcenter::Ovf::LibraryItem::OvfSummary.eulas`  .
-        # @!attribute [rw] network_mappings
-        #     @return [Hash<String, String>, nil]
-        #     Specification of the target network to use for sections of type ovf:NetworkSection in the OVF descriptor. The key in the  map  is the section identifier of the ovf:NetworkSection section in the OVF descriptor and the value is the target network to be used for deployment.
-        #     If  nil , the server will choose a network mapping.
-        # @!attribute [rw] storage_mappings
-        #     @return [Hash<String, Com::Vmware::Vcenter::Ovf::LibraryItem::StorageGroupMapping>, nil]
-        #     Specification of the target storage to use for sections of type vmw:StorageGroupSection in the OVF descriptor. The key in the  map  is the section identifier of the ovf:StorageGroupSection section in the OVF descriptor and the value is the target storage specification to be used for deployment. See   :class:`Com::Vmware::Vcenter::Ovf::LibraryItem::StorageGroupMapping`  .
-        #     If  nil , the server will choose a storage mapping.
-        # @!attribute [rw] storage_provisioning
-        #     @return [Com::Vmware::Vcenter::Ovf::DiskProvisioningType, nil]
-        #     Default storage provisioning type to use for all sections of type vmw:StorageSection in the OVF descriptor.
-        #     If  nil , the server will choose the provisioning type.
-        # @!attribute [rw] storage_profile_id
-        #     @return [String, nil]
-        #     Default storage profile to use for all sections of type vmw:StorageSection in the OVF descriptor.
-        #     If  nil , the server will choose the default profile.
-        # @!attribute [rw] locale
-        #     @return [String, nil]
-        #     The locale to use for parsing the OVF descriptor.
-        #     If  nil , the server locale will be used.
-        # @!attribute [rw] flags
-        #     @return [Array<String>, nil]
-        #     Flags to be use for deployment. The supported flag values can be obtained using   :func:`Com::Vmware::Vcenter::Ovf::ImportFlag.list`  .
-        #     If  nil , no flags will be used.
-        # @!attribute [rw] additional_parameters
-        #     @return [Array<VAPI::Bindings::VapiStruct>, nil]
-        #     Additional OVF parameters that may be needed for the deployment. Additional OVF parameters may be required by the OVF descriptor of the OVF package in the library item. Examples of OVF parameters that can be specified through this  field  include, but are not limited to:  
-        #     
-        #       *  :class:`Com::Vmware::Vcenter::Ovf::DeploymentOptionParams` 
-        #        *  :class:`Com::Vmware::Vcenter::Ovf::ExtraConfigParams` 
-        #        *  :class:`Com::Vmware::Vcenter::Ovf::IpAllocationParams` 
-        #        *  :class:`Com::Vmware::Vcenter::Ovf::PropertyParams` 
-        #        *  :class:`Com::Vmware::Vcenter::Ovf::ScaleOutParams` 
-        #        *  :class:`Com::Vmware::Vcenter::Ovf::VcenterExtensionParams` 
-        #       
-        #     If  nil , the server will choose default settings for all parameters necessary for the  ``deploy``   method . See   :func:`Com::Vmware::Vcenter::Ovf::LibraryItem.deploy`  .
-        # @!attribute [rw] default_datastore_id
-        #     @return [String, nil]
-        #     Default datastore to use for all sections of type vmw:StorageSection in the OVF descriptor.
-        #     If  nil , the server will choose the default datastore.
-        class ResourcePoolDeploymentSpec < VAPI::Bindings::VapiStruct
-
-            class << self
-                # Holds (gets or creates) the binding type metadata for this structure type.
-                # @scope class
-                # @return [VAPI::Bindings::StructType] the binding type
-                def binding_type
-                    @binding_type ||= VAPI::Bindings::StructType.new(
-                        'com.vmware.vcenter.ovf.library_item.resource_pool_deployment_spec',
-                        {
-                            'name' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::StringType.instance),
-                            'annotation' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::StringType.instance),
-                            'accept_all_EULA' => VAPI::Bindings::BooleanType.instance,
-                            'network_mappings' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::MapType.new(VAPI::Bindings::StringType.instance, VAPI::Bindings::IdType.new)),
-                            'storage_mappings' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::MapType.new(VAPI::Bindings::StringType.instance, VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::Ovf::LibraryItem::StorageGroupMapping'))),
-                            'storage_provisioning' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::Ovf::DiskProvisioningType')),
-                            'storage_profile_id' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::IdType.new),
-                            'locale' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::StringType.instance),
-                            'flags' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::ListType.new(VAPI::Bindings::StringType.instance)),
-                            'additional_parameters' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::ListType.new(VAPI::Bindings::DynamicStructType.new([VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::Ovf::OvfParams')]))),
-                            'default_datastore_id' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::IdType.new),
-                        },
-                        ResourcePoolDeploymentSpec,
-                        false,
-                        nil)
-                end
-            end
-
-            attr_accessor :name,
-                          :annotation,
-                          :accept_all_eula,
-                          :network_mappings,
-                          :storage_mappings,
-                          :storage_provisioning,
-                          :storage_profile_id,
-                          :locale,
-                          :flags,
-                          :additional_parameters,
-                          :default_datastore_id
-
-            # Constructs a new instance.
-            # @param ruby_values [Hash] a map of initial property values (optional)
-            # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
-            def initialize(ruby_values=nil, struct_value=nil)
-                super(self.class.binding_type, ruby_values, struct_value)
-            end
-        end
-
-
-        # The  ``Com::Vmware::Vcenter::Ovf::LibraryItem::StorageGroupMapping``   class  defines the storage deployment target and storage provisioning type for a section of type vmw:StorageGroupSection in the OVF descriptor.
-        # @!attribute [rw] type
-        #     @return [Com::Vmware::Vcenter::Ovf::LibraryItem::StorageGroupMapping::Type]
-        #     Type of storage deployment target to use for the vmw:StorageGroupSection section. The specified value must be   :attr:`Com::Vmware::Vcenter::Ovf::LibraryItem::StorageGroupMapping::Type.DATASTORE`   or   :attr:`Com::Vmware::Vcenter::Ovf::LibraryItem::StorageGroupMapping::Type.STORAGE_PROFILE`  .
-        # @!attribute [rw] datastore_id
-        #     @return [String]
-        #     Target datastore to be used for the storage group.
-        #     This  field  is optional and it is only relevant when the value of  ``type``  is   :attr:`Com::Vmware::Vcenter::Ovf::LibraryItem::StorageGroupMapping::Type.DATASTORE`  .
-        # @!attribute [rw] storage_profile_id
-        #     @return [String]
-        #     Target storage profile to be used for the storage group.
-        #     This  field  is optional and it is only relevant when the value of  ``type``  is   :attr:`Com::Vmware::Vcenter::Ovf::LibraryItem::StorageGroupMapping::Type.STORAGE_PROFILE`  .
-        # @!attribute [rw] provisioning
-        #     @return [Com::Vmware::Vcenter::Ovf::DiskProvisioningType, nil]
-        #     Target provisioning type to use for the storage group.
-        #     If  nil ,   :attr:`Com::Vmware::Vcenter::Ovf::LibraryItem::ResourcePoolDeploymentSpec.storage_provisioning`   will be used.
-        class StorageGroupMapping < VAPI::Bindings::VapiStruct
-
-            class << self
-                # Holds (gets or creates) the binding type metadata for this structure type.
-                # @scope class
-                # @return [VAPI::Bindings::StructType] the binding type
-                def binding_type
-                    @binding_type ||= VAPI::Bindings::StructType.new(
-                        'com.vmware.vcenter.ovf.library_item.storage_group_mapping',
-                        {
-                            'type' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::Ovf::LibraryItem::StorageGroupMapping::Type'),
-                            'datastore_id' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::IdType.new),
-                            'storage_profile_id' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::IdType.new),
-                            'provisioning' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::Ovf::DiskProvisioningType')),
-                        },
-                        StorageGroupMapping,
-                        false,
-                        nil)
-                end
-            end
-
-            attr_accessor :type,
-                          :datastore_id,
-                          :storage_profile_id,
-                          :provisioning
-
-            # Constructs a new instance.
-            # @param ruby_values [Hash] a map of initial property values (optional)
-            # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
-            def initialize(ruby_values=nil, struct_value=nil)
-                super(self.class.binding_type, ruby_values, struct_value)
-            end
-
-
-            # The  ``Com::Vmware::Vcenter::Ovf::LibraryItem::StorageGroupMapping::Type``   enumerated type  defines the supported types of storage targets for sections of type vmw:StroageGroupSection in the OVF descriptor.
-            # @!attribute [rw] datastore
-            #     @return [Com::Vmware::Vcenter::Ovf::LibraryItem::StorageGroupMapping::Type]
-            #     Storage deployment target is a datastore.
-            # @!attribute [rw] storage_profile
-            #     @return [Com::Vmware::Vcenter::Ovf::LibraryItem::StorageGroupMapping::Type]
-            #     Storage deployment target is a storage profile.
-            class Type < VAPI::Bindings::VapiEnum
-
-                class << self
-                    # Holds (gets or creates) the binding type metadata for this enumeration type.
-                    # @scope class
-                    # @return [VAPI::Bindings::EnumType] the binding type
-                    def binding_type
-                        @binding_type ||= VAPI::Bindings::EnumType.new(
-                            'com.vmware.vcenter.ovf.library_item.storage_group_mapping.type',
-                            Type)
-                    end
-
-                    # Converts from a string value (perhaps off the wire) to an instance
-                    # of this enum type.
-                    # @param value [String] the actual value of the enum instance
-                    # @return [Type] the instance found for the value, otherwise
-                    #         an unknown instance will be built for the value
-                    def from_string(value)
-                        begin
-                            const_get(value)
-                        rescue NameError
-                            Type.new('UNKNOWN', value)
-                        end
-                    end
-                end
-
-                private
-
-                # Constructs a new instance.
-                # @param value [String] the actual value of the enum instance
-                # @param unknown [String] the unknown value when value is 'UKNOWN'
-                def initialize(value, unknown=nil)
-                    super(self.class.binding_type, value, unknown)
-                end
-
-                public
-
-                # @!attribute [rw] datastore
-                #     @return [Com::Vmware::Vcenter::Ovf::LibraryItem::StorageGroupMapping::Type]
-                #     Storage deployment target is a datastore.
-                DATASTORE = Type.new('DATASTORE')
-
-                # @!attribute [rw] storage_profile
-                #     @return [Com::Vmware::Vcenter::Ovf::LibraryItem::StorageGroupMapping::Type]
-                #     Storage deployment target is a storage profile.
-                STORAGE_PROFILE = Type.new('STORAGE_PROFILE')
-
-            end
-
-
-        end
-
-
-        # The  ``Com::Vmware::Vcenter::Ovf::LibraryItem::ResultInfo``   class  defines the information returned along with the result of a  ``create``  or  ``deploy``   method  to describe errors, warnings, and informational messages produced by the server.
-        # @!attribute [rw] errors
-        #     @return [Array<Com::Vmware::Vcenter::Ovf::OvfError>]
-        #     Errors reported by the  ``create``  or  ``deploy``   method . These errors would have prevented the  ``create``  or  ``deploy``   method  from completing successfully.
-        # @!attribute [rw] warnings
-        #     @return [Array<Com::Vmware::Vcenter::Ovf::OvfWarning>]
-        #     Warnings reported by the  ``create``  or  ``deploy``   method . These warnings would not have prevented the  ``create``  or  ``deploy``   method  from completing successfully, but there might be issues that warrant attention.
-        # @!attribute [rw] information
-        #     @return [Array<Com::Vmware::Vcenter::Ovf::OvfInfo>]
-        #     Information messages reported by the  ``create``  or  ``deploy``   method . For example, a non-required parameter was ignored.
-        class ResultInfo < VAPI::Bindings::VapiStruct
-
-            class << self
-                # Holds (gets or creates) the binding type metadata for this structure type.
-                # @scope class
-                # @return [VAPI::Bindings::StructType] the binding type
-                def binding_type
-                    @binding_type ||= VAPI::Bindings::StructType.new(
-                        'com.vmware.vcenter.ovf.library_item.result_info',
-                        {
-                            'errors' => VAPI::Bindings::ListType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::Ovf::OvfError')),
-                            'warnings' => VAPI::Bindings::ListType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::Ovf::OvfWarning')),
-                            'information' => VAPI::Bindings::ListType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::Ovf::OvfInfo')),
-                        },
-                        ResultInfo,
-                        false,
-                        nil)
-                end
-            end
-
-            attr_accessor :errors,
-                          :warnings,
-                          :information
-
-            # Constructs a new instance.
-            # @param ruby_values [Hash] a map of initial property values (optional)
-            # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
-            def initialize(ruby_values=nil, struct_value=nil)
-                super(self.class.binding_type, ruby_values, struct_value)
-            end
-        end
-
-
-        # The  ``Com::Vmware::Vcenter::Ovf::LibraryItem::DeploymentResult``   class  defines the result of the  ``deploy``   method . See   :func:`Com::Vmware::Vcenter::Ovf::LibraryItem.deploy`  .
-        # @!attribute [rw] succeeded
-        #     @return [Boolean]
-        #     Whether the  ``deploy``   method  completed successfully.
-        # @!attribute [rw] resource_id
-        #     @return [Com::Vmware::Vcenter::Ovf::LibraryItem::DeployableIdentity, nil]
-        #     Identifier of the deployed resource entity.
-        #     If  nil , the  ``deploy``   method  failed and   :attr:`Com::Vmware::Vcenter::Ovf::LibraryItem::DeploymentResult.error`   will describe the error(s) that caused the failure.
-        # @!attribute [rw] error
-        #     @return [Com::Vmware::Vcenter::Ovf::LibraryItem::ResultInfo, nil]
-        #     Errors, warnings, and informational messages produced by the  ``deploy``   method .
-        #     If  nil , no errors, warnings, or informational messages were reported by the  ``deploy``   method .
-        class DeploymentResult < VAPI::Bindings::VapiStruct
-
-            class << self
-                # Holds (gets or creates) the binding type metadata for this structure type.
-                # @scope class
-                # @return [VAPI::Bindings::StructType] the binding type
-                def binding_type
-                    @binding_type ||= VAPI::Bindings::StructType.new(
-                        'com.vmware.vcenter.ovf.library_item.deployment_result',
-                        {
-                            'succeeded' => VAPI::Bindings::BooleanType.instance,
-                            'resource_id' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::Ovf::LibraryItem::DeployableIdentity')),
-                            'error' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::Ovf::LibraryItem::ResultInfo')),
-                        },
-                        DeploymentResult,
-                        false,
-                        nil)
-                end
-            end
-
-            attr_accessor :succeeded,
-                          :resource_id,
-                          :error
-
-            # Constructs a new instance.
-            # @param ruby_values [Hash] a map of initial property values (optional)
-            # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
-            def initialize(ruby_values=nil, struct_value=nil)
-                super(self.class.binding_type, ruby_values, struct_value)
-            end
-        end
-
-
-        # The  ``Com::Vmware::Vcenter::Ovf::LibraryItem::DeploymentTarget``   class  describes the location (target) where a virtual machine or virtual appliance should be deployed. It is used in the  ``deploy``  and  ``filter``   methods . See   :func:`Com::Vmware::Vcenter::Ovf::LibraryItem.deploy`   and   :func:`Com::Vmware::Vcenter::Ovf::LibraryItem.filter`  .
-        # @!attribute [rw] resource_pool_id
-        #     @return [String]
-        #     Identifier of the resource pool to which the virtual machine or virtual appliance should be attached.
-        # @!attribute [rw] host_id
-        #     @return [String, nil]
-        #     Identifier of the target host on which the virtual machine or virtual appliance will run. The target host must be a member of the cluster that contains the resource pool identified by   :attr:`Com::Vmware::Vcenter::Ovf::LibraryItem::DeploymentTarget.resource_pool_id`  .
-        #     If  nil , the server will automatically select a target host from the resource pool if   :attr:`Com::Vmware::Vcenter::Ovf::LibraryItem::DeploymentTarget.resource_pool_id`   is a stand-alone host or a cluster with Distributed Resource Scheduling (DRS) enabled.
-        # @!attribute [rw] folder_id
-        #     @return [String, nil]
-        #     Identifier of the vCenter folder that should contain the virtual machine or virtual appliance. The folder must be virtual machine folder.
-        #     If  nil , the server will choose the deployment folder.
-        class DeploymentTarget < VAPI::Bindings::VapiStruct
-
-            class << self
-                # Holds (gets or creates) the binding type metadata for this structure type.
-                # @scope class
-                # @return [VAPI::Bindings::StructType] the binding type
-                def binding_type
-                    @binding_type ||= VAPI::Bindings::StructType.new(
-                        'com.vmware.vcenter.ovf.library_item.deployment_target',
-                        {
-                            'resource_pool_id' => VAPI::Bindings::IdType.new(resource_types='ResourcePool'),
-                            'host_id' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::IdType.new),
-                            'folder_id' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::IdType.new),
-                        },
-                        DeploymentTarget,
-                        false,
-                        nil)
-                end
-            end
-
-            attr_accessor :resource_pool_id,
-                          :host_id,
-                          :folder_id
-
-            # Constructs a new instance.
-            # @param ruby_values [Hash] a map of initial property values (optional)
-            # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
-            def initialize(ruby_values=nil, struct_value=nil)
-                super(self.class.binding_type, ruby_values, struct_value)
-            end
-        end
-
-
-        # The  ``Com::Vmware::Vcenter::Ovf::LibraryItem::OvfSummary``   class  defines the result of the  ``filter``   method . See   :func:`Com::Vmware::Vcenter::Ovf::LibraryItem.filter`  . The  fields  in the  class  describe parameterizable information in the OVF descriptor, with respect to a deployment target, for the  ``deploy``   method . See   :func:`Com::Vmware::Vcenter::Ovf::LibraryItem.deploy`  .
-        # @!attribute [rw] name
-        #     @return [String, nil]
-        #     Default name for the virtual machine or virtual appliance.
-        #     If  nil , the OVF descriptor did not specify a name.
-        # @!attribute [rw] annotation
-        #     @return [String, nil]
-        #     Default annotation for the virtual machine or virtual appliance.
-        #     If  nil , the OVF descriptor did not specify an annotation.
-        # @!attribute [rw] eulas
-        #     @return [Array<String>]
-        #     End User License Agreements specified in the OVF descriptor. All end user license agreements must be accepted in order for the  ``deploy``   method  to succeed. See   :attr:`Com::Vmware::Vcenter::Ovf::LibraryItem::ResourcePoolDeploymentSpec.accept_all_eula`  .
-        # @!attribute [rw] networks
-        #     @return [Array<String>, nil]
-        #     Section identifiers for sections of type ovf:NetworkSection in the OVF descriptor. These identifiers can be used as keys in   :attr:`Com::Vmware::Vcenter::Ovf::LibraryItem::ResourcePoolDeploymentSpec.network_mappings`  .
-        #     If  nil , the OVF descriptor did not specify any networks.
-        # @!attribute [rw] storage_groups
-        #     @return [Array<String>, nil]
-        #     Section identifiers for sections of type vmw:StorageGroupSection in the OVF descriptor. These identifiers can be used as keys in   :attr:`Com::Vmware::Vcenter::Ovf::LibraryItem::ResourcePoolDeploymentSpec.storage_mappings`  .
-        #     If  nil , the OVF descriptor did not specify any storage groups.
-        # @!attribute [rw] additional_params
-        #     @return [Array<VAPI::Bindings::VapiStruct>, nil]
-        #     Additional OVF parameters which can be specified for the deployment target. These OVF parameters can be inspected, optionally modified, and used as values in   :attr:`Com::Vmware::Vcenter::Ovf::LibraryItem::ResourcePoolDeploymentSpec.additional_parameters`   for the  ``deploy``   method .
-        #     If  nil , the OVF descriptor does not require addtional parameters or does not have additional parameters suitable for the deployment target.
-        class OvfSummary < VAPI::Bindings::VapiStruct
-
-            class << self
-                # Holds (gets or creates) the binding type metadata for this structure type.
-                # @scope class
-                # @return [VAPI::Bindings::StructType] the binding type
-                def binding_type
-                    @binding_type ||= VAPI::Bindings::StructType.new(
-                        'com.vmware.vcenter.ovf.library_item.ovf_summary',
-                        {
-                            'name' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::StringType.instance),
-                            'annotation' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::StringType.instance),
-                            'EULAs' => VAPI::Bindings::ListType.new(VAPI::Bindings::StringType.instance),
-                            'networks' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::ListType.new(VAPI::Bindings::StringType.instance)),
-                            'storage_groups' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::ListType.new(VAPI::Bindings::StringType.instance)),
-                            'additional_params' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::ListType.new(VAPI::Bindings::DynamicStructType.new([VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::Ovf::OvfParams')]))),
-                        },
-                        OvfSummary,
-                        false,
-                        nil)
-                end
-            end
-
-            attr_accessor :name,
-                          :annotation,
-                          :eulas,
-                          :networks,
-                          :storage_groups,
-                          :additional_params
-
-            # Constructs a new instance.
-            # @param ruby_values [Hash] a map of initial property values (optional)
-            # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
-            def initialize(ruby_values=nil, struct_value=nil)
-                super(self.class.binding_type, ruby_values, struct_value)
-            end
-        end
-
-
-        # The  ``Com::Vmware::Vcenter::Ovf::LibraryItem::CreateTarget``   class  specifies the target library item when capturing a virtual machine or virtual appliance as an OVF package in a library item in a content library. The target can be an existing library item, which will be updated, creating a new version, or it can be a newly created library item in a specified library. See   :func:`Com::Vmware::Vcenter::Ovf::LibraryItem.create`  .
-        # @!attribute [rw] library_id
-        #     @return [String, nil]
-        #     Identifier of the library in which a new library item should be created. This  field  is not used if the  ``libraryItemId``   field  is specified.
-        #     If  nil , the  ``libraryItemId``   field  must be specified.
-        # @!attribute [rw] library_item_id
-        #     @return [String, nil]
-        #     Identifier of the library item that should be should be updated.
-        #     If  nil , a new library item will be created. The  ``libraryId``   field  must be specified if this  field  is  nil .
-        class CreateTarget < VAPI::Bindings::VapiStruct
-
-            class << self
-                # Holds (gets or creates) the binding type metadata for this structure type.
-                # @scope class
-                # @return [VAPI::Bindings::StructType] the binding type
-                def binding_type
-                    @binding_type ||= VAPI::Bindings::StructType.new(
-                        'com.vmware.vcenter.ovf.library_item.create_target',
-                        {
-                            'library_id' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::IdType.new),
-                            'library_item_id' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::IdType.new),
-                        },
-                        CreateTarget,
-                        false,
-                        nil)
-                end
-            end
-
-            attr_accessor :library_id,
-                          :library_item_id
-
-            # Constructs a new instance.
-            # @param ruby_values [Hash] a map of initial property values (optional)
-            # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
-            def initialize(ruby_values=nil, struct_value=nil)
-                super(self.class.binding_type, ruby_values, struct_value)
-            end
-        end
-
-
-        # The  ``Com::Vmware::Vcenter::Ovf::LibraryItem::CreateSpec``   class  defines the information used to create or update a library item containing an OVF package.
-        # @!attribute [rw] name
-        #     @return [String, nil]
-        #     Name to use in the OVF descriptor stored in the library item.
-        #     If  nil , the server will use source's current name.
-        # @!attribute [rw] description
-        #     @return [String, nil]
-        #     Description to use in the OVF descriptor stored in the library item.
-        #     If  nil , the server will use source's current annotation.
-        # @!attribute [rw] flags
-        #     @return [Array<String>, nil]
-        #     Flags to use for OVF package creation. The supported flags can be obtained using   :func:`Com::Vmware::Vcenter::Ovf::ExportFlag.list`  .
-        #     If  nil , no flags will be used.
-        class CreateSpec < VAPI::Bindings::VapiStruct
-
-            class << self
-                # Holds (gets or creates) the binding type metadata for this structure type.
-                # @scope class
-                # @return [VAPI::Bindings::StructType] the binding type
-                def binding_type
-                    @binding_type ||= VAPI::Bindings::StructType.new(
-                        'com.vmware.vcenter.ovf.library_item.create_spec',
-                        {
-                            'name' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::StringType.instance),
-                            'description' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::StringType.instance),
-                            'flags' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::ListType.new(VAPI::Bindings::StringType.instance)),
-                        },
-                        CreateSpec,
-                        false,
-                        nil)
-                end
-            end
-
-            attr_accessor :name,
-                          :description,
-                          :flags
-
-            # Constructs a new instance.
-            # @param ruby_values [Hash] a map of initial property values (optional)
-            # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
-            def initialize(ruby_values=nil, struct_value=nil)
-                super(self.class.binding_type, ruby_values, struct_value)
-            end
-        end
-
-
-        # The  ``Com::Vmware::Vcenter::Ovf::LibraryItem::CreateResult``   class  defines the result of the  ``create``   method . See   :func:`Com::Vmware::Vcenter::Ovf::LibraryItem.create`  .
-        # @!attribute [rw] succeeded
-        #     @return [Boolean]
-        #     Whether the  ``create``   method  completed successfully.
-        # @!attribute [rw] ovf_library_item_id
-        #     @return [String, nil]
-        #     Identifier of the created or updated library item.
-        #     If  nil , the  ``create``   method  failed and   :attr:`Com::Vmware::Vcenter::Ovf::LibraryItem::CreateResult.error`   will describe the error(s) that caused the failure.
-        # @!attribute [rw] error
-        #     @return [Com::Vmware::Vcenter::Ovf::LibraryItem::ResultInfo, nil]
-        #     Errors, warnings, and informational messages produced by the  ``create``   method .
-        #     If  nil , no errors, warnings, or informational messages were reported by the  ``create``   method .
-        class CreateResult < VAPI::Bindings::VapiStruct
-
-            class << self
-                # Holds (gets or creates) the binding type metadata for this structure type.
-                # @scope class
-                # @return [VAPI::Bindings::StructType] the binding type
-                def binding_type
-                    @binding_type ||= VAPI::Bindings::StructType.new(
-                        'com.vmware.vcenter.ovf.library_item.create_result',
-                        {
-                            'succeeded' => VAPI::Bindings::BooleanType.instance,
-                            'ovf_library_item_id' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::IdType.new),
-                            'error' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::Ovf::LibraryItem::ResultInfo')),
-                        },
-                        CreateResult,
-                        false,
-                        nil)
-                end
-            end
-
-            attr_accessor :succeeded,
-                          :ovf_library_item_id,
-                          :error
-
-            # Constructs a new instance.
-            # @param ruby_values [Hash] a map of initial property values (optional)
-            # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
-            def initialize(ruby_values=nil, struct_value=nil)
-                super(self.class.binding_type, ruby_values, struct_value)
-            end
-        end
-
-
-    end
-
-
-
-    # The  ``Com::Vmware::Vcenter::Ovf::CertificateParams``   class  contains information about the public key certificate used to sign the OVF package. This  class  will only be returned if the OVF package is signed.  
-    # 
-    #  See   :func:`Com::Vmware::Vcenter::Ovf::LibraryItem.deploy`   and   :func:`Com::Vmware::Vcenter::Ovf::LibraryItem.filter`  .
-    # @!attribute [rw] issuer
+    # The  ``Com::Vmware::Vcenter::Ovf::ExportFlag::Info``   class  describes an export flag supported by the server.
+    # @!attribute [rw] option
     #     @return [String]
-    #     Certificate issuer. For example: /C=US/ST=California/L=Palo Alto/O=VMware, Inc.
-    #     This  field  is not used in the input parameters when deploying an OVF package. This  field  will always be present in the result when retrieving information about an OVF package.
-    # @!attribute [rw] subject
-    #     @return [String]
-    #     Certificate subject. For example: /C=US/ST=Massachusetts/L=Hopkinton/O=EMC Corporation/OU=EMC Avamar/CN=EMC Corporation.
-    #     This  field  is not used in the input parameters when deploying an OVF package. This  field  will always be present in the result when retrieving information about an OVF package.
-    # @!attribute [rw] is_valid
-    #     @return [Boolean]
-    #     Is the certificate chain validated.
-    #     This  field  is not used in the input parameters when deploying an OVF package. This  field  will always be present in the result when retrieving information about an OVF package.
-    # @!attribute [rw] is_self_signed
-    #     @return [Boolean]
-    #     Is the certificate self-signed.
-    #     This  field  is not used in the input parameters when deploying an OVF package. This  field  will always be present in the result when retrieving information about an OVF package.
-    # @!attribute [rw] x509
-    #     @return [String]
-    #     The X509 representation of the certificate.
-    #     This  field  is not used in the input parameters when deploying an OVF package. This  field  will always be present in the result when retrieving information about an OVF package.
-    class CertificateParams < VAPI::Bindings::VapiStruct
-
-        class << self
-            # Holds (gets or creates) the binding type metadata for this structure type.
-            # @scope class
-            # @return [VAPI::Bindings::StructType] the binding type
-            def binding_type
-                @binding_type ||= VAPI::Bindings::StructType.new(
-                    'com.vmware.vcenter.ovf.certificate_params',
-                    {
-                        'issuer' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::StringType.instance),
-                        'subject' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::StringType.instance),
-                        'is_valid' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::BooleanType.instance),
-                        'is_self_signed' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::BooleanType.instance),
-                        'x509' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::StringType.instance),
-                        'type' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::StringType.instance),
-                    },
-                    CertificateParams,
-                    false,
-                    nil)
-            end
-        end
-
-        attr_accessor :issuer,
-                      :subject,
-                      :is_valid,
-                      :is_self_signed,
-                      :x509,
-                      :type
-
-        # Constructs a new instance.
-        # @param ruby_values [Hash] a map of initial property values (optional)
-        # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
-        def initialize(ruby_values=nil, struct_value=nil)
-            super(self.class.binding_type, ruby_values, struct_value)
-        end
-    end
-
-
-    # The  ``Com::Vmware::Vcenter::Ovf::DeploymentOption``   class  contains the information about a deployment option as defined in the OVF specification.  
-    # 
-    #  This corresponds to the ovf:Configuration element of the ovf:DeploymentOptionSection in the specification. The ovf:DeploymentOptionSection specifies a discrete set of intended resource allocation configurations. This  class  represents one item from that set.  
-    # 
-    #  See   :func:`Com::Vmware::Vcenter::Ovf::LibraryItem.deploy`   and   :func:`Com::Vmware::Vcenter::Ovf::LibraryItem.filter`  .
-    # @!attribute [rw] key
-    #     @return [String]
-    #     The key of the deployment option, corresponding to the ovf:id attribute in the OVF descriptor.
-    #     This  field  is not used in the input parameters when deploying an OVF package. This  field  will always be present in the result when retrieving information about an OVF package.
-    # @!attribute [rw] label
-    #     @return [String]
-    #     A localizable label for the deployment option.
-    #     This  field  is not used in the input parameters when deploying an OVF package. This  field  will always be present in the result when retrieving information about an OVF package.
+    #     The name of the export flag that is supported by the server.
     # @!attribute [rw] description
-    #     @return [String]
-    #     A localizable description for the deployment option.
-    #     This  field  is not used in the input parameters when deploying an OVF package. This  field  will always be present in the result when retrieving information about an OVF package.
-    # @!attribute [rw] default_choice
-    #     @return [Boolean]
-    #     A  boolean  flag indicates whether this deployment option is the default choice.
-    #     This  field  is not used in the input parameters when deploying an OVF package. This  field  is optional in the result when retrieving information about an OVF package. If  nil  or false, it is not the default.
-    class DeploymentOption < VAPI::Bindings::VapiStruct
-
-        class << self
-            # Holds (gets or creates) the binding type metadata for this structure type.
-            # @scope class
-            # @return [VAPI::Bindings::StructType] the binding type
-            def binding_type
-                @binding_type ||= VAPI::Bindings::StructType.new(
-                    'com.vmware.vcenter.ovf.deployment_option',
-                    {
-                        'key' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::StringType.instance),
-                        'label' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::StringType.instance),
-                        'description' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::StringType.instance),
-                        'default_choice' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::BooleanType.instance),
-                    },
-                    DeploymentOption,
-                    false,
-                    nil)
-            end
+    #     @return [Com::Vmware::Vapi::Std::LocalizableMessage]
+    #     Localizable description of the export flag.
+    class Info < VAPI::Bindings::VapiStruct
+      class << self
+        # Holds (gets or creates) the binding type metadata for this structure type.
+        # @scope class
+        # @return [VAPI::Bindings::StructType] the binding type
+        def binding_type
+          @binding_type ||= VAPI::Bindings::StructType.new(
+            'com.vmware.vcenter.ovf.export_flag.info',
+            {
+              'option' => VAPI::Bindings::StringType.instance,
+              'description' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::LocalizableMessage')
+            },
+            Info,
+            false,
+            nil
+          )
         end
+      end
 
-        attr_accessor :key,
-                      :label,
-                      :description,
-                      :default_choice
+      attr_accessor :option,
+                    :description
 
-        # Constructs a new instance.
-        # @param ruby_values [Hash] a map of initial property values (optional)
-        # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
-        def initialize(ruby_values=nil, struct_value=nil)
-            super(self.class.binding_type, ruby_values, struct_value)
-        end
+      # Constructs a new instance.
+      # @param ruby_values [Hash] a map of initial property values (optional)
+      # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
+      def initialize(ruby_values = nil, struct_value = nil)
+        super(self.class.binding_type, ruby_values, struct_value)
+      end
     end
 
+  end
+  # The  ``Com::Vmware::Vcenter::Ovf::ImportFlag``   class  provides  methods  for retrieving information about the import flags supported by the deployment platform. Import flags can be specified in a   :class:`Com::Vmware::Vcenter::Ovf::LibraryItem::ResourcePoolDeploymentSpec`   to customize an OVF deployment.
+  class ImportFlag < VAPI::Bindings::VapiService
+    # static metamodel definitions
+    SERVICE_ID = VAPI::Core::ServiceIdentifier.new('com.vmware.vcenter.ovf.import_flag')
 
-    # The  ``Com::Vmware::Vcenter::Ovf::DeploymentOptionParams``   class  describes the possible deployment options as well as the choice provided by the user.  
-    # 
-    #  This information based on the ovf:DeploymentOptionSection.  
-    # 
-    #  See   :func:`Com::Vmware::Vcenter::Ovf::LibraryItem.deploy`   and   :func:`Com::Vmware::Vcenter::Ovf::LibraryItem.filter`  .
-    # @!attribute [rw] deployment_options
-    #     @return [Array<Com::Vmware::Vcenter::Ovf::DeploymentOption>]
-    #     List  of deployment options. This  field  corresponds to the ovf:Configuration elements of the ovf:DeploymentOptionSection in the specification. It is a discrete set of intended resource allocation configurations from which one can be selected.
-    #     This  field  is not used in the input parameters when deploying an OVF package. This  field  will always be present in the result when retrieving information about an OVF package.
-    # @!attribute [rw] selected_key
-    #     @return [String]
-    #     The selected deployment option. Identifies the   :class:`Com::Vmware::Vcenter::Ovf::DeploymentOption`   in the list in the  ``deploymentOptions``   field  with a matching value in the   :attr:`Com::Vmware::Vcenter::Ovf::DeploymentOption.key`    field .
-    #     This  field  is optional in the input parameters when deploying an OVF package. If  nil  the server will use the default deployment configuration, usually it's the first one in   :attr:`Com::Vmware::Vcenter::Ovf::DeploymentOptionParams.deployment_options`    list . This  field  is optional in the result when retrieving information about an OVF package. The value will be set only if it is specified with the optional ovf:default attribute.
-    class DeploymentOptionParams < VAPI::Bindings::VapiStruct
+    LIST_INFO = VAPI::Bindings::OperationInfo.new(
+      VAPI::Core::OperationIdentifier.new('list', SERVICE_ID),
+      VAPI::Bindings::OperationInputType.new(
+        'rp' => VAPI::Bindings::IdType.new('ResourcePool')
+      ),
+      VAPI::Bindings::ListType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::Ovf::ImportFlag::Info')),
+      {
+        'com.vmware.vapi.std.errors.not_found' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::NotFound')
+      },
+      [],
+      []
+    )
 
-        class << self
-            # Holds (gets or creates) the binding type metadata for this structure type.
-            # @scope class
-            # @return [VAPI::Bindings::StructType] the binding type
-            def binding_type
-                @binding_type ||= VAPI::Bindings::StructType.new(
-                    'com.vmware.vcenter.ovf.deployment_option_params',
-                    {
-                        'deployment_options' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::ListType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::Ovf::DeploymentOption'))),
-                        'selected_key' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::StringType.instance),
-                        'type' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::StringType.instance),
-                    },
-                    DeploymentOptionParams,
-                    false,
-                    nil)
-            end
-        end
+    SERVICE_INFO = VAPI::Bindings::ServiceInfo.new(
+      SERVICE_ID,
+      'list' => LIST_INFO
+    )
 
-        attr_accessor :deployment_options,
-                      :selected_key,
-                      :type
-
-        # Constructs a new instance.
-        # @param ruby_values [Hash] a map of initial property values (optional)
-        # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
-        def initialize(ruby_values=nil, struct_value=nil)
-            super(self.class.binding_type, ruby_values, struct_value)
-        end
+    # Constructs a new instance.
+    #
+    # @param config [VAPI::Bindings::StubConfig] A hash with the api provider details.
+    def initialize(config)
+      super(config, SERVICE_INFO)
     end
 
-
-    # The  ``Com::Vmware::Vcenter::Ovf::ExtraConfig``   class  contains the information about a vmw:ExtraConfig element which can be used to specify configuration settings that are transferred directly to the  ``.vmx``  file. The behavior of the vmw:ExtraConfig element is similar to the  ``extraConfig``  property of the  ``VirtualMachineConfigSpec``  object in the VMware vSphere API. Thus, the same restrictions apply, such as you cannot set values that could otherwise be set with other properties in the  ``VirtualMachineConfigSpec``  object. See the VMware vSphere API reference for details on this.  
+    # Returns information about the import flags supported by the deployment platform.  
     # 
-    #  vmw:ExtraConfig elements may occur as direct child elements of a VirtualHardwareSection, or as child elements of individual virtual hardware items.  
+    #  The supported flags are:  
+    #   LAX
+    #        Lax mode parsing of the OVF descriptor.
+    #      
     # 
-    #  See   :func:`Com::Vmware::Vcenter::Ovf::LibraryItem.deploy`   and   :func:`Com::Vmware::Vcenter::Ovf::LibraryItem.filter`  .
-    # @!attribute [rw] key
-    #     @return [String]
-    #     The key of the ExtraConfig element.
-    #     This  field  must be provided in the input parameters when deploying an OVF package. This  field  will always be present in the result when retrieving information about an OVF package.
-    # @!attribute [rw] value
-    #     @return [String]
-    #     The value of the ExtraConfig element.
-    #     This  field  must be provided in the input parameters when deploying an OVF package. This  field  will always be present in the result when retrieving information about an OVF package.
-    # @!attribute [rw] virtual_system_id
-    #     @return [String]
-    #     The identifier of the virtual system containing the vmw:ExtraConfig element.
-    #     This  field  is not used in the input parameters when deploying an OVF package. This  field  will always be present in the result when retrieving information about an OVF package.
-    class ExtraConfig < VAPI::Bindings::VapiStruct
-
-        class << self
-            # Holds (gets or creates) the binding type metadata for this structure type.
-            # @scope class
-            # @return [VAPI::Bindings::StructType] the binding type
-            def binding_type
-                @binding_type ||= VAPI::Bindings::StructType.new(
-                    'com.vmware.vcenter.ovf.extra_config',
-                    {
-                        'key' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::StringType.instance),
-                        'value' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::StringType.instance),
-                        'virtual_system_id' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::StringType.instance),
-                    },
-                    ExtraConfig,
-                    false,
-                    nil)
-            end
-        end
-
-        attr_accessor :key,
-                      :value,
-                      :virtual_system_id
-
-        # Constructs a new instance.
-        # @param ruby_values [Hash] a map of initial property values (optional)
-        # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
-        def initialize(ruby_values=nil, struct_value=nil)
-            super(self.class.binding_type, ruby_values, struct_value)
-        end
+    #  Future server versions might support additional flags.
+    #
+    # @param rp [String]
+    #      The identifier of resource pool target for retrieving the import flag(s).
+    # @return [Array<Com::Vmware::Vcenter::Ovf::ImportFlag::Info>]
+    #     A  list  of supported import flags.
+    # @raise [Com::Vmware::Vapi::Std::Errors::NotFound]
+    #      If the resource pool associated with  ``rp``  does not exist.
+    # @raise [Com::Vmware::Vapi::Std::Errors::Unauthorized]
+    #     If you do not have all of the privileges described in the following list:
+    #
+    #     System.Read
+    def list(rp)
+      invoke_with_info(LIST_INFO,
+                       'rp' => rp)
     end
 
+    # The  ``Com::Vmware::Vcenter::Ovf::ImportFlag::Info``   class  describes an import flag supported by the deployment platform.
+    # @!attribute [rw] option
+    #     @return [String]
+    #     The name of the import flag that is supported by the deployment platform.
+    # @!attribute [rw] description
+    #     @return [Com::Vmware::Vapi::Std::LocalizableMessage]
+    #     Localizable description of the import flag.
+    class Info < VAPI::Bindings::VapiStruct
+      class << self
+        # Holds (gets or creates) the binding type metadata for this structure type.
+        # @scope class
+        # @return [VAPI::Bindings::StructType] the binding type
+        def binding_type
+          @binding_type ||= VAPI::Bindings::StructType.new(
+            'com.vmware.vcenter.ovf.import_flag.info',
+            {
+              'option' => VAPI::Bindings::StringType.instance,
+              'description' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::LocalizableMessage')
+            },
+            Info,
+            false,
+            nil
+          )
+        end
+      end
 
-    # The  ``Com::Vmware::Vcenter::Ovf::ExtraConfigParams``   class  contains the parameters with information about the vmw:ExtraConfig elements in an OVF package.  
+      attr_accessor :option,
+                    :description
+
+      # Constructs a new instance.
+      # @param ruby_values [Hash] a map of initial property values (optional)
+      # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
+      def initialize(ruby_values = nil, struct_value = nil)
+        super(self.class.binding_type, ruby_values, struct_value)
+      end
+    end
+
+  end
+  # The  ``Com::Vmware::Vcenter::Ovf::LibraryItem``   class  provides  methods  to deploy virtual machines and virtual appliances from library items containing Open Virtualization Format (OVF) packages in content library, as well as  methods  to create library items in content library from virtual machines and virtual appliances.  
+  # 
+  #  To deploy a virtual machine or a virtual appliance from a library item:  
+  # 
+  #   #  Create a   :class:`Com::Vmware::Vcenter::Ovf::LibraryItem::DeploymentTarget`   to specify the target deployment type and target deployment designation. 
+  #    #  Create a   :class:`Com::Vmware::Vcenter::Ovf::LibraryItem::ResourcePoolDeploymentSpec`   to specify the parameters for the target deployment. 
+  #    #  Use the  ``deploy``   method  with the created target and parameter specifications, along with the identifier of the specified source content library item. See   :func:`Com::Vmware::Vcenter::Ovf::LibraryItem.deploy`  . 
+  #   
+  #    
+  # 
+  #    
+  # 
+  #  To create a library item in content library from a virtual machine or virtual appliance:  
+  # 
+  #   #  Create a   :class:`Com::Vmware::Vcenter::Ovf::LibraryItem::DeployableIdentity`   to specify the source virtual machine or virtual appliance to be used as the OVF template source. 
+  #    #  Create a   :class:`Com::Vmware::Vcenter::Ovf::LibraryItem::CreateTarget`   to specify the target library and library item. 
+  #    #  Create a   :class:`Com::Vmware::Vcenter::Ovf::LibraryItem::CreateSpec`   to specify the settings for the OVF package to be created.
+  #    #  Use the  ``create``   method  with the created target and parameter specifications, along with the specified source entity. See   :func:`Com::Vmware::Vcenter::Ovf::LibraryItem.create`  . 
+  #   
+  #    
+  class LibraryItem < VAPI::Bindings::VapiService
+    # static metamodel definitions
+    SERVICE_ID = VAPI::Core::ServiceIdentifier.new('com.vmware.vcenter.ovf.library_item')
+
+    DEPLOY_INFO = VAPI::Bindings::OperationInfo.new(
+      VAPI::Core::OperationIdentifier.new('deploy', SERVICE_ID),
+      VAPI::Bindings::OperationInputType.new(
+        'client_token' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::StringType.instance),
+        'ovf_library_item_id' => VAPI::Bindings::IdType.new('com.vmware.content.library.Item'),
+        'target' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::Ovf::LibraryItem::DeploymentTarget'),
+        'deployment_spec' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::Ovf::LibraryItem::ResourcePoolDeploymentSpec')
+      ),
+      VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::Ovf::LibraryItem::DeploymentResult'),
+      {
+        'com.vmware.vapi.std.errors.invalid_argument' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::InvalidArgument'),
+        'com.vmware.vapi.std.errors.not_found' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::NotFound'),
+        'com.vmware.vapi.std.errors.resource_inaccessible' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::ResourceInaccessible'),
+        'com.vmware.vapi.std.errors.unauthorized' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Unauthorized')
+      },
+      [],
+      []
+    )
+
+    FILTER_INFO = VAPI::Bindings::OperationInfo.new(
+      VAPI::Core::OperationIdentifier.new('filter', SERVICE_ID),
+      VAPI::Bindings::OperationInputType.new(
+        'ovf_library_item_id' => VAPI::Bindings::IdType.new('com.vmware.content.library.Item'),
+        'target' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::Ovf::LibraryItem::DeploymentTarget')
+      ),
+      VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::Ovf::LibraryItem::OvfSummary'),
+      {
+        'com.vmware.vapi.std.errors.invalid_argument' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::InvalidArgument'),
+        'com.vmware.vapi.std.errors.not_found' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::NotFound'),
+        'com.vmware.vapi.std.errors.resource_inaccessible' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::ResourceInaccessible')
+      },
+      [],
+      []
+    )
+
+    CREATE_INFO = VAPI::Bindings::OperationInfo.new(
+      VAPI::Core::OperationIdentifier.new('create', SERVICE_ID),
+      VAPI::Bindings::OperationInputType.new(
+        'client_token' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::StringType.instance),
+        'source' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::Ovf::LibraryItem::DeployableIdentity'),
+        'target' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::Ovf::LibraryItem::CreateTarget'),
+        'create_spec' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::Ovf::LibraryItem::CreateSpec')
+      ),
+      VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::Ovf::LibraryItem::CreateResult'),
+      {
+        'com.vmware.vapi.std.errors.invalid_argument' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::InvalidArgument'),
+        'com.vmware.vapi.std.errors.not_found' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::NotFound'),
+        'com.vmware.vapi.std.errors.not_allowed_in_current_state' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::NotAllowedInCurrentState'),
+        'com.vmware.vapi.std.errors.resource_inaccessible' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::ResourceInaccessible'),
+        'com.vmware.vapi.std.errors.resource_busy' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::ResourceBusy')
+      },
+      [],
+      []
+    )
+
+    SERVICE_INFO = VAPI::Bindings::ServiceInfo.new(
+      SERVICE_ID,
+      'deploy' => DEPLOY_INFO,
+      'filter' => FILTER_INFO,
+      'create' => CREATE_INFO
+    )
+
+    # Constructs a new instance.
+    #
+    # @param config [VAPI::Bindings::StubConfig] A hash with the api provider details.
+    def initialize(config)
+      super(config, SERVICE_INFO)
+    end
+
+    DEPLOYABLE = ['VirtualMachine', 'VirtualApp']
+    # Deploys an OVF package stored in content library to a newly created virtual machine or virtual appliance.  
     # 
-    #  vmw:ExtraConfig elements can be used to specify configuration settings that are transferred directly to the  ``.vmx``  file.  
-    # 
-    #  The behavior of the vmw:ExtraConfig element is similar to the  ``extraConfig``  property of the  ``VirtualMachineConfigSpec``  object in the VMware vSphere API. Thus, the same restrictions apply, such as you cannot set values that could otherwise be set with other properties in the  ``VirtualMachineConfigSpec``  object. See the VMware vSphere API reference for details on this.  
-    # 
-    #  See   :func:`Com::Vmware::Vcenter::Ovf::LibraryItem.deploy`   and   :func:`Com::Vmware::Vcenter::Ovf::LibraryItem.filter`  .
-    # @!attribute [rw] extra_configs
-    #     @return [Array<Com::Vmware::Vcenter::Ovf::ExtraConfig>]
-    #     List  of vmw:ExtraConfig elements in the OVF package.
-    #     This  field  is optional in the input parameters when deploying an OVF package. If  nil  there are no extra configuration elements to use for this OVF package deployment. This  field  will always be present in the result when retrieving information about an OVF package. It will be an empty  list  if there are no extra configuration elements in the OVF package.
-    # @!attribute [rw] exclude_keys
-    #     @return [Array<String>]
-    #     Specifies which extra configuration items in the  list  in the  ``extraConfigs``   ``field``  should be ignored during deployment.  
+    #  This  method  deploys an OVF package which is stored in the library item specified by  ``ovf_library_item_id`` . It uses the deployment specification in  ``deployment_spec``  to deploy the OVF package to the location specified by  ``target`` . 
+    #
+    # @param client_token [String, nil]
+    #      Client-generated token used to retry a request if the client fails to get a response from the server. If the original request succeeded, the result of that request will be returned, otherwise the operation will be retried.
+    #     If  nil , the server will create a token.
+    # @param ovf_library_item_id [String]
+    #      Identifier of the content library item containing the OVF package to be deployed.
+    # @param target [Com::Vmware::Vcenter::Ovf::LibraryItem::DeploymentTarget]
+    #      Specification of the deployment target.
+    # @param deployment_spec [Com::Vmware::Vcenter::Ovf::LibraryItem::ResourcePoolDeploymentSpec]
+    #      Specification of how the OVF package should be deployed to the target.
+    # @return [Com::Vmware::Vcenter::Ovf::LibraryItem::DeploymentResult]
+    #     Information about the success or failure of the  method , along with the details of the result or failure.
+    # @raise [Com::Vmware::Vapi::Std::Errors::InvalidArgument]
+    #      if  ``target``  contains invalid arguments.
+    # @raise [Com::Vmware::Vapi::Std::Errors::InvalidArgument]
+    #      if  ``deployment_spec``  contains invalid arguments or has  fields  that are inconsistent with  ``target`` .
+    # @raise [Com::Vmware::Vapi::Std::Errors::NotFound]
+    #      if the library item specified by  ``ovf_library_item_id``  does not exist.
+    # @raise [Com::Vmware::Vapi::Std::Errors::NotFound]
+    #      if any resource specified by a  field  of the   :class:`Com::Vmware::Vcenter::Ovf::LibraryItem::DeploymentTarget`    class , specified by  ``target`` , does not exist.
+    # @raise [Com::Vmware::Vapi::Std::Errors::ResourceInaccessible]
+    #      if there was an error accessing the OVF package stored in the library item specified by  ``ovf_library_item_id`` .
+    # @raise [Com::Vmware::Vapi::Std::Errors::Unauthorized]
+    #      if you do not have all of the privileges described as follows :  
     #     
-    #      If set, the given keys for extra configurations will be ignored during deployment. The key is defined in the   :attr:`Com::Vmware::Vcenter::Ovf::ExtraConfig.key`    field .
-    #     This  field  is optional in the input parameters when deploying an OVF package. It is an error to set both this and   :attr:`Com::Vmware::Vcenter::Ovf::ExtraConfigParams.include_keys`  . This  field  is optional in the result when retrieving information about an OVF package. It is an error to set both this and   :attr:`Com::Vmware::Vcenter::Ovf::ExtraConfigParams.include_keys`  .
-    # @!attribute [rw] include_keys
-    #     @return [Array<String>]
-    #     Specifies which extra configuration items in the  list  in the  ``extraConfigs``   ``field``  should be included during deployment.  
-    #     
-    #      If set, all but the given keys for extra configurations will be ignored during deployment. The key is defined in the   :attr:`Com::Vmware::Vcenter::Ovf::ExtraConfig.key`    field .
-    #     This  field  is optional in the input parameters when deploying an OVF package. It is an error to set both this and   :attr:`Com::Vmware::Vcenter::Ovf::ExtraConfigParams.exclude_keys`  . This  field  is optional in the result when retrieving information about an OVF package. It is an error to set both this and   :attr:`Com::Vmware::Vcenter::Ovf::ExtraConfigParams.exclude_keys`  .
-    class ExtraConfigParams < VAPI::Bindings::VapiStruct
-
-        class << self
-            # Holds (gets or creates) the binding type metadata for this structure type.
-            # @scope class
-            # @return [VAPI::Bindings::StructType] the binding type
-            def binding_type
-                @binding_type ||= VAPI::Bindings::StructType.new(
-                    'com.vmware.vcenter.ovf.extra_config_params',
-                    {
-                        'extra_configs' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::ListType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::Ovf::ExtraConfig'))),
-                        'exclude_keys' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::ListType.new(VAPI::Bindings::StringType.instance)),
-                        'include_keys' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::ListType.new(VAPI::Bindings::StringType.instance)),
-                        'type' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::StringType.instance),
-                    },
-                    ExtraConfigParams,
-                    false,
-                    nil)
-            end
-        end
-
-        attr_accessor :extra_configs,
-                      :exclude_keys,
-                      :include_keys,
-                      :type
-
-        # Constructs a new instance.
-        # @param ruby_values [Hash] a map of initial property values (optional)
-        # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
-        def initialize(ruby_values=nil, struct_value=nil)
-            super(self.class.binding_type, ruby_values, struct_value)
-        end
+    #       * Method  execution requires VirtualMachine.Config.AddNewDisk if the OVF descriptor has a disk drive (type 17) section. 
+    #        * Method  execution requires VirtualMachine.Config.AdvancedConfig if the OVF descriptor has an ExtraConfig section. 
+    #        * Method  execution requires Extension.Register for specified resource group if the OVF descriptor has a vServiceDependency section. 
+    #        * Method  execution requires Network.Assign for target network if specified. 
+    #        * Method  execution requires Datastore.AllocateSpace for target datastore if specified. 
+    #       
+    # @raise [Com::Vmware::Vapi::Std::Errors::Unauthorized]
+    #     If you do not have all of the privileges described in the following list:
+    #
+    #     System.Read
+    def deploy(ovf_library_item_id, target, deployment_spec, client_token = nil)
+      invoke_with_info(DEPLOY_INFO,
+                       'client_token' => client_token,
+                       'ovf_library_item_id' => ovf_library_item_id,
+                       'target' => target,
+                       'deployment_spec' => deployment_spec)
     end
 
-
-    # The  ``Com::Vmware::Vcenter::Ovf::IpAllocationParams``   class  specifies how IP addresses are allocated to OVF properties. In particular, it informs the deployment platform whether the guest supports IPv4, IPv6, or both. It also specifies whether the IP addresses can be obtained through DHCP or through the properties provided in the OVF environment.  
+    # Queries an OVF package stored in content library to retrieve information to use when deploying the package. See   :func:`Com::Vmware::Vcenter::Ovf::LibraryItem.deploy`  .  
     # 
-    #  Ovf Property elements are exposed to the guest software through the OVF environment. Each Property element exposed in the OVF environment shall be constructed from the value of the ovf:key attribute. A Property element contains a key/value pair, it may optionally specify type qualifiers using the ovf:qualifiers attribute with multiple qualifiers separated by commas.  
-    # 
-    #  The settings in  ``Com::Vmware::Vcenter::Ovf::IpAllocationParams``   class  are global to a deployment. Thus, if a virtual machine is part of a virtual appliance, then its settings are ignored and the settings for the virtual appliance is used.  
-    # 
-    #  This information is based on the vmw:IpAssignmentSection in OVF package.  
-    # 
-    #  See   :func:`Com::Vmware::Vcenter::Ovf::LibraryItem.deploy`   and   :func:`Com::Vmware::Vcenter::Ovf::LibraryItem.filter`  .
-    # @!attribute [rw] supported_allocation_scheme
-    #     @return [Array<Com::Vmware::Vcenter::Ovf::IpAllocationParams::IpAllocationScheme>]
-    #     Specifies the IP allocation schemes supported by the guest software. This  field  defines the valid values for the IP allocation policy. This setting is often configured by the virtual appliance template author or OVF package author to reflect what the guest software supports, and the IP allocation policy is configured at deployment time. See   :attr:`Com::Vmware::Vcenter::Ovf::IpAllocationParams.ip_allocation_policy`  .
-    #     This  field  is not used in the input parameters when deploying an OVF package. This  field  will always be present in the result when retrieving information about an OVF package.
-    # @!attribute [rw] supported_ip_allocation_policy
-    #     @return [Array<Com::Vmware::Vcenter::Ovf::IpAllocationParams::IpAllocationPolicy>]
-    #     Specifies the IP allocation policies supported. The set of valid options for the policy is based on the capabilities of the virtual appliance software, as specified by the   :attr:`Com::Vmware::Vcenter::Ovf::IpAllocationParams.supported_allocation_scheme`    field .
-    #     This  field  is not used in the input parameters when deploying an OVF package. This  field  will always be present in the result when retrieving information about an OVF package.
-    # @!attribute [rw] ip_allocation_policy
-    #     @return [Com::Vmware::Vcenter::Ovf::IpAllocationParams::IpAllocationPolicy]
-    #     Specifies how IP allocation is done through an IP Pool. This is typically specified by the deployer.
-    #     This  field  is optional in the input parameters when deploying an OVF package. If  nil  there is no IP allocation policy. This  field  will always be present in the result when retrieving information about an OVF package.
-    # @!attribute [rw] supported_ip_protocol
-    #     @return [Array<Com::Vmware::Vcenter::Ovf::IpAllocationParams::IpProtocol>]
-    #     Specifies the IP protocols supported by the guest.
-    #     This  field  is not used in the input parameters when deploying an OVF package. This  field  will always be present in the result when retrieving information about an OVF package.
-    # @!attribute [rw] ip_protocol
-    #     @return [Com::Vmware::Vcenter::Ovf::IpAllocationParams::IpProtocol]
-    #     Specifies the chosen IP protocol for this deployment. This must be one of the IP protocols supported by the guest software. See   :attr:`Com::Vmware::Vcenter::Ovf::IpAllocationParams.supported_ip_protocol`  .
-    #     This  field  is optional in the input parameters when deploying an OVF package. If  nil  there is no IP protocol chosen. This  field  will always be present in the result when retrieving information about an OVF package.
-    class IpAllocationParams < VAPI::Bindings::VapiStruct
-
-        class << self
-            # Holds (gets or creates) the binding type metadata for this structure type.
-            # @scope class
-            # @return [VAPI::Bindings::StructType] the binding type
-            def binding_type
-                @binding_type ||= VAPI::Bindings::StructType.new(
-                    'com.vmware.vcenter.ovf.ip_allocation_params',
-                    {
-                        'supported_allocation_scheme' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::ListType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::Ovf::IpAllocationParams::IpAllocationScheme'))),
-                        'supported_ip_allocation_policy' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::ListType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::Ovf::IpAllocationParams::IpAllocationPolicy'))),
-                        'ip_allocation_policy' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::Ovf::IpAllocationParams::IpAllocationPolicy')),
-                        'supported_ip_protocol' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::ListType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::Ovf::IpAllocationParams::IpProtocol'))),
-                        'ip_protocol' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::Ovf::IpAllocationParams::IpProtocol')),
-                        'type' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::StringType.instance),
-                    },
-                    IpAllocationParams,
-                    false,
-                    nil)
-            end
-        end
-
-        attr_accessor :supported_allocation_scheme,
-                      :supported_ip_allocation_policy,
-                      :ip_allocation_policy,
-                      :supported_ip_protocol,
-                      :ip_protocol,
-                      :type
-
-        # Constructs a new instance.
-        # @param ruby_values [Hash] a map of initial property values (optional)
-        # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
-        def initialize(ruby_values=nil, struct_value=nil)
-            super(self.class.binding_type, ruby_values, struct_value)
-        end
-
-
-        # The  ``Com::Vmware::Vcenter::Ovf::IpAllocationParams::IpAllocationPolicy``   enumerated type  defines the possible IP allocation policy for a deployment.
-        # @!attribute [rw] dhcp
-        #     @return [Com::Vmware::Vcenter::Ovf::IpAllocationParams::IpAllocationPolicy]
-        #     Specifies that DHCP will be used to allocate IP addresses.
-        # @!attribute [rw] transient_ippool
-        #     @return [Com::Vmware::Vcenter::Ovf::IpAllocationParams::IpAllocationPolicy]
-        #     Specifies that IP addresses are allocated from an IP pool. The IP addresses are allocated when needed, typically at power-on, and deallocated during power-off. There is no guarantee that a property will receive same IP address when restarted.
-        # @!attribute [rw] static_manual
-        #     @return [Com::Vmware::Vcenter::Ovf::IpAllocationParams::IpAllocationPolicy]
-        #     Specifies that IP addresses are configured manually upon deployment, and will be kept until reconfigured or the virtual appliance destroyed. This ensures that a property gets a consistent IP for its lifetime.
-        # @!attribute [rw] static_ippool
-        #     @return [Com::Vmware::Vcenter::Ovf::IpAllocationParams::IpAllocationPolicy]
-        #     Specifies that IP addresses are allocated from the range managed by an IP pool. The IP addresses are allocated at first power-on, and remain allocated at power-off. This ensures that a virtual appliance gets a consistent IP for its life-time.
-        class IpAllocationPolicy < VAPI::Bindings::VapiEnum
-
-            class << self
-                # Holds (gets or creates) the binding type metadata for this enumeration type.
-                # @scope class
-                # @return [VAPI::Bindings::EnumType] the binding type
-                def binding_type
-                    @binding_type ||= VAPI::Bindings::EnumType.new(
-                        'com.vmware.vcenter.ovf.ip_allocation_params.ip_allocation_policy',
-                        IpAllocationPolicy)
-                end
-
-                # Converts from a string value (perhaps off the wire) to an instance
-                # of this enum type.
-                # @param value [String] the actual value of the enum instance
-                # @return [IpAllocationPolicy] the instance found for the value, otherwise
-                #         an unknown instance will be built for the value
-                def from_string(value)
-                    begin
-                        const_get(value)
-                    rescue NameError
-                        IpAllocationPolicy.new('UNKNOWN', value)
-                    end
-                end
-            end
-
-            private
-
-            # Constructs a new instance.
-            # @param value [String] the actual value of the enum instance
-            # @param unknown [String] the unknown value when value is 'UKNOWN'
-            def initialize(value, unknown=nil)
-                super(self.class.binding_type, value, unknown)
-            end
-
-            public
-
-            # @!attribute [rw] dhcp
-            #     @return [Com::Vmware::Vcenter::Ovf::IpAllocationParams::IpAllocationPolicy]
-            #     Specifies that DHCP will be used to allocate IP addresses.
-            DHCP = IpAllocationPolicy.new('DHCP')
-
-            # @!attribute [rw] transient_ippool
-            #     @return [Com::Vmware::Vcenter::Ovf::IpAllocationParams::IpAllocationPolicy]
-            #     Specifies that IP addresses are allocated from an IP pool. The IP addresses are allocated when needed, typically at power-on, and deallocated during power-off. There is no guarantee that a property will receive same IP address when restarted.
-            TRANSIENT_IPPOOL = IpAllocationPolicy.new('TRANSIENT_IPPOOL')
-
-            # @!attribute [rw] static_manual
-            #     @return [Com::Vmware::Vcenter::Ovf::IpAllocationParams::IpAllocationPolicy]
-            #     Specifies that IP addresses are configured manually upon deployment, and will be kept until reconfigured or the virtual appliance destroyed. This ensures that a property gets a consistent IP for its lifetime.
-            STATIC_MANUAL = IpAllocationPolicy.new('STATIC_MANUAL')
-
-            # @!attribute [rw] static_ippool
-            #     @return [Com::Vmware::Vcenter::Ovf::IpAllocationParams::IpAllocationPolicy]
-            #     Specifies that IP addresses are allocated from the range managed by an IP pool. The IP addresses are allocated at first power-on, and remain allocated at power-off. This ensures that a virtual appliance gets a consistent IP for its life-time.
-            STATIC_IPPOOL = IpAllocationPolicy.new('STATIC_IPPOOL')
-
-        end
-
-
-        # The  ``Com::Vmware::Vcenter::Ovf::IpAllocationParams::IpAllocationScheme``   enumerated type  defines the possible IP allocation schemes that can be supported by the guest software.
-        # @!attribute [rw] dhcp
-        #     @return [Com::Vmware::Vcenter::Ovf::IpAllocationParams::IpAllocationScheme]
-        #     It supports DHCP to acquire IP configuration.
-        # @!attribute [rw] ovf_environment
-        #     @return [Com::Vmware::Vcenter::Ovf::IpAllocationParams::IpAllocationScheme]
-        #     It supports setting the IP configuration through the properties provided in the OVF environment.
-        class IpAllocationScheme < VAPI::Bindings::VapiEnum
-
-            class << self
-                # Holds (gets or creates) the binding type metadata for this enumeration type.
-                # @scope class
-                # @return [VAPI::Bindings::EnumType] the binding type
-                def binding_type
-                    @binding_type ||= VAPI::Bindings::EnumType.new(
-                        'com.vmware.vcenter.ovf.ip_allocation_params.ip_allocation_scheme',
-                        IpAllocationScheme)
-                end
-
-                # Converts from a string value (perhaps off the wire) to an instance
-                # of this enum type.
-                # @param value [String] the actual value of the enum instance
-                # @return [IpAllocationScheme] the instance found for the value, otherwise
-                #         an unknown instance will be built for the value
-                def from_string(value)
-                    begin
-                        const_get(value)
-                    rescue NameError
-                        IpAllocationScheme.new('UNKNOWN', value)
-                    end
-                end
-            end
-
-            private
-
-            # Constructs a new instance.
-            # @param value [String] the actual value of the enum instance
-            # @param unknown [String] the unknown value when value is 'UKNOWN'
-            def initialize(value, unknown=nil)
-                super(self.class.binding_type, value, unknown)
-            end
-
-            public
-
-            # @!attribute [rw] dhcp
-            #     @return [Com::Vmware::Vcenter::Ovf::IpAllocationParams::IpAllocationScheme]
-            #     It supports DHCP to acquire IP configuration.
-            DHCP = IpAllocationScheme.new('DHCP')
-
-            # @!attribute [rw] ovf_environment
-            #     @return [Com::Vmware::Vcenter::Ovf::IpAllocationParams::IpAllocationScheme]
-            #     It supports setting the IP configuration through the properties provided in the OVF environment.
-            OVF_ENVIRONMENT = IpAllocationScheme.new('OVF_ENVIRONMENT')
-
-        end
-
-
-        # The  ``Com::Vmware::Vcenter::Ovf::IpAllocationParams::IpProtocol``   enumerated type  defines the IP protocols supported by the guest software.
-        # @!attribute [rw] ip_v4
-        #     @return [Com::Vmware::Vcenter::Ovf::IpAllocationParams::IpProtocol]
-        #     It supports the IPv4 protocol.
-        # @!attribute [rw] ip_v6
-        #     @return [Com::Vmware::Vcenter::Ovf::IpAllocationParams::IpProtocol]
-        #     It supports the IPv6 protocol.
-        class IpProtocol < VAPI::Bindings::VapiEnum
-
-            class << self
-                # Holds (gets or creates) the binding type metadata for this enumeration type.
-                # @scope class
-                # @return [VAPI::Bindings::EnumType] the binding type
-                def binding_type
-                    @binding_type ||= VAPI::Bindings::EnumType.new(
-                        'com.vmware.vcenter.ovf.ip_allocation_params.ip_protocol',
-                        IpProtocol)
-                end
-
-                # Converts from a string value (perhaps off the wire) to an instance
-                # of this enum type.
-                # @param value [String] the actual value of the enum instance
-                # @return [IpProtocol] the instance found for the value, otherwise
-                #         an unknown instance will be built for the value
-                def from_string(value)
-                    begin
-                        const_get(value)
-                    rescue NameError
-                        IpProtocol.new('UNKNOWN', value)
-                    end
-                end
-            end
-
-            private
-
-            # Constructs a new instance.
-            # @param value [String] the actual value of the enum instance
-            # @param unknown [String] the unknown value when value is 'UKNOWN'
-            def initialize(value, unknown=nil)
-                super(self.class.binding_type, value, unknown)
-            end
-
-            public
-
-            # @!attribute [rw] ip_v4
-            #     @return [Com::Vmware::Vcenter::Ovf::IpAllocationParams::IpProtocol]
-            #     It supports the IPv4 protocol.
-            IP_V4 = IpProtocol.new('IP_V4')
-
-            # @!attribute [rw] ip_v6
-            #     @return [Com::Vmware::Vcenter::Ovf::IpAllocationParams::IpProtocol]
-            #     It supports the IPv6 protocol.
-            IP_V6 = IpProtocol.new('IP_V6')
-
-        end
-
-
+    #  This  method  retrieves information from the descriptor of the OVF package stored in the library item specified by  ``ovf_library_item_id`` . The information returned by the  method  can be used to populate the deployment specification (see   :class:`Com::Vmware::Vcenter::Ovf::LibraryItem::ResourcePoolDeploymentSpec`   when deploying the OVF package to the deployment target specified by  ``target`` . 
+    #
+    # @param ovf_library_item_id [String]
+    #      Identifier of the content library item containing the OVF package to query.
+    # @param target [Com::Vmware::Vcenter::Ovf::LibraryItem::DeploymentTarget]
+    #      Specification of the deployment target.
+    # @return [Com::Vmware::Vcenter::Ovf::LibraryItem::OvfSummary]
+    #     Information that can be used to populate the deployment specification (see   :class:`Com::Vmware::Vcenter::Ovf::LibraryItem::ResourcePoolDeploymentSpec`  ) when deploying the OVF package to the deployment target specified by  ``target`` .
+    # @raise [Com::Vmware::Vapi::Std::Errors::InvalidArgument]
+    #      if  ``target``  contains invalid arguments.
+    # @raise [Com::Vmware::Vapi::Std::Errors::NotFound]
+    #      if the library item specified by  ``ovf_library_item_id``  does not exist.
+    # @raise [Com::Vmware::Vapi::Std::Errors::NotFound]
+    #      if any resource specified by a  field  of the   :class:`Com::Vmware::Vcenter::Ovf::LibraryItem::DeploymentTarget`    class , specified by  ``target`` , does not exist.
+    # @raise [Com::Vmware::Vapi::Std::Errors::ResourceInaccessible]
+    #      if there was an error accessing the OVF package at the specified  ``ovf_library_item_id`` .
+    # @raise [Com::Vmware::Vapi::Std::Errors::Unauthorized]
+    #     If you do not have all of the privileges described in the following list:
+    #
+    #     System.Read
+    def filter(ovf_library_item_id, target)
+      invoke_with_info(FILTER_INFO,
+                       'ovf_library_item_id' => ovf_library_item_id,
+                       'target' => target)
     end
 
-
-    # The  ``Com::Vmware::Vcenter::Ovf::OvfMessage``   class  describes a base OVF handling error message related to accessing, validating, deploying, or exporting an OVF package.  
+    # Creates a library item in content library from a virtual machine or virtual appliance.  
     # 
-    #  These messages fall into different categories defined in   :class:`Com::Vmware::Vcenter::Ovf::OvfMessage::Category`  :
-    # @!attribute [rw] category
-    #     @return [Com::Vmware::Vcenter::Ovf::OvfMessage::Category]
-    #     The message category.
-    # @!attribute [rw] issues
-    #     @return [Array<Com::Vmware::Vcenter::Ovf::ParseIssue>]
-    #     List  of parse issues (see   :class:`Com::Vmware::Vcenter::Ovf::ParseIssue`  ).
-    #     This  field  is optional and it is only relevant when the value of  ``category``  is   :attr:`Com::Vmware::Vcenter::Ovf::OvfMessage::Category.VALIDATION`  .
+    #  This  method  creates a library item in content library whose content is an OVF package derived from a source virtual machine or virtual appliance, using the supplied create specification. The OVF package may be stored as in a newly created library item or in an in an existing library item. For an existing library item whose content is updated by this  method , the original content is overwritten. 
+    #
+    # @param client_token [String, nil]
+    #      Client-generated token used to retry a request if the client fails to get a response from the server. If the original request succeeded, the result of that request will be returned, otherwise the operation will be retried.
+    #     If  nil , the server will create a token.
+    # @param source [Com::Vmware::Vcenter::Ovf::LibraryItem::DeployableIdentity]
+    #      Identifier of the virtual machine or virtual appliance to use as the source.
+    # @param target [Com::Vmware::Vcenter::Ovf::LibraryItem::CreateTarget]
+    #      Specification of the target content library and library item.
+    # @param create_spec [Com::Vmware::Vcenter::Ovf::LibraryItem::CreateSpec]
+    #      Information used to create the OVF package from the source virtual machine or virtual appliance.
+    # @return [Com::Vmware::Vcenter::Ovf::LibraryItem::CreateResult]
+    #     Information about the success or failure of the  method , along with the details of the result or failure.
+    # @raise [Com::Vmware::Vapi::Std::Errors::InvalidArgument]
+    #      if  ``create_spec``  contains invalid arguments.
+    # @raise [Com::Vmware::Vapi::Std::Errors::InvalidArgument]
+    #      if  ``source``  describes an unexpected resource type.
+    # @raise [Com::Vmware::Vapi::Std::Errors::NotFound]
+    #      if the virtual machine or virtual appliance specified by  ``source``  does not exist.
+    # @raise [Com::Vmware::Vapi::Std::Errors::NotFound]
+    #      if the library or library item specified by  ``target``  does not exist.
+    # @raise [Com::Vmware::Vapi::Std::Errors::NotAllowedInCurrentState]
+    #      if the operation cannot be performed because of the specified virtual machine or virtual appliance's current state. For example, if the virtual machine configuration information is not available, or if the virtual appliance is running.
+    # @raise [Com::Vmware::Vapi::Std::Errors::ResourceInaccessible]
+    #      if there was an error accessing a file from the source virtual machine or virtual appliance.
+    # @raise [Com::Vmware::Vapi::Std::Errors::ResourceBusy]
+    #      if the specified virtual machine or virtual appliance is busy.
+    # @raise [Com::Vmware::Vapi::Std::Errors::Unauthorized]
+    #     If you do not have all of the privileges described in the following list:
+    #
+    #     System.Read
+    def create(source, target, create_spec, client_token = nil)
+      invoke_with_info(CREATE_INFO,
+                       'client_token' => client_token,
+                       'source' => source,
+                       'target' => target,
+                       'create_spec' => create_spec)
+    end
+
+    # The  ``Com::Vmware::Vcenter::Ovf::LibraryItem::DeployableIdentity``   class  describes the resource created by a deployment, or the source resource from which library item can be created, by specifying its resource type and resource identifier.
+    # @!attribute [rw] type
+    #     @return [String]
+    #     Type of the deployable resource.
+    # @!attribute [rw] id
+    #     @return [String]
+    #     Identifier of the deployable resource.
+    class DeployableIdentity < VAPI::Bindings::VapiStruct
+      class << self
+        # Holds (gets or creates) the binding type metadata for this structure type.
+        # @scope class
+        # @return [VAPI::Bindings::StructType] the binding type
+        def binding_type
+          @binding_type ||= VAPI::Bindings::StructType.new(
+            'com.vmware.vcenter.ovf.library_item.deployable_identity',
+            {
+              'type' => VAPI::Bindings::StringType.instance,
+              'id' => VAPI::Bindings::IdType.new([], "type")
+            },
+            DeployableIdentity,
+            false,
+            nil
+          )
+        end
+      end
+
+      attr_accessor :type,
+                    :id
+
+      # Constructs a new instance.
+      # @param ruby_values [Hash] a map of initial property values (optional)
+      # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
+      def initialize(ruby_values = nil, struct_value = nil)
+        super(self.class.binding_type, ruby_values, struct_value)
+      end
+    end
+
+    # The  ``Com::Vmware::Vcenter::Ovf::LibraryItem::ResourcePoolDeploymentSpec``   class  defines the deployment parameters that can be specified for the  ``deploy``   method  where the deployment target is a resource pool. See   :func:`Com::Vmware::Vcenter::Ovf::LibraryItem.deploy`  .
     # @!attribute [rw] name
+    #     @return [String, nil]
+    #     Name assigned to the deployed target virtual machine or virtual appliance.
+    #     If  nil , the server will use the name from the OVF package.
+    # @!attribute [rw] annotation
+    #     @return [String, nil]
+    #     Annotation assigned to the deployed target virtual machine or virtual appliance.
+    #     If  nil , the server will use the annotation from the OVF package.
+    # @!attribute [rw] accept_all_eula
+    #     @return [Boolean]
+    #     Whether to accept all End User License Agreements. See   :attr:`Com::Vmware::Vcenter::Ovf::LibraryItem::OvfSummary.eulas`  .
+    # @!attribute [rw] network_mappings
+    #     @return [Hash<String, String>, nil]
+    #     Specification of the target network to use for sections of type ovf:NetworkSection in the OVF descriptor. The key in the  map  is the section identifier of the ovf:NetworkSection section in the OVF descriptor and the value is the target network to be used for deployment.
+    #     If  nil , the server will choose a network mapping.
+    # @!attribute [rw] storage_mappings
+    #     @return [Hash<String, Com::Vmware::Vcenter::Ovf::LibraryItem::StorageGroupMapping>, nil]
+    #     Specification of the target storage to use for sections of type vmw:StorageGroupSection in the OVF descriptor. The key in the  map  is the section identifier of the ovf:StorageGroupSection section in the OVF descriptor and the value is the target storage specification to be used for deployment. See   :class:`Com::Vmware::Vcenter::Ovf::LibraryItem::StorageGroupMapping`  .
+    #     If  nil , the server will choose a storage mapping.
+    # @!attribute [rw] storage_provisioning
+    #     @return [Com::Vmware::Vcenter::Ovf::DiskProvisioningType, nil]
+    #     Default storage provisioning type to use for all sections of type vmw:StorageSection in the OVF descriptor.
+    #     If  nil , the server will choose the provisioning type.
+    # @!attribute [rw] storage_profile_id
+    #     @return [String, nil]
+    #     Default storage profile to use for all sections of type vmw:StorageSection in the OVF descriptor.
+    #     If  nil , the server will choose the default profile.
+    # @!attribute [rw] locale
+    #     @return [String, nil]
+    #     The locale to use for parsing the OVF descriptor.
+    #     If  nil , the server locale will be used.
+    # @!attribute [rw] flags
+    #     @return [Array<String>, nil]
+    #     Flags to be use for deployment. The supported flag values can be obtained using   :func:`Com::Vmware::Vcenter::Ovf::ImportFlag.list`  .
+    #     If  nil , no flags will be used.
+    # @!attribute [rw] additional_parameters
+    #     @return [Array<VAPI::Bindings::VapiStruct>, nil]
+    #     Additional OVF parameters that may be needed for the deployment. Additional OVF parameters may be required by the OVF descriptor of the OVF package in the library item. Examples of OVF parameters that can be specified through this  field  include, but are not limited to:  
+    #     
+    #       *  :class:`Com::Vmware::Vcenter::Ovf::DeploymentOptionParams` 
+    #        *  :class:`Com::Vmware::Vcenter::Ovf::ExtraConfigParams` 
+    #        *  :class:`Com::Vmware::Vcenter::Ovf::IpAllocationParams` 
+    #        *  :class:`Com::Vmware::Vcenter::Ovf::PropertyParams` 
+    #        *  :class:`Com::Vmware::Vcenter::Ovf::ScaleOutParams` 
+    #        *  :class:`Com::Vmware::Vcenter::Ovf::VcenterExtensionParams` 
+    #       
+    #     If  nil , the server will choose default settings for all parameters necessary for the  ``deploy``   method . See   :func:`Com::Vmware::Vcenter::Ovf::LibraryItem.deploy`  .
+    # @!attribute [rw] default_datastore_id
+    #     @return [String, nil]
+    #     Default datastore to use for all sections of type vmw:StorageSection in the OVF descriptor.
+    #     If  nil , the server will choose the default datastore.
+    class ResourcePoolDeploymentSpec < VAPI::Bindings::VapiStruct
+      class << self
+        # Holds (gets or creates) the binding type metadata for this structure type.
+        # @scope class
+        # @return [VAPI::Bindings::StructType] the binding type
+        def binding_type
+          @binding_type ||= VAPI::Bindings::StructType.new(
+            'com.vmware.vcenter.ovf.library_item.resource_pool_deployment_spec',
+            {
+              'name' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::StringType.instance),
+              'annotation' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::StringType.instance),
+              'accept_all_EULA' => VAPI::Bindings::BooleanType.instance,
+              'network_mappings' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::MapType.new(VAPI::Bindings::StringType.instance, VAPI::Bindings::IdType.new)),
+              'storage_mappings' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::MapType.new(VAPI::Bindings::StringType.instance, VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::Ovf::LibraryItem::StorageGroupMapping'))),
+              'storage_provisioning' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::Ovf::DiskProvisioningType')),
+              'storage_profile_id' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::IdType.new),
+              'locale' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::StringType.instance),
+              'flags' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::ListType.new(VAPI::Bindings::StringType.instance)),
+              'additional_parameters' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::ListType.new(VAPI::Bindings::DynamicStructType.new([VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::Ovf::OvfParams')]))),
+              'default_datastore_id' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::IdType.new)
+            },
+            ResourcePoolDeploymentSpec,
+            false,
+            nil
+          )
+        end
+      end
+
+      attr_accessor :name,
+                    :annotation,
+                    :accept_all_eula,
+                    :network_mappings,
+                    :storage_mappings,
+                    :storage_provisioning,
+                    :storage_profile_id,
+                    :locale,
+                    :flags,
+                    :additional_parameters,
+                    :default_datastore_id
+
+      # Constructs a new instance.
+      # @param ruby_values [Hash] a map of initial property values (optional)
+      # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
+      def initialize(ruby_values = nil, struct_value = nil)
+        super(self.class.binding_type, ruby_values, struct_value)
+      end
+    end
+
+    # The  ``Com::Vmware::Vcenter::Ovf::LibraryItem::StorageGroupMapping``   class  defines the storage deployment target and storage provisioning type for a section of type vmw:StorageGroupSection in the OVF descriptor.
+    # @!attribute [rw] type
+    #     @return [Com::Vmware::Vcenter::Ovf::LibraryItem::StorageGroupMapping::Type]
+    #     Type of storage deployment target to use for the vmw:StorageGroupSection section. The specified value must be   :attr:`Com::Vmware::Vcenter::Ovf::LibraryItem::StorageGroupMapping::Type.DATASTORE`   or   :attr:`Com::Vmware::Vcenter::Ovf::LibraryItem::StorageGroupMapping::Type.STORAGE_PROFILE`  .
+    # @!attribute [rw] datastore_id
     #     @return [String]
-    #     The name of input parameter.
-    #     This  field  is optional and it is only relevant when the value of  ``category``  is   :attr:`Com::Vmware::Vcenter::Ovf::OvfMessage::Category.INPUT`  .
-    # @!attribute [rw] value
+    #     Target datastore to be used for the storage group.
+    #     This  field  is optional and it is only relevant when the value of  ``type``  is   :attr:`Com::Vmware::Vcenter::Ovf::LibraryItem::StorageGroupMapping::Type.DATASTORE`  .
+    # @!attribute [rw] storage_profile_id
     #     @return [String]
-    #     The value of input parameter.
-    #     This  field  is optional and it is only relevant when the value of  ``category``  is   :attr:`Com::Vmware::Vcenter::Ovf::OvfMessage::Category.INPUT`  .
-    # @!attribute [rw] message
-    #     @return [Com::Vmware::Vapi::Std::LocalizableMessage]
-    #     A localizable message.
-    #     This  field  is optional and it is only relevant when the value of  ``category``  is   :attr:`Com::Vmware::Vcenter::Ovf::OvfMessage::Category.INPUT`  .
+    #     Target storage profile to be used for the storage group.
+    #     This  field  is optional and it is only relevant when the value of  ``type``  is   :attr:`Com::Vmware::Vcenter::Ovf::LibraryItem::StorageGroupMapping::Type.STORAGE_PROFILE`  .
+    # @!attribute [rw] provisioning
+    #     @return [Com::Vmware::Vcenter::Ovf::DiskProvisioningType, nil]
+    #     Target provisioning type to use for the storage group.
+    #     If  nil ,   :attr:`Com::Vmware::Vcenter::Ovf::LibraryItem::ResourcePoolDeploymentSpec.storage_provisioning`   will be used.
+    class StorageGroupMapping < VAPI::Bindings::VapiStruct
+      class << self
+        # Holds (gets or creates) the binding type metadata for this structure type.
+        # @scope class
+        # @return [VAPI::Bindings::StructType] the binding type
+        def binding_type
+          @binding_type ||= VAPI::Bindings::StructType.new(
+            'com.vmware.vcenter.ovf.library_item.storage_group_mapping',
+            {
+              'type' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::Ovf::LibraryItem::StorageGroupMapping::Type'),
+              'datastore_id' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::IdType.new),
+              'storage_profile_id' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::IdType.new),
+              'provisioning' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::Ovf::DiskProvisioningType'))
+            },
+            StorageGroupMapping,
+            false,
+            nil
+          )
+        end
+      end
+
+      attr_accessor :type,
+                    :datastore_id,
+                    :storage_profile_id,
+                    :provisioning
+
+      # Constructs a new instance.
+      # @param ruby_values [Hash] a map of initial property values (optional)
+      # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
+      def initialize(ruby_values = nil, struct_value = nil)
+        super(self.class.binding_type, ruby_values, struct_value)
+      end
+
+      # The  ``Com::Vmware::Vcenter::Ovf::LibraryItem::StorageGroupMapping::Type``   enumerated type  defines the supported types of storage targets for sections of type vmw:StroageGroupSection in the OVF descriptor.
+      # @!attribute [rw] datastore
+      #     @return [Com::Vmware::Vcenter::Ovf::LibraryItem::StorageGroupMapping::Type]
+      #     Storage deployment target is a datastore.
+      # @!attribute [rw] storage_profile
+      #     @return [Com::Vmware::Vcenter::Ovf::LibraryItem::StorageGroupMapping::Type]
+      #     Storage deployment target is a storage profile.
+      class Type < VAPI::Bindings::VapiEnum
+        class << self
+          # Holds (gets or creates) the binding type metadata for this enumeration type.
+          # @scope class
+          # @return [VAPI::Bindings::EnumType] the binding type
+          def binding_type
+            @binding_type ||= VAPI::Bindings::EnumType.new(
+              'com.vmware.vcenter.ovf.library_item.storage_group_mapping.type',
+              Type
+            )
+          end
+
+          # Converts from a string value (perhaps off the wire) to an instance
+          # of this enum type.
+          # @param value [String] the actual value of the enum instance
+          # @return [Type] the instance found for the value, otherwise
+          #         an unknown instance will be built for the value
+          def from_string(value)
+            const_get(value)
+          rescue NameError
+            Type.send(:new, 'UNKNOWN', value)
+          end
+        end
+
+        # Constructs a new instance.
+        # @param value [String] the actual value of the enum instance
+        # @param unknown [String] the unknown value when value is 'UKNOWN'
+        def initialize(value, unknown = nil)
+          super(self.class.binding_type, value, unknown)
+        end
+
+        private_class_method :new
+
+        # @!attribute [rw] datastore
+        #     @return [Com::Vmware::Vcenter::Ovf::LibraryItem::StorageGroupMapping::Type]
+        #     Storage deployment target is a datastore.
+        DATASTORE = Type.send(:new, 'DATASTORE')
+
+        # @!attribute [rw] storage_profile
+        #     @return [Com::Vmware::Vcenter::Ovf::LibraryItem::StorageGroupMapping::Type]
+        #     Storage deployment target is a storage profile.
+        STORAGE_PROFILE = Type.send(:new, 'STORAGE_PROFILE')
+      end
+    end
+
+    # The  ``Com::Vmware::Vcenter::Ovf::LibraryItem::ResultInfo``   class  defines the information returned along with the result of a  ``create``  or  ``deploy``   method  to describe errors, warnings, and informational messages produced by the server.
+    # @!attribute [rw] errors
+    #     @return [Array<Com::Vmware::Vcenter::Ovf::OvfError>]
+    #     Errors reported by the  ``create``  or  ``deploy``   method . These errors would have prevented the  ``create``  or  ``deploy``   method  from completing successfully.
+    # @!attribute [rw] warnings
+    #     @return [Array<Com::Vmware::Vcenter::Ovf::OvfWarning>]
+    #     Warnings reported by the  ``create``  or  ``deploy``   method . These warnings would not have prevented the  ``create``  or  ``deploy``   method  from completing successfully, but there might be issues that warrant attention.
+    # @!attribute [rw] information
+    #     @return [Array<Com::Vmware::Vcenter::Ovf::OvfInfo>]
+    #     Information messages reported by the  ``create``  or  ``deploy``   method . For example, a non-required parameter was ignored.
+    class ResultInfo < VAPI::Bindings::VapiStruct
+      class << self
+        # Holds (gets or creates) the binding type metadata for this structure type.
+        # @scope class
+        # @return [VAPI::Bindings::StructType] the binding type
+        def binding_type
+          @binding_type ||= VAPI::Bindings::StructType.new(
+            'com.vmware.vcenter.ovf.library_item.result_info',
+            {
+              'errors' => VAPI::Bindings::ListType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::Ovf::OvfError')),
+              'warnings' => VAPI::Bindings::ListType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::Ovf::OvfWarning')),
+              'information' => VAPI::Bindings::ListType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::Ovf::OvfInfo'))
+            },
+            ResultInfo,
+            false,
+            nil
+          )
+        end
+      end
+
+      attr_accessor :errors,
+                    :warnings,
+                    :information
+
+      # Constructs a new instance.
+      # @param ruby_values [Hash] a map of initial property values (optional)
+      # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
+      def initialize(ruby_values = nil, struct_value = nil)
+        super(self.class.binding_type, ruby_values, struct_value)
+      end
+    end
+
+    # The  ``Com::Vmware::Vcenter::Ovf::LibraryItem::DeploymentResult``   class  defines the result of the  ``deploy``   method . See   :func:`Com::Vmware::Vcenter::Ovf::LibraryItem.deploy`  .
+    # @!attribute [rw] succeeded
+    #     @return [Boolean]
+    #     Whether the  ``deploy``   method  completed successfully.
+    # @!attribute [rw] resource_id
+    #     @return [Com::Vmware::Vcenter::Ovf::LibraryItem::DeployableIdentity, nil]
+    #     Identifier of the deployed resource entity.
+    #     If  nil , the  ``deploy``   method  failed and   :attr:`Com::Vmware::Vcenter::Ovf::LibraryItem::DeploymentResult.error`   will describe the error(s) that caused the failure.
     # @!attribute [rw] error
-    #     @return [VAPI::Bindings::VapiStruct]
-    #     Represents a server   :class:`Com::Vmware::Vapi::Std::Errors::Error`  .
-    #     This  field  is optional and it is only relevant when the value of  ``category``  is   :attr:`Com::Vmware::Vcenter::Ovf::OvfMessage::Category.SERVER`  .
-    class OvfMessage < VAPI::Bindings::VapiStruct
-
-        class << self
-            # Holds (gets or creates) the binding type metadata for this structure type.
-            # @scope class
-            # @return [VAPI::Bindings::StructType] the binding type
-            def binding_type
-                @binding_type ||= VAPI::Bindings::StructType.new(
-                    'com.vmware.vcenter.ovf.ovf_message',
-                    {
-                        'category' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::Ovf::OvfMessage::Category'),
-                        'issues' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::ListType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::Ovf::ParseIssue'))),
-                        'name' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::StringType.instance),
-                        'value' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::StringType.instance),
-                        'message' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::LocalizableMessage')),
-                        'error' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::DynamicStructType.new([VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Error')])),
-                    },
-                    OvfMessage,
-                    false,
-                    nil)
-            end
+    #     @return [Com::Vmware::Vcenter::Ovf::LibraryItem::ResultInfo, nil]
+    #     Errors, warnings, and informational messages produced by the  ``deploy``   method .
+    #     If  nil , no errors, warnings, or informational messages were reported by the  ``deploy``   method .
+    class DeploymentResult < VAPI::Bindings::VapiStruct
+      class << self
+        # Holds (gets or creates) the binding type metadata for this structure type.
+        # @scope class
+        # @return [VAPI::Bindings::StructType] the binding type
+        def binding_type
+          @binding_type ||= VAPI::Bindings::StructType.new(
+            'com.vmware.vcenter.ovf.library_item.deployment_result',
+            {
+              'succeeded' => VAPI::Bindings::BooleanType.instance,
+              'resource_id' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::Ovf::LibraryItem::DeployableIdentity')),
+              'error' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::Ovf::LibraryItem::ResultInfo'))
+            },
+            DeploymentResult,
+            false,
+            nil
+          )
         end
+      end
 
-        attr_accessor :category,
-                      :issues,
-                      :name,
-                      :value,
-                      :message,
-                      :error
+      attr_accessor :succeeded,
+                    :resource_id,
+                    :error
 
-        # Constructs a new instance.
-        # @param ruby_values [Hash] a map of initial property values (optional)
-        # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
-        def initialize(ruby_values=nil, struct_value=nil)
-            super(self.class.binding_type, ruby_values, struct_value)
-        end
-
-
-        # The  ``Com::Vmware::Vcenter::Ovf::OvfMessage::Category``   enumerated type  defines the categories of messages (see   :class:`Com::Vmware::Vcenter::Ovf::OvfMessage`  ).
-        # @!attribute [rw] validation
-        #     @return [Com::Vmware::Vcenter::Ovf::OvfMessage::Category]
-        #     The OVF descriptor is invalid, for example, syntax errors or schema errors.
-        # @!attribute [rw] input
-        #     @return [Com::Vmware::Vcenter::Ovf::OvfMessage::Category]
-        #     The user provided input parameters are invalid.
-        # @!attribute [rw] server
-        #     @return [Com::Vmware::Vcenter::Ovf::OvfMessage::Category]
-        #     Server error.
-        class Category < VAPI::Bindings::VapiEnum
-
-            class << self
-                # Holds (gets or creates) the binding type metadata for this enumeration type.
-                # @scope class
-                # @return [VAPI::Bindings::EnumType] the binding type
-                def binding_type
-                    @binding_type ||= VAPI::Bindings::EnumType.new(
-                        'com.vmware.vcenter.ovf.ovf_message.category',
-                        Category)
-                end
-
-                # Converts from a string value (perhaps off the wire) to an instance
-                # of this enum type.
-                # @param value [String] the actual value of the enum instance
-                # @return [Category] the instance found for the value, otherwise
-                #         an unknown instance will be built for the value
-                def from_string(value)
-                    begin
-                        const_get(value)
-                    rescue NameError
-                        Category.new('UNKNOWN', value)
-                    end
-                end
-            end
-
-            private
-
-            # Constructs a new instance.
-            # @param value [String] the actual value of the enum instance
-            # @param unknown [String] the unknown value when value is 'UKNOWN'
-            def initialize(value, unknown=nil)
-                super(self.class.binding_type, value, unknown)
-            end
-
-            public
-
-            # @!attribute [rw] validation
-            #     @return [Com::Vmware::Vcenter::Ovf::OvfMessage::Category]
-            #     The OVF descriptor is invalid, for example, syntax errors or schema errors.
-            VALIDATION = Category.new('VALIDATION')
-
-            # @!attribute [rw] input
-            #     @return [Com::Vmware::Vcenter::Ovf::OvfMessage::Category]
-            #     The user provided input parameters are invalid.
-            INPUT = Category.new('INPUT')
-
-            # @!attribute [rw] server
-            #     @return [Com::Vmware::Vcenter::Ovf::OvfMessage::Category]
-            #     Server error.
-            SERVER = Category.new('SERVER')
-
-        end
-
-
+      # Constructs a new instance.
+      # @param ruby_values [Hash] a map of initial property values (optional)
+      # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
+      def initialize(ruby_values = nil, struct_value = nil)
+        super(self.class.binding_type, ruby_values, struct_value)
+      end
     end
 
+    # The  ``Com::Vmware::Vcenter::Ovf::LibraryItem::DeploymentTarget``   class  describes the location (target) where a virtual machine or virtual appliance should be deployed. It is used in the  ``deploy``  and  ``filter``   methods . See   :func:`Com::Vmware::Vcenter::Ovf::LibraryItem.deploy`   and   :func:`Com::Vmware::Vcenter::Ovf::LibraryItem.filter`  .
+    # @!attribute [rw] resource_pool_id
+    #     @return [String]
+    #     Identifier of the resource pool to which the virtual machine or virtual appliance should be attached.
+    # @!attribute [rw] host_id
+    #     @return [String, nil]
+    #     Identifier of the target host on which the virtual machine or virtual appliance will run. The target host must be a member of the cluster that contains the resource pool identified by   :attr:`Com::Vmware::Vcenter::Ovf::LibraryItem::DeploymentTarget.resource_pool_id`  .
+    #     If  nil , the server will automatically select a target host from the resource pool if   :attr:`Com::Vmware::Vcenter::Ovf::LibraryItem::DeploymentTarget.resource_pool_id`   is a stand-alone host or a cluster with Distributed Resource Scheduling (DRS) enabled.
+    # @!attribute [rw] folder_id
+    #     @return [String, nil]
+    #     Identifier of the vCenter folder that should contain the virtual machine or virtual appliance. The folder must be virtual machine folder.
+    #     If  nil , the server will choose the deployment folder.
+    class DeploymentTarget < VAPI::Bindings::VapiStruct
+      class << self
+        # Holds (gets or creates) the binding type metadata for this structure type.
+        # @scope class
+        # @return [VAPI::Bindings::StructType] the binding type
+        def binding_type
+          @binding_type ||= VAPI::Bindings::StructType.new(
+            'com.vmware.vcenter.ovf.library_item.deployment_target',
+            {
+              'resource_pool_id' => VAPI::Bindings::IdType.new('ResourcePool'),
+              'host_id' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::IdType.new),
+              'folder_id' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::IdType.new)
+            },
+            DeploymentTarget,
+            false,
+            nil
+          )
+        end
+      end
 
-    # The  ``Com::Vmware::Vcenter::Ovf::ParseIssue``   class  contains the information about the issue found when parsing an OVF package during deployment or exporting an OVF package including:  
-    # 
-    #   * Parsing and validation error on OVF descriptor (which is an XML document), manifest and certificate files. 
-    #  * OVF descriptor generating and device error. 
-    #  * Unexpected server error. 
-    # @!attribute [rw] category
+      attr_accessor :resource_pool_id,
+                    :host_id,
+                    :folder_id
+
+      # Constructs a new instance.
+      # @param ruby_values [Hash] a map of initial property values (optional)
+      # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
+      def initialize(ruby_values = nil, struct_value = nil)
+        super(self.class.binding_type, ruby_values, struct_value)
+      end
+    end
+
+    # The  ``Com::Vmware::Vcenter::Ovf::LibraryItem::OvfSummary``   class  defines the result of the  ``filter``   method . See   :func:`Com::Vmware::Vcenter::Ovf::LibraryItem.filter`  . The  fields  in the  class  describe parameterizable information in the OVF descriptor, with respect to a deployment target, for the  ``deploy``   method . See   :func:`Com::Vmware::Vcenter::Ovf::LibraryItem.deploy`  .
+    # @!attribute [rw] name
+    #     @return [String, nil]
+    #     Default name for the virtual machine or virtual appliance.
+    #     If  nil , the OVF descriptor did not specify a name.
+    # @!attribute [rw] annotation
+    #     @return [String, nil]
+    #     Default annotation for the virtual machine or virtual appliance.
+    #     If  nil , the OVF descriptor did not specify an annotation.
+    # @!attribute [rw] eulas
+    #     @return [Array<String>]
+    #     End User License Agreements specified in the OVF descriptor. All end user license agreements must be accepted in order for the  ``deploy``   method  to succeed. See   :attr:`Com::Vmware::Vcenter::Ovf::LibraryItem::ResourcePoolDeploymentSpec.accept_all_eula`  .
+    # @!attribute [rw] networks
+    #     @return [Array<String>, nil]
+    #     Section identifiers for sections of type ovf:NetworkSection in the OVF descriptor. These identifiers can be used as keys in   :attr:`Com::Vmware::Vcenter::Ovf::LibraryItem::ResourcePoolDeploymentSpec.network_mappings`  .
+    #     If  nil , the OVF descriptor did not specify any networks.
+    # @!attribute [rw] storage_groups
+    #     @return [Array<String>, nil]
+    #     Section identifiers for sections of type vmw:StorageGroupSection in the OVF descriptor. These identifiers can be used as keys in   :attr:`Com::Vmware::Vcenter::Ovf::LibraryItem::ResourcePoolDeploymentSpec.storage_mappings`  .
+    #     If  nil , the OVF descriptor did not specify any storage groups.
+    # @!attribute [rw] additional_params
+    #     @return [Array<VAPI::Bindings::VapiStruct>, nil]
+    #     Additional OVF parameters which can be specified for the deployment target. These OVF parameters can be inspected, optionally modified, and used as values in   :attr:`Com::Vmware::Vcenter::Ovf::LibraryItem::ResourcePoolDeploymentSpec.additional_parameters`   for the  ``deploy``   method .
+    #     If  nil , the OVF descriptor does not require addtional parameters or does not have additional parameters suitable for the deployment target.
+    class OvfSummary < VAPI::Bindings::VapiStruct
+      class << self
+        # Holds (gets or creates) the binding type metadata for this structure type.
+        # @scope class
+        # @return [VAPI::Bindings::StructType] the binding type
+        def binding_type
+          @binding_type ||= VAPI::Bindings::StructType.new(
+            'com.vmware.vcenter.ovf.library_item.ovf_summary',
+            {
+              'name' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::StringType.instance),
+              'annotation' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::StringType.instance),
+              'EULAs' => VAPI::Bindings::ListType.new(VAPI::Bindings::StringType.instance),
+              'networks' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::ListType.new(VAPI::Bindings::StringType.instance)),
+              'storage_groups' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::ListType.new(VAPI::Bindings::StringType.instance)),
+              'additional_params' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::ListType.new(VAPI::Bindings::DynamicStructType.new([VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::Ovf::OvfParams')])))
+            },
+            OvfSummary,
+            false,
+            nil
+          )
+        end
+      end
+
+      attr_accessor :name,
+                    :annotation,
+                    :eulas,
+                    :networks,
+                    :storage_groups,
+                    :additional_params
+
+      # Constructs a new instance.
+      # @param ruby_values [Hash] a map of initial property values (optional)
+      # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
+      def initialize(ruby_values = nil, struct_value = nil)
+        super(self.class.binding_type, ruby_values, struct_value)
+      end
+    end
+
+    # The  ``Com::Vmware::Vcenter::Ovf::LibraryItem::CreateTarget``   class  specifies the target library item when capturing a virtual machine or virtual appliance as an OVF package in a library item in a content library. The target can be an existing library item, which will be updated, creating a new version, or it can be a newly created library item in a specified library. See   :func:`Com::Vmware::Vcenter::Ovf::LibraryItem.create`  .
+    # @!attribute [rw] library_id
+    #     @return [String, nil]
+    #     Identifier of the library in which a new library item should be created. This  field  is not used if the  ``libraryItemId``   field  is specified.
+    #     If  nil , the  ``libraryItemId``   field  must be specified.
+    # @!attribute [rw] library_item_id
+    #     @return [String, nil]
+    #     Identifier of the library item that should be should be updated.
+    #     If  nil , a new library item will be created. The  ``libraryId``   field  must be specified if this  field  is  nil .
+    class CreateTarget < VAPI::Bindings::VapiStruct
+      class << self
+        # Holds (gets or creates) the binding type metadata for this structure type.
+        # @scope class
+        # @return [VAPI::Bindings::StructType] the binding type
+        def binding_type
+          @binding_type ||= VAPI::Bindings::StructType.new(
+            'com.vmware.vcenter.ovf.library_item.create_target',
+            {
+              'library_id' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::IdType.new),
+              'library_item_id' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::IdType.new)
+            },
+            CreateTarget,
+            false,
+            nil
+          )
+        end
+      end
+
+      attr_accessor :library_id,
+                    :library_item_id
+
+      # Constructs a new instance.
+      # @param ruby_values [Hash] a map of initial property values (optional)
+      # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
+      def initialize(ruby_values = nil, struct_value = nil)
+        super(self.class.binding_type, ruby_values, struct_value)
+      end
+    end
+
+    # The  ``Com::Vmware::Vcenter::Ovf::LibraryItem::CreateSpec``   class  defines the information used to create or update a library item containing an OVF package.
+    # @!attribute [rw] name
+    #     @return [String, nil]
+    #     Name to use in the OVF descriptor stored in the library item.
+    #     If  nil , the server will use source's current name.
+    # @!attribute [rw] description
+    #     @return [String, nil]
+    #     Description to use in the OVF descriptor stored in the library item.
+    #     If  nil , the server will use source's current annotation.
+    # @!attribute [rw] flags
+    #     @return [Array<String>, nil]
+    #     Flags to use for OVF package creation. The supported flags can be obtained using   :func:`Com::Vmware::Vcenter::Ovf::ExportFlag.list`  .
+    #     If  nil , no flags will be used.
+    class CreateSpec < VAPI::Bindings::VapiStruct
+      class << self
+        # Holds (gets or creates) the binding type metadata for this structure type.
+        # @scope class
+        # @return [VAPI::Bindings::StructType] the binding type
+        def binding_type
+          @binding_type ||= VAPI::Bindings::StructType.new(
+            'com.vmware.vcenter.ovf.library_item.create_spec',
+            {
+              'name' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::StringType.instance),
+              'description' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::StringType.instance),
+              'flags' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::ListType.new(VAPI::Bindings::StringType.instance))
+            },
+            CreateSpec,
+            false,
+            nil
+          )
+        end
+      end
+
+      attr_accessor :name,
+                    :description,
+                    :flags
+
+      # Constructs a new instance.
+      # @param ruby_values [Hash] a map of initial property values (optional)
+      # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
+      def initialize(ruby_values = nil, struct_value = nil)
+        super(self.class.binding_type, ruby_values, struct_value)
+      end
+    end
+
+    # The  ``Com::Vmware::Vcenter::Ovf::LibraryItem::CreateResult``   class  defines the result of the  ``create``   method . See   :func:`Com::Vmware::Vcenter::Ovf::LibraryItem.create`  .
+    # @!attribute [rw] succeeded
+    #     @return [Boolean]
+    #     Whether the  ``create``   method  completed successfully.
+    # @!attribute [rw] ovf_library_item_id
+    #     @return [String, nil]
+    #     Identifier of the created or updated library item.
+    #     If  nil , the  ``create``   method  failed and   :attr:`Com::Vmware::Vcenter::Ovf::LibraryItem::CreateResult.error`   will describe the error(s) that caused the failure.
+    # @!attribute [rw] error
+    #     @return [Com::Vmware::Vcenter::Ovf::LibraryItem::ResultInfo, nil]
+    #     Errors, warnings, and informational messages produced by the  ``create``   method .
+    #     If  nil , no errors, warnings, or informational messages were reported by the  ``create``   method .
+    class CreateResult < VAPI::Bindings::VapiStruct
+      class << self
+        # Holds (gets or creates) the binding type metadata for this structure type.
+        # @scope class
+        # @return [VAPI::Bindings::StructType] the binding type
+        def binding_type
+          @binding_type ||= VAPI::Bindings::StructType.new(
+            'com.vmware.vcenter.ovf.library_item.create_result',
+            {
+              'succeeded' => VAPI::Bindings::BooleanType.instance,
+              'ovf_library_item_id' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::IdType.new),
+              'error' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::Ovf::LibraryItem::ResultInfo'))
+            },
+            CreateResult,
+            false,
+            nil
+          )
+        end
+      end
+
+      attr_accessor :succeeded,
+                    :ovf_library_item_id,
+                    :error
+
+      # Constructs a new instance.
+      # @param ruby_values [Hash] a map of initial property values (optional)
+      # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
+      def initialize(ruby_values = nil, struct_value = nil)
+        super(self.class.binding_type, ruby_values, struct_value)
+      end
+    end
+
+  end
+  # The  ``Com::Vmware::Vcenter::Ovf::CertificateParams``   class  contains information about the public key certificate used to sign the OVF package. This  class  will only be returned if the OVF package is signed.  
+  # 
+  #  See   :func:`Com::Vmware::Vcenter::Ovf::LibraryItem.deploy`   and   :func:`Com::Vmware::Vcenter::Ovf::LibraryItem.filter`  .
+  # @!attribute [rw] issuer
+  #     @return [String]
+  #     Certificate issuer. For example: /C=US/ST=California/L=Palo Alto/O=VMware, Inc.
+  #     This  field  is not used in the input parameters when deploying an OVF package. This  field  will always be present in the result when retrieving information about an OVF package.
+  # @!attribute [rw] subject
+  #     @return [String]
+  #     Certificate subject. For example: /C=US/ST=Massachusetts/L=Hopkinton/O=EMC Corporation/OU=EMC Avamar/CN=EMC Corporation.
+  #     This  field  is not used in the input parameters when deploying an OVF package. This  field  will always be present in the result when retrieving information about an OVF package.
+  # @!attribute [rw] is_valid
+  #     @return [Boolean]
+  #     Is the certificate chain validated.
+  #     This  field  is not used in the input parameters when deploying an OVF package. This  field  will always be present in the result when retrieving information about an OVF package.
+  # @!attribute [rw] is_self_signed
+  #     @return [Boolean]
+  #     Is the certificate self-signed.
+  #     This  field  is not used in the input parameters when deploying an OVF package. This  field  will always be present in the result when retrieving information about an OVF package.
+  # @!attribute [rw] x509
+  #     @return [String]
+  #     The X509 representation of the certificate.
+  #     This  field  is not used in the input parameters when deploying an OVF package. This  field  will always be present in the result when retrieving information about an OVF package.
+  class CertificateParams < VAPI::Bindings::VapiStruct
+    class << self
+      # Holds (gets or creates) the binding type metadata for this structure type.
+      # @scope class
+      # @return [VAPI::Bindings::StructType] the binding type
+      def binding_type
+        @binding_type ||= VAPI::Bindings::StructType.new(
+          'com.vmware.vcenter.ovf.certificate_params',
+          {
+            'issuer' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::StringType.instance),
+            'subject' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::StringType.instance),
+            'is_valid' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::BooleanType.instance),
+            'is_self_signed' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::BooleanType.instance),
+            'x509' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::StringType.instance),
+            'type' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::StringType.instance)
+          },
+          CertificateParams,
+          false,
+          nil
+        )
+      end
+    end
+
+    attr_accessor :issuer,
+                  :subject,
+                  :is_valid,
+                  :is_self_signed,
+                  :x509,
+                  :type
+
+    # Constructs a new instance.
+    # @param ruby_values [Hash] a map of initial property values (optional)
+    # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
+    def initialize(ruby_values = nil, struct_value = nil)
+      super(self.class.binding_type, ruby_values, struct_value)
+    end
+  end
+  # The  ``Com::Vmware::Vcenter::Ovf::DeploymentOption``   class  contains the information about a deployment option as defined in the OVF specification.  
+  # 
+  #  This corresponds to the ovf:Configuration element of the ovf:DeploymentOptionSection in the specification. The ovf:DeploymentOptionSection specifies a discrete set of intended resource allocation configurations. This  class  represents one item from that set.  
+  # 
+  #  See   :func:`Com::Vmware::Vcenter::Ovf::LibraryItem.deploy`   and   :func:`Com::Vmware::Vcenter::Ovf::LibraryItem.filter`  .
+  # @!attribute [rw] key
+  #     @return [String]
+  #     The key of the deployment option, corresponding to the ovf:id attribute in the OVF descriptor.
+  #     This  field  is not used in the input parameters when deploying an OVF package. This  field  will always be present in the result when retrieving information about an OVF package.
+  # @!attribute [rw] label
+  #     @return [String]
+  #     A localizable label for the deployment option.
+  #     This  field  is not used in the input parameters when deploying an OVF package. This  field  will always be present in the result when retrieving information about an OVF package.
+  # @!attribute [rw] description
+  #     @return [String]
+  #     A localizable description for the deployment option.
+  #     This  field  is not used in the input parameters when deploying an OVF package. This  field  will always be present in the result when retrieving information about an OVF package.
+  # @!attribute [rw] default_choice
+  #     @return [Boolean]
+  #     A  boolean  flag indicates whether this deployment option is the default choice.
+  #     This  field  is not used in the input parameters when deploying an OVF package. This  field  is optional in the result when retrieving information about an OVF package. If  nil  or false, it is not the default.
+  class DeploymentOption < VAPI::Bindings::VapiStruct
+    class << self
+      # Holds (gets or creates) the binding type metadata for this structure type.
+      # @scope class
+      # @return [VAPI::Bindings::StructType] the binding type
+      def binding_type
+        @binding_type ||= VAPI::Bindings::StructType.new(
+          'com.vmware.vcenter.ovf.deployment_option',
+          {
+            'key' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::StringType.instance),
+            'label' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::StringType.instance),
+            'description' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::StringType.instance),
+            'default_choice' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::BooleanType.instance)
+          },
+          DeploymentOption,
+          false,
+          nil
+        )
+      end
+    end
+
+    attr_accessor :key,
+                  :label,
+                  :description,
+                  :default_choice
+
+    # Constructs a new instance.
+    # @param ruby_values [Hash] a map of initial property values (optional)
+    # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
+    def initialize(ruby_values = nil, struct_value = nil)
+      super(self.class.binding_type, ruby_values, struct_value)
+    end
+  end
+  # The  ``Com::Vmware::Vcenter::Ovf::DeploymentOptionParams``   class  describes the possible deployment options as well as the choice provided by the user.  
+  # 
+  #  This information based on the ovf:DeploymentOptionSection.  
+  # 
+  #  See   :func:`Com::Vmware::Vcenter::Ovf::LibraryItem.deploy`   and   :func:`Com::Vmware::Vcenter::Ovf::LibraryItem.filter`  .
+  # @!attribute [rw] deployment_options
+  #     @return [Array<Com::Vmware::Vcenter::Ovf::DeploymentOption>]
+  #     List  of deployment options. This  field  corresponds to the ovf:Configuration elements of the ovf:DeploymentOptionSection in the specification. It is a discrete set of intended resource allocation configurations from which one can be selected.
+  #     This  field  is not used in the input parameters when deploying an OVF package. This  field  will always be present in the result when retrieving information about an OVF package.
+  # @!attribute [rw] selected_key
+  #     @return [String]
+  #     The selected deployment option. Identifies the   :class:`Com::Vmware::Vcenter::Ovf::DeploymentOption`   in the list in the  ``deploymentOptions``   field  with a matching value in the   :attr:`Com::Vmware::Vcenter::Ovf::DeploymentOption.key`    field .
+  #     This  field  is optional in the input parameters when deploying an OVF package. If  nil  the server will use the default deployment configuration, usually it's the first one in   :attr:`Com::Vmware::Vcenter::Ovf::DeploymentOptionParams.deployment_options`    list . This  field  is optional in the result when retrieving information about an OVF package. The value will be set only if it is specified with the optional ovf:default attribute.
+  class DeploymentOptionParams < VAPI::Bindings::VapiStruct
+    class << self
+      # Holds (gets or creates) the binding type metadata for this structure type.
+      # @scope class
+      # @return [VAPI::Bindings::StructType] the binding type
+      def binding_type
+        @binding_type ||= VAPI::Bindings::StructType.new(
+          'com.vmware.vcenter.ovf.deployment_option_params',
+          {
+            'deployment_options' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::ListType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::Ovf::DeploymentOption'))),
+            'selected_key' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::StringType.instance),
+            'type' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::StringType.instance)
+          },
+          DeploymentOptionParams,
+          false,
+          nil
+        )
+      end
+    end
+
+    attr_accessor :deployment_options,
+                  :selected_key,
+                  :type
+
+    # Constructs a new instance.
+    # @param ruby_values [Hash] a map of initial property values (optional)
+    # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
+    def initialize(ruby_values = nil, struct_value = nil)
+      super(self.class.binding_type, ruby_values, struct_value)
+    end
+  end
+  # The  ``Com::Vmware::Vcenter::Ovf::ExtraConfig``   class  contains the information about a vmw:ExtraConfig element which can be used to specify configuration settings that are transferred directly to the  ``.vmx``  file. The behavior of the vmw:ExtraConfig element is similar to the  ``extraConfig``  property of the  ``VirtualMachineConfigSpec``  object in the VMware vSphere API. Thus, the same restrictions apply, such as you cannot set values that could otherwise be set with other properties in the  ``VirtualMachineConfigSpec``  object. See the VMware vSphere API reference for details on this.  
+  # 
+  #  vmw:ExtraConfig elements may occur as direct child elements of a VirtualHardwareSection, or as child elements of individual virtual hardware items.  
+  # 
+  #  See   :func:`Com::Vmware::Vcenter::Ovf::LibraryItem.deploy`   and   :func:`Com::Vmware::Vcenter::Ovf::LibraryItem.filter`  .
+  # @!attribute [rw] key
+  #     @return [String]
+  #     The key of the ExtraConfig element.
+  #     This  field  must be provided in the input parameters when deploying an OVF package. This  field  will always be present in the result when retrieving information about an OVF package.
+  # @!attribute [rw] value
+  #     @return [String]
+  #     The value of the ExtraConfig element.
+  #     This  field  must be provided in the input parameters when deploying an OVF package. This  field  will always be present in the result when retrieving information about an OVF package.
+  # @!attribute [rw] virtual_system_id
+  #     @return [String]
+  #     The identifier of the virtual system containing the vmw:ExtraConfig element.
+  #     This  field  is not used in the input parameters when deploying an OVF package. This  field  will always be present in the result when retrieving information about an OVF package.
+  class ExtraConfig < VAPI::Bindings::VapiStruct
+    class << self
+      # Holds (gets or creates) the binding type metadata for this structure type.
+      # @scope class
+      # @return [VAPI::Bindings::StructType] the binding type
+      def binding_type
+        @binding_type ||= VAPI::Bindings::StructType.new(
+          'com.vmware.vcenter.ovf.extra_config',
+          {
+            'key' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::StringType.instance),
+            'value' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::StringType.instance),
+            'virtual_system_id' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::StringType.instance)
+          },
+          ExtraConfig,
+          false,
+          nil
+        )
+      end
+    end
+
+    attr_accessor :key,
+                  :value,
+                  :virtual_system_id
+
+    # Constructs a new instance.
+    # @param ruby_values [Hash] a map of initial property values (optional)
+    # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
+    def initialize(ruby_values = nil, struct_value = nil)
+      super(self.class.binding_type, ruby_values, struct_value)
+    end
+  end
+  # The  ``Com::Vmware::Vcenter::Ovf::ExtraConfigParams``   class  contains the parameters with information about the vmw:ExtraConfig elements in an OVF package.  
+  # 
+  #  vmw:ExtraConfig elements can be used to specify configuration settings that are transferred directly to the  ``.vmx``  file.  
+  # 
+  #  The behavior of the vmw:ExtraConfig element is similar to the  ``extraConfig``  property of the  ``VirtualMachineConfigSpec``  object in the VMware vSphere API. Thus, the same restrictions apply, such as you cannot set values that could otherwise be set with other properties in the  ``VirtualMachineConfigSpec``  object. See the VMware vSphere API reference for details on this.  
+  # 
+  #  See   :func:`Com::Vmware::Vcenter::Ovf::LibraryItem.deploy`   and   :func:`Com::Vmware::Vcenter::Ovf::LibraryItem.filter`  .
+  # @!attribute [rw] extra_configs
+  #     @return [Array<Com::Vmware::Vcenter::Ovf::ExtraConfig>]
+  #     List  of vmw:ExtraConfig elements in the OVF package.
+  #     This  field  is optional in the input parameters when deploying an OVF package. If  nil  there are no extra configuration elements to use for this OVF package deployment. This  field  will always be present in the result when retrieving information about an OVF package. It will be an empty  list  if there are no extra configuration elements in the OVF package.
+  # @!attribute [rw] exclude_keys
+  #     @return [Array<String>]
+  #     Specifies which extra configuration items in the  list  in the  ``extraConfigs``   ``field``  should be ignored during deployment.  
+  #     
+  #      If set, the given keys for extra configurations will be ignored during deployment. The key is defined in the   :attr:`Com::Vmware::Vcenter::Ovf::ExtraConfig.key`    field .
+  #     This  field  is optional in the input parameters when deploying an OVF package. It is an error to set both this and   :attr:`Com::Vmware::Vcenter::Ovf::ExtraConfigParams.include_keys`  . This  field  is optional in the result when retrieving information about an OVF package. It is an error to set both this and   :attr:`Com::Vmware::Vcenter::Ovf::ExtraConfigParams.include_keys`  .
+  # @!attribute [rw] include_keys
+  #     @return [Array<String>]
+  #     Specifies which extra configuration items in the  list  in the  ``extraConfigs``   ``field``  should be included during deployment.  
+  #     
+  #      If set, all but the given keys for extra configurations will be ignored during deployment. The key is defined in the   :attr:`Com::Vmware::Vcenter::Ovf::ExtraConfig.key`    field .
+  #     This  field  is optional in the input parameters when deploying an OVF package. It is an error to set both this and   :attr:`Com::Vmware::Vcenter::Ovf::ExtraConfigParams.exclude_keys`  . This  field  is optional in the result when retrieving information about an OVF package. It is an error to set both this and   :attr:`Com::Vmware::Vcenter::Ovf::ExtraConfigParams.exclude_keys`  .
+  class ExtraConfigParams < VAPI::Bindings::VapiStruct
+    class << self
+      # Holds (gets or creates) the binding type metadata for this structure type.
+      # @scope class
+      # @return [VAPI::Bindings::StructType] the binding type
+      def binding_type
+        @binding_type ||= VAPI::Bindings::StructType.new(
+          'com.vmware.vcenter.ovf.extra_config_params',
+          {
+            'extra_configs' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::ListType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::Ovf::ExtraConfig'))),
+            'exclude_keys' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::ListType.new(VAPI::Bindings::StringType.instance)),
+            'include_keys' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::ListType.new(VAPI::Bindings::StringType.instance)),
+            'type' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::StringType.instance)
+          },
+          ExtraConfigParams,
+          false,
+          nil
+        )
+      end
+    end
+
+    attr_accessor :extra_configs,
+                  :exclude_keys,
+                  :include_keys,
+                  :type
+
+    # Constructs a new instance.
+    # @param ruby_values [Hash] a map of initial property values (optional)
+    # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
+    def initialize(ruby_values = nil, struct_value = nil)
+      super(self.class.binding_type, ruby_values, struct_value)
+    end
+  end
+  # The  ``Com::Vmware::Vcenter::Ovf::IpAllocationParams``   class  specifies how IP addresses are allocated to OVF properties. In particular, it informs the deployment platform whether the guest supports IPv4, IPv6, or both. It also specifies whether the IP addresses can be obtained through DHCP or through the properties provided in the OVF environment.  
+  # 
+  #  Ovf Property elements are exposed to the guest software through the OVF environment. Each Property element exposed in the OVF environment shall be constructed from the value of the ovf:key attribute. A Property element contains a key/value pair, it may optionally specify type qualifiers using the ovf:qualifiers attribute with multiple qualifiers separated by commas.  
+  # 
+  #  The settings in  ``Com::Vmware::Vcenter::Ovf::IpAllocationParams``   class  are global to a deployment. Thus, if a virtual machine is part of a virtual appliance, then its settings are ignored and the settings for the virtual appliance is used.  
+  # 
+  #  This information is based on the vmw:IpAssignmentSection in OVF package.  
+  # 
+  #  See   :func:`Com::Vmware::Vcenter::Ovf::LibraryItem.deploy`   and   :func:`Com::Vmware::Vcenter::Ovf::LibraryItem.filter`  .
+  # @!attribute [rw] supported_allocation_scheme
+  #     @return [Array<Com::Vmware::Vcenter::Ovf::IpAllocationParams::IpAllocationScheme>]
+  #     Specifies the IP allocation schemes supported by the guest software. This  field  defines the valid values for the IP allocation policy. This setting is often configured by the virtual appliance template author or OVF package author to reflect what the guest software supports, and the IP allocation policy is configured at deployment time. See   :attr:`Com::Vmware::Vcenter::Ovf::IpAllocationParams.ip_allocation_policy`  .
+  #     This  field  is not used in the input parameters when deploying an OVF package. This  field  will always be present in the result when retrieving information about an OVF package.
+  # @!attribute [rw] supported_ip_allocation_policy
+  #     @return [Array<Com::Vmware::Vcenter::Ovf::IpAllocationParams::IpAllocationPolicy>]
+  #     Specifies the IP allocation policies supported. The set of valid options for the policy is based on the capabilities of the virtual appliance software, as specified by the   :attr:`Com::Vmware::Vcenter::Ovf::IpAllocationParams.supported_allocation_scheme`    field .
+  #     This  field  is not used in the input parameters when deploying an OVF package. This  field  will always be present in the result when retrieving information about an OVF package.
+  # @!attribute [rw] ip_allocation_policy
+  #     @return [Com::Vmware::Vcenter::Ovf::IpAllocationParams::IpAllocationPolicy]
+  #     Specifies how IP allocation is done through an IP Pool. This is typically specified by the deployer.
+  #     This  field  is optional in the input parameters when deploying an OVF package. If  nil  there is no IP allocation policy. This  field  will always be present in the result when retrieving information about an OVF package.
+  # @!attribute [rw] supported_ip_protocol
+  #     @return [Array<Com::Vmware::Vcenter::Ovf::IpAllocationParams::IpProtocol>]
+  #     Specifies the IP protocols supported by the guest.
+  #     This  field  is not used in the input parameters when deploying an OVF package. This  field  will always be present in the result when retrieving information about an OVF package.
+  # @!attribute [rw] ip_protocol
+  #     @return [Com::Vmware::Vcenter::Ovf::IpAllocationParams::IpProtocol]
+  #     Specifies the chosen IP protocol for this deployment. This must be one of the IP protocols supported by the guest software. See   :attr:`Com::Vmware::Vcenter::Ovf::IpAllocationParams.supported_ip_protocol`  .
+  #     This  field  is optional in the input parameters when deploying an OVF package. If  nil  there is no IP protocol chosen. This  field  will always be present in the result when retrieving information about an OVF package.
+  class IpAllocationParams < VAPI::Bindings::VapiStruct
+    class << self
+      # Holds (gets or creates) the binding type metadata for this structure type.
+      # @scope class
+      # @return [VAPI::Bindings::StructType] the binding type
+      def binding_type
+        @binding_type ||= VAPI::Bindings::StructType.new(
+          'com.vmware.vcenter.ovf.ip_allocation_params',
+          {
+            'supported_allocation_scheme' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::ListType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::Ovf::IpAllocationParams::IpAllocationScheme'))),
+            'supported_ip_allocation_policy' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::ListType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::Ovf::IpAllocationParams::IpAllocationPolicy'))),
+            'ip_allocation_policy' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::Ovf::IpAllocationParams::IpAllocationPolicy')),
+            'supported_ip_protocol' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::ListType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::Ovf::IpAllocationParams::IpProtocol'))),
+            'ip_protocol' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::Ovf::IpAllocationParams::IpProtocol')),
+            'type' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::StringType.instance)
+          },
+          IpAllocationParams,
+          false,
+          nil
+        )
+      end
+    end
+
+    attr_accessor :supported_allocation_scheme,
+                  :supported_ip_allocation_policy,
+                  :ip_allocation_policy,
+                  :supported_ip_protocol,
+                  :ip_protocol,
+                  :type
+
+    # Constructs a new instance.
+    # @param ruby_values [Hash] a map of initial property values (optional)
+    # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
+    def initialize(ruby_values = nil, struct_value = nil)
+      super(self.class.binding_type, ruby_values, struct_value)
+    end
+
+    # The  ``Com::Vmware::Vcenter::Ovf::IpAllocationParams::IpAllocationPolicy``   enumerated type  defines the possible IP allocation policy for a deployment.
+    # @!attribute [rw] dhcp
+    #     @return [Com::Vmware::Vcenter::Ovf::IpAllocationParams::IpAllocationPolicy]
+    #     Specifies that DHCP will be used to allocate IP addresses.
+    # @!attribute [rw] transient_ippool
+    #     @return [Com::Vmware::Vcenter::Ovf::IpAllocationParams::IpAllocationPolicy]
+    #     Specifies that IP addresses are allocated from an IP pool. The IP addresses are allocated when needed, typically at power-on, and deallocated during power-off. There is no guarantee that a property will receive same IP address when restarted.
+    # @!attribute [rw] static_manual
+    #     @return [Com::Vmware::Vcenter::Ovf::IpAllocationParams::IpAllocationPolicy]
+    #     Specifies that IP addresses are configured manually upon deployment, and will be kept until reconfigured or the virtual appliance destroyed. This ensures that a property gets a consistent IP for its lifetime.
+    # @!attribute [rw] static_ippool
+    #     @return [Com::Vmware::Vcenter::Ovf::IpAllocationParams::IpAllocationPolicy]
+    #     Specifies that IP addresses are allocated from the range managed by an IP pool. The IP addresses are allocated at first power-on, and remain allocated at power-off. This ensures that a virtual appliance gets a consistent IP for its life-time.
+    class IpAllocationPolicy < VAPI::Bindings::VapiEnum
+      class << self
+        # Holds (gets or creates) the binding type metadata for this enumeration type.
+        # @scope class
+        # @return [VAPI::Bindings::EnumType] the binding type
+        def binding_type
+          @binding_type ||= VAPI::Bindings::EnumType.new(
+            'com.vmware.vcenter.ovf.ip_allocation_params.ip_allocation_policy',
+            IpAllocationPolicy
+          )
+        end
+
+        # Converts from a string value (perhaps off the wire) to an instance
+        # of this enum type.
+        # @param value [String] the actual value of the enum instance
+        # @return [IpAllocationPolicy] the instance found for the value, otherwise
+        #         an unknown instance will be built for the value
+        def from_string(value)
+          const_get(value)
+        rescue NameError
+          IpAllocationPolicy.send(:new, 'UNKNOWN', value)
+        end
+      end
+
+      # Constructs a new instance.
+      # @param value [String] the actual value of the enum instance
+      # @param unknown [String] the unknown value when value is 'UKNOWN'
+      def initialize(value, unknown = nil)
+        super(self.class.binding_type, value, unknown)
+      end
+
+      private_class_method :new
+
+      # @!attribute [rw] dhcp
+      #     @return [Com::Vmware::Vcenter::Ovf::IpAllocationParams::IpAllocationPolicy]
+      #     Specifies that DHCP will be used to allocate IP addresses.
+      DHCP = IpAllocationPolicy.send(:new, 'DHCP')
+
+      # @!attribute [rw] transient_ippool
+      #     @return [Com::Vmware::Vcenter::Ovf::IpAllocationParams::IpAllocationPolicy]
+      #     Specifies that IP addresses are allocated from an IP pool. The IP addresses are allocated when needed, typically at power-on, and deallocated during power-off. There is no guarantee that a property will receive same IP address when restarted.
+      TRANSIENT_IPPOOL = IpAllocationPolicy.send(:new, 'TRANSIENT_IPPOOL')
+
+      # @!attribute [rw] static_manual
+      #     @return [Com::Vmware::Vcenter::Ovf::IpAllocationParams::IpAllocationPolicy]
+      #     Specifies that IP addresses are configured manually upon deployment, and will be kept until reconfigured or the virtual appliance destroyed. This ensures that a property gets a consistent IP for its lifetime.
+      STATIC_MANUAL = IpAllocationPolicy.send(:new, 'STATIC_MANUAL')
+
+      # @!attribute [rw] static_ippool
+      #     @return [Com::Vmware::Vcenter::Ovf::IpAllocationParams::IpAllocationPolicy]
+      #     Specifies that IP addresses are allocated from the range managed by an IP pool. The IP addresses are allocated at first power-on, and remain allocated at power-off. This ensures that a virtual appliance gets a consistent IP for its life-time.
+      STATIC_IPPOOL = IpAllocationPolicy.send(:new, 'STATIC_IPPOOL')
+    end
+
+    # The  ``Com::Vmware::Vcenter::Ovf::IpAllocationParams::IpAllocationScheme``   enumerated type  defines the possible IP allocation schemes that can be supported by the guest software.
+    # @!attribute [rw] dhcp
+    #     @return [Com::Vmware::Vcenter::Ovf::IpAllocationParams::IpAllocationScheme]
+    #     It supports DHCP to acquire IP configuration.
+    # @!attribute [rw] ovf_environment
+    #     @return [Com::Vmware::Vcenter::Ovf::IpAllocationParams::IpAllocationScheme]
+    #     It supports setting the IP configuration through the properties provided in the OVF environment.
+    class IpAllocationScheme < VAPI::Bindings::VapiEnum
+      class << self
+        # Holds (gets or creates) the binding type metadata for this enumeration type.
+        # @scope class
+        # @return [VAPI::Bindings::EnumType] the binding type
+        def binding_type
+          @binding_type ||= VAPI::Bindings::EnumType.new(
+            'com.vmware.vcenter.ovf.ip_allocation_params.ip_allocation_scheme',
+            IpAllocationScheme
+          )
+        end
+
+        # Converts from a string value (perhaps off the wire) to an instance
+        # of this enum type.
+        # @param value [String] the actual value of the enum instance
+        # @return [IpAllocationScheme] the instance found for the value, otherwise
+        #         an unknown instance will be built for the value
+        def from_string(value)
+          const_get(value)
+        rescue NameError
+          IpAllocationScheme.send(:new, 'UNKNOWN', value)
+        end
+      end
+
+      # Constructs a new instance.
+      # @param value [String] the actual value of the enum instance
+      # @param unknown [String] the unknown value when value is 'UKNOWN'
+      def initialize(value, unknown = nil)
+        super(self.class.binding_type, value, unknown)
+      end
+
+      private_class_method :new
+
+      # @!attribute [rw] dhcp
+      #     @return [Com::Vmware::Vcenter::Ovf::IpAllocationParams::IpAllocationScheme]
+      #     It supports DHCP to acquire IP configuration.
+      DHCP = IpAllocationScheme.send(:new, 'DHCP')
+
+      # @!attribute [rw] ovf_environment
+      #     @return [Com::Vmware::Vcenter::Ovf::IpAllocationParams::IpAllocationScheme]
+      #     It supports setting the IP configuration through the properties provided in the OVF environment.
+      OVF_ENVIRONMENT = IpAllocationScheme.send(:new, 'OVF_ENVIRONMENT')
+    end
+
+    # The  ``Com::Vmware::Vcenter::Ovf::IpAllocationParams::IpProtocol``   enumerated type  defines the IP protocols supported by the guest software.
+    # @!attribute [rw] ip_v4
+    #     @return [Com::Vmware::Vcenter::Ovf::IpAllocationParams::IpProtocol]
+    #     It supports the IPv4 protocol.
+    # @!attribute [rw] ip_v6
+    #     @return [Com::Vmware::Vcenter::Ovf::IpAllocationParams::IpProtocol]
+    #     It supports the IPv6 protocol.
+    class IpProtocol < VAPI::Bindings::VapiEnum
+      class << self
+        # Holds (gets or creates) the binding type metadata for this enumeration type.
+        # @scope class
+        # @return [VAPI::Bindings::EnumType] the binding type
+        def binding_type
+          @binding_type ||= VAPI::Bindings::EnumType.new(
+            'com.vmware.vcenter.ovf.ip_allocation_params.ip_protocol',
+            IpProtocol
+          )
+        end
+
+        # Converts from a string value (perhaps off the wire) to an instance
+        # of this enum type.
+        # @param value [String] the actual value of the enum instance
+        # @return [IpProtocol] the instance found for the value, otherwise
+        #         an unknown instance will be built for the value
+        def from_string(value)
+          const_get(value)
+        rescue NameError
+          IpProtocol.send(:new, 'UNKNOWN', value)
+        end
+      end
+
+      # Constructs a new instance.
+      # @param value [String] the actual value of the enum instance
+      # @param unknown [String] the unknown value when value is 'UKNOWN'
+      def initialize(value, unknown = nil)
+        super(self.class.binding_type, value, unknown)
+      end
+
+      private_class_method :new
+
+      # @!attribute [rw] ip_v4
+      #     @return [Com::Vmware::Vcenter::Ovf::IpAllocationParams::IpProtocol]
+      #     It supports the IPv4 protocol.
+      IP_V4 = IpProtocol.send(:new, 'IP_V4')
+
+      # @!attribute [rw] ip_v6
+      #     @return [Com::Vmware::Vcenter::Ovf::IpAllocationParams::IpProtocol]
+      #     It supports the IPv6 protocol.
+      IP_V6 = IpProtocol.send(:new, 'IP_V6')
+    end
+  end
+  # The  ``Com::Vmware::Vcenter::Ovf::OvfMessage``   class  describes a base OVF handling error message related to accessing, validating, deploying, or exporting an OVF package.  
+  # 
+  #  These messages fall into different categories defined in   :class:`Com::Vmware::Vcenter::Ovf::OvfMessage::Category`  :
+  # @!attribute [rw] category
+  #     @return [Com::Vmware::Vcenter::Ovf::OvfMessage::Category]
+  #     The message category.
+  # @!attribute [rw] issues
+  #     @return [Array<Com::Vmware::Vcenter::Ovf::ParseIssue>]
+  #     List  of parse issues (see   :class:`Com::Vmware::Vcenter::Ovf::ParseIssue`  ).
+  #     This  field  is optional and it is only relevant when the value of  ``category``  is   :attr:`Com::Vmware::Vcenter::Ovf::OvfMessage::Category.VALIDATION`  .
+  # @!attribute [rw] name
+  #     @return [String]
+  #     The name of input parameter.
+  #     This  field  is optional and it is only relevant when the value of  ``category``  is   :attr:`Com::Vmware::Vcenter::Ovf::OvfMessage::Category.INPUT`  .
+  # @!attribute [rw] value
+  #     @return [String]
+  #     The value of input parameter.
+  #     This  field  is optional and it is only relevant when the value of  ``category``  is   :attr:`Com::Vmware::Vcenter::Ovf::OvfMessage::Category.INPUT`  .
+  # @!attribute [rw] message
+  #     @return [Com::Vmware::Vapi::Std::LocalizableMessage]
+  #     A localizable message.
+  #     This  field  is optional and it is only relevant when the value of  ``category``  is   :attr:`Com::Vmware::Vcenter::Ovf::OvfMessage::Category.INPUT`  .
+  # @!attribute [rw] error
+  #     @return [VAPI::Bindings::VapiStruct]
+  #     Represents a server   :class:`Com::Vmware::Vapi::Std::Errors::Error`  .
+  #     This  field  is optional and it is only relevant when the value of  ``category``  is   :attr:`Com::Vmware::Vcenter::Ovf::OvfMessage::Category.SERVER`  .
+  class OvfMessage < VAPI::Bindings::VapiStruct
+    class << self
+      # Holds (gets or creates) the binding type metadata for this structure type.
+      # @scope class
+      # @return [VAPI::Bindings::StructType] the binding type
+      def binding_type
+        @binding_type ||= VAPI::Bindings::StructType.new(
+          'com.vmware.vcenter.ovf.ovf_message',
+          {
+            'category' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::Ovf::OvfMessage::Category'),
+            'issues' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::ListType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::Ovf::ParseIssue'))),
+            'name' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::StringType.instance),
+            'value' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::StringType.instance),
+            'message' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::LocalizableMessage')),
+            'error' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::DynamicStructType.new([VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Error')]))
+          },
+          OvfMessage,
+          false,
+          nil
+        )
+      end
+    end
+
+    attr_accessor :category,
+                  :issues,
+                  :name,
+                  :value,
+                  :message,
+                  :error
+
+    # Constructs a new instance.
+    # @param ruby_values [Hash] a map of initial property values (optional)
+    # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
+    def initialize(ruby_values = nil, struct_value = nil)
+      super(self.class.binding_type, ruby_values, struct_value)
+    end
+
+    # The  ``Com::Vmware::Vcenter::Ovf::OvfMessage::Category``   enumerated type  defines the categories of messages (see   :class:`Com::Vmware::Vcenter::Ovf::OvfMessage`  ).
+    # @!attribute [rw] validation
+    #     @return [Com::Vmware::Vcenter::Ovf::OvfMessage::Category]
+    #     The OVF descriptor is invalid, for example, syntax errors or schema errors.
+    # @!attribute [rw] input
+    #     @return [Com::Vmware::Vcenter::Ovf::OvfMessage::Category]
+    #     The user provided input parameters are invalid.
+    # @!attribute [rw] server
+    #     @return [Com::Vmware::Vcenter::Ovf::OvfMessage::Category]
+    #     Server error.
+    class Category < VAPI::Bindings::VapiEnum
+      class << self
+        # Holds (gets or creates) the binding type metadata for this enumeration type.
+        # @scope class
+        # @return [VAPI::Bindings::EnumType] the binding type
+        def binding_type
+          @binding_type ||= VAPI::Bindings::EnumType.new(
+            'com.vmware.vcenter.ovf.ovf_message.category',
+            Category
+          )
+        end
+
+        # Converts from a string value (perhaps off the wire) to an instance
+        # of this enum type.
+        # @param value [String] the actual value of the enum instance
+        # @return [Category] the instance found for the value, otherwise
+        #         an unknown instance will be built for the value
+        def from_string(value)
+          const_get(value)
+        rescue NameError
+          Category.send(:new, 'UNKNOWN', value)
+        end
+      end
+
+      # Constructs a new instance.
+      # @param value [String] the actual value of the enum instance
+      # @param unknown [String] the unknown value when value is 'UKNOWN'
+      def initialize(value, unknown = nil)
+        super(self.class.binding_type, value, unknown)
+      end
+
+      private_class_method :new
+
+      # @!attribute [rw] validation
+      #     @return [Com::Vmware::Vcenter::Ovf::OvfMessage::Category]
+      #     The OVF descriptor is invalid, for example, syntax errors or schema errors.
+      VALIDATION = Category.send(:new, 'VALIDATION')
+
+      # @!attribute [rw] input
+      #     @return [Com::Vmware::Vcenter::Ovf::OvfMessage::Category]
+      #     The user provided input parameters are invalid.
+      INPUT = Category.send(:new, 'INPUT')
+
+      # @!attribute [rw] server
+      #     @return [Com::Vmware::Vcenter::Ovf::OvfMessage::Category]
+      #     Server error.
+      SERVER = Category.send(:new, 'SERVER')
+    end
+  end
+  # The  ``Com::Vmware::Vcenter::Ovf::ParseIssue``   class  contains the information about the issue found when parsing an OVF package during deployment or exporting an OVF package including:  
+  # 
+  #   * Parsing and validation error on OVF descriptor (which is an XML document), manifest and certificate files. 
+  #  * OVF descriptor generating and device error. 
+  #  * Unexpected server error. 
+  # @!attribute [rw] category
+  #     @return [Com::Vmware::Vcenter::Ovf::ParseIssue::Category]
+  #     The category of the parse issue.
+  # @!attribute [rw] file
+  #     @return [String]
+  #     The name of the file in which the parse issue was found.
+  # @!attribute [rw] line_number
+  #     @return [Fixnum]
+  #     The line number of the line in the file (see   :attr:`Com::Vmware::Vcenter::Ovf::ParseIssue.file`  ) where the parse issue was found (or -1 if not applicable).
+  # @!attribute [rw] column_number
+  #     @return [Fixnum]
+  #     The position in the line (see   :attr:`Com::Vmware::Vcenter::Ovf::ParseIssue.line_number`  ) (or -1 if not applicable).
+  # @!attribute [rw] message
+  #     @return [Com::Vmware::Vapi::Std::LocalizableMessage]
+  #     A localizable message describing the parse issue.
+  class ParseIssue < VAPI::Bindings::VapiStruct
+    class << self
+      # Holds (gets or creates) the binding type metadata for this structure type.
+      # @scope class
+      # @return [VAPI::Bindings::StructType] the binding type
+      def binding_type
+        @binding_type ||= VAPI::Bindings::StructType.new(
+          'com.vmware.vcenter.ovf.parse_issue',
+          {
+            'category' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::Ovf::ParseIssue::Category'),
+            'file' => VAPI::Bindings::StringType.instance,
+            'line_number' => VAPI::Bindings::IntegerType.instance,
+            'column_number' => VAPI::Bindings::IntegerType.instance,
+            'message' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::LocalizableMessage')
+          },
+          ParseIssue,
+          false,
+          nil
+        )
+      end
+    end
+
+    attr_accessor :category,
+                  :file,
+                  :line_number,
+                  :column_number,
+                  :message
+
+    # Constructs a new instance.
+    # @param ruby_values [Hash] a map of initial property values (optional)
+    # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
+    def initialize(ruby_values = nil, struct_value = nil)
+      super(self.class.binding_type, ruby_values, struct_value)
+    end
+
+    # The  ``Com::Vmware::Vcenter::Ovf::ParseIssue::Category``   enumerated type  defines the categories of issues that can be found when parsing files inside an OVF package (see   :class:`Com::Vmware::Vcenter::Ovf::ParseIssue`  ) including OVF descriptor (which is an XML document), manifest and certificate files, or exporting an OVF package.
+    # @!attribute [rw] value_illegal
     #     @return [Com::Vmware::Vcenter::Ovf::ParseIssue::Category]
-    #     The category of the parse issue.
-    # @!attribute [rw] file
-    #     @return [String]
-    #     The name of the file in which the parse issue was found.
-    # @!attribute [rw] line_number
-    #     @return [Fixnum]
-    #     The line number of the line in the file (see   :attr:`Com::Vmware::Vcenter::Ovf::ParseIssue.file`  ) where the parse issue was found (or -1 if not applicable).
-    # @!attribute [rw] column_number
-    #     @return [Fixnum]
-    #     The position in the line (see   :attr:`Com::Vmware::Vcenter::Ovf::ParseIssue.line_number`  ) (or -1 if not applicable).
-    # @!attribute [rw] message
-    #     @return [Com::Vmware::Vapi::Std::LocalizableMessage]
-    #     A localizable message describing the parse issue.
-    class ParseIssue < VAPI::Bindings::VapiStruct
-
-        class << self
-            # Holds (gets or creates) the binding type metadata for this structure type.
-            # @scope class
-            # @return [VAPI::Bindings::StructType] the binding type
-            def binding_type
-                @binding_type ||= VAPI::Bindings::StructType.new(
-                    'com.vmware.vcenter.ovf.parse_issue',
-                    {
-                        'category' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::Ovf::ParseIssue::Category'),
-                        'file' => VAPI::Bindings::StringType.instance,
-                        'line_number' => VAPI::Bindings::IntegerType.instance,
-                        'column_number' => VAPI::Bindings::IntegerType.instance,
-                        'message' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::LocalizableMessage'),
-                    },
-                    ParseIssue,
-                    false,
-                    nil)
-            end
-        end
-
-        attr_accessor :category,
-                      :file,
-                      :line_number,
-                      :column_number,
-                      :message
-
-        # Constructs a new instance.
-        # @param ruby_values [Hash] a map of initial property values (optional)
-        # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
-        def initialize(ruby_values=nil, struct_value=nil)
-            super(self.class.binding_type, ruby_values, struct_value)
-        end
-
-
-        # The  ``Com::Vmware::Vcenter::Ovf::ParseIssue::Category``   enumerated type  defines the categories of issues that can be found when parsing files inside an OVF package (see   :class:`Com::Vmware::Vcenter::Ovf::ParseIssue`  ) including OVF descriptor (which is an XML document), manifest and certificate files, or exporting an OVF package.
-        # @!attribute [rw] value_illegal
-        #     @return [Com::Vmware::Vcenter::Ovf::ParseIssue::Category]
-        #     Illegal value error. For example, the value is malformed, not a number, or outside of the given range, and so on.
-        # @!attribute [rw] attribute_required
-        #     @return [Com::Vmware::Vcenter::Ovf::ParseIssue::Category]
-        #     Required attribute error. It indicates that a required attribute is missing from an element in the OVF descriptor.
-        # @!attribute [rw] attribute_illegal
-        #     @return [Com::Vmware::Vcenter::Ovf::ParseIssue::Category]
-        #     Illegal attribute error. It indicates that an illegal attribute is set for an element in the OVF descriptor. For example, empty disks do not use format, parentRef, and populatedSize attributes, if these attributes are present in an empty disk element then will get this pasrse issue.
-        # @!attribute [rw] element_required
-        #     @return [Com::Vmware::Vcenter::Ovf::ParseIssue::Category]
-        #     Required element error. It indicates that a required element is missing from the OVF descriptor.
-        # @!attribute [rw] element_illegal
-        #     @return [Com::Vmware::Vcenter::Ovf::ParseIssue::Category]
-        #     Illegal element error. It indicates that an element is present in a location which is not allowed, or found multiple elements but only one is allowed at the location in the OVF descriptor.
-        # @!attribute [rw] element_unknown
-        #     @return [Com::Vmware::Vcenter::Ovf::ParseIssue::Category]
-        #     Unknown element error. It indicates that an element is unsupported when parsing an OVF descriptor.
-        # @!attribute [rw] section_unknown
-        #     @return [Com::Vmware::Vcenter::Ovf::ParseIssue::Category]
-        #     Section unknown error. It indicates that a section is unsupported when parsing an OVF descriptor.
-        # @!attribute [rw] section_restriction
-        #     @return [Com::Vmware::Vcenter::Ovf::ParseIssue::Category]
-        #     Section restriction error. It indicates that a section appears in place in the OVF descriptor where it is not allowed, a section appears fewer times than is required, or a section appears more times than is allowed.
-        # @!attribute [rw] parse_error
-        #     @return [Com::Vmware::Vcenter::Ovf::ParseIssue::Category]
-        #     OVF package parsing error, including:  
-        #     
-        #       * OVF descriptor parsing errors, for example, syntax errors or schema errors. 
-        #      * Manifest file parsing and verification errors. 
-        #      * Certificate file parsing and verification errors. 
-        # @!attribute [rw] generate_error
-        #     @return [Com::Vmware::Vcenter::Ovf::ParseIssue::Category]
-        #     OVF descriptor (which is an XML document) generating error, for example, well-formedness errors as well as unexpected processing conditions.
-        # @!attribute [rw] validation_error
-        #     @return [Com::Vmware::Vcenter::Ovf::ParseIssue::Category]
-        #     An issue with the manifest and signing.
-        # @!attribute [rw] export_error
-        #     @return [Com::Vmware::Vcenter::Ovf::ParseIssue::Category]
-        #     Issue during OVF export, for example, malformed deviceId, controller not found, or file backing for a device not found.
-        # @!attribute [rw] internal_error
-        #     @return [Com::Vmware::Vcenter::Ovf::ParseIssue::Category]
-        #     Server encountered an unexpected error which prevented it from fulfilling the request.
-        class Category < VAPI::Bindings::VapiEnum
-
-            class << self
-                # Holds (gets or creates) the binding type metadata for this enumeration type.
-                # @scope class
-                # @return [VAPI::Bindings::EnumType] the binding type
-                def binding_type
-                    @binding_type ||= VAPI::Bindings::EnumType.new(
-                        'com.vmware.vcenter.ovf.parse_issue.category',
-                        Category)
-                end
-
-                # Converts from a string value (perhaps off the wire) to an instance
-                # of this enum type.
-                # @param value [String] the actual value of the enum instance
-                # @return [Category] the instance found for the value, otherwise
-                #         an unknown instance will be built for the value
-                def from_string(value)
-                    begin
-                        const_get(value)
-                    rescue NameError
-                        Category.new('UNKNOWN', value)
-                    end
-                end
-            end
-
-            private
-
-            # Constructs a new instance.
-            # @param value [String] the actual value of the enum instance
-            # @param unknown [String] the unknown value when value is 'UKNOWN'
-            def initialize(value, unknown=nil)
-                super(self.class.binding_type, value, unknown)
-            end
-
-            public
-
-            # @!attribute [rw] value_illegal
-            #     @return [Com::Vmware::Vcenter::Ovf::ParseIssue::Category]
-            #     Illegal value error. For example, the value is malformed, not a number, or outside of the given range, and so on.
-            VALUE_ILLEGAL = Category.new('VALUE_ILLEGAL')
-
-            # @!attribute [rw] attribute_required
-            #     @return [Com::Vmware::Vcenter::Ovf::ParseIssue::Category]
-            #     Required attribute error. It indicates that a required attribute is missing from an element in the OVF descriptor.
-            ATTRIBUTE_REQUIRED = Category.new('ATTRIBUTE_REQUIRED')
-
-            # @!attribute [rw] attribute_illegal
-            #     @return [Com::Vmware::Vcenter::Ovf::ParseIssue::Category]
-            #     Illegal attribute error. It indicates that an illegal attribute is set for an element in the OVF descriptor. For example, empty disks do not use format, parentRef, and populatedSize attributes, if these attributes are present in an empty disk element then will get this pasrse issue.
-            ATTRIBUTE_ILLEGAL = Category.new('ATTRIBUTE_ILLEGAL')
-
-            # @!attribute [rw] element_required
-            #     @return [Com::Vmware::Vcenter::Ovf::ParseIssue::Category]
-            #     Required element error. It indicates that a required element is missing from the OVF descriptor.
-            ELEMENT_REQUIRED = Category.new('ELEMENT_REQUIRED')
-
-            # @!attribute [rw] element_illegal
-            #     @return [Com::Vmware::Vcenter::Ovf::ParseIssue::Category]
-            #     Illegal element error. It indicates that an element is present in a location which is not allowed, or found multiple elements but only one is allowed at the location in the OVF descriptor.
-            ELEMENT_ILLEGAL = Category.new('ELEMENT_ILLEGAL')
-
-            # @!attribute [rw] element_unknown
-            #     @return [Com::Vmware::Vcenter::Ovf::ParseIssue::Category]
-            #     Unknown element error. It indicates that an element is unsupported when parsing an OVF descriptor.
-            ELEMENT_UNKNOWN = Category.new('ELEMENT_UNKNOWN')
-
-            # @!attribute [rw] section_unknown
-            #     @return [Com::Vmware::Vcenter::Ovf::ParseIssue::Category]
-            #     Section unknown error. It indicates that a section is unsupported when parsing an OVF descriptor.
-            SECTION_UNKNOWN = Category.new('SECTION_UNKNOWN')
-
-            # @!attribute [rw] section_restriction
-            #     @return [Com::Vmware::Vcenter::Ovf::ParseIssue::Category]
-            #     Section restriction error. It indicates that a section appears in place in the OVF descriptor where it is not allowed, a section appears fewer times than is required, or a section appears more times than is allowed.
-            SECTION_RESTRICTION = Category.new('SECTION_RESTRICTION')
-
-            # @!attribute [rw] parse_error
-            #     @return [Com::Vmware::Vcenter::Ovf::ParseIssue::Category]
-            #     OVF package parsing error, including:  
-            #     
-            #       * OVF descriptor parsing errors, for example, syntax errors or schema errors. 
-            #      * Manifest file parsing and verification errors. 
-            #      * Certificate file parsing and verification errors. 
-            PARSE_ERROR = Category.new('PARSE_ERROR')
-
-            # @!attribute [rw] generate_error
-            #     @return [Com::Vmware::Vcenter::Ovf::ParseIssue::Category]
-            #     OVF descriptor (which is an XML document) generating error, for example, well-formedness errors as well as unexpected processing conditions.
-            GENERATE_ERROR = Category.new('GENERATE_ERROR')
-
-            # @!attribute [rw] validation_error
-            #     @return [Com::Vmware::Vcenter::Ovf::ParseIssue::Category]
-            #     An issue with the manifest and signing.
-            VALIDATION_ERROR = Category.new('VALIDATION_ERROR')
-
-            # @!attribute [rw] export_error
-            #     @return [Com::Vmware::Vcenter::Ovf::ParseIssue::Category]
-            #     Issue during OVF export, for example, malformed deviceId, controller not found, or file backing for a device not found.
-            EXPORT_ERROR = Category.new('EXPORT_ERROR')
-
-            # @!attribute [rw] internal_error
-            #     @return [Com::Vmware::Vcenter::Ovf::ParseIssue::Category]
-            #     Server encountered an unexpected error which prevented it from fulfilling the request.
-            INTERNAL_ERROR = Category.new('INTERNAL_ERROR')
-
-        end
-
-
-    end
-
-
-    # The  ``Com::Vmware::Vcenter::Ovf::OvfError``   class  describes an error related to accessing, validating, deploying, or exporting an OVF package.
-    class OvfError < VAPI::Bindings::VapiStruct
-
-        class << self
-            # Holds (gets or creates) the binding type metadata for this structure type.
-            # @scope class
-            # @return [VAPI::Bindings::StructType] the binding type
-            def binding_type
-                @binding_type ||= VAPI::Bindings::StructType.new(
-                    'com.vmware.vcenter.ovf.ovf_error',
-                    {
-                        'category' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::Ovf::OvfMessage::Category'),
-                        'issues' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::ListType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::Ovf::ParseIssue'))),
-                        'name' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::StringType.instance),
-                        'value' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::StringType.instance),
-                        'message' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::LocalizableMessage')),
-                        'error' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::DynamicStructType.new([VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Error')])),
-                    },
-                    OvfError,
-                    false,
-                    nil)
-            end
-        end
-
-        attr_accessor :category,
-                      :issues,
-                      :name,
-                      :value,
-                      :message,
-                      :error
-
-        # Constructs a new instance.
-        # @param ruby_values [Hash] a map of initial property values (optional)
-        # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
-        def initialize(ruby_values=nil, struct_value=nil)
-            super(self.class.binding_type, ruby_values, struct_value)
-        end
-    end
-
-
-    # The  ``Com::Vmware::Vcenter::Ovf::OvfWarning``   class  describes a warning related to accessing, validating, deploying, or exporting an OVF package.
-    class OvfWarning < VAPI::Bindings::VapiStruct
-
-        class << self
-            # Holds (gets or creates) the binding type metadata for this structure type.
-            # @scope class
-            # @return [VAPI::Bindings::StructType] the binding type
-            def binding_type
-                @binding_type ||= VAPI::Bindings::StructType.new(
-                    'com.vmware.vcenter.ovf.ovf_warning',
-                    {
-                        'category' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::Ovf::OvfMessage::Category'),
-                        'issues' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::ListType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::Ovf::ParseIssue'))),
-                        'name' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::StringType.instance),
-                        'value' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::StringType.instance),
-                        'message' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::LocalizableMessage')),
-                        'error' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::DynamicStructType.new([VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Error')])),
-                    },
-                    OvfWarning,
-                    false,
-                    nil)
-            end
-        end
-
-        attr_accessor :category,
-                      :issues,
-                      :name,
-                      :value,
-                      :message,
-                      :error
-
-        # Constructs a new instance.
-        # @param ruby_values [Hash] a map of initial property values (optional)
-        # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
-        def initialize(ruby_values=nil, struct_value=nil)
-            super(self.class.binding_type, ruby_values, struct_value)
-        end
-    end
-
-
-    # The  ``Com::Vmware::Vcenter::Ovf::OvfInfo``   class  contains informational messages related to accessing, validating, deploying, or exporting an OVF package.
-    # @!attribute [rw] messages
-    #     @return [Array<Com::Vmware::Vapi::Std::LocalizableMessage>]
-    #     A  list  of localizable messages (see   :class:`Com::Vmware::Vapi::Std::LocalizableMessage`  ).
-    class OvfInfo < VAPI::Bindings::VapiStruct
-
-        class << self
-            # Holds (gets or creates) the binding type metadata for this structure type.
-            # @scope class
-            # @return [VAPI::Bindings::StructType] the binding type
-            def binding_type
-                @binding_type ||= VAPI::Bindings::StructType.new(
-                    'com.vmware.vcenter.ovf.ovf_info',
-                    {
-                        'messages' => VAPI::Bindings::ListType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::LocalizableMessage')),
-                    },
-                    OvfInfo,
-                    false,
-                    nil)
-            end
-        end
-
-        attr_accessor :messages
-
-        # Constructs a new instance.
-        # @param ruby_values [Hash] a map of initial property values (optional)
-        # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
-        def initialize(ruby_values=nil, struct_value=nil)
-            super(self.class.binding_type, ruby_values, struct_value)
-        end
-    end
-
-
-    # The  ``Com::Vmware::Vcenter::Ovf::OvfParams``   class  defines the common  fields  for all OVF deployment parameters. OVF parameters serve several purposes:  
-    # 
-    #   * Describe information about a given OVF package. 
-    #  * Describe default deployment configuration. 
-    #  * Describe possible deployment values based on the deployment environment. 
-    #  * Provide deployment-specific configuration. 
-    # 
-    #   Each OVF parameters  class  specifies a particular configurable aspect of OVF deployment. An aspect has both a query-model and a deploy-model. The query-model is used when the OVF package is queried, and the deploy-model is used when deploying an OVF package.  
-    # 
-    #  Most OVF parameter  classes  provide both informational and deployment parameters. However, some are purely informational (for example, download size) and some are purely deployment parameters (for example, the flag to indicate whether registration as a vCenter extension is accepted).  
-    # 
-    #  See   :func:`Com::Vmware::Vcenter::Ovf::LibraryItem.deploy`   and   :func:`Com::Vmware::Vcenter::Ovf::LibraryItem.filter`  .
-    # @!attribute [rw] type
-    #     @return [String]
-    #     Unique identifier describing the type of the OVF parameters. The value is the name of the OVF parameters  class .
-    #     This  field  must be provided in the input parameters when deploying an OVF package. This  field  will always be present in the result when retrieving information about an OVF package.
-    class OvfParams < VAPI::Bindings::VapiStruct
-
-        class << self
-            # Holds (gets or creates) the binding type metadata for this structure type.
-            # @scope class
-            # @return [VAPI::Bindings::StructType] the binding type
-            def binding_type
-                @binding_type ||= VAPI::Bindings::StructType.new(
-                    'com.vmware.vcenter.ovf.ovf_params',
-                    {
-                        'type' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::StringType.instance),
-                    },
-                    OvfParams,
-                    false,
-                    nil)
-            end
-        end
-
-        attr_accessor :type
-
-        # Constructs a new instance.
-        # @param ruby_values [Hash] a map of initial property values (optional)
-        # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
-        def initialize(ruby_values=nil, struct_value=nil)
-            super(self.class.binding_type, ruby_values, struct_value)
-        end
-    end
-
-
-    # The  ``Com::Vmware::Vcenter::Ovf::Property``   class  contains the information about a property in an OVF package.  
-    # 
-    #  A property is uniquely identified by its [classid.]id[.instanceid] fully-qualified name (see   :attr:`Com::Vmware::Vcenter::Ovf::Property.class_id`  ,   :attr:`Com::Vmware::Vcenter::Ovf::Property.id`  , and   :attr:`Com::Vmware::Vcenter::Ovf::Property.instance_id`  ). If multiple properties in an OVF package have the same fully-qualified name, then the property is excluded and cannot be set. We do warn about this during import.  
-    # 
-    #  See   :func:`Com::Vmware::Vcenter::Ovf::LibraryItem.deploy`   and   :func:`Com::Vmware::Vcenter::Ovf::LibraryItem.filter`  .
-    # @!attribute [rw] class_id
-    #     @return [String]
-    #     The classId of this OVF property.
-    #     This  field  is not used in the input parameters when deploying an OVF package. This  field  will always be present in the result when retrieving information about an OVF package.
-    # @!attribute [rw] id
-    #     @return [String]
-    #     The identifier of this OVF property.
-    #     This  field  must be provided in the input parameters when deploying an OVF package. This  field  will always be present in the result when retrieving information about an OVF package.
-    # @!attribute [rw] instance_id
-    #     @return [String]
-    #     The instanceId of this OVF property.
-    #     This  field  is not used in the input parameters when deploying an OVF package. This  field  will always be present in the result when retrieving information about an OVF package.
-    # @!attribute [rw] category
-    #     @return [String]
-    #     If this is set to a non-empty string, this property starts a new category.
-    #     This  field  is not used in the input parameters when deploying an OVF package. This  field  is optional in the result when retrieving information about an OVF package. If  nil , the property is in the same category as the previous item, otherwise, it starts a new category.
-    # @!attribute [rw] ui_optional
-    #     @return [Boolean]
-    #     Whether a category is UI optional. This is only used if this property starts a new category (see   :attr:`Com::Vmware::Vcenter::Ovf::Property.category`  ).  
+    #     Illegal value error. For example, the value is malformed, not a number, or outside of the given range, and so on.
+    # @!attribute [rw] attribute_required
+    #     @return [Com::Vmware::Vcenter::Ovf::ParseIssue::Category]
+    #     Required attribute error. It indicates that a required attribute is missing from an element in the OVF descriptor.
+    # @!attribute [rw] attribute_illegal
+    #     @return [Com::Vmware::Vcenter::Ovf::ParseIssue::Category]
+    #     Illegal attribute error. It indicates that an illegal attribute is set for an element in the OVF descriptor. For example, empty disks do not use format, parentRef, and populatedSize attributes, if these attributes are present in an empty disk element then will get this pasrse issue.
+    # @!attribute [rw] element_required
+    #     @return [Com::Vmware::Vcenter::Ovf::ParseIssue::Category]
+    #     Required element error. It indicates that a required element is missing from the OVF descriptor.
+    # @!attribute [rw] element_illegal
+    #     @return [Com::Vmware::Vcenter::Ovf::ParseIssue::Category]
+    #     Illegal element error. It indicates that an element is present in a location which is not allowed, or found multiple elements but only one is allowed at the location in the OVF descriptor.
+    # @!attribute [rw] element_unknown
+    #     @return [Com::Vmware::Vcenter::Ovf::ParseIssue::Category]
+    #     Unknown element error. It indicates that an element is unsupported when parsing an OVF descriptor.
+    # @!attribute [rw] section_unknown
+    #     @return [Com::Vmware::Vcenter::Ovf::ParseIssue::Category]
+    #     Section unknown error. It indicates that a section is unsupported when parsing an OVF descriptor.
+    # @!attribute [rw] section_restriction
+    #     @return [Com::Vmware::Vcenter::Ovf::ParseIssue::Category]
+    #     Section restriction error. It indicates that a section appears in place in the OVF descriptor where it is not allowed, a section appears fewer times than is required, or a section appears more times than is allowed.
+    # @!attribute [rw] parse_error
+    #     @return [Com::Vmware::Vcenter::Ovf::ParseIssue::Category]
+    #     OVF package parsing error, including:  
     #     
-    #      The value is stored in an optional attribute vmw:uioptional to the ovf:Category element. The default value is false. If this value is true, the properties within this category are optional. The UI renders this as a group with a check box, and the group is grayed out until the check box is selected. When the check box is selected, the input values are read and used in deployment. If properties within the same category specify conflicting values the default is used. Only implemented in vSphere Web Client 5.1 and later as of Nov 2012.
-    #     This  field  is not used in the input parameters when deploying an OVF package. This  field  is optional in the result when retrieving information about an OVF package.
-    # @!attribute [rw] label
-    #     @return [String]
-    #     The display name of this OVF property.
-    #     This  field  is not used in the input parameters when deploying an OVF package. This  field  will always be present in the result when retrieving information about an OVF package.
-    # @!attribute [rw] description
-    #     @return [String]
-    #     A description of this OVF property.
-    #     This  field  is not used in the input parameters when deploying an OVF package. This  field  is optional in the result when retrieving information about an OVF package.
-    # @!attribute [rw] type
-    #     @return [String]
-    #     The type of this OVF property. Refer to the configuration of a virtual appliance/virtual machine for the valid values.
-    #     This  field  is not used in the input parameters when deploying an OVF package. This  field  will always be present in the result when retrieving information about an OVF package.
-    # @!attribute [rw] value
-    #     @return [String]
-    #     The OVF property value. This contains the default value from ovf:defaultValue if ovf:value is not present when read.
-    #     This  field  must be provided in the input parameters when deploying an OVF package. This  field  will always be present in the result when retrieving information about an OVF package.
-    class Property < VAPI::Bindings::VapiStruct
-
-        class << self
-            # Holds (gets or creates) the binding type metadata for this structure type.
-            # @scope class
-            # @return [VAPI::Bindings::StructType] the binding type
-            def binding_type
-                @binding_type ||= VAPI::Bindings::StructType.new(
-                    'com.vmware.vcenter.ovf.property',
-                    {
-                        'class_id' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::StringType.instance),
-                        'id' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::StringType.instance),
-                        'instance_id' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::StringType.instance),
-                        'category' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::StringType.instance),
-                        'ui_optional' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::BooleanType.instance),
-                        'label' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::StringType.instance),
-                        'description' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::StringType.instance),
-                        'type' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::StringType.instance),
-                        'value' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::StringType.instance),
-                    },
-                    Property,
-                    false,
-                    nil)
-            end
+    #       * OVF descriptor parsing errors, for example, syntax errors or schema errors. 
+    #      * Manifest file parsing and verification errors. 
+    #      * Certificate file parsing and verification errors. 
+    # @!attribute [rw] generate_error
+    #     @return [Com::Vmware::Vcenter::Ovf::ParseIssue::Category]
+    #     OVF descriptor (which is an XML document) generating error, for example, well-formedness errors as well as unexpected processing conditions.
+    # @!attribute [rw] validation_error
+    #     @return [Com::Vmware::Vcenter::Ovf::ParseIssue::Category]
+    #     An issue with the manifest and signing.
+    # @!attribute [rw] export_error
+    #     @return [Com::Vmware::Vcenter::Ovf::ParseIssue::Category]
+    #     Issue during OVF export, for example, malformed deviceId, controller not found, or file backing for a device not found.
+    # @!attribute [rw] internal_error
+    #     @return [Com::Vmware::Vcenter::Ovf::ParseIssue::Category]
+    #     Server encountered an unexpected error which prevented it from fulfilling the request.
+    class Category < VAPI::Bindings::VapiEnum
+      class << self
+        # Holds (gets or creates) the binding type metadata for this enumeration type.
+        # @scope class
+        # @return [VAPI::Bindings::EnumType] the binding type
+        def binding_type
+          @binding_type ||= VAPI::Bindings::EnumType.new(
+            'com.vmware.vcenter.ovf.parse_issue.category',
+            Category
+          )
         end
 
-        attr_accessor :class_id,
-                      :id,
-                      :instance_id,
-                      :category,
-                      :ui_optional,
-                      :label,
-                      :description,
-                      :type,
-                      :value
-
-        # Constructs a new instance.
-        # @param ruby_values [Hash] a map of initial property values (optional)
-        # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
-        def initialize(ruby_values=nil, struct_value=nil)
-            super(self.class.binding_type, ruby_values, struct_value)
+        # Converts from a string value (perhaps off the wire) to an instance
+        # of this enum type.
+        # @param value [String] the actual value of the enum instance
+        # @return [Category] the instance found for the value, otherwise
+        #         an unknown instance will be built for the value
+        def from_string(value)
+          const_get(value)
+        rescue NameError
+          Category.send(:new, 'UNKNOWN', value)
         end
+      end
+
+      # Constructs a new instance.
+      # @param value [String] the actual value of the enum instance
+      # @param unknown [String] the unknown value when value is 'UKNOWN'
+      def initialize(value, unknown = nil)
+        super(self.class.binding_type, value, unknown)
+      end
+
+      private_class_method :new
+
+      # @!attribute [rw] value_illegal
+      #     @return [Com::Vmware::Vcenter::Ovf::ParseIssue::Category]
+      #     Illegal value error. For example, the value is malformed, not a number, or outside of the given range, and so on.
+      VALUE_ILLEGAL = Category.send(:new, 'VALUE_ILLEGAL')
+
+      # @!attribute [rw] attribute_required
+      #     @return [Com::Vmware::Vcenter::Ovf::ParseIssue::Category]
+      #     Required attribute error. It indicates that a required attribute is missing from an element in the OVF descriptor.
+      ATTRIBUTE_REQUIRED = Category.send(:new, 'ATTRIBUTE_REQUIRED')
+
+      # @!attribute [rw] attribute_illegal
+      #     @return [Com::Vmware::Vcenter::Ovf::ParseIssue::Category]
+      #     Illegal attribute error. It indicates that an illegal attribute is set for an element in the OVF descriptor. For example, empty disks do not use format, parentRef, and populatedSize attributes, if these attributes are present in an empty disk element then will get this pasrse issue.
+      ATTRIBUTE_ILLEGAL = Category.send(:new, 'ATTRIBUTE_ILLEGAL')
+
+      # @!attribute [rw] element_required
+      #     @return [Com::Vmware::Vcenter::Ovf::ParseIssue::Category]
+      #     Required element error. It indicates that a required element is missing from the OVF descriptor.
+      ELEMENT_REQUIRED = Category.send(:new, 'ELEMENT_REQUIRED')
+
+      # @!attribute [rw] element_illegal
+      #     @return [Com::Vmware::Vcenter::Ovf::ParseIssue::Category]
+      #     Illegal element error. It indicates that an element is present in a location which is not allowed, or found multiple elements but only one is allowed at the location in the OVF descriptor.
+      ELEMENT_ILLEGAL = Category.send(:new, 'ELEMENT_ILLEGAL')
+
+      # @!attribute [rw] element_unknown
+      #     @return [Com::Vmware::Vcenter::Ovf::ParseIssue::Category]
+      #     Unknown element error. It indicates that an element is unsupported when parsing an OVF descriptor.
+      ELEMENT_UNKNOWN = Category.send(:new, 'ELEMENT_UNKNOWN')
+
+      # @!attribute [rw] section_unknown
+      #     @return [Com::Vmware::Vcenter::Ovf::ParseIssue::Category]
+      #     Section unknown error. It indicates that a section is unsupported when parsing an OVF descriptor.
+      SECTION_UNKNOWN = Category.send(:new, 'SECTION_UNKNOWN')
+
+      # @!attribute [rw] section_restriction
+      #     @return [Com::Vmware::Vcenter::Ovf::ParseIssue::Category]
+      #     Section restriction error. It indicates that a section appears in place in the OVF descriptor where it is not allowed, a section appears fewer times than is required, or a section appears more times than is allowed.
+      SECTION_RESTRICTION = Category.send(:new, 'SECTION_RESTRICTION')
+
+      # @!attribute [rw] parse_error
+      #     @return [Com::Vmware::Vcenter::Ovf::ParseIssue::Category]
+      #     OVF package parsing error, including:  
+      #     
+      #       * OVF descriptor parsing errors, for example, syntax errors or schema errors. 
+      #      * Manifest file parsing and verification errors. 
+      #      * Certificate file parsing and verification errors. 
+      PARSE_ERROR = Category.send(:new, 'PARSE_ERROR')
+
+      # @!attribute [rw] generate_error
+      #     @return [Com::Vmware::Vcenter::Ovf::ParseIssue::Category]
+      #     OVF descriptor (which is an XML document) generating error, for example, well-formedness errors as well as unexpected processing conditions.
+      GENERATE_ERROR = Category.send(:new, 'GENERATE_ERROR')
+
+      # @!attribute [rw] validation_error
+      #     @return [Com::Vmware::Vcenter::Ovf::ParseIssue::Category]
+      #     An issue with the manifest and signing.
+      VALIDATION_ERROR = Category.send(:new, 'VALIDATION_ERROR')
+
+      # @!attribute [rw] export_error
+      #     @return [Com::Vmware::Vcenter::Ovf::ParseIssue::Category]
+      #     Issue during OVF export, for example, malformed deviceId, controller not found, or file backing for a device not found.
+      EXPORT_ERROR = Category.send(:new, 'EXPORT_ERROR')
+
+      # @!attribute [rw] internal_error
+      #     @return [Com::Vmware::Vcenter::Ovf::ParseIssue::Category]
+      #     Server encountered an unexpected error which prevented it from fulfilling the request.
+      INTERNAL_ERROR = Category.send(:new, 'INTERNAL_ERROR')
+    end
+  end
+  # The  ``Com::Vmware::Vcenter::Ovf::OvfError``   class  describes an error related to accessing, validating, deploying, or exporting an OVF package.
+  class OvfError < VAPI::Bindings::VapiStruct
+    class << self
+      # Holds (gets or creates) the binding type metadata for this structure type.
+      # @scope class
+      # @return [VAPI::Bindings::StructType] the binding type
+      def binding_type
+        @binding_type ||= VAPI::Bindings::StructType.new(
+          'com.vmware.vcenter.ovf.ovf_error',
+          {
+            'category' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::Ovf::OvfMessage::Category'),
+            'issues' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::ListType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::Ovf::ParseIssue'))),
+            'name' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::StringType.instance),
+            'value' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::StringType.instance),
+            'message' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::LocalizableMessage')),
+            'error' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::DynamicStructType.new([VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Error')]))
+          },
+          OvfError,
+          false,
+          nil
+        )
+      end
     end
 
+    attr_accessor :category,
+                  :issues,
+                  :name,
+                  :value,
+                  :message,
+                  :error
 
-    # The  ``Com::Vmware::Vcenter::Ovf::PropertyParams``   class  contains a  list  of OVF properties that can be configured when the OVF package is deployed.  
-    # 
-    #  This is based on the ovf:ProductSection.  
-    # 
-    #  See   :func:`Com::Vmware::Vcenter::Ovf::LibraryItem.deploy`   and   :func:`Com::Vmware::Vcenter::Ovf::LibraryItem.filter`  .
-    # @!attribute [rw] properties
-    #     @return [Array<Com::Vmware::Vcenter::Ovf::Property>]
-    #     List  of OVF properties.
-    #     This  field  is optional in the input parameters when deploying an OVF package. This  field  will always be present in the result when retrieving information about an OVF package.
-    class PropertyParams < VAPI::Bindings::VapiStruct
-
-        class << self
-            # Holds (gets or creates) the binding type metadata for this structure type.
-            # @scope class
-            # @return [VAPI::Bindings::StructType] the binding type
-            def binding_type
-                @binding_type ||= VAPI::Bindings::StructType.new(
-                    'com.vmware.vcenter.ovf.property_params',
-                    {
-                        'properties' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::ListType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::Ovf::Property'))),
-                        'type' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::StringType.instance),
-                    },
-                    PropertyParams,
-                    false,
-                    nil)
-            end
-        end
-
-        attr_accessor :properties,
-                      :type
-
-        # Constructs a new instance.
-        # @param ruby_values [Hash] a map of initial property values (optional)
-        # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
-        def initialize(ruby_values=nil, struct_value=nil)
-            super(self.class.binding_type, ruby_values, struct_value)
-        end
+    # Constructs a new instance.
+    # @param ruby_values [Hash] a map of initial property values (optional)
+    # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
+    def initialize(ruby_values = nil, struct_value = nil)
+      super(self.class.binding_type, ruby_values, struct_value)
+    end
+  end
+  # The  ``Com::Vmware::Vcenter::Ovf::OvfWarning``   class  describes a warning related to accessing, validating, deploying, or exporting an OVF package.
+  class OvfWarning < VAPI::Bindings::VapiStruct
+    class << self
+      # Holds (gets or creates) the binding type metadata for this structure type.
+      # @scope class
+      # @return [VAPI::Bindings::StructType] the binding type
+      def binding_type
+        @binding_type ||= VAPI::Bindings::StructType.new(
+          'com.vmware.vcenter.ovf.ovf_warning',
+          {
+            'category' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::Ovf::OvfMessage::Category'),
+            'issues' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::ListType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::Ovf::ParseIssue'))),
+            'name' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::StringType.instance),
+            'value' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::StringType.instance),
+            'message' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::LocalizableMessage')),
+            'error' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::DynamicStructType.new([VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Error')]))
+          },
+          OvfWarning,
+          false,
+          nil
+        )
+      end
     end
 
+    attr_accessor :category,
+                  :issues,
+                  :name,
+                  :value,
+                  :message,
+                  :error
 
-    # The  ``Com::Vmware::Vcenter::Ovf::ScaleOutGroup``   class  contains information about a scale-out group.  
-    # 
-    #  It allows a virtual system collection to contain a set of children that are homogeneous with respect to a prototypical virtual system or virtual system collection. It shall cause the deployment function to replicate the prototype a number of times, thus allowing the number of instantiated virtual systems to be configured dynamically at deployment time.  
-    # 
-    #  This is based on the ovf2:ScaleOutSection.  
-    # 
-    #  See   :func:`Com::Vmware::Vcenter::Ovf::LibraryItem.deploy`   and   :func:`Com::Vmware::Vcenter::Ovf::LibraryItem.filter`  .
-    # @!attribute [rw] id
-    #     @return [String]
-    #     The identifier of the scale-out group.
-    #     This  field  must be provided in the input parameters when deploying an OVF package. This  field  will always be present in the result when retrieving information about an OVF package.
-    # @!attribute [rw] description
-    #     @return [String]
-    #     The description of the scale-out group.
-    #     This  field  is not used in the input parameters when deploying an OVF package. This  field  will always be present in the result when retrieving information about an OVF package.
-    # @!attribute [rw] instance_count
-    #     @return [Fixnum]
-    #     The scaling factor to use. It defines the number of replicas of the prototypical virtual system or virtual system collection.
-    #     This  field  must be provided in the input parameters when deploying an OVF package. This  field  will always be present in the result when retrieving information about an OVF package.
-    # @!attribute [rw] minimum_instance_count
-    #     @return [Fixnum]
-    #     The minimum scaling factor.
-    #     This  field  is not used in the input parameters when deploying an OVF package. This  field  will always be present in the result when retrieving information about an OVF package. This will be 1 if there is no explicit limit.
-    # @!attribute [rw] maximum_instance_count
-    #     @return [Fixnum]
-    #     The maximum scaling factor.
-    #     This  field  is not used in the input parameters when deploying an OVF package. This  field  is optional in the result when retrieving information about an OVF package. This will be  nil  if there is no explicit limit.
-    class ScaleOutGroup < VAPI::Bindings::VapiStruct
-
-        class << self
-            # Holds (gets or creates) the binding type metadata for this structure type.
-            # @scope class
-            # @return [VAPI::Bindings::StructType] the binding type
-            def binding_type
-                @binding_type ||= VAPI::Bindings::StructType.new(
-                    'com.vmware.vcenter.ovf.scale_out_group',
-                    {
-                        'id' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::StringType.instance),
-                        'description' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::StringType.instance),
-                        'instance_count' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::IntegerType.instance),
-                        'minimum_instance_count' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::IntegerType.instance),
-                        'maximum_instance_count' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::IntegerType.instance),
-                    },
-                    ScaleOutGroup,
-                    false,
-                    nil)
-            end
-        end
-
-        attr_accessor :id,
-                      :description,
-                      :instance_count,
-                      :minimum_instance_count,
-                      :maximum_instance_count
-
-        # Constructs a new instance.
-        # @param ruby_values [Hash] a map of initial property values (optional)
-        # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
-        def initialize(ruby_values=nil, struct_value=nil)
-            super(self.class.binding_type, ruby_values, struct_value)
-        end
+    # Constructs a new instance.
+    # @param ruby_values [Hash] a map of initial property values (optional)
+    # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
+    def initialize(ruby_values = nil, struct_value = nil)
+      super(self.class.binding_type, ruby_values, struct_value)
+    end
+  end
+  # The  ``Com::Vmware::Vcenter::Ovf::OvfInfo``   class  contains informational messages related to accessing, validating, deploying, or exporting an OVF package.
+  # @!attribute [rw] messages
+  #     @return [Array<Com::Vmware::Vapi::Std::LocalizableMessage>]
+  #     A  list  of localizable messages (see   :class:`Com::Vmware::Vapi::Std::LocalizableMessage`  ).
+  class OvfInfo < VAPI::Bindings::VapiStruct
+    class << self
+      # Holds (gets or creates) the binding type metadata for this structure type.
+      # @scope class
+      # @return [VAPI::Bindings::StructType] the binding type
+      def binding_type
+        @binding_type ||= VAPI::Bindings::StructType.new(
+          'com.vmware.vcenter.ovf.ovf_info',
+          {
+            'messages' => VAPI::Bindings::ListType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::LocalizableMessage'))
+          },
+          OvfInfo,
+          false,
+          nil
+        )
+      end
     end
 
+    attr_accessor :messages
 
-    # The  ``Com::Vmware::Vcenter::Ovf::ScaleOutParams``   class  contains information about the scale-out groups described in the OVF package.  
-    # 
-    #  When deploying an OVF package, a deployment specific instance count can be specified (see   :attr:`Com::Vmware::Vcenter::Ovf::ScaleOutGroup.instance_count`  .  
-    # 
-    #  This is based on the ovf2:ScaleOutSection.  
-    # 
-    #  See   :func:`Com::Vmware::Vcenter::Ovf::LibraryItem.deploy`   and   :func:`Com::Vmware::Vcenter::Ovf::LibraryItem.filter`  .
-    # @!attribute [rw] groups
-    #     @return [Array<Com::Vmware::Vcenter::Ovf::ScaleOutGroup>]
-    #     The  list  of scale-out groups.
-    #     This  field  is optional in the input parameters when deploying an OVF package. If  nil  there are no scale-out groups. This  field  will always be present in the result when retrieving information about an OVF package.
-    class ScaleOutParams < VAPI::Bindings::VapiStruct
-
-        class << self
-            # Holds (gets or creates) the binding type metadata for this structure type.
-            # @scope class
-            # @return [VAPI::Bindings::StructType] the binding type
-            def binding_type
-                @binding_type ||= VAPI::Bindings::StructType.new(
-                    'com.vmware.vcenter.ovf.scale_out_params',
-                    {
-                        'groups' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::ListType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::Ovf::ScaleOutGroup'))),
-                        'type' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::StringType.instance),
-                    },
-                    ScaleOutParams,
-                    false,
-                    nil)
-            end
-        end
-
-        attr_accessor :groups,
-                      :type
-
-        # Constructs a new instance.
-        # @param ruby_values [Hash] a map of initial property values (optional)
-        # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
-        def initialize(ruby_values=nil, struct_value=nil)
-            super(self.class.binding_type, ruby_values, struct_value)
-        end
+    # Constructs a new instance.
+    # @param ruby_values [Hash] a map of initial property values (optional)
+    # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
+    def initialize(ruby_values = nil, struct_value = nil)
+      super(self.class.binding_type, ruby_values, struct_value)
+    end
+  end
+  # The  ``Com::Vmware::Vcenter::Ovf::OvfParams``   class  defines the common  fields  for all OVF deployment parameters. OVF parameters serve several purposes:  
+  # 
+  #   * Describe information about a given OVF package. 
+  #  * Describe default deployment configuration. 
+  #  * Describe possible deployment values based on the deployment environment. 
+  #  * Provide deployment-specific configuration. 
+  # 
+  #   Each OVF parameters  class  specifies a particular configurable aspect of OVF deployment. An aspect has both a query-model and a deploy-model. The query-model is used when the OVF package is queried, and the deploy-model is used when deploying an OVF package.  
+  # 
+  #  Most OVF parameter  classes  provide both informational and deployment parameters. However, some are purely informational (for example, download size) and some are purely deployment parameters (for example, the flag to indicate whether registration as a vCenter extension is accepted).  
+  # 
+  #  See   :func:`Com::Vmware::Vcenter::Ovf::LibraryItem.deploy`   and   :func:`Com::Vmware::Vcenter::Ovf::LibraryItem.filter`  .
+  # @!attribute [rw] type
+  #     @return [String]
+  #     Unique identifier describing the type of the OVF parameters. The value is the name of the OVF parameters  class .
+  #     This  field  must be provided in the input parameters when deploying an OVF package. This  field  will always be present in the result when retrieving information about an OVF package.
+  class OvfParams < VAPI::Bindings::VapiStruct
+    class << self
+      # Holds (gets or creates) the binding type metadata for this structure type.
+      # @scope class
+      # @return [VAPI::Bindings::StructType] the binding type
+      def binding_type
+        @binding_type ||= VAPI::Bindings::StructType.new(
+          'com.vmware.vcenter.ovf.ovf_params',
+          {
+            'type' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::StringType.instance)
+          },
+          OvfParams,
+          false,
+          nil
+        )
+      end
     end
 
+    attr_accessor :type
 
-    # The  ``Com::Vmware::Vcenter::Ovf::SizeParams``   class  contains estimates of the download and deployment sizes.  
-    # 
-    #  This information is based on the file references and the ovf:DiskSection in the OVF descriptor.  
-    # 
-    #  See   :func:`Com::Vmware::Vcenter::Ovf::LibraryItem.deploy`   and   :func:`Com::Vmware::Vcenter::Ovf::LibraryItem.filter`  .
-    # @!attribute [rw] approximate_download_size
-    #     @return [Fixnum]
-    #     A best guess as to the total amount of data that must be transferred to download the OVF package.  
-    #     
-    #      This may be inaccurate due to disk compression etc.
-    #     This  field  is not used in the input parameters when deploying an OVF package. This  field  is optional in the result when retrieving information about an OVF package. It will be  nil  if there is insufficient information to provide a proper estimate.
-    # @!attribute [rw] approximate_flat_deployment_size
-    #     @return [Fixnum]
-    #     A best guess as to the total amount of space required to deploy the OVF package if using flat disks.
-    #     This  field  is not used in the input parameters when deploying an OVF package. This  field  is optional in the result when retrieving information about an OVF package. It will be  nil  if there is insufficient information to provide a proper estimate.
-    # @!attribute [rw] approximate_sparse_deployment_size
-    #     @return [Fixnum]
-    #     A best guess as to the total amount of space required to deploy the OVF package using sparse disks.
-    #     This  field  is not used in the input parameters when deploying an OVF package. This  field  is optional in the result when retrieving information about an OVF package. It will be  nil  if there is insufficient information to provide a proper estimate.
-    # @!attribute [rw] variable_disk_size
-    #     @return [Boolean]
-    #     Whether the OVF uses variable disk sizes.  
-    #     
-    #      For empty disks, rather than specifying a fixed virtual disk capacity, the capacity may be given using a reference to a ovf:Property element in a ovf:ProductSection element in OVF package.
-    #     This  field  is not used in the input parameters when deploying an OVF package. This  field  is optional in the result when retrieving information about an OVF package. If  nil  or false, the OVF does not use variable disk sizes.
-    class SizeParams < VAPI::Bindings::VapiStruct
-
-        class << self
-            # Holds (gets or creates) the binding type metadata for this structure type.
-            # @scope class
-            # @return [VAPI::Bindings::StructType] the binding type
-            def binding_type
-                @binding_type ||= VAPI::Bindings::StructType.new(
-                    'com.vmware.vcenter.ovf.size_params',
-                    {
-                        'approximate_download_size' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::IntegerType.instance),
-                        'approximate_flat_deployment_size' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::IntegerType.instance),
-                        'approximate_sparse_deployment_size' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::IntegerType.instance),
-                        'variable_disk_size' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::BooleanType.instance),
-                        'type' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::StringType.instance),
-                    },
-                    SizeParams,
-                    false,
-                    nil)
-            end
-        end
-
-        attr_accessor :approximate_download_size,
-                      :approximate_flat_deployment_size,
-                      :approximate_sparse_deployment_size,
-                      :variable_disk_size,
-                      :type
-
-        # Constructs a new instance.
-        # @param ruby_values [Hash] a map of initial property values (optional)
-        # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
-        def initialize(ruby_values=nil, struct_value=nil)
-            super(self.class.binding_type, ruby_values, struct_value)
-        end
+    # Constructs a new instance.
+    # @param ruby_values [Hash] a map of initial property values (optional)
+    # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
+    def initialize(ruby_values = nil, struct_value = nil)
+      super(self.class.binding_type, ruby_values, struct_value)
+    end
+  end
+  # The  ``Com::Vmware::Vcenter::Ovf::Property``   class  contains the information about a property in an OVF package.  
+  # 
+  #  A property is uniquely identified by its [classid.]id[.instanceid] fully-qualified name (see   :attr:`Com::Vmware::Vcenter::Ovf::Property.class_id`  ,   :attr:`Com::Vmware::Vcenter::Ovf::Property.id`  , and   :attr:`Com::Vmware::Vcenter::Ovf::Property.instance_id`  ). If multiple properties in an OVF package have the same fully-qualified name, then the property is excluded and cannot be set. We do warn about this during import.  
+  # 
+  #  See   :func:`Com::Vmware::Vcenter::Ovf::LibraryItem.deploy`   and   :func:`Com::Vmware::Vcenter::Ovf::LibraryItem.filter`  .
+  # @!attribute [rw] class_id
+  #     @return [String]
+  #     The classId of this OVF property.
+  #     This  field  is not used in the input parameters when deploying an OVF package. This  field  will always be present in the result when retrieving information about an OVF package.
+  # @!attribute [rw] id
+  #     @return [String]
+  #     The identifier of this OVF property.
+  #     This  field  must be provided in the input parameters when deploying an OVF package. This  field  will always be present in the result when retrieving information about an OVF package.
+  # @!attribute [rw] instance_id
+  #     @return [String]
+  #     The instanceId of this OVF property.
+  #     This  field  is not used in the input parameters when deploying an OVF package. This  field  will always be present in the result when retrieving information about an OVF package.
+  # @!attribute [rw] category
+  #     @return [String]
+  #     If this is set to a non-empty string, this property starts a new category.
+  #     This  field  is not used in the input parameters when deploying an OVF package. This  field  is optional in the result when retrieving information about an OVF package. If  nil , the property is in the same category as the previous item, otherwise, it starts a new category.
+  # @!attribute [rw] ui_optional
+  #     @return [Boolean]
+  #     Whether a category is UI optional. This is only used if this property starts a new category (see   :attr:`Com::Vmware::Vcenter::Ovf::Property.category`  ).  
+  #     
+  #      The value is stored in an optional attribute vmw:uioptional to the ovf:Category element. The default value is false. If this value is true, the properties within this category are optional. The UI renders this as a group with a check box, and the group is grayed out until the check box is selected. When the check box is selected, the input values are read and used in deployment. If properties within the same category specify conflicting values the default is used. Only implemented in vSphere Web Client 5.1 and later as of Nov 2012.
+  #     This  field  is not used in the input parameters when deploying an OVF package. This  field  is optional in the result when retrieving information about an OVF package.
+  # @!attribute [rw] label
+  #     @return [String]
+  #     The display name of this OVF property.
+  #     This  field  is not used in the input parameters when deploying an OVF package. This  field  will always be present in the result when retrieving information about an OVF package.
+  # @!attribute [rw] description
+  #     @return [String]
+  #     A description of this OVF property.
+  #     This  field  is not used in the input parameters when deploying an OVF package. This  field  is optional in the result when retrieving information about an OVF package.
+  # @!attribute [rw] type
+  #     @return [String]
+  #     The type of this OVF property. Refer to the configuration of a virtual appliance/virtual machine for the valid values.
+  #     This  field  is not used in the input parameters when deploying an OVF package. This  field  will always be present in the result when retrieving information about an OVF package.
+  # @!attribute [rw] value
+  #     @return [String]
+  #     The OVF property value. This contains the default value from ovf:defaultValue if ovf:value is not present when read.
+  #     This  field  must be provided in the input parameters when deploying an OVF package. This  field  will always be present in the result when retrieving information about an OVF package.
+  class Property < VAPI::Bindings::VapiStruct
+    class << self
+      # Holds (gets or creates) the binding type metadata for this structure type.
+      # @scope class
+      # @return [VAPI::Bindings::StructType] the binding type
+      def binding_type
+        @binding_type ||= VAPI::Bindings::StructType.new(
+          'com.vmware.vcenter.ovf.property',
+          {
+            'class_id' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::StringType.instance),
+            'id' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::StringType.instance),
+            'instance_id' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::StringType.instance),
+            'category' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::StringType.instance),
+            'ui_optional' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::BooleanType.instance),
+            'label' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::StringType.instance),
+            'description' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::StringType.instance),
+            'type' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::StringType.instance),
+            'value' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::StringType.instance)
+          },
+          Property,
+          false,
+          nil
+        )
+      end
     end
 
+    attr_accessor :class_id,
+                  :id,
+                  :instance_id,
+                  :category,
+                  :ui_optional,
+                  :label,
+                  :description,
+                  :type,
+                  :value
 
-    # The  ``Com::Vmware::Vcenter::Ovf::UnknownSection``   class  contains information about an unknown section in an OVF package.
-    # @!attribute [rw] tag
-    #     @return [String]
-    #     A namespace-qualified tag in the form  ``{ns}tag`` .
-    # @!attribute [rw] info
-    #     @return [String]
-    #     The description of the Info element.
-    class UnknownSection < VAPI::Bindings::VapiStruct
-
-        class << self
-            # Holds (gets or creates) the binding type metadata for this structure type.
-            # @scope class
-            # @return [VAPI::Bindings::StructType] the binding type
-            def binding_type
-                @binding_type ||= VAPI::Bindings::StructType.new(
-                    'com.vmware.vcenter.ovf.unknown_section',
-                    {
-                        'tag' => VAPI::Bindings::StringType.instance,
-                        'info' => VAPI::Bindings::StringType.instance,
-                    },
-                    UnknownSection,
-                    false,
-                    nil)
-            end
-        end
-
-        attr_accessor :tag,
-                      :info
-
-        # Constructs a new instance.
-        # @param ruby_values [Hash] a map of initial property values (optional)
-        # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
-        def initialize(ruby_values=nil, struct_value=nil)
-            super(self.class.binding_type, ruby_values, struct_value)
-        end
+    # Constructs a new instance.
+    # @param ruby_values [Hash] a map of initial property values (optional)
+    # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
+    def initialize(ruby_values = nil, struct_value = nil)
+      super(self.class.binding_type, ruby_values, struct_value)
+    end
+  end
+  # The  ``Com::Vmware::Vcenter::Ovf::PropertyParams``   class  contains a  list  of OVF properties that can be configured when the OVF package is deployed.  
+  # 
+  #  This is based on the ovf:ProductSection.  
+  # 
+  #  See   :func:`Com::Vmware::Vcenter::Ovf::LibraryItem.deploy`   and   :func:`Com::Vmware::Vcenter::Ovf::LibraryItem.filter`  .
+  # @!attribute [rw] properties
+  #     @return [Array<Com::Vmware::Vcenter::Ovf::Property>]
+  #     List  of OVF properties.
+  #     This  field  is optional in the input parameters when deploying an OVF package. This  field  will always be present in the result when retrieving information about an OVF package.
+  class PropertyParams < VAPI::Bindings::VapiStruct
+    class << self
+      # Holds (gets or creates) the binding type metadata for this structure type.
+      # @scope class
+      # @return [VAPI::Bindings::StructType] the binding type
+      def binding_type
+        @binding_type ||= VAPI::Bindings::StructType.new(
+          'com.vmware.vcenter.ovf.property_params',
+          {
+            'properties' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::ListType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::Ovf::Property'))),
+            'type' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::StringType.instance)
+          },
+          PropertyParams,
+          false,
+          nil
+        )
+      end
     end
 
+    attr_accessor :properties,
+                  :type
 
-    # The  ``Com::Vmware::Vcenter::Ovf::UnknownSectionParams``   class  contains a  list  of unknown, non-required sections.  
-    # 
-    #  See   :func:`Com::Vmware::Vcenter::Ovf::LibraryItem.deploy`   and   :func:`Com::Vmware::Vcenter::Ovf::LibraryItem.filter`  .
-    # @!attribute [rw] unknown_sections
-    #     @return [Array<Com::Vmware::Vcenter::Ovf::UnknownSection>]
-    #     List  of unknown, non-required sections.
-    #     This  field  is not used in the input parameters when deploying an OVF package. This  field  will always be present in the result when retrieving information about an OVF package.
-    class UnknownSectionParams < VAPI::Bindings::VapiStruct
-
-        class << self
-            # Holds (gets or creates) the binding type metadata for this structure type.
-            # @scope class
-            # @return [VAPI::Bindings::StructType] the binding type
-            def binding_type
-                @binding_type ||= VAPI::Bindings::StructType.new(
-                    'com.vmware.vcenter.ovf.unknown_section_params',
-                    {
-                        'unknown_sections' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::ListType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::Ovf::UnknownSection'))),
-                        'type' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::StringType.instance),
-                    },
-                    UnknownSectionParams,
-                    false,
-                    nil)
-            end
-        end
-
-        attr_accessor :unknown_sections,
-                      :type
-
-        # Constructs a new instance.
-        # @param ruby_values [Hash] a map of initial property values (optional)
-        # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
-        def initialize(ruby_values=nil, struct_value=nil)
-            super(self.class.binding_type, ruby_values, struct_value)
-        end
+    # Constructs a new instance.
+    # @param ruby_values [Hash] a map of initial property values (optional)
+    # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
+    def initialize(ruby_values = nil, struct_value = nil)
+      super(self.class.binding_type, ruby_values, struct_value)
+    end
+  end
+  # The  ``Com::Vmware::Vcenter::Ovf::ScaleOutGroup``   class  contains information about a scale-out group.  
+  # 
+  #  It allows a virtual system collection to contain a set of children that are homogeneous with respect to a prototypical virtual system or virtual system collection. It shall cause the deployment function to replicate the prototype a number of times, thus allowing the number of instantiated virtual systems to be configured dynamically at deployment time.  
+  # 
+  #  This is based on the ovf2:ScaleOutSection.  
+  # 
+  #  See   :func:`Com::Vmware::Vcenter::Ovf::LibraryItem.deploy`   and   :func:`Com::Vmware::Vcenter::Ovf::LibraryItem.filter`  .
+  # @!attribute [rw] id
+  #     @return [String]
+  #     The identifier of the scale-out group.
+  #     This  field  must be provided in the input parameters when deploying an OVF package. This  field  will always be present in the result when retrieving information about an OVF package.
+  # @!attribute [rw] description
+  #     @return [String]
+  #     The description of the scale-out group.
+  #     This  field  is not used in the input parameters when deploying an OVF package. This  field  will always be present in the result when retrieving information about an OVF package.
+  # @!attribute [rw] instance_count
+  #     @return [Fixnum]
+  #     The scaling factor to use. It defines the number of replicas of the prototypical virtual system or virtual system collection.
+  #     This  field  must be provided in the input parameters when deploying an OVF package. This  field  will always be present in the result when retrieving information about an OVF package.
+  # @!attribute [rw] minimum_instance_count
+  #     @return [Fixnum]
+  #     The minimum scaling factor.
+  #     This  field  is not used in the input parameters when deploying an OVF package. This  field  will always be present in the result when retrieving information about an OVF package. This will be 1 if there is no explicit limit.
+  # @!attribute [rw] maximum_instance_count
+  #     @return [Fixnum]
+  #     The maximum scaling factor.
+  #     This  field  is not used in the input parameters when deploying an OVF package. This  field  is optional in the result when retrieving information about an OVF package. This will be  nil  if there is no explicit limit.
+  class ScaleOutGroup < VAPI::Bindings::VapiStruct
+    class << self
+      # Holds (gets or creates) the binding type metadata for this structure type.
+      # @scope class
+      # @return [VAPI::Bindings::StructType] the binding type
+      def binding_type
+        @binding_type ||= VAPI::Bindings::StructType.new(
+          'com.vmware.vcenter.ovf.scale_out_group',
+          {
+            'id' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::StringType.instance),
+            'description' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::StringType.instance),
+            'instance_count' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::IntegerType.instance),
+            'minimum_instance_count' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::IntegerType.instance),
+            'maximum_instance_count' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::IntegerType.instance)
+          },
+          ScaleOutGroup,
+          false,
+          nil
+        )
+      end
     end
 
+    attr_accessor :id,
+                  :description,
+                  :instance_count,
+                  :minimum_instance_count,
+                  :maximum_instance_count
 
-    # The  ``Com::Vmware::Vcenter::Ovf::VcenterExtensionParams``   class  specifies that the OVF package should be registered as a vCenter extension. The virtual machine or virtual appliance will gain unrestricted access to the vCenter Server APIs. It must be connected to a network with connectivity to the vCenter server.  
-    # 
-    #  See   :func:`Com::Vmware::Vcenter::Ovf::LibraryItem.deploy`   and   :func:`Com::Vmware::Vcenter::Ovf::LibraryItem.filter`  .
-    # @!attribute [rw] required
-    #     @return [Boolean]
-    #     Whether registration as a vCenter extension is required.
-    #     This  field  is not used in the input parameters when deploying an OVF package. This  field  will always be present in the result when retrieving information about an OVF package.
-    # @!attribute [rw] registration_accepted
-    #     @return [Boolean]
-    #     Whether registration as a vCenter extension is accepted.  
-    #     
-    #      If registration as a vCenter extension is required (see   :attr:`Com::Vmware::Vcenter::Ovf::VcenterExtensionParams.required`  ), this must be set to true during deployment. Defaults to false when returned from server.
-    #     This  field  must be provided in the input parameters when deploying an OVF package. This  field  will always be present in the result when retrieving information about an OVF package.
-    class VcenterExtensionParams < VAPI::Bindings::VapiStruct
-
-        class << self
-            # Holds (gets or creates) the binding type metadata for this structure type.
-            # @scope class
-            # @return [VAPI::Bindings::StructType] the binding type
-            def binding_type
-                @binding_type ||= VAPI::Bindings::StructType.new(
-                    'com.vmware.vcenter.ovf.vcenter_extension_params',
-                    {
-                        'required' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::BooleanType.instance),
-                        'registration_accepted' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::BooleanType.instance),
-                        'type' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::StringType.instance),
-                    },
-                    VcenterExtensionParams,
-                    false,
-                    nil)
-            end
-        end
-
-        attr_accessor :required,
-                      :registration_accepted,
-                      :type
-
-        # Constructs a new instance.
-        # @param ruby_values [Hash] a map of initial property values (optional)
-        # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
-        def initialize(ruby_values=nil, struct_value=nil)
-            super(self.class.binding_type, ruby_values, struct_value)
-        end
+    # Constructs a new instance.
+    # @param ruby_values [Hash] a map of initial property values (optional)
+    # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
+    def initialize(ruby_values = nil, struct_value = nil)
+      super(self.class.binding_type, ruby_values, struct_value)
+    end
+  end
+  # The  ``Com::Vmware::Vcenter::Ovf::ScaleOutParams``   class  contains information about the scale-out groups described in the OVF package.  
+  # 
+  #  When deploying an OVF package, a deployment specific instance count can be specified (see   :attr:`Com::Vmware::Vcenter::Ovf::ScaleOutGroup.instance_count`  .  
+  # 
+  #  This is based on the ovf2:ScaleOutSection.  
+  # 
+  #  See   :func:`Com::Vmware::Vcenter::Ovf::LibraryItem.deploy`   and   :func:`Com::Vmware::Vcenter::Ovf::LibraryItem.filter`  .
+  # @!attribute [rw] groups
+  #     @return [Array<Com::Vmware::Vcenter::Ovf::ScaleOutGroup>]
+  #     The  list  of scale-out groups.
+  #     This  field  is optional in the input parameters when deploying an OVF package. If  nil  there are no scale-out groups. This  field  will always be present in the result when retrieving information about an OVF package.
+  class ScaleOutParams < VAPI::Bindings::VapiStruct
+    class << self
+      # Holds (gets or creates) the binding type metadata for this structure type.
+      # @scope class
+      # @return [VAPI::Bindings::StructType] the binding type
+      def binding_type
+        @binding_type ||= VAPI::Bindings::StructType.new(
+          'com.vmware.vcenter.ovf.scale_out_params',
+          {
+            'groups' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::ListType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::Ovf::ScaleOutGroup'))),
+            'type' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::StringType.instance)
+          },
+          ScaleOutParams,
+          false,
+          nil
+        )
+      end
     end
 
+    attr_accessor :groups,
+                  :type
 
-    # The  ``Com::Vmware::Vcenter::Ovf::DiskProvisioningType``   enumerated type  defines the virtual disk provisioning types that can be set for a disk on the target platform.
+    # Constructs a new instance.
+    # @param ruby_values [Hash] a map of initial property values (optional)
+    # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
+    def initialize(ruby_values = nil, struct_value = nil)
+      super(self.class.binding_type, ruby_values, struct_value)
+    end
+  end
+  # The  ``Com::Vmware::Vcenter::Ovf::SizeParams``   class  contains estimates of the download and deployment sizes.  
+  # 
+  #  This information is based on the file references and the ovf:DiskSection in the OVF descriptor.  
+  # 
+  #  See   :func:`Com::Vmware::Vcenter::Ovf::LibraryItem.deploy`   and   :func:`Com::Vmware::Vcenter::Ovf::LibraryItem.filter`  .
+  # @!attribute [rw] approximate_download_size
+  #     @return [Fixnum]
+  #     A best guess as to the total amount of data that must be transferred to download the OVF package.  
+  #     
+  #      This may be inaccurate due to disk compression etc.
+  #     This  field  is not used in the input parameters when deploying an OVF package. This  field  is optional in the result when retrieving information about an OVF package. It will be  nil  if there is insufficient information to provide a proper estimate.
+  # @!attribute [rw] approximate_flat_deployment_size
+  #     @return [Fixnum]
+  #     A best guess as to the total amount of space required to deploy the OVF package if using flat disks.
+  #     This  field  is not used in the input parameters when deploying an OVF package. This  field  is optional in the result when retrieving information about an OVF package. It will be  nil  if there is insufficient information to provide a proper estimate.
+  # @!attribute [rw] approximate_sparse_deployment_size
+  #     @return [Fixnum]
+  #     A best guess as to the total amount of space required to deploy the OVF package using sparse disks.
+  #     This  field  is not used in the input parameters when deploying an OVF package. This  field  is optional in the result when retrieving information about an OVF package. It will be  nil  if there is insufficient information to provide a proper estimate.
+  # @!attribute [rw] variable_disk_size
+  #     @return [Boolean]
+  #     Whether the OVF uses variable disk sizes.  
+  #     
+  #      For empty disks, rather than specifying a fixed virtual disk capacity, the capacity may be given using a reference to a ovf:Property element in a ovf:ProductSection element in OVF package.
+  #     This  field  is not used in the input parameters when deploying an OVF package. This  field  is optional in the result when retrieving information about an OVF package. If  nil  or false, the OVF does not use variable disk sizes.
+  class SizeParams < VAPI::Bindings::VapiStruct
+    class << self
+      # Holds (gets or creates) the binding type metadata for this structure type.
+      # @scope class
+      # @return [VAPI::Bindings::StructType] the binding type
+      def binding_type
+        @binding_type ||= VAPI::Bindings::StructType.new(
+          'com.vmware.vcenter.ovf.size_params',
+          {
+            'approximate_download_size' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::IntegerType.instance),
+            'approximate_flat_deployment_size' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::IntegerType.instance),
+            'approximate_sparse_deployment_size' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::IntegerType.instance),
+            'variable_disk_size' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::BooleanType.instance),
+            'type' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::StringType.instance)
+          },
+          SizeParams,
+          false,
+          nil
+        )
+      end
+    end
+
+    attr_accessor :approximate_download_size,
+                  :approximate_flat_deployment_size,
+                  :approximate_sparse_deployment_size,
+                  :variable_disk_size,
+                  :type
+
+    # Constructs a new instance.
+    # @param ruby_values [Hash] a map of initial property values (optional)
+    # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
+    def initialize(ruby_values = nil, struct_value = nil)
+      super(self.class.binding_type, ruby_values, struct_value)
+    end
+  end
+  # The  ``Com::Vmware::Vcenter::Ovf::UnknownSection``   class  contains information about an unknown section in an OVF package.
+  # @!attribute [rw] tag
+  #     @return [String]
+  #     A namespace-qualified tag in the form  ``{ns}tag`` .
+  # @!attribute [rw] info
+  #     @return [String]
+  #     The description of the Info element.
+  class UnknownSection < VAPI::Bindings::VapiStruct
+    class << self
+      # Holds (gets or creates) the binding type metadata for this structure type.
+      # @scope class
+      # @return [VAPI::Bindings::StructType] the binding type
+      def binding_type
+        @binding_type ||= VAPI::Bindings::StructType.new(
+          'com.vmware.vcenter.ovf.unknown_section',
+          {
+            'tag' => VAPI::Bindings::StringType.instance,
+            'info' => VAPI::Bindings::StringType.instance
+          },
+          UnknownSection,
+          false,
+          nil
+        )
+      end
+    end
+
+    attr_accessor :tag,
+                  :info
+
+    # Constructs a new instance.
+    # @param ruby_values [Hash] a map of initial property values (optional)
+    # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
+    def initialize(ruby_values = nil, struct_value = nil)
+      super(self.class.binding_type, ruby_values, struct_value)
+    end
+  end
+  # The  ``Com::Vmware::Vcenter::Ovf::UnknownSectionParams``   class  contains a  list  of unknown, non-required sections.  
+  # 
+  #  See   :func:`Com::Vmware::Vcenter::Ovf::LibraryItem.deploy`   and   :func:`Com::Vmware::Vcenter::Ovf::LibraryItem.filter`  .
+  # @!attribute [rw] unknown_sections
+  #     @return [Array<Com::Vmware::Vcenter::Ovf::UnknownSection>]
+  #     List  of unknown, non-required sections.
+  #     This  field  is not used in the input parameters when deploying an OVF package. This  field  will always be present in the result when retrieving information about an OVF package.
+  class UnknownSectionParams < VAPI::Bindings::VapiStruct
+    class << self
+      # Holds (gets or creates) the binding type metadata for this structure type.
+      # @scope class
+      # @return [VAPI::Bindings::StructType] the binding type
+      def binding_type
+        @binding_type ||= VAPI::Bindings::StructType.new(
+          'com.vmware.vcenter.ovf.unknown_section_params',
+          {
+            'unknown_sections' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::ListType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::Ovf::UnknownSection'))),
+            'type' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::StringType.instance)
+          },
+          UnknownSectionParams,
+          false,
+          nil
+        )
+      end
+    end
+
+    attr_accessor :unknown_sections,
+                  :type
+
+    # Constructs a new instance.
+    # @param ruby_values [Hash] a map of initial property values (optional)
+    # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
+    def initialize(ruby_values = nil, struct_value = nil)
+      super(self.class.binding_type, ruby_values, struct_value)
+    end
+  end
+  # The  ``Com::Vmware::Vcenter::Ovf::VcenterExtensionParams``   class  specifies that the OVF package should be registered as a vCenter extension. The virtual machine or virtual appliance will gain unrestricted access to the vCenter Server APIs. It must be connected to a network with connectivity to the vCenter server.  
+  # 
+  #  See   :func:`Com::Vmware::Vcenter::Ovf::LibraryItem.deploy`   and   :func:`Com::Vmware::Vcenter::Ovf::LibraryItem.filter`  .
+  # @!attribute [rw] required
+  #     @return [Boolean]
+  #     Whether registration as a vCenter extension is required.
+  #     This  field  is not used in the input parameters when deploying an OVF package. This  field  will always be present in the result when retrieving information about an OVF package.
+  # @!attribute [rw] registration_accepted
+  #     @return [Boolean]
+  #     Whether registration as a vCenter extension is accepted.  
+  #     
+  #      If registration as a vCenter extension is required (see   :attr:`Com::Vmware::Vcenter::Ovf::VcenterExtensionParams.required`  ), this must be set to true during deployment. Defaults to false when returned from server.
+  #     This  field  must be provided in the input parameters when deploying an OVF package. This  field  will always be present in the result when retrieving information about an OVF package.
+  class VcenterExtensionParams < VAPI::Bindings::VapiStruct
+    class << self
+      # Holds (gets or creates) the binding type metadata for this structure type.
+      # @scope class
+      # @return [VAPI::Bindings::StructType] the binding type
+      def binding_type
+        @binding_type ||= VAPI::Bindings::StructType.new(
+          'com.vmware.vcenter.ovf.vcenter_extension_params',
+          {
+            'required' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::BooleanType.instance),
+            'registration_accepted' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::BooleanType.instance),
+            'type' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::StringType.instance)
+          },
+          VcenterExtensionParams,
+          false,
+          nil
+        )
+      end
+    end
+
+    attr_accessor :required,
+                  :registration_accepted,
+                  :type
+
+    # Constructs a new instance.
+    # @param ruby_values [Hash] a map of initial property values (optional)
+    # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
+    def initialize(ruby_values = nil, struct_value = nil)
+      super(self.class.binding_type, ruby_values, struct_value)
+    end
+  end
+  # The  ``Com::Vmware::Vcenter::Ovf::DiskProvisioningType``   enumerated type  defines the virtual disk provisioning types that can be set for a disk on the target platform.
+  # @!attribute [rw] thin
+  #     @return [Com::Vmware::Vcenter::Ovf::DiskProvisioningType]
+  #     A thin provisioned virtual disk has space allocated and zeroed on demand as the space is used.
+  # @!attribute [rw] thick
+  #     @return [Com::Vmware::Vcenter::Ovf::DiskProvisioningType]
+  #     A thick provisioned virtual disk has all space allocated at creation time and the space is zeroed on demand as the space is used.
+  # @!attribute [rw] eager_zeroed_thick
+  #     @return [Com::Vmware::Vcenter::Ovf::DiskProvisioningType]
+  #     An eager zeroed thick provisioned virtual disk has all space allocated and wiped clean of any previous contents on the physical media at creation time.  
+  #     
+  #      Disks specified as eager zeroed thick may take longer time to create than disks specified with the other disk provisioning types.
+  class DiskProvisioningType < VAPI::Bindings::VapiEnum
+    class << self
+      # Holds (gets or creates) the binding type metadata for this enumeration type.
+      # @scope class
+      # @return [VAPI::Bindings::EnumType] the binding type
+      def binding_type
+        @binding_type ||= VAPI::Bindings::EnumType.new(
+          'com.vmware.vcenter.ovf.disk_provisioning_type',
+          DiskProvisioningType
+        )
+      end
+
+      # Converts from a string value (perhaps off the wire) to an instance
+      # of this enum type.
+      # @param value [String] the actual value of the enum instance
+      # @return [DiskProvisioningType] the instance found for the value, otherwise
+      #         an unknown instance will be built for the value
+      def from_string(value)
+        const_get(value)
+      rescue NameError
+        DiskProvisioningType.send(:new, 'UNKNOWN', value)
+      end
+    end
+
+    # Constructs a new instance.
+    # @param value [String] the actual value of the enum instance
+    # @param unknown [String] the unknown value when value is 'UKNOWN'
+    def initialize(value, unknown = nil)
+      super(self.class.binding_type, value, unknown)
+    end
+
+    private_class_method :new
+
     # @!attribute [rw] thin
     #     @return [Com::Vmware::Vcenter::Ovf::DiskProvisioningType]
     #     A thin provisioned virtual disk has space allocated and zeroed on demand as the space is used.
+    THIN = DiskProvisioningType.send(:new, 'THIN')
+
     # @!attribute [rw] thick
     #     @return [Com::Vmware::Vcenter::Ovf::DiskProvisioningType]
     #     A thick provisioned virtual disk has all space allocated at creation time and the space is zeroed on demand as the space is used.
+    THICK = DiskProvisioningType.send(:new, 'THICK')
+
     # @!attribute [rw] eager_zeroed_thick
     #     @return [Com::Vmware::Vcenter::Ovf::DiskProvisioningType]
     #     An eager zeroed thick provisioned virtual disk has all space allocated and wiped clean of any previous contents on the physical media at creation time.  
     #     
     #      Disks specified as eager zeroed thick may take longer time to create than disks specified with the other disk provisioning types.
-    class DiskProvisioningType < VAPI::Bindings::VapiEnum
-
-        class << self
-            # Holds (gets or creates) the binding type metadata for this enumeration type.
-            # @scope class
-            # @return [VAPI::Bindings::EnumType] the binding type
-            def binding_type
-                @binding_type ||= VAPI::Bindings::EnumType.new(
-                    'com.vmware.vcenter.ovf.disk_provisioning_type',
-                    DiskProvisioningType)
-            end
-
-            # Converts from a string value (perhaps off the wire) to an instance
-            # of this enum type.
-            # @param value [String] the actual value of the enum instance
-            # @return [DiskProvisioningType] the instance found for the value, otherwise
-            #         an unknown instance will be built for the value
-            def from_string(value)
-                begin
-                    const_get(value)
-                rescue NameError
-                    DiskProvisioningType.new('UNKNOWN', value)
-                end
-            end
-        end
-
-        private
-
-        # Constructs a new instance.
-        # @param value [String] the actual value of the enum instance
-        # @param unknown [String] the unknown value when value is 'UKNOWN'
-        def initialize(value, unknown=nil)
-            super(self.class.binding_type, value, unknown)
-        end
-
-        public
-
-        # @!attribute [rw] thin
-        #     @return [Com::Vmware::Vcenter::Ovf::DiskProvisioningType]
-        #     A thin provisioned virtual disk has space allocated and zeroed on demand as the space is used.
-        THIN = DiskProvisioningType.new('THIN')
-
-        # @!attribute [rw] thick
-        #     @return [Com::Vmware::Vcenter::Ovf::DiskProvisioningType]
-        #     A thick provisioned virtual disk has all space allocated at creation time and the space is zeroed on demand as the space is used.
-        THICK = DiskProvisioningType.new('THICK')
-
-        # @!attribute [rw] eager_zeroed_thick
-        #     @return [Com::Vmware::Vcenter::Ovf::DiskProvisioningType]
-        #     An eager zeroed thick provisioned virtual disk has all space allocated and wiped clean of any previous contents on the physical media at creation time.  
-        #     
-        #      Disks specified as eager zeroed thick may take longer time to create than disks specified with the other disk provisioning types.
-        EAGER_ZEROED_THICK = DiskProvisioningType.new('EAGER_ZEROED_THICK')
-
-    end
-
-
+    EAGER_ZEROED_THICK = DiskProvisioningType.send(:new, 'EAGER_ZEROED_THICK')
+  end
 end

--- a/client/sdk/com/vmware/vcenter/ovf/vapi.rb
+++ b/client/sdk/com/vmware/vcenter/ovf/vapi.rb
@@ -1,5 +1,6 @@
 #---------------------------------------------------------------------------
-# Copyright 2016 VMware, Inc.  All rights reserved.
+# Copyright 2017 VMware, Inc.  All rights reserved.
+#
 # AUTO GENERATED FILE -- DO NOT MODIFY!
 #---------------------------------------------------------------------------
 require 'vapi'

--- a/client/sdk/com/vmware/vcenter/vapi.rb
+++ b/client/sdk/com/vmware/vcenter/vapi.rb
@@ -1,5 +1,6 @@
 #---------------------------------------------------------------------------
-# Copyright 2016 VMware, Inc.  All rights reserved.
+# Copyright 2017 VMware, Inc.  All rights reserved.
+#
 # AUTO GENERATED FILE -- DO NOT MODIFY!
 #---------------------------------------------------------------------------
 require 'vapi'

--- a/client/sdk/com/vmware/vcenter/vm.rb
+++ b/client/sdk/com/vmware/vcenter/vm.rb
@@ -1,5 +1,6 @@
 #---------------------------------------------------------------------------
-# Copyright 2016 VMware, Inc.  All rights reserved.
+# Copyright 2017 VMware, Inc.  All rights reserved.
+#
 # AUTO GENERATED FILE -- DO NOT MODIFY!
 #
 # vAPI type descriptors for package com.vmware.vcenter.vm.
@@ -8,2158 +9,2090 @@ require 'vapi'
 
 # declare the module hierarchy before we use the shorthand syntax below
 module Com
-    module Vmware
-        module Vcenter
-            module Vm
-            end
-        end
+  module Vmware
+    module Vcenter
+      module Vm
+      end
     end
+  end
 end
 
 # The  ``com.vmware.vcenter.vm``   package  provides  classs  for managing virtual machines.
 module Com::Vmware::Vcenter::Vm
-
-    # The  ``Com::Vmware::Vcenter::Vm::Hardware``   class  provides  methods  for configuring the virtual hardware of a virtual machine.
-    class HardwareService < VAPI::Bindings::VapiService
-
-        protected
-
-        # static metamodel definitions
-        @@service_id = VAPI::Core::ServiceIdentifier.new('com.vmware.vcenter.vm.hardware')
-
-        @@get_info = VAPI::Bindings::OperationInfo.new(
-            VAPI::Core::OperationIdentifier.new('get', @@service_id),
-            VAPI::Bindings::OperationInputType.new({
-                'vm' => VAPI::Bindings::IdType.new(resource_types='VirtualMachine'),
-            }),
-            VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::Vm::Hardware::Info'),
-            {
-                'com.vmware.vapi.std.errors.error' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Error'),
-                'com.vmware.vapi.std.errors.not_found' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::NotFound'),
-                'com.vmware.vapi.std.errors.resource_inaccessible' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::ResourceInaccessible'),
-                'com.vmware.vapi.std.errors.service_unavailable' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::ServiceUnavailable'),
-                'com.vmware.vapi.std.errors.unauthenticated' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Unauthenticated'),
-                'com.vmware.vapi.std.errors.unauthorized' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Unauthorized'),
-
-            },
-            [],
-            [])
-        @@update_info = VAPI::Bindings::OperationInfo.new(
-            VAPI::Core::OperationIdentifier.new('update', @@service_id),
-            VAPI::Bindings::OperationInputType.new({
-                'vm' => VAPI::Bindings::IdType.new(resource_types='VirtualMachine'),
-                'spec' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::Vm::Hardware::UpdateSpec'),
-            }),
-            VAPI::Bindings::VoidType.instance,
-            {
-                'com.vmware.vapi.std.errors.error' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Error'),
-                'com.vmware.vapi.std.errors.not_found' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::NotFound'),
-                'com.vmware.vapi.std.errors.already_in_desired_state' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::AlreadyInDesiredState'),
-                'com.vmware.vapi.std.errors.invalid_argument' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::InvalidArgument'),
-                'com.vmware.vapi.std.errors.unsupported' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Unsupported'),
-                'com.vmware.vapi.std.errors.resource_busy' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::ResourceBusy'),
-                'com.vmware.vapi.std.errors.resource_inaccessible' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::ResourceInaccessible'),
-                'com.vmware.vapi.std.errors.service_unavailable' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::ServiceUnavailable'),
-                'com.vmware.vapi.std.errors.unauthenticated' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Unauthenticated'),
-                'com.vmware.vapi.std.errors.unauthorized' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Unauthorized'),
-
-            },
-            [],
-            [])
-        @@upgrade_info = VAPI::Bindings::OperationInfo.new(
-            VAPI::Core::OperationIdentifier.new('upgrade', @@service_id),
-            VAPI::Bindings::OperationInputType.new({
-                'vm' => VAPI::Bindings::IdType.new(resource_types='VirtualMachine'),
-                'version' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::Vm::Hardware::Version')),
-            }),
-            VAPI::Bindings::VoidType.instance,
-            {
-                'com.vmware.vapi.std.errors.error' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Error'),
-                'com.vmware.vapi.std.errors.not_found' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::NotFound'),
-                'com.vmware.vapi.std.errors.not_allowed_in_current_state' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::NotAllowedInCurrentState'),
-                'com.vmware.vapi.std.errors.already_in_desired_state' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::AlreadyInDesiredState'),
-                'com.vmware.vapi.std.errors.invalid_argument' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::InvalidArgument'),
-                'com.vmware.vapi.std.errors.unsupported' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Unsupported'),
-                'com.vmware.vapi.std.errors.resource_busy' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::ResourceBusy'),
-                'com.vmware.vapi.std.errors.resource_inaccessible' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::ResourceInaccessible'),
-                'com.vmware.vapi.std.errors.service_unavailable' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::ServiceUnavailable'),
-                'com.vmware.vapi.std.errors.unauthenticated' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Unauthenticated'),
-                'com.vmware.vapi.std.errors.unauthorized' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Unauthorized'),
-
-            },
-            [],
-            [])
-
-        @@service_info = VAPI::Bindings::ServiceInfo.new(@@service_id, {
-            'get' => @@get_info,
-            'update' => @@update_info,
-            'upgrade' => @@upgrade_info,
-        })
-
-        public
-
-        # Constructs a new instance.
-        #
-        # @param config [VAPI::Bindings::StubConfig] A hash with the api provider details.
-        def initialize(config)
-            super(config, @@service_info)
-        end
-
-
-        # Returns the virtual hardware settings of a virtual machine.
-        #
-        # @param vm [String]
-        #     Virtual machine identifier.
-        # @return [Com::Vmware::Vcenter::Vm::Hardware::Info]
-        #     Virtual hardware settings of the virtual machine.
-        # @raise [Com::Vmware::Vapi::Std::Errors::Error]
-        #     if the system reports an error while responding to the request.
-        # @raise [Com::Vmware::Vapi::Std::Errors::NotFound]
-        #     if the virtual machine is not found.
-        # @raise [Com::Vmware::Vapi::Std::Errors::ResourceInaccessible]
-        #     if the virtual machine's configuration state cannot be accessed.
-        # @raise [Com::Vmware::Vapi::Std::Errors::ServiceUnavailable]
-        #     if the system is unable to communicate with a service to complete the request.
-        # @raise [Com::Vmware::Vapi::Std::Errors::Unauthenticated]
-        #     if the user can not be authenticated.
-        # @raise [Com::Vmware::Vapi::Std::Errors::Unauthorized]
-        #     if the user doesn't have the required privileges.
-        def get(vm)
-            invoke_with_info(@@get_info, {
-                'vm' => vm,
-            })
-        end
-
-
-        # Updates the virtual hardware settings of a virtual machine.
-        #
-        # @param vm [String]
-        #     Virtual machine identifier.
-        # @param spec [Com::Vmware::Vcenter::Vm::Hardware::UpdateSpec]
-        #     Specification for updating the virtual hardware settings of the virtual machine.
-        # @return [Void]
-        # @raise [Com::Vmware::Vapi::Std::Errors::Error]
-        #     if the system reports an error while responding to the request.
-        # @raise [Com::Vmware::Vapi::Std::Errors::NotFound]
-        #     if the virtual machine is not found.
-        # @raise [Com::Vmware::Vapi::Std::Errors::AlreadyInDesiredState]
-        #     if the virtual machine is already configured for the desired hardware version.
-        # @raise [Com::Vmware::Vapi::Std::Errors::InvalidArgument]
-        #     if the requested virtual hardware version is not newer than the current version.
-        # @raise [Com::Vmware::Vapi::Std::Errors::Unsupported]
-        #     if the requested virtual hardware version is not supported by the server.
-        # @raise [Com::Vmware::Vapi::Std::Errors::ResourceBusy]
-        #     if the virtual machine is busy performing another operation.
-        # @raise [Com::Vmware::Vapi::Std::Errors::ResourceInaccessible]
-        #     if the virtual machine's configuration state cannot be accessed.
-        # @raise [Com::Vmware::Vapi::Std::Errors::ServiceUnavailable]
-        #     if the system is unable to communicate with a service to complete the request.
-        # @raise [Com::Vmware::Vapi::Std::Errors::Unauthenticated]
-        #     if the user can not be authenticated.
-        # @raise [Com::Vmware::Vapi::Std::Errors::Unauthorized]
-        #     if the user doesn't have the required privileges.
-        def update(vm, spec)
-            invoke_with_info(@@update_info, {
-                'vm' => vm,
-                'spec' => spec,
-            })
-        end
-
-
-        # Upgrades the virtual machine to a newer virtual hardware version.
-        #
-        # @param vm [String]
-        #     Virtual machine identifier.
-        # @param version [Com::Vmware::Vcenter::Vm::Hardware::Version, nil]
-        #     New virtual machine version.
-        #     If  nil , defaults to the most recent virtual hardware version supported by the server.
-        # @return [Void]
-        # @raise [Com::Vmware::Vapi::Std::Errors::Error]
-        #     if the system reports an error while responding to the request.
-        # @raise [Com::Vmware::Vapi::Std::Errors::NotFound]
-        #     if the virtual machine is not found.
-        # @raise [Com::Vmware::Vapi::Std::Errors::NotAllowedInCurrentState]
-        #     if the virtual machine is not powered off.
-        # @raise [Com::Vmware::Vapi::Std::Errors::AlreadyInDesiredState]
-        #     if the virtual machine is already configured for the desired hardware version.
-        # @raise [Com::Vmware::Vapi::Std::Errors::InvalidArgument]
-        #     if  ``version``  is older than the current virtual hardware version.
-        # @raise [Com::Vmware::Vapi::Std::Errors::Unsupported]
-        #     if  ``version``  is not supported by the server.
-        # @raise [Com::Vmware::Vapi::Std::Errors::ResourceBusy]
-        #     if the virtual machine is busy performing another operation.
-        # @raise [Com::Vmware::Vapi::Std::Errors::ResourceInaccessible]
-        #     if the virtual machine's configuration state cannot be accessed.
-        # @raise [Com::Vmware::Vapi::Std::Errors::ServiceUnavailable]
-        #     if the system is unable to communicate with a service to complete the request.
-        # @raise [Com::Vmware::Vapi::Std::Errors::Unauthenticated]
-        #     if the user can not be authenticated.
-        # @raise [Com::Vmware::Vapi::Std::Errors::Unauthorized]
-        #     if the user doesn't have the required privileges.
-        def upgrade(vm, version=nil)
-            invoke_with_info(@@upgrade_info, {
-                'vm' => vm,
-                'version' => version,
-            })
-        end
-
-
-
-        # The  ``Com::Vmware::Vcenter::Vm::Hardware::Info``   class  contains information related to the virtual hardware of a virtual machine.
-        # @!attribute [rw] version
-        #     @return [Com::Vmware::Vcenter::Vm::Hardware::Version]
-        #     Virtual hardware version.
-        # @!attribute [rw] upgrade_policy
-        #     @return [Com::Vmware::Vcenter::Vm::Hardware::UpgradePolicy]
-        #     Scheduled upgrade policy.
-        # @!attribute [rw] upgrade_version
-        #     @return [Com::Vmware::Vcenter::Vm::Hardware::Version]
-        #     Target hardware version to be used on the next scheduled virtual hardware upgrade.
-        #     This  field  is optional and it is only relevant when the value of  ``upgradePolicy``  is one of   :attr:`Com::Vmware::Vcenter::Vm::Hardware::UpgradePolicy.AFTER_CLEAN_SHUTDOWN`   or   :attr:`Com::Vmware::Vcenter::Vm::Hardware::UpgradePolicy.ALWAYS`  .
-        # @!attribute [rw] upgrade_status
-        #     @return [Com::Vmware::Vcenter::Vm::Hardware::UpgradeStatus]
-        #     Scheduled upgrade status.
-        # @!attribute [rw] upgrade_error
-        #     @return [Exception]
-        #     Reason for the scheduled upgrade failure.
-        #     This  field  is optional and it is only relevant when the value of  ``upgradeStatus``  is   :attr:`Com::Vmware::Vcenter::Vm::Hardware::UpgradeStatus.FAILED`  .
-        class Info < VAPI::Bindings::VapiStruct
-
-            class << self
-                # Holds (gets or creates) the binding type metadata for this structure type.
-                # @scope class
-                # @return [VAPI::Bindings::StructType] the binding type
-                def binding_type
-                    @binding_type ||= VAPI::Bindings::StructType.new(
-                        'com.vmware.vcenter.vm.hardware.info',
-                        {
-                            'version' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::Vm::Hardware::Version'),
-                            'upgrade_policy' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::Vm::Hardware::UpgradePolicy'),
-                            'upgrade_version' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::Vm::Hardware::Version')),
-                            'upgrade_status' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::Vm::Hardware::UpgradeStatus'),
-                            'upgrade_error' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::AnyErrorType.instance),
-                        },
-                        Info,
-                        false,
-                        nil)
-                end
-            end
-
-            attr_accessor :version,
-                          :upgrade_policy,
-                          :upgrade_version,
-                          :upgrade_status,
-                          :upgrade_error
-
-            # Constructs a new instance.
-            # @param ruby_values [Hash] a map of initial property values (optional)
-            # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
-            def initialize(ruby_values=nil, struct_value=nil)
-                super(self.class.binding_type, ruby_values, struct_value)
-            end
-        end
-
-
-        # The  ``Com::Vmware::Vcenter::Vm::Hardware::UpdateSpec``   class  describes the updates to virtual hardware settings of a virtual machine.
-        # @!attribute [rw] upgrade_policy
-        #     @return [Com::Vmware::Vcenter::Vm::Hardware::UpgradePolicy, nil]
-        #     Scheduled upgrade policy.  
-        #     
-        #      If set to   :attr:`Com::Vmware::Vcenter::Vm::Hardware::UpgradePolicy.NEVER`  , the   :attr:`Com::Vmware::Vcenter::Vm::Hardware::Info.upgrade_version`    field  will be reset to  nil .
-        #     If  nil , the value is unchanged.
-        # @!attribute [rw] upgrade_version
-        #     @return [Com::Vmware::Vcenter::Vm::Hardware::Version, nil]
-        #     Target hardware version to be used on the next scheduled virtual hardware upgrade.  
-        #     
-        #      If specified, this  field  must represent a newer virtual hardware version than the current virtual hardware version reported in   :attr:`Com::Vmware::Vcenter::Vm::Hardware::Info.version`  .
-        #     If   :attr:`Com::Vmware::Vcenter::Vm::Hardware::UpdateSpec.upgrade_policy`   is set to   :attr:`Com::Vmware::Vcenter::Vm::Hardware::UpgradePolicy.NEVER`  , this  field  must be  nil . Otherwise, if this  field  is  nil , default to the most recent virtual hardware version supported by the server.
-        class UpdateSpec < VAPI::Bindings::VapiStruct
-
-            class << self
-                # Holds (gets or creates) the binding type metadata for this structure type.
-                # @scope class
-                # @return [VAPI::Bindings::StructType] the binding type
-                def binding_type
-                    @binding_type ||= VAPI::Bindings::StructType.new(
-                        'com.vmware.vcenter.vm.hardware.update_spec',
-                        {
-                            'upgrade_policy' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::Vm::Hardware::UpgradePolicy')),
-                            'upgrade_version' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::Vm::Hardware::Version')),
-                        },
-                        UpdateSpec,
-                        false,
-                        nil)
-                end
-            end
-
-            attr_accessor :upgrade_policy,
-                          :upgrade_version
-
-            # Constructs a new instance.
-            # @param ruby_values [Hash] a map of initial property values (optional)
-            # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
-            def initialize(ruby_values=nil, struct_value=nil)
-                super(self.class.binding_type, ruby_values, struct_value)
-            end
-        end
-
-
-
-        # The  ``Com::Vmware::Vcenter::Vm::Hardware::Version``   enumerated type  defines the valid virtual hardware versions for a virtual machine.
-        # @!attribute [rw] vmx_03
-        #     @return [Com::Vmware::Vcenter::Vm::Hardware::Version]
-        #     Hardware version 3.
-        # @!attribute [rw] vmx_04
-        #     @return [Com::Vmware::Vcenter::Vm::Hardware::Version]
-        #     Hardware version 4.
-        # @!attribute [rw] vmx_06
-        #     @return [Com::Vmware::Vcenter::Vm::Hardware::Version]
-        #     Hardware version 6.
-        # @!attribute [rw] vmx_07
-        #     @return [Com::Vmware::Vcenter::Vm::Hardware::Version]
-        #     Hardware version 7.
-        # @!attribute [rw] vmx_08
-        #     @return [Com::Vmware::Vcenter::Vm::Hardware::Version]
-        #     Hardware version 8.
-        # @!attribute [rw] vmx_09
-        #     @return [Com::Vmware::Vcenter::Vm::Hardware::Version]
-        #     Hardware version 9.
-        # @!attribute [rw] vmx_10
-        #     @return [Com::Vmware::Vcenter::Vm::Hardware::Version]
-        #     Hardware version 10.
-        # @!attribute [rw] vmx_11
-        #     @return [Com::Vmware::Vcenter::Vm::Hardware::Version]
-        #     Hardware version 11.
-        # @!attribute [rw] vmx_12
-        #     @return [Com::Vmware::Vcenter::Vm::Hardware::Version]
-        #     Hardware version 12.
-        # @!attribute [rw] vmx_13
-        #     @return [Com::Vmware::Vcenter::Vm::Hardware::Version]
-        #     Hardware version 13.
-        class Version < VAPI::Bindings::VapiEnum
-
-            class << self
-                # Holds (gets or creates) the binding type metadata for this enumeration type.
-                # @scope class
-                # @return [VAPI::Bindings::EnumType] the binding type
-                def binding_type
-                    @binding_type ||= VAPI::Bindings::EnumType.new(
-                        'com.vmware.vcenter.vm.hardware.version',
-                        Version)
-                end
-
-                # Converts from a string value (perhaps off the wire) to an instance
-                # of this enum type.
-                # @param value [String] the actual value of the enum instance
-                # @return [Version] the instance found for the value, otherwise
-                #         an unknown instance will be built for the value
-                def from_string(value)
-                    begin
-                        const_get(value)
-                    rescue NameError
-                        Version.new('UNKNOWN', value)
-                    end
-                end
-            end
-
-            private
-
-            # Constructs a new instance.
-            # @param value [String] the actual value of the enum instance
-            # @param unknown [String] the unknown value when value is 'UKNOWN'
-            def initialize(value, unknown=nil)
-                super(self.class.binding_type, value, unknown)
-            end
-
-            public
-
-            # @!attribute [rw] vmx_03
-            #     @return [Com::Vmware::Vcenter::Vm::Hardware::Version]
-            #     Hardware version 3.
-            VMX_03 = Version.new('VMX_03')
-
-            # @!attribute [rw] vmx_04
-            #     @return [Com::Vmware::Vcenter::Vm::Hardware::Version]
-            #     Hardware version 4.
-            VMX_04 = Version.new('VMX_04')
-
-            # @!attribute [rw] vmx_06
-            #     @return [Com::Vmware::Vcenter::Vm::Hardware::Version]
-            #     Hardware version 6.
-            VMX_06 = Version.new('VMX_06')
-
-            # @!attribute [rw] vmx_07
-            #     @return [Com::Vmware::Vcenter::Vm::Hardware::Version]
-            #     Hardware version 7.
-            VMX_07 = Version.new('VMX_07')
-
-            # @!attribute [rw] vmx_08
-            #     @return [Com::Vmware::Vcenter::Vm::Hardware::Version]
-            #     Hardware version 8.
-            VMX_08 = Version.new('VMX_08')
-
-            # @!attribute [rw] vmx_09
-            #     @return [Com::Vmware::Vcenter::Vm::Hardware::Version]
-            #     Hardware version 9.
-            VMX_09 = Version.new('VMX_09')
-
-            # @!attribute [rw] vmx_10
-            #     @return [Com::Vmware::Vcenter::Vm::Hardware::Version]
-            #     Hardware version 10.
-            VMX_10 = Version.new('VMX_10')
-
-            # @!attribute [rw] vmx_11
-            #     @return [Com::Vmware::Vcenter::Vm::Hardware::Version]
-            #     Hardware version 11.
-            VMX_11 = Version.new('VMX_11')
-
-            # @!attribute [rw] vmx_12
-            #     @return [Com::Vmware::Vcenter::Vm::Hardware::Version]
-            #     Hardware version 12.
-            VMX_12 = Version.new('VMX_12')
-
-            # @!attribute [rw] vmx_13
-            #     @return [Com::Vmware::Vcenter::Vm::Hardware::Version]
-            #     Hardware version 13.
-            VMX_13 = Version.new('VMX_13')
-
-        end
-
-
-        # The  ``Com::Vmware::Vcenter::Vm::Hardware::UpgradePolicy``   enumerated type  defines the valid virtual hardware upgrade policies for a virtual machine.
-        # @!attribute [rw] never
-        #     @return [Com::Vmware::Vcenter::Vm::Hardware::UpgradePolicy]
-        #     Do not upgrade the virtual machine when it is powered on.
-        # @!attribute [rw] after_clean_shutdown
-        #     @return [Com::Vmware::Vcenter::Vm::Hardware::UpgradePolicy]
-        #     Run scheduled upgrade when the virtual machine is powered on after a clean shutdown of the guest operating system.
-        # @!attribute [rw] always
-        #     @return [Com::Vmware::Vcenter::Vm::Hardware::UpgradePolicy]
-        #     Run scheduled upgrade when the virtual machine is powered on.
-        class UpgradePolicy < VAPI::Bindings::VapiEnum
-
-            class << self
-                # Holds (gets or creates) the binding type metadata for this enumeration type.
-                # @scope class
-                # @return [VAPI::Bindings::EnumType] the binding type
-                def binding_type
-                    @binding_type ||= VAPI::Bindings::EnumType.new(
-                        'com.vmware.vcenter.vm.hardware.upgrade_policy',
-                        UpgradePolicy)
-                end
-
-                # Converts from a string value (perhaps off the wire) to an instance
-                # of this enum type.
-                # @param value [String] the actual value of the enum instance
-                # @return [UpgradePolicy] the instance found for the value, otherwise
-                #         an unknown instance will be built for the value
-                def from_string(value)
-                    begin
-                        const_get(value)
-                    rescue NameError
-                        UpgradePolicy.new('UNKNOWN', value)
-                    end
-                end
-            end
-
-            private
-
-            # Constructs a new instance.
-            # @param value [String] the actual value of the enum instance
-            # @param unknown [String] the unknown value when value is 'UKNOWN'
-            def initialize(value, unknown=nil)
-                super(self.class.binding_type, value, unknown)
-            end
-
-            public
-
-            # @!attribute [rw] never
-            #     @return [Com::Vmware::Vcenter::Vm::Hardware::UpgradePolicy]
-            #     Do not upgrade the virtual machine when it is powered on.
-            NEVER = UpgradePolicy.new('NEVER')
-
-            # @!attribute [rw] after_clean_shutdown
-            #     @return [Com::Vmware::Vcenter::Vm::Hardware::UpgradePolicy]
-            #     Run scheduled upgrade when the virtual machine is powered on after a clean shutdown of the guest operating system.
-            AFTER_CLEAN_SHUTDOWN = UpgradePolicy.new('AFTER_CLEAN_SHUTDOWN')
-
-            # @!attribute [rw] always
-            #     @return [Com::Vmware::Vcenter::Vm::Hardware::UpgradePolicy]
-            #     Run scheduled upgrade when the virtual machine is powered on.
-            ALWAYS = UpgradePolicy.new('ALWAYS')
-
-        end
-
-
-        # The  ``Com::Vmware::Vcenter::Vm::Hardware::UpgradeStatus``   enumerated type  defines the valid virtual hardware upgrade statuses for a virtual machine.
-        # @!attribute [rw] none
-        #     @return [Com::Vmware::Vcenter::Vm::Hardware::UpgradeStatus]
-        #     No scheduled upgrade has been attempted.
-        # @!attribute [rw] pending
-        #     @return [Com::Vmware::Vcenter::Vm::Hardware::UpgradeStatus]
-        #     Upgrade is scheduled but has not yet been run.
-        # @!attribute [rw] success
-        #     @return [Com::Vmware::Vcenter::Vm::Hardware::UpgradeStatus]
-        #     The most recent scheduled upgrade was successful.
-        # @!attribute [rw] failed
-        #     @return [Com::Vmware::Vcenter::Vm::Hardware::UpgradeStatus]
-        #     The most recent scheduled upgrade was not successful.
-        class UpgradeStatus < VAPI::Bindings::VapiEnum
-
-            class << self
-                # Holds (gets or creates) the binding type metadata for this enumeration type.
-                # @scope class
-                # @return [VAPI::Bindings::EnumType] the binding type
-                def binding_type
-                    @binding_type ||= VAPI::Bindings::EnumType.new(
-                        'com.vmware.vcenter.vm.hardware.upgrade_status',
-                        UpgradeStatus)
-                end
-
-                # Converts from a string value (perhaps off the wire) to an instance
-                # of this enum type.
-                # @param value [String] the actual value of the enum instance
-                # @return [UpgradeStatus] the instance found for the value, otherwise
-                #         an unknown instance will be built for the value
-                def from_string(value)
-                    begin
-                        const_get(value)
-                    rescue NameError
-                        UpgradeStatus.new('UNKNOWN', value)
-                    end
-                end
-            end
-
-            private
-
-            # Constructs a new instance.
-            # @param value [String] the actual value of the enum instance
-            # @param unknown [String] the unknown value when value is 'UKNOWN'
-            def initialize(value, unknown=nil)
-                super(self.class.binding_type, value, unknown)
-            end
-
-            public
-
-            # @!attribute [rw] none
-            #     @return [Com::Vmware::Vcenter::Vm::Hardware::UpgradeStatus]
-            #     No scheduled upgrade has been attempted.
-            NONE = UpgradeStatus.new('NONE')
-
-            # @!attribute [rw] pending
-            #     @return [Com::Vmware::Vcenter::Vm::Hardware::UpgradeStatus]
-            #     Upgrade is scheduled but has not yet been run.
-            PENDING = UpgradeStatus.new('PENDING')
-
-            # @!attribute [rw] success
-            #     @return [Com::Vmware::Vcenter::Vm::Hardware::UpgradeStatus]
-            #     The most recent scheduled upgrade was successful.
-            SUCCESS = UpgradeStatus.new('SUCCESS')
-
-            # @!attribute [rw] failed
-            #     @return [Com::Vmware::Vcenter::Vm::Hardware::UpgradeStatus]
-            #     The most recent scheduled upgrade was not successful.
-            FAILED = UpgradeStatus.new('FAILED')
-
-        end
-
-
+  # The  ``Com::Vmware::Vcenter::VM::Hardware``   class  provides  methods  for configuring the virtual hardware of a virtual machine.
+  class HardwareService < VAPI::Bindings::VapiService
+    # static metamodel definitions
+    SERVICE_ID = VAPI::Core::ServiceIdentifier.new('com.vmware.vcenter.vm.hardware')
+
+    GET_INFO = VAPI::Bindings::OperationInfo.new(
+      VAPI::Core::OperationIdentifier.new('get', SERVICE_ID),
+      VAPI::Bindings::OperationInputType.new(
+        'vm' => VAPI::Bindings::IdType.new('VirtualMachine')
+      ),
+      VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::VM::Hardware::Info'),
+      {
+        'com.vmware.vapi.std.errors.error' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Error'),
+        'com.vmware.vapi.std.errors.not_found' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::NotFound'),
+        'com.vmware.vapi.std.errors.resource_inaccessible' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::ResourceInaccessible'),
+        'com.vmware.vapi.std.errors.service_unavailable' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::ServiceUnavailable'),
+        'com.vmware.vapi.std.errors.unauthenticated' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Unauthenticated'),
+        'com.vmware.vapi.std.errors.unauthorized' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Unauthorized')
+      },
+      [],
+      []
+    )
+
+    UPDATE_INFO = VAPI::Bindings::OperationInfo.new(
+      VAPI::Core::OperationIdentifier.new('update', SERVICE_ID),
+      VAPI::Bindings::OperationInputType.new(
+        'vm' => VAPI::Bindings::IdType.new('VirtualMachine'),
+        'spec' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::VM::Hardware::UpdateSpec')
+      ),
+      VAPI::Bindings::VoidType.instance,
+      {
+        'com.vmware.vapi.std.errors.error' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Error'),
+        'com.vmware.vapi.std.errors.not_found' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::NotFound'),
+        'com.vmware.vapi.std.errors.already_in_desired_state' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::AlreadyInDesiredState'),
+        'com.vmware.vapi.std.errors.invalid_argument' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::InvalidArgument'),
+        'com.vmware.vapi.std.errors.unsupported' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Unsupported'),
+        'com.vmware.vapi.std.errors.resource_busy' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::ResourceBusy'),
+        'com.vmware.vapi.std.errors.resource_inaccessible' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::ResourceInaccessible'),
+        'com.vmware.vapi.std.errors.service_unavailable' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::ServiceUnavailable'),
+        'com.vmware.vapi.std.errors.unauthenticated' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Unauthenticated'),
+        'com.vmware.vapi.std.errors.unauthorized' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Unauthorized')
+      },
+      [],
+      []
+    )
+
+    UPGRADE_INFO = VAPI::Bindings::OperationInfo.new(
+      VAPI::Core::OperationIdentifier.new('upgrade', SERVICE_ID),
+      VAPI::Bindings::OperationInputType.new(
+        'vm' => VAPI::Bindings::IdType.new('VirtualMachine'),
+        'version' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::VM::Hardware::Version'))
+      ),
+      VAPI::Bindings::VoidType.instance,
+      {
+        'com.vmware.vapi.std.errors.error' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Error'),
+        'com.vmware.vapi.std.errors.not_found' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::NotFound'),
+        'com.vmware.vapi.std.errors.not_allowed_in_current_state' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::NotAllowedInCurrentState'),
+        'com.vmware.vapi.std.errors.already_in_desired_state' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::AlreadyInDesiredState'),
+        'com.vmware.vapi.std.errors.invalid_argument' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::InvalidArgument'),
+        'com.vmware.vapi.std.errors.unsupported' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Unsupported'),
+        'com.vmware.vapi.std.errors.resource_busy' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::ResourceBusy'),
+        'com.vmware.vapi.std.errors.resource_inaccessible' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::ResourceInaccessible'),
+        'com.vmware.vapi.std.errors.service_unavailable' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::ServiceUnavailable'),
+        'com.vmware.vapi.std.errors.unauthenticated' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Unauthenticated'),
+        'com.vmware.vapi.std.errors.unauthorized' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Unauthorized')
+      },
+      [],
+      []
+    )
+
+    SERVICE_INFO = VAPI::Bindings::ServiceInfo.new(
+      SERVICE_ID,
+      'get' => GET_INFO,
+      'update' => UPDATE_INFO,
+      'upgrade' => UPGRADE_INFO
+    )
+
+    # Constructs a new instance.
+    #
+    # @param config [VAPI::Bindings::StubConfig] A hash with the api provider details.
+    def initialize(config)
+      super(config, SERVICE_INFO)
     end
 
-
-    # The  ``Com::Vmware::Vcenter::Vm::Power``   class  provides  methods  for managing the power state of a virtual machine.
-    class Power < VAPI::Bindings::VapiService
-
-        protected
-
-        # static metamodel definitions
-        @@service_id = VAPI::Core::ServiceIdentifier.new('com.vmware.vcenter.vm.power')
-
-        @@get_info = VAPI::Bindings::OperationInfo.new(
-            VAPI::Core::OperationIdentifier.new('get', @@service_id),
-            VAPI::Bindings::OperationInputType.new({
-                'vm' => VAPI::Bindings::IdType.new(resource_types='VirtualMachine'),
-            }),
-            VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::Vm::Power::Info'),
-            {
-                'com.vmware.vapi.std.errors.error' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Error'),
-                'com.vmware.vapi.std.errors.not_found' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::NotFound'),
-                'com.vmware.vapi.std.errors.resource_inaccessible' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::ResourceInaccessible'),
-                'com.vmware.vapi.std.errors.service_unavailable' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::ServiceUnavailable'),
-                'com.vmware.vapi.std.errors.unauthenticated' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Unauthenticated'),
-                'com.vmware.vapi.std.errors.unauthorized' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Unauthorized'),
-
-            },
-            [],
-            [])
-        @@start_info = VAPI::Bindings::OperationInfo.new(
-            VAPI::Core::OperationIdentifier.new('start', @@service_id),
-            VAPI::Bindings::OperationInputType.new({
-                'vm' => VAPI::Bindings::IdType.new(resource_types='VirtualMachine'),
-            }),
-            VAPI::Bindings::VoidType.instance,
-            {
-                'com.vmware.vapi.std.errors.error' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Error'),
-                'com.vmware.vapi.std.errors.not_found' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::NotFound'),
-                'com.vmware.vapi.std.errors.already_in_desired_state' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::AlreadyInDesiredState'),
-                'com.vmware.vapi.std.errors.unsupported' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Unsupported'),
-                'com.vmware.vapi.std.errors.unable_to_allocate_resource' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::UnableToAllocateResource'),
-                'com.vmware.vapi.std.errors.resource_inaccessible' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::ResourceInaccessible'),
-                'com.vmware.vapi.std.errors.resource_in_use' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::ResourceInUse'),
-                'com.vmware.vapi.std.errors.resource_busy' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::ResourceBusy'),
-                'com.vmware.vapi.std.errors.service_unavailable' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::ServiceUnavailable'),
-                'com.vmware.vapi.std.errors.unauthenticated' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Unauthenticated'),
-                'com.vmware.vapi.std.errors.unauthorized' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Unauthorized'),
-
-            },
-            [],
-            [])
-        @@stop_info = VAPI::Bindings::OperationInfo.new(
-            VAPI::Core::OperationIdentifier.new('stop', @@service_id),
-            VAPI::Bindings::OperationInputType.new({
-                'vm' => VAPI::Bindings::IdType.new(resource_types='VirtualMachine'),
-            }),
-            VAPI::Bindings::VoidType.instance,
-            {
-                'com.vmware.vapi.std.errors.error' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Error'),
-                'com.vmware.vapi.std.errors.not_found' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::NotFound'),
-                'com.vmware.vapi.std.errors.already_in_desired_state' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::AlreadyInDesiredState'),
-                'com.vmware.vapi.std.errors.resource_busy' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::ResourceBusy'),
-                'com.vmware.vapi.std.errors.service_unavailable' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::ServiceUnavailable'),
-                'com.vmware.vapi.std.errors.unauthenticated' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Unauthenticated'),
-                'com.vmware.vapi.std.errors.unauthorized' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Unauthorized'),
-
-            },
-            [],
-            [])
-        @@suspend_info = VAPI::Bindings::OperationInfo.new(
-            VAPI::Core::OperationIdentifier.new('suspend', @@service_id),
-            VAPI::Bindings::OperationInputType.new({
-                'vm' => VAPI::Bindings::IdType.new(resource_types='VirtualMachine'),
-            }),
-            VAPI::Bindings::VoidType.instance,
-            {
-                'com.vmware.vapi.std.errors.error' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Error'),
-                'com.vmware.vapi.std.errors.not_found' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::NotFound'),
-                'com.vmware.vapi.std.errors.already_in_desired_state' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::AlreadyInDesiredState'),
-                'com.vmware.vapi.std.errors.not_allowed_in_current_state' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::NotAllowedInCurrentState'),
-                'com.vmware.vapi.std.errors.resource_busy' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::ResourceBusy'),
-                'com.vmware.vapi.std.errors.service_unavailable' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::ServiceUnavailable'),
-                'com.vmware.vapi.std.errors.unauthenticated' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Unauthenticated'),
-                'com.vmware.vapi.std.errors.unauthorized' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Unauthorized'),
-
-            },
-            [],
-            [])
-        @@reset_info = VAPI::Bindings::OperationInfo.new(
-            VAPI::Core::OperationIdentifier.new('reset', @@service_id),
-            VAPI::Bindings::OperationInputType.new({
-                'vm' => VAPI::Bindings::IdType.new(resource_types='VirtualMachine'),
-            }),
-            VAPI::Bindings::VoidType.instance,
-            {
-                'com.vmware.vapi.std.errors.error' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Error'),
-                'com.vmware.vapi.std.errors.not_found' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::NotFound'),
-                'com.vmware.vapi.std.errors.not_allowed_in_current_state' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::NotAllowedInCurrentState'),
-                'com.vmware.vapi.std.errors.resource_busy' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::ResourceBusy'),
-                'com.vmware.vapi.std.errors.service_unavailable' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::ServiceUnavailable'),
-                'com.vmware.vapi.std.errors.unauthenticated' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Unauthenticated'),
-                'com.vmware.vapi.std.errors.unauthorized' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Unauthorized'),
-
-            },
-            [],
-            [])
-
-        @@service_info = VAPI::Bindings::ServiceInfo.new(@@service_id, {
-            'get' => @@get_info,
-            'start' => @@start_info,
-            'stop' => @@stop_info,
-            'suspend' => @@suspend_info,
-            'reset' => @@reset_info,
-        })
-
-        public
-
-        # Constructs a new instance.
-        #
-        # @param config [VAPI::Bindings::StubConfig] A hash with the api provider details.
-        def initialize(config)
-            super(config, @@service_info)
-        end
-
-
-        # Returns the power state information of a virtual machine.
-        #
-        # @param vm [String]
-        #     Virtual machine identifier.
-        # @return [Com::Vmware::Vcenter::Vm::Power::Info]
-        #     Power state information for the specified virtual machine.
-        # @raise [Com::Vmware::Vapi::Std::Errors::Error]
-        #     if the system reports an error while responding to the request.
-        # @raise [Com::Vmware::Vapi::Std::Errors::NotFound]
-        #     if the virtual machine is not found.
-        # @raise [Com::Vmware::Vapi::Std::Errors::ResourceInaccessible]
-        #     if the virtual machine's configuration or execution state cannot be accessed.
-        # @raise [Com::Vmware::Vapi::Std::Errors::ServiceUnavailable]
-        #     if the system is unable to communicate with a service to complete the request.
-        # @raise [Com::Vmware::Vapi::Std::Errors::Unauthenticated]
-        #     if the user can not be authenticated.
-        # @raise [Com::Vmware::Vapi::Std::Errors::Unauthorized]
-        #     if the user doesn't have the required privileges.
-        def get(vm)
-            invoke_with_info(@@get_info, {
-                'vm' => vm,
-            })
-        end
-
-
-        # Powers on a powered-off or suspended virtual machine.
-        #
-        # @param vm [String]
-        #     Virtual machine identifier.
-        # @return [Void]
-        # @raise [Com::Vmware::Vapi::Std::Errors::Error]
-        #     if the system reports an error while responding to the request.
-        # @raise [Com::Vmware::Vapi::Std::Errors::NotFound]
-        #     if the virtual machine is not found.
-        # @raise [Com::Vmware::Vapi::Std::Errors::AlreadyInDesiredState]
-        #     if the virtual machine is already powered on.
-        # @raise [Com::Vmware::Vapi::Std::Errors::Unsupported]
-        #     if the virtual machine does not support being powered on (e.g. marked as a template, serving as a fault-tolerance secondary virtual machine).
-        # @raise [Com::Vmware::Vapi::Std::Errors::UnableToAllocateResource]
-        #     if resources cannot be allocated for the virtual machine (e.g. physical resource allocation policy cannot be satisfied, insufficient licenses are available to run the virtual machine).
-        # @raise [Com::Vmware::Vapi::Std::Errors::ResourceInaccessible]
-        #     if resources required by the virtual machine are not accessible (e.g. virtual machine configuration files or virtual disks are on inaccessible storage, no hosts are available to run the virtual machine).
-        # @raise [Com::Vmware::Vapi::Std::Errors::ResourceInUse]
-        #     if resources required by the virtual machine are in use (e.g. virtual machine configuration files or virtual disks are locked, host containing the virtual machine is an HA failover host).
-        # @raise [Com::Vmware::Vapi::Std::Errors::ResourceBusy]
-        #     if the virtual machine is performing another operation.
-        # @raise [Com::Vmware::Vapi::Std::Errors::ServiceUnavailable]
-        #     if the system is unable to communicate with a service to complete the request.
-        # @raise [Com::Vmware::Vapi::Std::Errors::Unauthenticated]
-        #     if the user can not be authenticated.
-        # @raise [Com::Vmware::Vapi::Std::Errors::Unauthorized]
-        #     if the user doesn't have the required privileges.
-        def start(vm)
-            invoke_with_info(@@start_info, {
-                'vm' => vm,
-            })
-        end
-
-
-        # Powers off a powered-on or suspended virtual machine.
-        #
-        # @param vm [String]
-        #     Virtual machine identifier.
-        # @return [Void]
-        # @raise [Com::Vmware::Vapi::Std::Errors::Error]
-        #     if the system reports an error while responding to the request.
-        # @raise [Com::Vmware::Vapi::Std::Errors::NotFound]
-        #     if the virtual machine is not found.
-        # @raise [Com::Vmware::Vapi::Std::Errors::AlreadyInDesiredState]
-        #     if the virtual machine is already powered off.
-        # @raise [Com::Vmware::Vapi::Std::Errors::ResourceBusy]
-        #     if the virtual machine is performing another operation.
-        # @raise [Com::Vmware::Vapi::Std::Errors::ServiceUnavailable]
-        #     if the system is unable to communicate with a service to complete the request.
-        # @raise [Com::Vmware::Vapi::Std::Errors::Unauthenticated]
-        #     if the user can not be authenticated.
-        # @raise [Com::Vmware::Vapi::Std::Errors::Unauthorized]
-        #     if the user doesn't have the required privileges.
-        def stop(vm)
-            invoke_with_info(@@stop_info, {
-                'vm' => vm,
-            })
-        end
-
-
-        # Suspends a powered-on virtual machine.
-        #
-        # @param vm [String]
-        #     Virtual machine identifier.
-        # @return [Void]
-        # @raise [Com::Vmware::Vapi::Std::Errors::Error]
-        #     if the system reports an error while responding to the request.
-        # @raise [Com::Vmware::Vapi::Std::Errors::NotFound]
-        #     if the virtual machine is not found.
-        # @raise [Com::Vmware::Vapi::Std::Errors::AlreadyInDesiredState]
-        #     if the virtual machine is already suspended.
-        # @raise [Com::Vmware::Vapi::Std::Errors::NotAllowedInCurrentState]
-        #     if the virtual machine is powered off.
-        # @raise [Com::Vmware::Vapi::Std::Errors::ResourceBusy]
-        #     if the virtual machine is performing another operation.
-        # @raise [Com::Vmware::Vapi::Std::Errors::ServiceUnavailable]
-        #     if the system is unable to communicate with a service to complete the request.
-        # @raise [Com::Vmware::Vapi::Std::Errors::Unauthenticated]
-        #     if the user can not be authenticated.
-        # @raise [Com::Vmware::Vapi::Std::Errors::Unauthorized]
-        #     if the user doesn't have the required privileges.
-        def suspend(vm)
-            invoke_with_info(@@suspend_info, {
-                'vm' => vm,
-            })
-        end
-
-
-        # Resets a powered-on virtual machine.
-        #
-        # @param vm [String]
-        #     Virtual machine identifier.
-        # @return [Void]
-        # @raise [Com::Vmware::Vapi::Std::Errors::Error]
-        #     if the system reports an error while responding to the request.
-        # @raise [Com::Vmware::Vapi::Std::Errors::NotFound]
-        #     if the virtual machine is not found.
-        # @raise [Com::Vmware::Vapi::Std::Errors::NotAllowedInCurrentState]
-        #     if the virtual machine is powered off or suspended.
-        # @raise [Com::Vmware::Vapi::Std::Errors::ResourceBusy]
-        #     if the virtual machine is performing another operation
-        # @raise [Com::Vmware::Vapi::Std::Errors::ServiceUnavailable]
-        #     if the system is unable to communicate with a service to complete the request.
-        # @raise [Com::Vmware::Vapi::Std::Errors::Unauthenticated]
-        #     if the user can not be authenticated.
-        # @raise [Com::Vmware::Vapi::Std::Errors::Unauthorized]
-        #     if the user doesn't have the required privileges.
-        def reset(vm)
-            invoke_with_info(@@reset_info, {
-                'vm' => vm,
-            })
-        end
-
-
-
-        # The  ``Com::Vmware::Vcenter::Vm::Power::Info``   class  contains information about the power state of a virtual machine.
-        # @!attribute [rw] state
-        #     @return [Com::Vmware::Vcenter::Vm::Power::State]
-        #     Power state of the virtual machine.
-        # @!attribute [rw] clean_power_off
-        #     @return [Boolean]
-        #     Flag indicating whether the virtual machine was powered off cleanly. This  field  may be used to detect that the virtual machine crashed unexpectedly and should be restarted.
-        #     This  field  is optional and it is only relevant when the value of  ``state``  is   :attr:`Com::Vmware::Vcenter::Vm::Power::State.POWERED_OFF`  .
-        class Info < VAPI::Bindings::VapiStruct
-
-            class << self
-                # Holds (gets or creates) the binding type metadata for this structure type.
-                # @scope class
-                # @return [VAPI::Bindings::StructType] the binding type
-                def binding_type
-                    @binding_type ||= VAPI::Bindings::StructType.new(
-                        'com.vmware.vcenter.vm.power.info',
-                        {
-                            'state' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::Vm::Power::State'),
-                            'clean_power_off' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::BooleanType.instance),
-                        },
-                        Info,
-                        false,
-                        nil)
-                end
-            end
-
-            attr_accessor :state,
-                          :clean_power_off
-
-            # Constructs a new instance.
-            # @param ruby_values [Hash] a map of initial property values (optional)
-            # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
-            def initialize(ruby_values=nil, struct_value=nil)
-                super(self.class.binding_type, ruby_values, struct_value)
-            end
-        end
-
-
-
-        # The  ``Com::Vmware::Vcenter::Vm::Power::State``   enumerated type  defines the valid power states for a virtual machine.
-        # @!attribute [rw] powered_off
-        #     @return [Com::Vmware::Vcenter::Vm::Power::State]
-        #     The virtual machine is powered off.
-        # @!attribute [rw] powered_on
-        #     @return [Com::Vmware::Vcenter::Vm::Power::State]
-        #     The virtual machine is powered on.
-        # @!attribute [rw] suspended
-        #     @return [Com::Vmware::Vcenter::Vm::Power::State]
-        #     The virtual machine is suspended.
-        class State < VAPI::Bindings::VapiEnum
-
-            class << self
-                # Holds (gets or creates) the binding type metadata for this enumeration type.
-                # @scope class
-                # @return [VAPI::Bindings::EnumType] the binding type
-                def binding_type
-                    @binding_type ||= VAPI::Bindings::EnumType.new(
-                        'com.vmware.vcenter.vm.power.state',
-                        State)
-                end
-
-                # Converts from a string value (perhaps off the wire) to an instance
-                # of this enum type.
-                # @param value [String] the actual value of the enum instance
-                # @return [State] the instance found for the value, otherwise
-                #         an unknown instance will be built for the value
-                def from_string(value)
-                    begin
-                        const_get(value)
-                    rescue NameError
-                        State.new('UNKNOWN', value)
-                    end
-                end
-            end
-
-            private
-
-            # Constructs a new instance.
-            # @param value [String] the actual value of the enum instance
-            # @param unknown [String] the unknown value when value is 'UKNOWN'
-            def initialize(value, unknown=nil)
-                super(self.class.binding_type, value, unknown)
-            end
-
-            public
-
-            # @!attribute [rw] powered_off
-            #     @return [Com::Vmware::Vcenter::Vm::Power::State]
-            #     The virtual machine is powered off.
-            POWERED_OFF = State.new('POWERED_OFF')
-
-            # @!attribute [rw] powered_on
-            #     @return [Com::Vmware::Vcenter::Vm::Power::State]
-            #     The virtual machine is powered on.
-            POWERED_ON = State.new('POWERED_ON')
-
-            # @!attribute [rw] suspended
-            #     @return [Com::Vmware::Vcenter::Vm::Power::State]
-            #     The virtual machine is suspended.
-            SUSPENDED = State.new('SUSPENDED')
-
-        end
-
-
+    # Returns the virtual hardware settings of a virtual machine.
+    #
+    # @param vm [String]
+    #     Virtual machine identifier.
+    # @return [Com::Vmware::Vcenter::VM::Hardware::Info]
+    #     Virtual hardware settings of the virtual machine.
+    # @raise [Com::Vmware::Vapi::Std::Errors::Error]
+    #     if the system reports an error while responding to the request.
+    # @raise [Com::Vmware::Vapi::Std::Errors::NotFound]
+    #     if the virtual machine is not found.
+    # @raise [Com::Vmware::Vapi::Std::Errors::ResourceInaccessible]
+    #     if the virtual machine's configuration state cannot be accessed.
+    # @raise [Com::Vmware::Vapi::Std::Errors::ServiceUnavailable]
+    #     if the system is unable to communicate with a service to complete the request.
+    # @raise [Com::Vmware::Vapi::Std::Errors::Unauthenticated]
+    #     if the user can not be authenticated.
+    # @raise [Com::Vmware::Vapi::Std::Errors::Unauthorized]
+    #     if the user doesn't have the required privileges.
+    def get(vm)
+      invoke_with_info(GET_INFO,
+                       'vm' => vm)
     end
 
+    # Updates the virtual hardware settings of a virtual machine.
+    #
+    # @param vm [String]
+    #     Virtual machine identifier.
+    # @param spec [Com::Vmware::Vcenter::VM::Hardware::UpdateSpec]
+    #     Specification for updating the virtual hardware settings of the virtual machine.
+    # @return [Void]
+    # @raise [Com::Vmware::Vapi::Std::Errors::Error]
+    #     if the system reports an error while responding to the request.
+    # @raise [Com::Vmware::Vapi::Std::Errors::NotFound]
+    #     if the virtual machine is not found.
+    # @raise [Com::Vmware::Vapi::Std::Errors::AlreadyInDesiredState]
+    #     if the virtual machine is already configured for the desired hardware version.
+    # @raise [Com::Vmware::Vapi::Std::Errors::InvalidArgument]
+    #     if the requested virtual hardware version is not newer than the current version.
+    # @raise [Com::Vmware::Vapi::Std::Errors::Unsupported]
+    #     if the requested virtual hardware version is not supported by the server.
+    # @raise [Com::Vmware::Vapi::Std::Errors::ResourceBusy]
+    #     if the virtual machine is busy performing another operation.
+    # @raise [Com::Vmware::Vapi::Std::Errors::ResourceInaccessible]
+    #     if the virtual machine's configuration state cannot be accessed.
+    # @raise [Com::Vmware::Vapi::Std::Errors::ServiceUnavailable]
+    #     if the system is unable to communicate with a service to complete the request.
+    # @raise [Com::Vmware::Vapi::Std::Errors::Unauthenticated]
+    #     if the user can not be authenticated.
+    # @raise [Com::Vmware::Vapi::Std::Errors::Unauthorized]
+    #     if the user doesn't have the required privileges.
+    def update(vm, spec)
+      invoke_with_info(UPDATE_INFO,
+                       'vm' => vm,
+                       'spec' => spec)
+    end
 
+    # Upgrades the virtual machine to a newer virtual hardware version.
+    #
+    # @param vm [String]
+    #     Virtual machine identifier.
+    # @param version [Com::Vmware::Vcenter::VM::Hardware::Version, nil]
+    #     New virtual machine version.
+    #     If  nil , defaults to the most recent virtual hardware version supported by the server.
+    # @return [Void]
+    # @raise [Com::Vmware::Vapi::Std::Errors::Error]
+    #     if the system reports an error while responding to the request.
+    # @raise [Com::Vmware::Vapi::Std::Errors::NotFound]
+    #     if the virtual machine is not found.
+    # @raise [Com::Vmware::Vapi::Std::Errors::NotAllowedInCurrentState]
+    #     if the virtual machine is not powered off.
+    # @raise [Com::Vmware::Vapi::Std::Errors::AlreadyInDesiredState]
+    #     if the virtual machine is already configured for the desired hardware version.
+    # @raise [Com::Vmware::Vapi::Std::Errors::InvalidArgument]
+    #     if  ``version``  is older than the current virtual hardware version.
+    # @raise [Com::Vmware::Vapi::Std::Errors::Unsupported]
+    #     if  ``version``  is not supported by the server.
+    # @raise [Com::Vmware::Vapi::Std::Errors::ResourceBusy]
+    #     if the virtual machine is busy performing another operation.
+    # @raise [Com::Vmware::Vapi::Std::Errors::ResourceInaccessible]
+    #     if the virtual machine's configuration state cannot be accessed.
+    # @raise [Com::Vmware::Vapi::Std::Errors::ServiceUnavailable]
+    #     if the system is unable to communicate with a service to complete the request.
+    # @raise [Com::Vmware::Vapi::Std::Errors::Unauthenticated]
+    #     if the user can not be authenticated.
+    # @raise [Com::Vmware::Vapi::Std::Errors::Unauthorized]
+    #     if the user doesn't have the required privileges.
+    def upgrade(vm, version = nil)
+      invoke_with_info(UPGRADE_INFO,
+                       'vm' => vm,
+                       'version' => version)
+    end
 
-    # The  ``Com::Vmware::Vcenter::Vm::GuestOS``   enumerated type  defines the valid guest operating system types used for configuring a virtual machine.
-    # @!attribute [rw] dos
-    #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
-    #     MS-DOS.
-    # @!attribute [rw] win_31
-    #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
-    #     Windows 3.1
-    # @!attribute [rw] win_95
-    #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
-    #     Windows 95
-    # @!attribute [rw] win_98
-    #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
-    #     Windows 98
-    # @!attribute [rw] win_me
-    #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
-    #     Windows Millennium Edition
-    # @!attribute [rw] win_nt
-    #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
-    #     Windows NT 4
-    # @!attribute [rw] win_2000_pro
-    #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
-    #     Windows 2000 Professional
-    # @!attribute [rw] win_2000_serv
-    #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
-    #     Windows 2000 Server
-    # @!attribute [rw] win_2000_adv_serv
-    #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
-    #     Windows 2000 Advanced Server
-    # @!attribute [rw] win_xp_home
-    #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
-    #     Windows XP Home Edition
-    # @!attribute [rw] win_xp_pro
-    #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
-    #     Windows XP Professional
-    # @!attribute [rw] win_xp_pro_64
-    #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
-    #     Windows XP Professional Edition (64 bit)
-    # @!attribute [rw] win_net_web
-    #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
-    #     Windows Server 2003, Web Edition
-    # @!attribute [rw] win_net_standard
-    #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
-    #     Windows Server 2003, Standard Edition
-    # @!attribute [rw] win_net_enterprise
-    #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
-    #     Windows Server 2003, Enterprise Edition
-    # @!attribute [rw] win_net_datacenter
-    #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
-    #     Windows Server 2003, Datacenter Edition
-    # @!attribute [rw] win_net_business
-    #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
-    #     Windows Small Business Server 2003
-    # @!attribute [rw] win_net_standard_64
-    #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
-    #     Windows Server 2003, Standard Edition (64 bit)
-    # @!attribute [rw] win_net_enterprise_64
-    #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
-    #     Windows Server 2003, Enterprise Edition (64 bit)
-    # @!attribute [rw] win_longhorn
-    #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
-    #     Windows Longhorn (experimental)
-    # @!attribute [rw] win_longhorn_64
-    #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
-    #     Windows Longhorn (64 bit) (experimental)
-    # @!attribute [rw] win_net_datacenter_64
-    #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
-    #     Windows Server 2003, Datacenter Edition (64 bit) (experimental)
-    # @!attribute [rw] win_vista
-    #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
-    #     Windows Vista
-    # @!attribute [rw] win_vista_64
-    #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
-    #     Windows Vista (64 bit)
-    # @!attribute [rw] windows_7
-    #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
-    #     Windows 7
-    # @!attribute [rw] windows_7_64
-    #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
-    #     Windows 7 (64 bit)
-    # @!attribute [rw] windows_7_server_64
-    #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
-    #     Windows Server 2008 R2 (64 bit)
-    # @!attribute [rw] windows_8
-    #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
-    #     Windows 8
-    # @!attribute [rw] windows_8_64
-    #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
-    #     Windows 8 (64 bit)
-    # @!attribute [rw] windows_8_server_64
-    #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
-    #     Windows 8 Server (64 bit)
-    # @!attribute [rw] windows_9
-    #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
-    #     Windows 10
-    # @!attribute [rw] windows_9_64
-    #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
-    #     Windows 10 (64 bit)
-    # @!attribute [rw] windows_9_server_64
-    #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
-    #     Windows 10 Server (64 bit)
-    # @!attribute [rw] windows_hyperv
-    #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
-    #     Windows Hyper-V
-    # @!attribute [rw] freebsd
-    #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
-    #     FreeBSD
-    # @!attribute [rw] freebsd_64
-    #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
-    #     FreeBSD x64
-    # @!attribute [rw] redhat
-    #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
-    #     Red Hat Linux 2.1
-    # @!attribute [rw] rhel_2
-    #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
-    #     Red Hat Enterprise Linux 2
-    # @!attribute [rw] rhel_3
-    #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
-    #     Red Hat Enterprise Linux 3
-    # @!attribute [rw] rhel_3_64
-    #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
-    #     Red Hat Enterprise Linux 3 (64 bit)
-    # @!attribute [rw] rhel_4
-    #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
-    #     Red Hat Enterprise Linux 4
-    # @!attribute [rw] rhel_4_64
-    #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
-    #     Red Hat Enterprise Linux 4 (64 bit)
-    # @!attribute [rw] rhel_5
-    #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
-    #     Red Hat Enterprise Linux 5
-    # @!attribute [rw] rhel_5_64
-    #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
-    #     Red Hat Enterprise Linux 5 (64 bit) (experimental)
-    # @!attribute [rw] rhel_6
-    #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
-    #     Red Hat Enterprise Linux 6
-    # @!attribute [rw] rhel_6_64
-    #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
-    #     Red Hat Enterprise Linux 6 (64 bit)
-    # @!attribute [rw] rhel_7
-    #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
-    #     Red Hat Enterprise Linux 7
-    # @!attribute [rw] rhel_7_64
-    #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
-    #     Red Hat Enterprise Linux 7 (64 bit)
-    # @!attribute [rw] centos
-    #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
-    #     CentOS 4/5
-    # @!attribute [rw] centos_64
-    #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
-    #     CentOS 4/5 (64-bit)
-    # @!attribute [rw] centos_6
-    #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
-    #     CentOS 6
-    # @!attribute [rw] centos_6_64
-    #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
-    #     CentOS 6 (64-bit)
-    # @!attribute [rw] centos_7
-    #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
-    #     CentOS 7
-    # @!attribute [rw] centos_7_64
-    #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
-    #     CentOS 7 (64-bit)
-    # @!attribute [rw] oracle_linux
-    #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
-    #     Oracle Linux 4/5
-    # @!attribute [rw] oracle_linux_64
-    #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
-    #     Oracle Linux 4/5 (64-bit)
-    # @!attribute [rw] oracle_linux_6
-    #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
-    #     Oracle Linux 6
-    # @!attribute [rw] oracle_linux_6_64
-    #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
-    #     Oracle Linux 6 (64-bit)
-    # @!attribute [rw] oracle_linux_7
-    #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
-    #     Oracle Linux 7
-    # @!attribute [rw] oracle_linux_7_64
-    #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
-    #     Oracle Linux 7 (64-bit)
-    # @!attribute [rw] suse
-    #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
-    #     Suse Linux
-    # @!attribute [rw] suse_64
-    #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
-    #     Suse Linux (64 bit)
-    # @!attribute [rw] sles
-    #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
-    #     Suse Linux Enterprise Server 9
-    # @!attribute [rw] sles_64
-    #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
-    #     Suse Linux Enterprise Server 9 (64 bit)
-    # @!attribute [rw] sles_10
-    #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
-    #     Suse linux Enterprise Server 10
-    # @!attribute [rw] sles_10_64
-    #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
-    #     Suse Linux Enterprise Server 10 (64 bit) (experimental)
-    # @!attribute [rw] sles_11
-    #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
-    #     Suse linux Enterprise Server 11
-    # @!attribute [rw] sles_11_64
-    #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
-    #     Suse Linux Enterprise Server 11 (64 bit)
-    # @!attribute [rw] sles_12
-    #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
-    #     Suse linux Enterprise Server 12
-    # @!attribute [rw] sles_12_64
-    #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
-    #     Suse Linux Enterprise Server 12 (64 bit)
-    # @!attribute [rw] nld_9
-    #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
-    #     Novell Linux Desktop 9
-    # @!attribute [rw] oes
-    #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
-    #     Open Enterprise Server
-    # @!attribute [rw] sjds
-    #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
-    #     Sun Java Desktop System
-    # @!attribute [rw] mandrake
-    #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
-    #     Mandrake Linux
-    # @!attribute [rw] mandriva
-    #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
-    #     Mandriva Linux
-    # @!attribute [rw] mandriva_64
-    #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
-    #     Mandriva Linux (64 bit)
-    # @!attribute [rw] turbo_linux
-    #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
-    #     Turbolinux
-    # @!attribute [rw] turbo_linux_64
-    #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
-    #     Turbolinux (64 bit)
-    # @!attribute [rw] ubuntu
-    #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
-    #     Ubuntu Linux
-    # @!attribute [rw] ubuntu_64
-    #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
-    #     Ubuntu Linux (64 bit)
-    # @!attribute [rw] debian_4
-    #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
-    #     Debian GNU/Linux 4
-    # @!attribute [rw] debian_4_64
-    #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
-    #     Debian GNU/Linux 4 (64 bit)
-    # @!attribute [rw] debian_5
-    #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
-    #     Debian GNU/Linux 5
-    # @!attribute [rw] debian_5_64
-    #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
-    #     Debian GNU/Linux 5 (64 bit)
-    # @!attribute [rw] debian_6
-    #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
-    #     Debian GNU/Linux 6
-    # @!attribute [rw] debian_6_64
-    #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
-    #     Debian GNU/Linux 6 (64 bit)
-    # @!attribute [rw] debian_7
-    #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
-    #     Debian GNU/Linux 7
-    # @!attribute [rw] debian_7_64
-    #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
-    #     Debian GNU/Linux 7 (64 bit)
-    # @!attribute [rw] debian_8
-    #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
-    #     Debian GNU/Linux 8
-    # @!attribute [rw] debian_8_64
-    #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
-    #     Debian GNU/Linux 8 (64 bit)
-    # @!attribute [rw] debian_9
-    #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
-    #     Debian GNU/Linux 9
-    # @!attribute [rw] debian_9_64
-    #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
-    #     Debian GNU/Linux 9 (64 bit)
-    # @!attribute [rw] debian_10
-    #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
-    #     Debian GNU/Linux 10
-    # @!attribute [rw] debian_10_64
-    #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
-    #     Debian GNU/Linux 10 (64 bit)
-    # @!attribute [rw] asianux_3
-    #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
-    #     Asianux Server 3
-    # @!attribute [rw] asianux_3_64
-    #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
-    #     Asianux Server 3 (64 bit)
-    # @!attribute [rw] asianux_4
-    #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
-    #     Asianux Server 4
-    # @!attribute [rw] asianux_4_64
-    #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
-    #     Asianux Server 4 (64 bit)
-    # @!attribute [rw] asianux_5_64
-    #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
-    #     Asianux Server 5 (64 bit)
-    # @!attribute [rw] asianux_7_64
-    #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
-    #     Asianux Server 7 (64 bit)
-    # @!attribute [rw] opensuse
-    #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
-    #     OpenSUSE Linux
-    # @!attribute [rw] opensuse_64
-    #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
-    #     OpenSUSE Linux (64 bit)
-    # @!attribute [rw] fedora
-    #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
-    #     Fedora Linux
-    # @!attribute [rw] fedora_64
-    #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
-    #     Fedora Linux (64 bit)
-    # @!attribute [rw] coreos_64
-    #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
-    #     CoreOS Linux (64 bit)
-    # @!attribute [rw] vmware_photon_64
-    #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
-    #     VMware Photon (64 bit)
-    # @!attribute [rw] other_24x_linux
-    #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
-    #     Linux 2.4x Kernel
-    # @!attribute [rw] other_24x_linux_64
-    #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
-    #     Linux 2.4x Kernel (64 bit) (experimental)
-    # @!attribute [rw] other_26x_linux
-    #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
-    #     Linux 2.6x Kernel
-    # @!attribute [rw] other_26x_linux_64
-    #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
-    #     Linux 2.6x Kernel (64 bit) (experimental)
-    # @!attribute [rw] other_3x_linux
-    #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
-    #     Linux 3.x Kernel
-    # @!attribute [rw] other_3x_linux_64
-    #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
-    #     Linux 3.x Kernel (64 bit)
-    # @!attribute [rw] other_linux
-    #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
-    #     Linux 2.2x Kernel
-    # @!attribute [rw] generic_linux
-    #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
-    #     Other Linux
-    # @!attribute [rw] other_linux_64
-    #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
-    #     Linux (64 bit) (experimental)
-    # @!attribute [rw] solaris_6
-    #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
-    #     Solaris 6
-    # @!attribute [rw] solaris_7
-    #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
-    #     Solaris 7
-    # @!attribute [rw] solaris_8
-    #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
-    #     Solaris 8
-    # @!attribute [rw] solaris_9
-    #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
-    #     Solaris 9
-    # @!attribute [rw] solaris_10
-    #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
-    #     Solaris 10 (32 bit) (experimental)
-    # @!attribute [rw] solaris_10_64
-    #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
-    #     Solaris 10 (64 bit) (experimental)
-    # @!attribute [rw] solaris_11_64
-    #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
-    #     Solaris 11 (64 bit)
-    # @!attribute [rw] o_s2
-    #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
-    #     OS/2
-    # @!attribute [rw] ecomstation
-    #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
-    #     eComStation 1.x
-    # @!attribute [rw] ecomstation_2
-    #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
-    #     eComStation 2.0
-    # @!attribute [rw] netware_4
-    #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
-    #     Novell NetWare 4
-    # @!attribute [rw] netware_5
-    #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
-    #     Novell NetWare 5.1
-    # @!attribute [rw] netware_6
-    #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
-    #     Novell NetWare 6.x
-    # @!attribute [rw] openserver_5
-    #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
-    #     SCO OpenServer 5
-    # @!attribute [rw] openserver_6
-    #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
-    #     SCO OpenServer 6
-    # @!attribute [rw] unixware_7
-    #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
-    #     SCO UnixWare 7
-    # @!attribute [rw] darwin
-    #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
-    #     Mac OS 10.5
-    # @!attribute [rw] darwin_64
-    #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
-    #     Mac OS 10.5 (64 bit)
-    # @!attribute [rw] darwin_10
-    #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
-    #     Mac OS 10.6
-    # @!attribute [rw] darwin_10_64
-    #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
-    #     Mac OS 10.6 (64 bit)
-    # @!attribute [rw] darwin_11
-    #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
-    #     Mac OS 10.7
-    # @!attribute [rw] darwin_11_64
-    #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
-    #     Mac OS 10.7 (64 bit)
-    # @!attribute [rw] darwin_12_64
-    #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
-    #     Mac OS 10.8 (64 bit)
-    # @!attribute [rw] darwin_13_64
-    #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
-    #     Mac OS 10.9 (64 bit)
-    # @!attribute [rw] darwin_14_64
-    #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
-    #     Mac OS 10.10 (64 bit)
-    # @!attribute [rw] darwin_15_64
-    #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
-    #     Mac OS 10.11 (64 bit)
-    # @!attribute [rw] darwin_16_64
-    #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
-    #     Mac OS 10.12 (64 bit)
-    # @!attribute [rw] vmkernel
-    #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
-    #     VMware ESX 4
-    # @!attribute [rw] vmkernel_5
-    #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
-    #     VMware ESX 5
-    # @!attribute [rw] vmkernel_6
-    #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
-    #     VMware ESX 6
-    # @!attribute [rw] vmkernel_65
-    #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
-    #     VMware ESX 6.5
-    # @!attribute [rw] other
-    #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
-    #     Other Operating System
-    # @!attribute [rw] other_64
-    #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
-    #     Other Operating System (64 bit) (experimental)
-    class GuestOS < VAPI::Bindings::VapiEnum
+    # The  ``Com::Vmware::Vcenter::VM::Hardware::Info``   class  contains information related to the virtual hardware of a virtual machine.
+    # @!attribute [rw] version
+    #     @return [Com::Vmware::Vcenter::VM::Hardware::Version]
+    #     Virtual hardware version.
+    # @!attribute [rw] upgrade_policy
+    #     @return [Com::Vmware::Vcenter::VM::Hardware::UpgradePolicy]
+    #     Scheduled upgrade policy.
+    # @!attribute [rw] upgrade_version
+    #     @return [Com::Vmware::Vcenter::VM::Hardware::Version]
+    #     Target hardware version to be used on the next scheduled virtual hardware upgrade.
+    #     This  field  is optional and it is only relevant when the value of  ``upgradePolicy``  is one of   :attr:`Com::Vmware::Vcenter::VM::Hardware::UpgradePolicy.AFTER_CLEAN_SHUTDOWN`   or   :attr:`Com::Vmware::Vcenter::VM::Hardware::UpgradePolicy.ALWAYS`  .
+    # @!attribute [rw] upgrade_status
+    #     @return [Com::Vmware::Vcenter::VM::Hardware::UpgradeStatus]
+    #     Scheduled upgrade status.
+    # @!attribute [rw] upgrade_error
+    #     @return [Exception]
+    #     Reason for the scheduled upgrade failure.
+    #     This  field  is optional and it is only relevant when the value of  ``upgradeStatus``  is   :attr:`Com::Vmware::Vcenter::VM::Hardware::UpgradeStatus.FAILED`  .
+    class Info < VAPI::Bindings::VapiStruct
+      class << self
+        # Holds (gets or creates) the binding type metadata for this structure type.
+        # @scope class
+        # @return [VAPI::Bindings::StructType] the binding type
+        def binding_type
+          @binding_type ||= VAPI::Bindings::StructType.new(
+            'com.vmware.vcenter.vm.hardware.info',
+            {
+              'version' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::VM::Hardware::Version'),
+              'upgrade_policy' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::VM::Hardware::UpgradePolicy'),
+              'upgrade_version' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::VM::Hardware::Version')),
+              'upgrade_status' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::VM::Hardware::UpgradeStatus'),
+              'upgrade_error' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::AnyErrorType.instance)
+            },
+            Info,
+            false,
+            nil
+          )
+        end
+      end
 
-        class << self
-            # Holds (gets or creates) the binding type metadata for this enumeration type.
-            # @scope class
-            # @return [VAPI::Bindings::EnumType] the binding type
-            def binding_type
-                @binding_type ||= VAPI::Bindings::EnumType.new(
-                    'com.vmware.vcenter.vm.guest_OS',
-                    GuestOS)
-            end
+      attr_accessor :version,
+                    :upgrade_policy,
+                    :upgrade_version,
+                    :upgrade_status,
+                    :upgrade_error
 
-            # Converts from a string value (perhaps off the wire) to an instance
-            # of this enum type.
-            # @param value [String] the actual value of the enum instance
-            # @return [GuestOS] the instance found for the value, otherwise
-            #         an unknown instance will be built for the value
-            def from_string(value)
-                begin
-                    const_get(value)
-                rescue NameError
-                    GuestOS.new('UNKNOWN', value)
-                end
-            end
+      # Constructs a new instance.
+      # @param ruby_values [Hash] a map of initial property values (optional)
+      # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
+      def initialize(ruby_values = nil, struct_value = nil)
+        super(self.class.binding_type, ruby_values, struct_value)
+      end
+    end
+
+    # The  ``Com::Vmware::Vcenter::VM::Hardware::UpdateSpec``   class  describes the updates to virtual hardware settings of a virtual machine.
+    # @!attribute [rw] upgrade_policy
+    #     @return [Com::Vmware::Vcenter::VM::Hardware::UpgradePolicy, nil]
+    #     Scheduled upgrade policy.  
+    #     
+    #      If set to   :attr:`Com::Vmware::Vcenter::VM::Hardware::UpgradePolicy.NEVER`  , the   :attr:`Com::Vmware::Vcenter::VM::Hardware::Info.upgrade_version`    field  will be reset to  nil .
+    #     If  nil , the value is unchanged.
+    # @!attribute [rw] upgrade_version
+    #     @return [Com::Vmware::Vcenter::VM::Hardware::Version, nil]
+    #     Target hardware version to be used on the next scheduled virtual hardware upgrade.  
+    #     
+    #      If specified, this  field  must represent a newer virtual hardware version than the current virtual hardware version reported in   :attr:`Com::Vmware::Vcenter::VM::Hardware::Info.version`  .
+    #     If   :attr:`Com::Vmware::Vcenter::VM::Hardware::UpdateSpec.upgrade_policy`   is set to   :attr:`Com::Vmware::Vcenter::VM::Hardware::UpgradePolicy.NEVER`  , this  field  must be  nil . Otherwise, if this  field  is  nil , default to the most recent virtual hardware version supported by the server.
+    class UpdateSpec < VAPI::Bindings::VapiStruct
+      class << self
+        # Holds (gets or creates) the binding type metadata for this structure type.
+        # @scope class
+        # @return [VAPI::Bindings::StructType] the binding type
+        def binding_type
+          @binding_type ||= VAPI::Bindings::StructType.new(
+            'com.vmware.vcenter.vm.hardware.update_spec',
+            {
+              'upgrade_policy' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::VM::Hardware::UpgradePolicy')),
+              'upgrade_version' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::VM::Hardware::Version'))
+            },
+            UpdateSpec,
+            false,
+            nil
+          )
+        end
+      end
+
+      attr_accessor :upgrade_policy,
+                    :upgrade_version
+
+      # Constructs a new instance.
+      # @param ruby_values [Hash] a map of initial property values (optional)
+      # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
+      def initialize(ruby_values = nil, struct_value = nil)
+        super(self.class.binding_type, ruby_values, struct_value)
+      end
+    end
+
+    # The  ``Com::Vmware::Vcenter::VM::Hardware::Version``   enumerated type  defines the valid virtual hardware versions for a virtual machine.
+    # @!attribute [rw] vmx_03
+    #     @return [Com::Vmware::Vcenter::VM::Hardware::Version]
+    #     Hardware version 3.
+    # @!attribute [rw] vmx_04
+    #     @return [Com::Vmware::Vcenter::VM::Hardware::Version]
+    #     Hardware version 4.
+    # @!attribute [rw] vmx_06
+    #     @return [Com::Vmware::Vcenter::VM::Hardware::Version]
+    #     Hardware version 6.
+    # @!attribute [rw] vmx_07
+    #     @return [Com::Vmware::Vcenter::VM::Hardware::Version]
+    #     Hardware version 7.
+    # @!attribute [rw] vmx_08
+    #     @return [Com::Vmware::Vcenter::VM::Hardware::Version]
+    #     Hardware version 8.
+    # @!attribute [rw] vmx_09
+    #     @return [Com::Vmware::Vcenter::VM::Hardware::Version]
+    #     Hardware version 9.
+    # @!attribute [rw] vmx_10
+    #     @return [Com::Vmware::Vcenter::VM::Hardware::Version]
+    #     Hardware version 10.
+    # @!attribute [rw] vmx_11
+    #     @return [Com::Vmware::Vcenter::VM::Hardware::Version]
+    #     Hardware version 11.
+    # @!attribute [rw] vmx_12
+    #     @return [Com::Vmware::Vcenter::VM::Hardware::Version]
+    #     Hardware version 12.
+    # @!attribute [rw] vmx_13
+    #     @return [Com::Vmware::Vcenter::VM::Hardware::Version]
+    #     Hardware version 13.
+    class Version < VAPI::Bindings::VapiEnum
+      class << self
+        # Holds (gets or creates) the binding type metadata for this enumeration type.
+        # @scope class
+        # @return [VAPI::Bindings::EnumType] the binding type
+        def binding_type
+          @binding_type ||= VAPI::Bindings::EnumType.new(
+            'com.vmware.vcenter.vm.hardware.version',
+            Version
+          )
         end
 
-        private
-
-        # Constructs a new instance.
+        # Converts from a string value (perhaps off the wire) to an instance
+        # of this enum type.
         # @param value [String] the actual value of the enum instance
-        # @param unknown [String] the unknown value when value is 'UKNOWN'
-        def initialize(value, unknown=nil)
-            super(self.class.binding_type, value, unknown)
+        # @return [Version] the instance found for the value, otherwise
+        #         an unknown instance will be built for the value
+        def from_string(value)
+          const_get(value)
+        rescue NameError
+          Version.send(:new, 'UNKNOWN', value)
+        end
+      end
+
+      # Constructs a new instance.
+      # @param value [String] the actual value of the enum instance
+      # @param unknown [String] the unknown value when value is 'UKNOWN'
+      def initialize(value, unknown = nil)
+        super(self.class.binding_type, value, unknown)
+      end
+
+      private_class_method :new
+
+      # @!attribute [rw] vmx_03
+      #     @return [Com::Vmware::Vcenter::VM::Hardware::Version]
+      #     Hardware version 3.
+      VMX_03 = Version.send(:new, 'VMX_03')
+
+      # @!attribute [rw] vmx_04
+      #     @return [Com::Vmware::Vcenter::VM::Hardware::Version]
+      #     Hardware version 4.
+      VMX_04 = Version.send(:new, 'VMX_04')
+
+      # @!attribute [rw] vmx_06
+      #     @return [Com::Vmware::Vcenter::VM::Hardware::Version]
+      #     Hardware version 6.
+      VMX_06 = Version.send(:new, 'VMX_06')
+
+      # @!attribute [rw] vmx_07
+      #     @return [Com::Vmware::Vcenter::VM::Hardware::Version]
+      #     Hardware version 7.
+      VMX_07 = Version.send(:new, 'VMX_07')
+
+      # @!attribute [rw] vmx_08
+      #     @return [Com::Vmware::Vcenter::VM::Hardware::Version]
+      #     Hardware version 8.
+      VMX_08 = Version.send(:new, 'VMX_08')
+
+      # @!attribute [rw] vmx_09
+      #     @return [Com::Vmware::Vcenter::VM::Hardware::Version]
+      #     Hardware version 9.
+      VMX_09 = Version.send(:new, 'VMX_09')
+
+      # @!attribute [rw] vmx_10
+      #     @return [Com::Vmware::Vcenter::VM::Hardware::Version]
+      #     Hardware version 10.
+      VMX_10 = Version.send(:new, 'VMX_10')
+
+      # @!attribute [rw] vmx_11
+      #     @return [Com::Vmware::Vcenter::VM::Hardware::Version]
+      #     Hardware version 11.
+      VMX_11 = Version.send(:new, 'VMX_11')
+
+      # @!attribute [rw] vmx_12
+      #     @return [Com::Vmware::Vcenter::VM::Hardware::Version]
+      #     Hardware version 12.
+      VMX_12 = Version.send(:new, 'VMX_12')
+
+      # @!attribute [rw] vmx_13
+      #     @return [Com::Vmware::Vcenter::VM::Hardware::Version]
+      #     Hardware version 13.
+      VMX_13 = Version.send(:new, 'VMX_13')
+    end
+    # The  ``Com::Vmware::Vcenter::VM::Hardware::UpgradePolicy``   enumerated type  defines the valid virtual hardware upgrade policies for a virtual machine.
+    # @!attribute [rw] never
+    #     @return [Com::Vmware::Vcenter::VM::Hardware::UpgradePolicy]
+    #     Do not upgrade the virtual machine when it is powered on.
+    # @!attribute [rw] after_clean_shutdown
+    #     @return [Com::Vmware::Vcenter::VM::Hardware::UpgradePolicy]
+    #     Run scheduled upgrade when the virtual machine is powered on after a clean shutdown of the guest operating system.
+    # @!attribute [rw] always
+    #     @return [Com::Vmware::Vcenter::VM::Hardware::UpgradePolicy]
+    #     Run scheduled upgrade when the virtual machine is powered on.
+    class UpgradePolicy < VAPI::Bindings::VapiEnum
+      class << self
+        # Holds (gets or creates) the binding type metadata for this enumeration type.
+        # @scope class
+        # @return [VAPI::Bindings::EnumType] the binding type
+        def binding_type
+          @binding_type ||= VAPI::Bindings::EnumType.new(
+            'com.vmware.vcenter.vm.hardware.upgrade_policy',
+            UpgradePolicy
+          )
         end
 
-        public
-
-        # @!attribute [rw] dos
-        #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
-        #     MS-DOS.
-        DOS = GuestOS.new('DOS')
-
-        # @!attribute [rw] win_31
-        #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
-        #     Windows 3.1
-        WIN_31 = GuestOS.new('WIN_31')
-
-        # @!attribute [rw] win_95
-        #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
-        #     Windows 95
-        WIN_95 = GuestOS.new('WIN_95')
-
-        # @!attribute [rw] win_98
-        #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
-        #     Windows 98
-        WIN_98 = GuestOS.new('WIN_98')
-
-        # @!attribute [rw] win_me
-        #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
-        #     Windows Millennium Edition
-        WIN_ME = GuestOS.new('WIN_ME')
-
-        # @!attribute [rw] win_nt
-        #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
-        #     Windows NT 4
-        WIN_NT = GuestOS.new('WIN_NT')
-
-        # @!attribute [rw] win_2000_pro
-        #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
-        #     Windows 2000 Professional
-        WIN_2000_PRO = GuestOS.new('WIN_2000_PRO')
-
-        # @!attribute [rw] win_2000_serv
-        #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
-        #     Windows 2000 Server
-        WIN_2000_SERV = GuestOS.new('WIN_2000_SERV')
-
-        # @!attribute [rw] win_2000_adv_serv
-        #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
-        #     Windows 2000 Advanced Server
-        WIN_2000_ADV_SERV = GuestOS.new('WIN_2000_ADV_SERV')
-
-        # @!attribute [rw] win_xp_home
-        #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
-        #     Windows XP Home Edition
-        WIN_XP_HOME = GuestOS.new('WIN_XP_HOME')
-
-        # @!attribute [rw] win_xp_pro
-        #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
-        #     Windows XP Professional
-        WIN_XP_PRO = GuestOS.new('WIN_XP_PRO')
-
-        # @!attribute [rw] win_xp_pro_64
-        #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
-        #     Windows XP Professional Edition (64 bit)
-        WIN_XP_PRO_64 = GuestOS.new('WIN_XP_PRO_64')
-
-        # @!attribute [rw] win_net_web
-        #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
-        #     Windows Server 2003, Web Edition
-        WIN_NET_WEB = GuestOS.new('WIN_NET_WEB')
-
-        # @!attribute [rw] win_net_standard
-        #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
-        #     Windows Server 2003, Standard Edition
-        WIN_NET_STANDARD = GuestOS.new('WIN_NET_STANDARD')
-
-        # @!attribute [rw] win_net_enterprise
-        #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
-        #     Windows Server 2003, Enterprise Edition
-        WIN_NET_ENTERPRISE = GuestOS.new('WIN_NET_ENTERPRISE')
-
-        # @!attribute [rw] win_net_datacenter
-        #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
-        #     Windows Server 2003, Datacenter Edition
-        WIN_NET_DATACENTER = GuestOS.new('WIN_NET_DATACENTER')
-
-        # @!attribute [rw] win_net_business
-        #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
-        #     Windows Small Business Server 2003
-        WIN_NET_BUSINESS = GuestOS.new('WIN_NET_BUSINESS')
-
-        # @!attribute [rw] win_net_standard_64
-        #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
-        #     Windows Server 2003, Standard Edition (64 bit)
-        WIN_NET_STANDARD_64 = GuestOS.new('WIN_NET_STANDARD_64')
-
-        # @!attribute [rw] win_net_enterprise_64
-        #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
-        #     Windows Server 2003, Enterprise Edition (64 bit)
-        WIN_NET_ENTERPRISE_64 = GuestOS.new('WIN_NET_ENTERPRISE_64')
-
-        # @!attribute [rw] win_longhorn
-        #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
-        #     Windows Longhorn (experimental)
-        WIN_LONGHORN = GuestOS.new('WIN_LONGHORN')
-
-        # @!attribute [rw] win_longhorn_64
-        #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
-        #     Windows Longhorn (64 bit) (experimental)
-        WIN_LONGHORN_64 = GuestOS.new('WIN_LONGHORN_64')
-
-        # @!attribute [rw] win_net_datacenter_64
-        #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
-        #     Windows Server 2003, Datacenter Edition (64 bit) (experimental)
-        WIN_NET_DATACENTER_64 = GuestOS.new('WIN_NET_DATACENTER_64')
-
-        # @!attribute [rw] win_vista
-        #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
-        #     Windows Vista
-        WIN_VISTA = GuestOS.new('WIN_VISTA')
-
-        # @!attribute [rw] win_vista_64
-        #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
-        #     Windows Vista (64 bit)
-        WIN_VISTA_64 = GuestOS.new('WIN_VISTA_64')
-
-        # @!attribute [rw] windows_7
-        #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
-        #     Windows 7
-        WINDOWS_7 = GuestOS.new('WINDOWS_7')
-
-        # @!attribute [rw] windows_7_64
-        #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
-        #     Windows 7 (64 bit)
-        WINDOWS_7_64 = GuestOS.new('WINDOWS_7_64')
-
-        # @!attribute [rw] windows_7_server_64
-        #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
-        #     Windows Server 2008 R2 (64 bit)
-        WINDOWS_7_SERVER_64 = GuestOS.new('WINDOWS_7_SERVER_64')
-
-        # @!attribute [rw] windows_8
-        #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
-        #     Windows 8
-        WINDOWS_8 = GuestOS.new('WINDOWS_8')
-
-        # @!attribute [rw] windows_8_64
-        #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
-        #     Windows 8 (64 bit)
-        WINDOWS_8_64 = GuestOS.new('WINDOWS_8_64')
-
-        # @!attribute [rw] windows_8_server_64
-        #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
-        #     Windows 8 Server (64 bit)
-        WINDOWS_8_SERVER_64 = GuestOS.new('WINDOWS_8_SERVER_64')
-
-        # @!attribute [rw] windows_9
-        #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
-        #     Windows 10
-        WINDOWS_9 = GuestOS.new('WINDOWS_9')
-
-        # @!attribute [rw] windows_9_64
-        #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
-        #     Windows 10 (64 bit)
-        WINDOWS_9_64 = GuestOS.new('WINDOWS_9_64')
-
-        # @!attribute [rw] windows_9_server_64
-        #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
-        #     Windows 10 Server (64 bit)
-        WINDOWS_9_SERVER_64 = GuestOS.new('WINDOWS_9_SERVER_64')
-
-        # @!attribute [rw] windows_hyperv
-        #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
-        #     Windows Hyper-V
-        WINDOWS_HYPERV = GuestOS.new('WINDOWS_HYPERV')
-
-        # @!attribute [rw] freebsd
-        #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
-        #     FreeBSD
-        FREEBSD = GuestOS.new('FREEBSD')
-
-        # @!attribute [rw] freebsd_64
-        #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
-        #     FreeBSD x64
-        FREEBSD_64 = GuestOS.new('FREEBSD_64')
-
-        # @!attribute [rw] redhat
-        #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
-        #     Red Hat Linux 2.1
-        REDHAT = GuestOS.new('REDHAT')
-
-        # @!attribute [rw] rhel_2
-        #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
-        #     Red Hat Enterprise Linux 2
-        RHEL_2 = GuestOS.new('RHEL_2')
-
-        # @!attribute [rw] rhel_3
-        #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
-        #     Red Hat Enterprise Linux 3
-        RHEL_3 = GuestOS.new('RHEL_3')
-
-        # @!attribute [rw] rhel_3_64
-        #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
-        #     Red Hat Enterprise Linux 3 (64 bit)
-        RHEL_3_64 = GuestOS.new('RHEL_3_64')
-
-        # @!attribute [rw] rhel_4
-        #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
-        #     Red Hat Enterprise Linux 4
-        RHEL_4 = GuestOS.new('RHEL_4')
-
-        # @!attribute [rw] rhel_4_64
-        #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
-        #     Red Hat Enterprise Linux 4 (64 bit)
-        RHEL_4_64 = GuestOS.new('RHEL_4_64')
-
-        # @!attribute [rw] rhel_5
-        #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
-        #     Red Hat Enterprise Linux 5
-        RHEL_5 = GuestOS.new('RHEL_5')
-
-        # @!attribute [rw] rhel_5_64
-        #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
-        #     Red Hat Enterprise Linux 5 (64 bit) (experimental)
-        RHEL_5_64 = GuestOS.new('RHEL_5_64')
-
-        # @!attribute [rw] rhel_6
-        #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
-        #     Red Hat Enterprise Linux 6
-        RHEL_6 = GuestOS.new('RHEL_6')
-
-        # @!attribute [rw] rhel_6_64
-        #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
-        #     Red Hat Enterprise Linux 6 (64 bit)
-        RHEL_6_64 = GuestOS.new('RHEL_6_64')
-
-        # @!attribute [rw] rhel_7
-        #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
-        #     Red Hat Enterprise Linux 7
-        RHEL_7 = GuestOS.new('RHEL_7')
-
-        # @!attribute [rw] rhel_7_64
-        #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
-        #     Red Hat Enterprise Linux 7 (64 bit)
-        RHEL_7_64 = GuestOS.new('RHEL_7_64')
-
-        # @!attribute [rw] centos
-        #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
-        #     CentOS 4/5
-        CENTOS = GuestOS.new('CENTOS')
-
-        # @!attribute [rw] centos_64
-        #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
-        #     CentOS 4/5 (64-bit)
-        CENTOS_64 = GuestOS.new('CENTOS_64')
-
-        # @!attribute [rw] centos_6
-        #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
-        #     CentOS 6
-        CENTOS_6 = GuestOS.new('CENTOS_6')
-
-        # @!attribute [rw] centos_6_64
-        #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
-        #     CentOS 6 (64-bit)
-        CENTOS_6_64 = GuestOS.new('CENTOS_6_64')
-
-        # @!attribute [rw] centos_7
-        #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
-        #     CentOS 7
-        CENTOS_7 = GuestOS.new('CENTOS_7')
-
-        # @!attribute [rw] centos_7_64
-        #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
-        #     CentOS 7 (64-bit)
-        CENTOS_7_64 = GuestOS.new('CENTOS_7_64')
-
-        # @!attribute [rw] oracle_linux
-        #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
-        #     Oracle Linux 4/5
-        ORACLE_LINUX = GuestOS.new('ORACLE_LINUX')
-
-        # @!attribute [rw] oracle_linux_64
-        #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
-        #     Oracle Linux 4/5 (64-bit)
-        ORACLE_LINUX_64 = GuestOS.new('ORACLE_LINUX_64')
-
-        # @!attribute [rw] oracle_linux_6
-        #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
-        #     Oracle Linux 6
-        ORACLE_LINUX_6 = GuestOS.new('ORACLE_LINUX_6')
-
-        # @!attribute [rw] oracle_linux_6_64
-        #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
-        #     Oracle Linux 6 (64-bit)
-        ORACLE_LINUX_6_64 = GuestOS.new('ORACLE_LINUX_6_64')
-
-        # @!attribute [rw] oracle_linux_7
-        #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
-        #     Oracle Linux 7
-        ORACLE_LINUX_7 = GuestOS.new('ORACLE_LINUX_7')
-
-        # @!attribute [rw] oracle_linux_7_64
-        #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
-        #     Oracle Linux 7 (64-bit)
-        ORACLE_LINUX_7_64 = GuestOS.new('ORACLE_LINUX_7_64')
-
-        # @!attribute [rw] suse
-        #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
-        #     Suse Linux
-        SUSE = GuestOS.new('SUSE')
-
-        # @!attribute [rw] suse_64
-        #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
-        #     Suse Linux (64 bit)
-        SUSE_64 = GuestOS.new('SUSE_64')
-
-        # @!attribute [rw] sles
-        #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
-        #     Suse Linux Enterprise Server 9
-        SLES = GuestOS.new('SLES')
-
-        # @!attribute [rw] sles_64
-        #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
-        #     Suse Linux Enterprise Server 9 (64 bit)
-        SLES_64 = GuestOS.new('SLES_64')
-
-        # @!attribute [rw] sles_10
-        #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
-        #     Suse linux Enterprise Server 10
-        SLES_10 = GuestOS.new('SLES_10')
-
-        # @!attribute [rw] sles_10_64
-        #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
-        #     Suse Linux Enterprise Server 10 (64 bit) (experimental)
-        SLES_10_64 = GuestOS.new('SLES_10_64')
-
-        # @!attribute [rw] sles_11
-        #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
-        #     Suse linux Enterprise Server 11
-        SLES_11 = GuestOS.new('SLES_11')
-
-        # @!attribute [rw] sles_11_64
-        #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
-        #     Suse Linux Enterprise Server 11 (64 bit)
-        SLES_11_64 = GuestOS.new('SLES_11_64')
-
-        # @!attribute [rw] sles_12
-        #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
-        #     Suse linux Enterprise Server 12
-        SLES_12 = GuestOS.new('SLES_12')
-
-        # @!attribute [rw] sles_12_64
-        #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
-        #     Suse Linux Enterprise Server 12 (64 bit)
-        SLES_12_64 = GuestOS.new('SLES_12_64')
-
-        # @!attribute [rw] nld_9
-        #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
-        #     Novell Linux Desktop 9
-        NLD_9 = GuestOS.new('NLD_9')
-
-        # @!attribute [rw] oes
-        #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
-        #     Open Enterprise Server
-        OES = GuestOS.new('OES')
-
-        # @!attribute [rw] sjds
-        #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
-        #     Sun Java Desktop System
-        SJDS = GuestOS.new('SJDS')
-
-        # @!attribute [rw] mandrake
-        #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
-        #     Mandrake Linux
-        MANDRAKE = GuestOS.new('MANDRAKE')
-
-        # @!attribute [rw] mandriva
-        #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
-        #     Mandriva Linux
-        MANDRIVA = GuestOS.new('MANDRIVA')
-
-        # @!attribute [rw] mandriva_64
-        #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
-        #     Mandriva Linux (64 bit)
-        MANDRIVA_64 = GuestOS.new('MANDRIVA_64')
-
-        # @!attribute [rw] turbo_linux
-        #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
-        #     Turbolinux
-        TURBO_LINUX = GuestOS.new('TURBO_LINUX')
-
-        # @!attribute [rw] turbo_linux_64
-        #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
-        #     Turbolinux (64 bit)
-        TURBO_LINUX_64 = GuestOS.new('TURBO_LINUX_64')
-
-        # @!attribute [rw] ubuntu
-        #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
-        #     Ubuntu Linux
-        UBUNTU = GuestOS.new('UBUNTU')
-
-        # @!attribute [rw] ubuntu_64
-        #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
-        #     Ubuntu Linux (64 bit)
-        UBUNTU_64 = GuestOS.new('UBUNTU_64')
-
-        # @!attribute [rw] debian_4
-        #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
-        #     Debian GNU/Linux 4
-        DEBIAN_4 = GuestOS.new('DEBIAN_4')
-
-        # @!attribute [rw] debian_4_64
-        #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
-        #     Debian GNU/Linux 4 (64 bit)
-        DEBIAN_4_64 = GuestOS.new('DEBIAN_4_64')
-
-        # @!attribute [rw] debian_5
-        #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
-        #     Debian GNU/Linux 5
-        DEBIAN_5 = GuestOS.new('DEBIAN_5')
-
-        # @!attribute [rw] debian_5_64
-        #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
-        #     Debian GNU/Linux 5 (64 bit)
-        DEBIAN_5_64 = GuestOS.new('DEBIAN_5_64')
-
-        # @!attribute [rw] debian_6
-        #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
-        #     Debian GNU/Linux 6
-        DEBIAN_6 = GuestOS.new('DEBIAN_6')
-
-        # @!attribute [rw] debian_6_64
-        #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
-        #     Debian GNU/Linux 6 (64 bit)
-        DEBIAN_6_64 = GuestOS.new('DEBIAN_6_64')
-
-        # @!attribute [rw] debian_7
-        #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
-        #     Debian GNU/Linux 7
-        DEBIAN_7 = GuestOS.new('DEBIAN_7')
-
-        # @!attribute [rw] debian_7_64
-        #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
-        #     Debian GNU/Linux 7 (64 bit)
-        DEBIAN_7_64 = GuestOS.new('DEBIAN_7_64')
-
-        # @!attribute [rw] debian_8
-        #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
-        #     Debian GNU/Linux 8
-        DEBIAN_8 = GuestOS.new('DEBIAN_8')
-
-        # @!attribute [rw] debian_8_64
-        #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
-        #     Debian GNU/Linux 8 (64 bit)
-        DEBIAN_8_64 = GuestOS.new('DEBIAN_8_64')
-
-        # @!attribute [rw] debian_9
-        #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
-        #     Debian GNU/Linux 9
-        DEBIAN_9 = GuestOS.new('DEBIAN_9')
-
-        # @!attribute [rw] debian_9_64
-        #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
-        #     Debian GNU/Linux 9 (64 bit)
-        DEBIAN_9_64 = GuestOS.new('DEBIAN_9_64')
-
-        # @!attribute [rw] debian_10
-        #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
-        #     Debian GNU/Linux 10
-        DEBIAN_10 = GuestOS.new('DEBIAN_10')
-
-        # @!attribute [rw] debian_10_64
-        #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
-        #     Debian GNU/Linux 10 (64 bit)
-        DEBIAN_10_64 = GuestOS.new('DEBIAN_10_64')
-
-        # @!attribute [rw] asianux_3
-        #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
-        #     Asianux Server 3
-        ASIANUX_3 = GuestOS.new('ASIANUX_3')
-
-        # @!attribute [rw] asianux_3_64
-        #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
-        #     Asianux Server 3 (64 bit)
-        ASIANUX_3_64 = GuestOS.new('ASIANUX_3_64')
-
-        # @!attribute [rw] asianux_4
-        #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
-        #     Asianux Server 4
-        ASIANUX_4 = GuestOS.new('ASIANUX_4')
-
-        # @!attribute [rw] asianux_4_64
-        #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
-        #     Asianux Server 4 (64 bit)
-        ASIANUX_4_64 = GuestOS.new('ASIANUX_4_64')
-
-        # @!attribute [rw] asianux_5_64
-        #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
-        #     Asianux Server 5 (64 bit)
-        ASIANUX_5_64 = GuestOS.new('ASIANUX_5_64')
-
-        # @!attribute [rw] asianux_7_64
-        #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
-        #     Asianux Server 7 (64 bit)
-        ASIANUX_7_64 = GuestOS.new('ASIANUX_7_64')
-
-        # @!attribute [rw] opensuse
-        #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
-        #     OpenSUSE Linux
-        OPENSUSE = GuestOS.new('OPENSUSE')
-
-        # @!attribute [rw] opensuse_64
-        #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
-        #     OpenSUSE Linux (64 bit)
-        OPENSUSE_64 = GuestOS.new('OPENSUSE_64')
-
-        # @!attribute [rw] fedora
-        #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
-        #     Fedora Linux
-        FEDORA = GuestOS.new('FEDORA')
-
-        # @!attribute [rw] fedora_64
-        #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
-        #     Fedora Linux (64 bit)
-        FEDORA_64 = GuestOS.new('FEDORA_64')
-
-        # @!attribute [rw] coreos_64
-        #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
-        #     CoreOS Linux (64 bit)
-        COREOS_64 = GuestOS.new('COREOS_64')
-
-        # @!attribute [rw] vmware_photon_64
-        #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
-        #     VMware Photon (64 bit)
-        VMWARE_PHOTON_64 = GuestOS.new('VMWARE_PHOTON_64')
-
-        # @!attribute [rw] other_24x_linux
-        #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
-        #     Linux 2.4x Kernel
-        OTHER_24X_LINUX = GuestOS.new('OTHER_24X_LINUX')
-
-        # @!attribute [rw] other_24x_linux_64
-        #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
-        #     Linux 2.4x Kernel (64 bit) (experimental)
-        OTHER_24X_LINUX_64 = GuestOS.new('OTHER_24X_LINUX_64')
-
-        # @!attribute [rw] other_26x_linux
-        #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
-        #     Linux 2.6x Kernel
-        OTHER_26X_LINUX = GuestOS.new('OTHER_26X_LINUX')
-
-        # @!attribute [rw] other_26x_linux_64
-        #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
-        #     Linux 2.6x Kernel (64 bit) (experimental)
-        OTHER_26X_LINUX_64 = GuestOS.new('OTHER_26X_LINUX_64')
-
-        # @!attribute [rw] other_3x_linux
-        #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
-        #     Linux 3.x Kernel
-        OTHER_3X_LINUX = GuestOS.new('OTHER_3X_LINUX')
-
-        # @!attribute [rw] other_3x_linux_64
-        #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
-        #     Linux 3.x Kernel (64 bit)
-        OTHER_3X_LINUX_64 = GuestOS.new('OTHER_3X_LINUX_64')
-
-        # @!attribute [rw] other_linux
-        #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
-        #     Linux 2.2x Kernel
-        OTHER_LINUX = GuestOS.new('OTHER_LINUX')
-
-        # @!attribute [rw] generic_linux
-        #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
-        #     Other Linux
-        GENERIC_LINUX = GuestOS.new('GENERIC_LINUX')
-
-        # @!attribute [rw] other_linux_64
-        #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
-        #     Linux (64 bit) (experimental)
-        OTHER_LINUX_64 = GuestOS.new('OTHER_LINUX_64')
-
-        # @!attribute [rw] solaris_6
-        #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
-        #     Solaris 6
-        SOLARIS_6 = GuestOS.new('SOLARIS_6')
-
-        # @!attribute [rw] solaris_7
-        #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
-        #     Solaris 7
-        SOLARIS_7 = GuestOS.new('SOLARIS_7')
-
-        # @!attribute [rw] solaris_8
-        #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
-        #     Solaris 8
-        SOLARIS_8 = GuestOS.new('SOLARIS_8')
-
-        # @!attribute [rw] solaris_9
-        #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
-        #     Solaris 9
-        SOLARIS_9 = GuestOS.new('SOLARIS_9')
-
-        # @!attribute [rw] solaris_10
-        #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
-        #     Solaris 10 (32 bit) (experimental)
-        SOLARIS_10 = GuestOS.new('SOLARIS_10')
-
-        # @!attribute [rw] solaris_10_64
-        #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
-        #     Solaris 10 (64 bit) (experimental)
-        SOLARIS_10_64 = GuestOS.new('SOLARIS_10_64')
-
-        # @!attribute [rw] solaris_11_64
-        #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
-        #     Solaris 11 (64 bit)
-        SOLARIS_11_64 = GuestOS.new('SOLARIS_11_64')
-
-        # @!attribute [rw] o_s2
-        #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
-        #     OS/2
-        O_S2 = GuestOS.new('O_S2')
-
-        # @!attribute [rw] ecomstation
-        #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
-        #     eComStation 1.x
-        ECOMSTATION = GuestOS.new('ECOMSTATION')
-
-        # @!attribute [rw] ecomstation_2
-        #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
-        #     eComStation 2.0
-        ECOMSTATION_2 = GuestOS.new('ECOMSTATION_2')
-
-        # @!attribute [rw] netware_4
-        #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
-        #     Novell NetWare 4
-        NETWARE_4 = GuestOS.new('NETWARE_4')
-
-        # @!attribute [rw] netware_5
-        #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
-        #     Novell NetWare 5.1
-        NETWARE_5 = GuestOS.new('NETWARE_5')
-
-        # @!attribute [rw] netware_6
-        #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
-        #     Novell NetWare 6.x
-        NETWARE_6 = GuestOS.new('NETWARE_6')
-
-        # @!attribute [rw] openserver_5
-        #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
-        #     SCO OpenServer 5
-        OPENSERVER_5 = GuestOS.new('OPENSERVER_5')
-
-        # @!attribute [rw] openserver_6
-        #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
-        #     SCO OpenServer 6
-        OPENSERVER_6 = GuestOS.new('OPENSERVER_6')
-
-        # @!attribute [rw] unixware_7
-        #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
-        #     SCO UnixWare 7
-        UNIXWARE_7 = GuestOS.new('UNIXWARE_7')
-
-        # @!attribute [rw] darwin
-        #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
-        #     Mac OS 10.5
-        DARWIN = GuestOS.new('DARWIN')
-
-        # @!attribute [rw] darwin_64
-        #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
-        #     Mac OS 10.5 (64 bit)
-        DARWIN_64 = GuestOS.new('DARWIN_64')
-
-        # @!attribute [rw] darwin_10
-        #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
-        #     Mac OS 10.6
-        DARWIN_10 = GuestOS.new('DARWIN_10')
-
-        # @!attribute [rw] darwin_10_64
-        #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
-        #     Mac OS 10.6 (64 bit)
-        DARWIN_10_64 = GuestOS.new('DARWIN_10_64')
-
-        # @!attribute [rw] darwin_11
-        #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
-        #     Mac OS 10.7
-        DARWIN_11 = GuestOS.new('DARWIN_11')
-
-        # @!attribute [rw] darwin_11_64
-        #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
-        #     Mac OS 10.7 (64 bit)
-        DARWIN_11_64 = GuestOS.new('DARWIN_11_64')
-
-        # @!attribute [rw] darwin_12_64
-        #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
-        #     Mac OS 10.8 (64 bit)
-        DARWIN_12_64 = GuestOS.new('DARWIN_12_64')
-
-        # @!attribute [rw] darwin_13_64
-        #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
-        #     Mac OS 10.9 (64 bit)
-        DARWIN_13_64 = GuestOS.new('DARWIN_13_64')
-
-        # @!attribute [rw] darwin_14_64
-        #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
-        #     Mac OS 10.10 (64 bit)
-        DARWIN_14_64 = GuestOS.new('DARWIN_14_64')
-
-        # @!attribute [rw] darwin_15_64
-        #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
-        #     Mac OS 10.11 (64 bit)
-        DARWIN_15_64 = GuestOS.new('DARWIN_15_64')
-
-        # @!attribute [rw] darwin_16_64
-        #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
-        #     Mac OS 10.12 (64 bit)
-        DARWIN_16_64 = GuestOS.new('DARWIN_16_64')
-
-        # @!attribute [rw] vmkernel
-        #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
-        #     VMware ESX 4
-        VMKERNEL = GuestOS.new('VMKERNEL')
-
-        # @!attribute [rw] vmkernel_5
-        #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
-        #     VMware ESX 5
-        VMKERNEL_5 = GuestOS.new('VMKERNEL_5')
-
-        # @!attribute [rw] vmkernel_6
-        #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
-        #     VMware ESX 6
-        VMKERNEL_6 = GuestOS.new('VMKERNEL_6')
-
-        # @!attribute [rw] vmkernel_65
-        #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
-        #     VMware ESX 6.5
-        VMKERNEL_65 = GuestOS.new('VMKERNEL_65')
-
-        # @!attribute [rw] other
-        #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
-        #     Other Operating System
-        OTHER = GuestOS.new('OTHER')
-
-        # @!attribute [rw] other_64
-        #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
-        #     Other Operating System (64 bit) (experimental)
-        OTHER_64 = GuestOS.new('OTHER_64')
-
+        # Converts from a string value (perhaps off the wire) to an instance
+        # of this enum type.
+        # @param value [String] the actual value of the enum instance
+        # @return [UpgradePolicy] the instance found for the value, otherwise
+        #         an unknown instance will be built for the value
+        def from_string(value)
+          const_get(value)
+        rescue NameError
+          UpgradePolicy.send(:new, 'UNKNOWN', value)
+        end
+      end
+
+      # Constructs a new instance.
+      # @param value [String] the actual value of the enum instance
+      # @param unknown [String] the unknown value when value is 'UKNOWN'
+      def initialize(value, unknown = nil)
+        super(self.class.binding_type, value, unknown)
+      end
+
+      private_class_method :new
+
+      # @!attribute [rw] never
+      #     @return [Com::Vmware::Vcenter::VM::Hardware::UpgradePolicy]
+      #     Do not upgrade the virtual machine when it is powered on.
+      NEVER = UpgradePolicy.send(:new, 'NEVER')
+
+      # @!attribute [rw] after_clean_shutdown
+      #     @return [Com::Vmware::Vcenter::VM::Hardware::UpgradePolicy]
+      #     Run scheduled upgrade when the virtual machine is powered on after a clean shutdown of the guest operating system.
+      AFTER_CLEAN_SHUTDOWN = UpgradePolicy.send(:new, 'AFTER_CLEAN_SHUTDOWN')
+
+      # @!attribute [rw] always
+      #     @return [Com::Vmware::Vcenter::VM::Hardware::UpgradePolicy]
+      #     Run scheduled upgrade when the virtual machine is powered on.
+      ALWAYS = UpgradePolicy.send(:new, 'ALWAYS')
+    end
+    # The  ``Com::Vmware::Vcenter::VM::Hardware::UpgradeStatus``   enumerated type  defines the valid virtual hardware upgrade statuses for a virtual machine.
+    # @!attribute [rw] none
+    #     @return [Com::Vmware::Vcenter::VM::Hardware::UpgradeStatus]
+    #     No scheduled upgrade has been attempted.
+    # @!attribute [rw] pending
+    #     @return [Com::Vmware::Vcenter::VM::Hardware::UpgradeStatus]
+    #     Upgrade is scheduled but has not yet been run.
+    # @!attribute [rw] success
+    #     @return [Com::Vmware::Vcenter::VM::Hardware::UpgradeStatus]
+    #     The most recent scheduled upgrade was successful.
+    # @!attribute [rw] failed
+    #     @return [Com::Vmware::Vcenter::VM::Hardware::UpgradeStatus]
+    #     The most recent scheduled upgrade was not successful.
+    class UpgradeStatus < VAPI::Bindings::VapiEnum
+      class << self
+        # Holds (gets or creates) the binding type metadata for this enumeration type.
+        # @scope class
+        # @return [VAPI::Bindings::EnumType] the binding type
+        def binding_type
+          @binding_type ||= VAPI::Bindings::EnumType.new(
+            'com.vmware.vcenter.vm.hardware.upgrade_status',
+            UpgradeStatus
+          )
+        end
+
+        # Converts from a string value (perhaps off the wire) to an instance
+        # of this enum type.
+        # @param value [String] the actual value of the enum instance
+        # @return [UpgradeStatus] the instance found for the value, otherwise
+        #         an unknown instance will be built for the value
+        def from_string(value)
+          const_get(value)
+        rescue NameError
+          UpgradeStatus.send(:new, 'UNKNOWN', value)
+        end
+      end
+
+      # Constructs a new instance.
+      # @param value [String] the actual value of the enum instance
+      # @param unknown [String] the unknown value when value is 'UKNOWN'
+      def initialize(value, unknown = nil)
+        super(self.class.binding_type, value, unknown)
+      end
+
+      private_class_method :new
+
+      # @!attribute [rw] none
+      #     @return [Com::Vmware::Vcenter::VM::Hardware::UpgradeStatus]
+      #     No scheduled upgrade has been attempted.
+      NONE = UpgradeStatus.send(:new, 'NONE')
+
+      # @!attribute [rw] pending
+      #     @return [Com::Vmware::Vcenter::VM::Hardware::UpgradeStatus]
+      #     Upgrade is scheduled but has not yet been run.
+      PENDING = UpgradeStatus.send(:new, 'PENDING')
+
+      # @!attribute [rw] success
+      #     @return [Com::Vmware::Vcenter::VM::Hardware::UpgradeStatus]
+      #     The most recent scheduled upgrade was successful.
+      SUCCESS = UpgradeStatus.send(:new, 'SUCCESS')
+
+      # @!attribute [rw] failed
+      #     @return [Com::Vmware::Vcenter::VM::Hardware::UpgradeStatus]
+      #     The most recent scheduled upgrade was not successful.
+      FAILED = UpgradeStatus.send(:new, 'FAILED')
+    end
+  end
+  # The  ``Com::Vmware::Vcenter::Vm::Power``   class  provides  methods  for managing the power state of a virtual machine.
+  class Power < VAPI::Bindings::VapiService
+    # static metamodel definitions
+    SERVICE_ID = VAPI::Core::ServiceIdentifier.new('com.vmware.vcenter.vm.power')
+
+    GET_INFO = VAPI::Bindings::OperationInfo.new(
+      VAPI::Core::OperationIdentifier.new('get', SERVICE_ID),
+      VAPI::Bindings::OperationInputType.new(
+        'vm' => VAPI::Bindings::IdType.new('VirtualMachine')
+      ),
+      VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::Vm::Power::Info'),
+      {
+        'com.vmware.vapi.std.errors.error' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Error'),
+        'com.vmware.vapi.std.errors.not_found' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::NotFound'),
+        'com.vmware.vapi.std.errors.resource_inaccessible' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::ResourceInaccessible'),
+        'com.vmware.vapi.std.errors.service_unavailable' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::ServiceUnavailable'),
+        'com.vmware.vapi.std.errors.unauthenticated' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Unauthenticated'),
+        'com.vmware.vapi.std.errors.unauthorized' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Unauthorized')
+      },
+      [],
+      []
+    )
+
+    START_INFO = VAPI::Bindings::OperationInfo.new(
+      VAPI::Core::OperationIdentifier.new('start', SERVICE_ID),
+      VAPI::Bindings::OperationInputType.new(
+        'vm' => VAPI::Bindings::IdType.new('VirtualMachine')
+      ),
+      VAPI::Bindings::VoidType.instance,
+      {
+        'com.vmware.vapi.std.errors.error' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Error'),
+        'com.vmware.vapi.std.errors.not_found' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::NotFound'),
+        'com.vmware.vapi.std.errors.already_in_desired_state' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::AlreadyInDesiredState'),
+        'com.vmware.vapi.std.errors.unsupported' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Unsupported'),
+        'com.vmware.vapi.std.errors.unable_to_allocate_resource' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::UnableToAllocateResource'),
+        'com.vmware.vapi.std.errors.resource_inaccessible' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::ResourceInaccessible'),
+        'com.vmware.vapi.std.errors.resource_in_use' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::ResourceInUse'),
+        'com.vmware.vapi.std.errors.resource_busy' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::ResourceBusy'),
+        'com.vmware.vapi.std.errors.service_unavailable' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::ServiceUnavailable'),
+        'com.vmware.vapi.std.errors.unauthenticated' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Unauthenticated'),
+        'com.vmware.vapi.std.errors.unauthorized' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Unauthorized')
+      },
+      [],
+      []
+    )
+
+    STOP_INFO = VAPI::Bindings::OperationInfo.new(
+      VAPI::Core::OperationIdentifier.new('stop', SERVICE_ID),
+      VAPI::Bindings::OperationInputType.new(
+        'vm' => VAPI::Bindings::IdType.new('VirtualMachine')
+      ),
+      VAPI::Bindings::VoidType.instance,
+      {
+        'com.vmware.vapi.std.errors.error' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Error'),
+        'com.vmware.vapi.std.errors.not_found' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::NotFound'),
+        'com.vmware.vapi.std.errors.already_in_desired_state' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::AlreadyInDesiredState'),
+        'com.vmware.vapi.std.errors.resource_busy' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::ResourceBusy'),
+        'com.vmware.vapi.std.errors.service_unavailable' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::ServiceUnavailable'),
+        'com.vmware.vapi.std.errors.unauthenticated' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Unauthenticated'),
+        'com.vmware.vapi.std.errors.unauthorized' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Unauthorized')
+      },
+      [],
+      []
+    )
+
+    SUSPEND_INFO = VAPI::Bindings::OperationInfo.new(
+      VAPI::Core::OperationIdentifier.new('suspend', SERVICE_ID),
+      VAPI::Bindings::OperationInputType.new(
+        'vm' => VAPI::Bindings::IdType.new('VirtualMachine')
+      ),
+      VAPI::Bindings::VoidType.instance,
+      {
+        'com.vmware.vapi.std.errors.error' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Error'),
+        'com.vmware.vapi.std.errors.not_found' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::NotFound'),
+        'com.vmware.vapi.std.errors.already_in_desired_state' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::AlreadyInDesiredState'),
+        'com.vmware.vapi.std.errors.not_allowed_in_current_state' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::NotAllowedInCurrentState'),
+        'com.vmware.vapi.std.errors.resource_busy' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::ResourceBusy'),
+        'com.vmware.vapi.std.errors.service_unavailable' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::ServiceUnavailable'),
+        'com.vmware.vapi.std.errors.unauthenticated' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Unauthenticated'),
+        'com.vmware.vapi.std.errors.unauthorized' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Unauthorized')
+      },
+      [],
+      []
+    )
+
+    RESET_INFO = VAPI::Bindings::OperationInfo.new(
+      VAPI::Core::OperationIdentifier.new('reset', SERVICE_ID),
+      VAPI::Bindings::OperationInputType.new(
+        'vm' => VAPI::Bindings::IdType.new('VirtualMachine')
+      ),
+      VAPI::Bindings::VoidType.instance,
+      {
+        'com.vmware.vapi.std.errors.error' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Error'),
+        'com.vmware.vapi.std.errors.not_found' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::NotFound'),
+        'com.vmware.vapi.std.errors.not_allowed_in_current_state' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::NotAllowedInCurrentState'),
+        'com.vmware.vapi.std.errors.resource_busy' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::ResourceBusy'),
+        'com.vmware.vapi.std.errors.service_unavailable' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::ServiceUnavailable'),
+        'com.vmware.vapi.std.errors.unauthenticated' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Unauthenticated'),
+        'com.vmware.vapi.std.errors.unauthorized' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Unauthorized')
+      },
+      [],
+      []
+    )
+
+    SERVICE_INFO = VAPI::Bindings::ServiceInfo.new(
+      SERVICE_ID,
+      'get' => GET_INFO,
+      'start' => START_INFO,
+      'stop' => STOP_INFO,
+      'suspend' => SUSPEND_INFO,
+      'reset' => RESET_INFO
+    )
+
+    # Constructs a new instance.
+    #
+    # @param config [VAPI::Bindings::StubConfig] A hash with the api provider details.
+    def initialize(config)
+      super(config, SERVICE_INFO)
     end
 
+    # Returns the power state information of a virtual machine.
+    #
+    # @param vm [String]
+    #     Virtual machine identifier.
+    # @return [Com::Vmware::Vcenter::Vm::Power::Info]
+    #     Power state information for the specified virtual machine.
+    # @raise [Com::Vmware::Vapi::Std::Errors::Error]
+    #     if the system reports an error while responding to the request.
+    # @raise [Com::Vmware::Vapi::Std::Errors::NotFound]
+    #     if the virtual machine is not found.
+    # @raise [Com::Vmware::Vapi::Std::Errors::ResourceInaccessible]
+    #     if the virtual machine's configuration or execution state cannot be accessed.
+    # @raise [Com::Vmware::Vapi::Std::Errors::ServiceUnavailable]
+    #     if the system is unable to communicate with a service to complete the request.
+    # @raise [Com::Vmware::Vapi::Std::Errors::Unauthenticated]
+    #     if the user can not be authenticated.
+    # @raise [Com::Vmware::Vapi::Std::Errors::Unauthorized]
+    #     if the user doesn't have the required privileges.
+    def get(vm)
+      invoke_with_info(GET_INFO,
+                       'vm' => vm)
+    end
 
+    # Powers on a powered-off or suspended virtual machine.
+    #
+    # @param vm [String]
+    #     Virtual machine identifier.
+    # @return [Void]
+    # @raise [Com::Vmware::Vapi::Std::Errors::Error]
+    #     if the system reports an error while responding to the request.
+    # @raise [Com::Vmware::Vapi::Std::Errors::NotFound]
+    #     if the virtual machine is not found.
+    # @raise [Com::Vmware::Vapi::Std::Errors::AlreadyInDesiredState]
+    #     if the virtual machine is already powered on.
+    # @raise [Com::Vmware::Vapi::Std::Errors::Unsupported]
+    #     if the virtual machine does not support being powered on (e.g. marked as a template, serving as a fault-tolerance secondary virtual machine).
+    # @raise [Com::Vmware::Vapi::Std::Errors::UnableToAllocateResource]
+    #     if resources cannot be allocated for the virtual machine (e.g. physical resource allocation policy cannot be satisfied, insufficient licenses are available to run the virtual machine).
+    # @raise [Com::Vmware::Vapi::Std::Errors::ResourceInaccessible]
+    #     if resources required by the virtual machine are not accessible (e.g. virtual machine configuration files or virtual disks are on inaccessible storage, no hosts are available to run the virtual machine).
+    # @raise [Com::Vmware::Vapi::Std::Errors::ResourceInUse]
+    #     if resources required by the virtual machine are in use (e.g. virtual machine configuration files or virtual disks are locked, host containing the virtual machine is an HA failover host).
+    # @raise [Com::Vmware::Vapi::Std::Errors::ResourceBusy]
+    #     if the virtual machine is performing another operation.
+    # @raise [Com::Vmware::Vapi::Std::Errors::ServiceUnavailable]
+    #     if the system is unable to communicate with a service to complete the request.
+    # @raise [Com::Vmware::Vapi::Std::Errors::Unauthenticated]
+    #     if the user can not be authenticated.
+    # @raise [Com::Vmware::Vapi::Std::Errors::Unauthorized]
+    #     if the user doesn't have the required privileges.
+    def start(vm)
+      invoke_with_info(START_INFO,
+                       'vm' => vm)
+    end
+
+    # Powers off a powered-on or suspended virtual machine.
+    #
+    # @param vm [String]
+    #     Virtual machine identifier.
+    # @return [Void]
+    # @raise [Com::Vmware::Vapi::Std::Errors::Error]
+    #     if the system reports an error while responding to the request.
+    # @raise [Com::Vmware::Vapi::Std::Errors::NotFound]
+    #     if the virtual machine is not found.
+    # @raise [Com::Vmware::Vapi::Std::Errors::AlreadyInDesiredState]
+    #     if the virtual machine is already powered off.
+    # @raise [Com::Vmware::Vapi::Std::Errors::ResourceBusy]
+    #     if the virtual machine is performing another operation.
+    # @raise [Com::Vmware::Vapi::Std::Errors::ServiceUnavailable]
+    #     if the system is unable to communicate with a service to complete the request.
+    # @raise [Com::Vmware::Vapi::Std::Errors::Unauthenticated]
+    #     if the user can not be authenticated.
+    # @raise [Com::Vmware::Vapi::Std::Errors::Unauthorized]
+    #     if the user doesn't have the required privileges.
+    def stop(vm)
+      invoke_with_info(STOP_INFO,
+                       'vm' => vm)
+    end
+
+    # Suspends a powered-on virtual machine.
+    #
+    # @param vm [String]
+    #     Virtual machine identifier.
+    # @return [Void]
+    # @raise [Com::Vmware::Vapi::Std::Errors::Error]
+    #     if the system reports an error while responding to the request.
+    # @raise [Com::Vmware::Vapi::Std::Errors::NotFound]
+    #     if the virtual machine is not found.
+    # @raise [Com::Vmware::Vapi::Std::Errors::AlreadyInDesiredState]
+    #     if the virtual machine is already suspended.
+    # @raise [Com::Vmware::Vapi::Std::Errors::NotAllowedInCurrentState]
+    #     if the virtual machine is powered off.
+    # @raise [Com::Vmware::Vapi::Std::Errors::ResourceBusy]
+    #     if the virtual machine is performing another operation.
+    # @raise [Com::Vmware::Vapi::Std::Errors::ServiceUnavailable]
+    #     if the system is unable to communicate with a service to complete the request.
+    # @raise [Com::Vmware::Vapi::Std::Errors::Unauthenticated]
+    #     if the user can not be authenticated.
+    # @raise [Com::Vmware::Vapi::Std::Errors::Unauthorized]
+    #     if the user doesn't have the required privileges.
+    def suspend(vm)
+      invoke_with_info(SUSPEND_INFO,
+                       'vm' => vm)
+    end
+
+    # Resets a powered-on virtual machine.
+    #
+    # @param vm [String]
+    #     Virtual machine identifier.
+    # @return [Void]
+    # @raise [Com::Vmware::Vapi::Std::Errors::Error]
+    #     if the system reports an error while responding to the request.
+    # @raise [Com::Vmware::Vapi::Std::Errors::NotFound]
+    #     if the virtual machine is not found.
+    # @raise [Com::Vmware::Vapi::Std::Errors::NotAllowedInCurrentState]
+    #     if the virtual machine is powered off or suspended.
+    # @raise [Com::Vmware::Vapi::Std::Errors::ResourceBusy]
+    #     if the virtual machine is performing another operation
+    # @raise [Com::Vmware::Vapi::Std::Errors::ServiceUnavailable]
+    #     if the system is unable to communicate with a service to complete the request.
+    # @raise [Com::Vmware::Vapi::Std::Errors::Unauthenticated]
+    #     if the user can not be authenticated.
+    # @raise [Com::Vmware::Vapi::Std::Errors::Unauthorized]
+    #     if the user doesn't have the required privileges.
+    def reset(vm)
+      invoke_with_info(RESET_INFO,
+                       'vm' => vm)
+    end
+
+    # The  ``Com::Vmware::Vcenter::Vm::Power::Info``   class  contains information about the power state of a virtual machine.
+    # @!attribute [rw] state
+    #     @return [Com::Vmware::Vcenter::Vm::Power::State]
+    #     Power state of the virtual machine.
+    # @!attribute [rw] clean_power_off
+    #     @return [Boolean]
+    #     Flag indicating whether the virtual machine was powered off cleanly. This  field  may be used to detect that the virtual machine crashed unexpectedly and should be restarted.
+    #     This  field  is optional and it is only relevant when the value of  ``state``  is   :attr:`Com::Vmware::Vcenter::Vm::Power::State.POWERED_OFF`  .
+    class Info < VAPI::Bindings::VapiStruct
+      class << self
+        # Holds (gets or creates) the binding type metadata for this structure type.
+        # @scope class
+        # @return [VAPI::Bindings::StructType] the binding type
+        def binding_type
+          @binding_type ||= VAPI::Bindings::StructType.new(
+            'com.vmware.vcenter.vm.power.info',
+            {
+              'state' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::Vm::Power::State'),
+              'clean_power_off' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::BooleanType.instance)
+            },
+            Info,
+            false,
+            nil
+          )
+        end
+      end
+
+      attr_accessor :state,
+                    :clean_power_off
+
+      # Constructs a new instance.
+      # @param ruby_values [Hash] a map of initial property values (optional)
+      # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
+      def initialize(ruby_values = nil, struct_value = nil)
+        super(self.class.binding_type, ruby_values, struct_value)
+      end
+    end
+
+    # The  ``Com::Vmware::Vcenter::Vm::Power::State``   enumerated type  defines the valid power states for a virtual machine.
+    # @!attribute [rw] powered_off
+    #     @return [Com::Vmware::Vcenter::Vm::Power::State]
+    #     The virtual machine is powered off.
+    # @!attribute [rw] powered_on
+    #     @return [Com::Vmware::Vcenter::Vm::Power::State]
+    #     The virtual machine is powered on.
+    # @!attribute [rw] suspended
+    #     @return [Com::Vmware::Vcenter::Vm::Power::State]
+    #     The virtual machine is suspended.
+    class State < VAPI::Bindings::VapiEnum
+      class << self
+        # Holds (gets or creates) the binding type metadata for this enumeration type.
+        # @scope class
+        # @return [VAPI::Bindings::EnumType] the binding type
+        def binding_type
+          @binding_type ||= VAPI::Bindings::EnumType.new(
+            'com.vmware.vcenter.vm.power.state',
+            State
+          )
+        end
+
+        # Converts from a string value (perhaps off the wire) to an instance
+        # of this enum type.
+        # @param value [String] the actual value of the enum instance
+        # @return [State] the instance found for the value, otherwise
+        #         an unknown instance will be built for the value
+        def from_string(value)
+          const_get(value)
+        rescue NameError
+          State.send(:new, 'UNKNOWN', value)
+        end
+      end
+
+      # Constructs a new instance.
+      # @param value [String] the actual value of the enum instance
+      # @param unknown [String] the unknown value when value is 'UKNOWN'
+      def initialize(value, unknown = nil)
+        super(self.class.binding_type, value, unknown)
+      end
+
+      private_class_method :new
+
+      # @!attribute [rw] powered_off
+      #     @return [Com::Vmware::Vcenter::Vm::Power::State]
+      #     The virtual machine is powered off.
+      POWERED_OFF = State.send(:new, 'POWERED_OFF')
+
+      # @!attribute [rw] powered_on
+      #     @return [Com::Vmware::Vcenter::Vm::Power::State]
+      #     The virtual machine is powered on.
+      POWERED_ON = State.send(:new, 'POWERED_ON')
+
+      # @!attribute [rw] suspended
+      #     @return [Com::Vmware::Vcenter::Vm::Power::State]
+      #     The virtual machine is suspended.
+      SUSPENDED = State.send(:new, 'SUSPENDED')
+    end
+  end
+  # The  ``Com::Vmware::Vcenter::VM::GuestOS``   enumerated type  defines the valid guest operating system types used for configuring a virtual machine.
+  # @!attribute [rw] dos
+  #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+  #     MS-DOS.
+  # @!attribute [rw] win_31
+  #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+  #     Windows 3.1
+  # @!attribute [rw] win_95
+  #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+  #     Windows 95
+  # @!attribute [rw] win_98
+  #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+  #     Windows 98
+  # @!attribute [rw] win_me
+  #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+  #     Windows Millennium Edition
+  # @!attribute [rw] win_nt
+  #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+  #     Windows NT 4
+  # @!attribute [rw] win_2000_pro
+  #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+  #     Windows 2000 Professional
+  # @!attribute [rw] win_2000_serv
+  #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+  #     Windows 2000 Server
+  # @!attribute [rw] win_2000_adv_serv
+  #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+  #     Windows 2000 Advanced Server
+  # @!attribute [rw] win_xp_home
+  #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+  #     Windows XP Home Edition
+  # @!attribute [rw] win_xp_pro
+  #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+  #     Windows XP Professional
+  # @!attribute [rw] win_xp_pro_64
+  #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+  #     Windows XP Professional Edition (64 bit)
+  # @!attribute [rw] win_net_web
+  #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+  #     Windows Server 2003, Web Edition
+  # @!attribute [rw] win_net_standard
+  #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+  #     Windows Server 2003, Standard Edition
+  # @!attribute [rw] win_net_enterprise
+  #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+  #     Windows Server 2003, Enterprise Edition
+  # @!attribute [rw] win_net_datacenter
+  #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+  #     Windows Server 2003, Datacenter Edition
+  # @!attribute [rw] win_net_business
+  #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+  #     Windows Small Business Server 2003
+  # @!attribute [rw] win_net_standard_64
+  #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+  #     Windows Server 2003, Standard Edition (64 bit)
+  # @!attribute [rw] win_net_enterprise_64
+  #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+  #     Windows Server 2003, Enterprise Edition (64 bit)
+  # @!attribute [rw] win_longhorn
+  #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+  #     Windows Longhorn (experimental)
+  # @!attribute [rw] win_longhorn_64
+  #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+  #     Windows Longhorn (64 bit) (experimental)
+  # @!attribute [rw] win_net_datacenter_64
+  #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+  #     Windows Server 2003, Datacenter Edition (64 bit) (experimental)
+  # @!attribute [rw] win_vista
+  #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+  #     Windows Vista
+  # @!attribute [rw] win_vista_64
+  #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+  #     Windows Vista (64 bit)
+  # @!attribute [rw] windows_7
+  #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+  #     Windows 7
+  # @!attribute [rw] windows_7_64
+  #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+  #     Windows 7 (64 bit)
+  # @!attribute [rw] windows_7_server_64
+  #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+  #     Windows Server 2008 R2 (64 bit)
+  # @!attribute [rw] windows_8
+  #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+  #     Windows 8
+  # @!attribute [rw] windows_8_64
+  #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+  #     Windows 8 (64 bit)
+  # @!attribute [rw] windows_8_server_64
+  #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+  #     Windows 8 Server (64 bit)
+  # @!attribute [rw] windows_9
+  #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+  #     Windows 10
+  # @!attribute [rw] windows_9_64
+  #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+  #     Windows 10 (64 bit)
+  # @!attribute [rw] windows_9_server_64
+  #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+  #     Windows 10 Server (64 bit)
+  # @!attribute [rw] windows_hyperv
+  #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+  #     Windows Hyper-V
+  # @!attribute [rw] freebsd
+  #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+  #     FreeBSD
+  # @!attribute [rw] freebsd_64
+  #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+  #     FreeBSD x64
+  # @!attribute [rw] redhat
+  #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+  #     Red Hat Linux 2.1
+  # @!attribute [rw] rhel_2
+  #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+  #     Red Hat Enterprise Linux 2
+  # @!attribute [rw] rhel_3
+  #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+  #     Red Hat Enterprise Linux 3
+  # @!attribute [rw] rhel_3_64
+  #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+  #     Red Hat Enterprise Linux 3 (64 bit)
+  # @!attribute [rw] rhel_4
+  #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+  #     Red Hat Enterprise Linux 4
+  # @!attribute [rw] rhel_4_64
+  #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+  #     Red Hat Enterprise Linux 4 (64 bit)
+  # @!attribute [rw] rhel_5
+  #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+  #     Red Hat Enterprise Linux 5
+  # @!attribute [rw] rhel_5_64
+  #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+  #     Red Hat Enterprise Linux 5 (64 bit) (experimental)
+  # @!attribute [rw] rhel_6
+  #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+  #     Red Hat Enterprise Linux 6
+  # @!attribute [rw] rhel_6_64
+  #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+  #     Red Hat Enterprise Linux 6 (64 bit)
+  # @!attribute [rw] rhel_7
+  #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+  #     Red Hat Enterprise Linux 7
+  # @!attribute [rw] rhel_7_64
+  #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+  #     Red Hat Enterprise Linux 7 (64 bit)
+  # @!attribute [rw] centos
+  #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+  #     CentOS 4/5
+  # @!attribute [rw] centos_64
+  #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+  #     CentOS 4/5 (64-bit)
+  # @!attribute [rw] centos_6
+  #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+  #     CentOS 6
+  # @!attribute [rw] centos_6_64
+  #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+  #     CentOS 6 (64-bit)
+  # @!attribute [rw] centos_7
+  #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+  #     CentOS 7
+  # @!attribute [rw] centos_7_64
+  #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+  #     CentOS 7 (64-bit)
+  # @!attribute [rw] oracle_linux
+  #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+  #     Oracle Linux 4/5
+  # @!attribute [rw] oracle_linux_64
+  #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+  #     Oracle Linux 4/5 (64-bit)
+  # @!attribute [rw] oracle_linux_6
+  #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+  #     Oracle Linux 6
+  # @!attribute [rw] oracle_linux_6_64
+  #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+  #     Oracle Linux 6 (64-bit)
+  # @!attribute [rw] oracle_linux_7
+  #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+  #     Oracle Linux 7
+  # @!attribute [rw] oracle_linux_7_64
+  #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+  #     Oracle Linux 7 (64-bit)
+  # @!attribute [rw] suse
+  #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+  #     Suse Linux
+  # @!attribute [rw] suse_64
+  #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+  #     Suse Linux (64 bit)
+  # @!attribute [rw] sles
+  #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+  #     Suse Linux Enterprise Server 9
+  # @!attribute [rw] sles_64
+  #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+  #     Suse Linux Enterprise Server 9 (64 bit)
+  # @!attribute [rw] sles_10
+  #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+  #     Suse linux Enterprise Server 10
+  # @!attribute [rw] sles_10_64
+  #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+  #     Suse Linux Enterprise Server 10 (64 bit) (experimental)
+  # @!attribute [rw] sles_11
+  #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+  #     Suse linux Enterprise Server 11
+  # @!attribute [rw] sles_11_64
+  #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+  #     Suse Linux Enterprise Server 11 (64 bit)
+  # @!attribute [rw] sles_12
+  #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+  #     Suse linux Enterprise Server 12
+  # @!attribute [rw] sles_12_64
+  #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+  #     Suse Linux Enterprise Server 12 (64 bit)
+  # @!attribute [rw] nld_9
+  #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+  #     Novell Linux Desktop 9
+  # @!attribute [rw] oes
+  #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+  #     Open Enterprise Server
+  # @!attribute [rw] sjds
+  #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+  #     Sun Java Desktop System
+  # @!attribute [rw] mandrake
+  #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+  #     Mandrake Linux
+  # @!attribute [rw] mandriva
+  #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+  #     Mandriva Linux
+  # @!attribute [rw] mandriva_64
+  #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+  #     Mandriva Linux (64 bit)
+  # @!attribute [rw] turbo_linux
+  #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+  #     Turbolinux
+  # @!attribute [rw] turbo_linux_64
+  #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+  #     Turbolinux (64 bit)
+  # @!attribute [rw] ubuntu
+  #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+  #     Ubuntu Linux
+  # @!attribute [rw] ubuntu_64
+  #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+  #     Ubuntu Linux (64 bit)
+  # @!attribute [rw] debian_4
+  #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+  #     Debian GNU/Linux 4
+  # @!attribute [rw] debian_4_64
+  #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+  #     Debian GNU/Linux 4 (64 bit)
+  # @!attribute [rw] debian_5
+  #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+  #     Debian GNU/Linux 5
+  # @!attribute [rw] debian_5_64
+  #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+  #     Debian GNU/Linux 5 (64 bit)
+  # @!attribute [rw] debian_6
+  #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+  #     Debian GNU/Linux 6
+  # @!attribute [rw] debian_6_64
+  #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+  #     Debian GNU/Linux 6 (64 bit)
+  # @!attribute [rw] debian_7
+  #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+  #     Debian GNU/Linux 7
+  # @!attribute [rw] debian_7_64
+  #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+  #     Debian GNU/Linux 7 (64 bit)
+  # @!attribute [rw] debian_8
+  #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+  #     Debian GNU/Linux 8
+  # @!attribute [rw] debian_8_64
+  #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+  #     Debian GNU/Linux 8 (64 bit)
+  # @!attribute [rw] debian_9
+  #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+  #     Debian GNU/Linux 9
+  # @!attribute [rw] debian_9_64
+  #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+  #     Debian GNU/Linux 9 (64 bit)
+  # @!attribute [rw] debian_10
+  #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+  #     Debian GNU/Linux 10
+  # @!attribute [rw] debian_10_64
+  #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+  #     Debian GNU/Linux 10 (64 bit)
+  # @!attribute [rw] asianux_3
+  #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+  #     Asianux Server 3
+  # @!attribute [rw] asianux_3_64
+  #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+  #     Asianux Server 3 (64 bit)
+  # @!attribute [rw] asianux_4
+  #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+  #     Asianux Server 4
+  # @!attribute [rw] asianux_4_64
+  #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+  #     Asianux Server 4 (64 bit)
+  # @!attribute [rw] asianux_5_64
+  #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+  #     Asianux Server 5 (64 bit)
+  # @!attribute [rw] asianux_7_64
+  #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+  #     Asianux Server 7 (64 bit)
+  # @!attribute [rw] opensuse
+  #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+  #     OpenSUSE Linux
+  # @!attribute [rw] opensuse_64
+  #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+  #     OpenSUSE Linux (64 bit)
+  # @!attribute [rw] fedora
+  #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+  #     Fedora Linux
+  # @!attribute [rw] fedora_64
+  #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+  #     Fedora Linux (64 bit)
+  # @!attribute [rw] coreos_64
+  #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+  #     CoreOS Linux (64 bit)
+  # @!attribute [rw] vmware_photon_64
+  #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+  #     VMware Photon (64 bit)
+  # @!attribute [rw] other_24x_linux
+  #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+  #     Linux 2.4x Kernel
+  # @!attribute [rw] other_24x_linux_64
+  #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+  #     Linux 2.4x Kernel (64 bit) (experimental)
+  # @!attribute [rw] other_26x_linux
+  #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+  #     Linux 2.6x Kernel
+  # @!attribute [rw] other_26x_linux_64
+  #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+  #     Linux 2.6x Kernel (64 bit) (experimental)
+  # @!attribute [rw] other_3x_linux
+  #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+  #     Linux 3.x Kernel
+  # @!attribute [rw] other_3x_linux_64
+  #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+  #     Linux 3.x Kernel (64 bit)
+  # @!attribute [rw] other_linux
+  #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+  #     Linux 2.2x Kernel
+  # @!attribute [rw] generic_linux
+  #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+  #     Other Linux
+  # @!attribute [rw] other_linux_64
+  #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+  #     Linux (64 bit) (experimental)
+  # @!attribute [rw] solaris_6
+  #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+  #     Solaris 6
+  # @!attribute [rw] solaris_7
+  #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+  #     Solaris 7
+  # @!attribute [rw] solaris_8
+  #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+  #     Solaris 8
+  # @!attribute [rw] solaris_9
+  #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+  #     Solaris 9
+  # @!attribute [rw] solaris_10
+  #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+  #     Solaris 10 (32 bit) (experimental)
+  # @!attribute [rw] solaris_10_64
+  #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+  #     Solaris 10 (64 bit) (experimental)
+  # @!attribute [rw] solaris_11_64
+  #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+  #     Solaris 11 (64 bit)
+  # @!attribute [rw] o_s2
+  #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+  #     OS/2
+  # @!attribute [rw] ecomstation
+  #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+  #     eComStation 1.x
+  # @!attribute [rw] ecomstation_2
+  #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+  #     eComStation 2.0
+  # @!attribute [rw] netware_4
+  #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+  #     Novell NetWare 4
+  # @!attribute [rw] netware_5
+  #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+  #     Novell NetWare 5.1
+  # @!attribute [rw] netware_6
+  #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+  #     Novell NetWare 6.x
+  # @!attribute [rw] openserver_5
+  #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+  #     SCO OpenServer 5
+  # @!attribute [rw] openserver_6
+  #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+  #     SCO OpenServer 6
+  # @!attribute [rw] unixware_7
+  #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+  #     SCO UnixWare 7
+  # @!attribute [rw] darwin
+  #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+  #     Mac OS 10.5
+  # @!attribute [rw] darwin_64
+  #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+  #     Mac OS 10.5 (64 bit)
+  # @!attribute [rw] darwin_10
+  #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+  #     Mac OS 10.6
+  # @!attribute [rw] darwin_10_64
+  #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+  #     Mac OS 10.6 (64 bit)
+  # @!attribute [rw] darwin_11
+  #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+  #     Mac OS 10.7
+  # @!attribute [rw] darwin_11_64
+  #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+  #     Mac OS 10.7 (64 bit)
+  # @!attribute [rw] darwin_12_64
+  #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+  #     Mac OS 10.8 (64 bit)
+  # @!attribute [rw] darwin_13_64
+  #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+  #     Mac OS 10.9 (64 bit)
+  # @!attribute [rw] darwin_14_64
+  #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+  #     Mac OS 10.10 (64 bit)
+  # @!attribute [rw] darwin_15_64
+  #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+  #     Mac OS 10.11 (64 bit)
+  # @!attribute [rw] darwin_16_64
+  #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+  #     Mac OS 10.12 (64 bit)
+  # @!attribute [rw] vmkernel
+  #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+  #     VMware ESX 4
+  # @!attribute [rw] vmkernel_5
+  #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+  #     VMware ESX 5
+  # @!attribute [rw] vmkernel_6
+  #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+  #     VMware ESX 6
+  # @!attribute [rw] vmkernel_65
+  #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+  #     VMware ESX 6.5
+  # @!attribute [rw] other
+  #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+  #     Other Operating System
+  # @!attribute [rw] other_64
+  #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+  #     Other Operating System (64 bit) (experimental)
+  class GuestOS < VAPI::Bindings::VapiEnum
+    class << self
+      # Holds (gets or creates) the binding type metadata for this enumeration type.
+      # @scope class
+      # @return [VAPI::Bindings::EnumType] the binding type
+      def binding_type
+        @binding_type ||= VAPI::Bindings::EnumType.new(
+          'com.vmware.vcenter.vm.guest_OS',
+          GuestOS
+        )
+      end
+
+      # Converts from a string value (perhaps off the wire) to an instance
+      # of this enum type.
+      # @param value [String] the actual value of the enum instance
+      # @return [GuestOS] the instance found for the value, otherwise
+      #         an unknown instance will be built for the value
+      def from_string(value)
+        const_get(value)
+      rescue NameError
+        GuestOS.send(:new, 'UNKNOWN', value)
+      end
+    end
+
+    # Constructs a new instance.
+    # @param value [String] the actual value of the enum instance
+    # @param unknown [String] the unknown value when value is 'UKNOWN'
+    def initialize(value, unknown = nil)
+      super(self.class.binding_type, value, unknown)
+    end
+
+    private_class_method :new
+
+    # @!attribute [rw] dos
+    #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+    #     MS-DOS.
+    DOS = GuestOS.send(:new, 'DOS')
+
+    # @!attribute [rw] win_31
+    #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+    #     Windows 3.1
+    WIN_31 = GuestOS.send(:new, 'WIN_31')
+
+    # @!attribute [rw] win_95
+    #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+    #     Windows 95
+    WIN_95 = GuestOS.send(:new, 'WIN_95')
+
+    # @!attribute [rw] win_98
+    #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+    #     Windows 98
+    WIN_98 = GuestOS.send(:new, 'WIN_98')
+
+    # @!attribute [rw] win_me
+    #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+    #     Windows Millennium Edition
+    WIN_ME = GuestOS.send(:new, 'WIN_ME')
+
+    # @!attribute [rw] win_nt
+    #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+    #     Windows NT 4
+    WIN_NT = GuestOS.send(:new, 'WIN_NT')
+
+    # @!attribute [rw] win_2000_pro
+    #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+    #     Windows 2000 Professional
+    WIN_2000_PRO = GuestOS.send(:new, 'WIN_2000_PRO')
+
+    # @!attribute [rw] win_2000_serv
+    #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+    #     Windows 2000 Server
+    WIN_2000_SERV = GuestOS.send(:new, 'WIN_2000_SERV')
+
+    # @!attribute [rw] win_2000_adv_serv
+    #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+    #     Windows 2000 Advanced Server
+    WIN_2000_ADV_SERV = GuestOS.send(:new, 'WIN_2000_ADV_SERV')
+
+    # @!attribute [rw] win_xp_home
+    #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+    #     Windows XP Home Edition
+    WIN_XP_HOME = GuestOS.send(:new, 'WIN_XP_HOME')
+
+    # @!attribute [rw] win_xp_pro
+    #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+    #     Windows XP Professional
+    WIN_XP_PRO = GuestOS.send(:new, 'WIN_XP_PRO')
+
+    # @!attribute [rw] win_xp_pro_64
+    #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+    #     Windows XP Professional Edition (64 bit)
+    WIN_XP_PRO_64 = GuestOS.send(:new, 'WIN_XP_PRO_64')
+
+    # @!attribute [rw] win_net_web
+    #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+    #     Windows Server 2003, Web Edition
+    WIN_NET_WEB = GuestOS.send(:new, 'WIN_NET_WEB')
+
+    # @!attribute [rw] win_net_standard
+    #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+    #     Windows Server 2003, Standard Edition
+    WIN_NET_STANDARD = GuestOS.send(:new, 'WIN_NET_STANDARD')
+
+    # @!attribute [rw] win_net_enterprise
+    #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+    #     Windows Server 2003, Enterprise Edition
+    WIN_NET_ENTERPRISE = GuestOS.send(:new, 'WIN_NET_ENTERPRISE')
+
+    # @!attribute [rw] win_net_datacenter
+    #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+    #     Windows Server 2003, Datacenter Edition
+    WIN_NET_DATACENTER = GuestOS.send(:new, 'WIN_NET_DATACENTER')
+
+    # @!attribute [rw] win_net_business
+    #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+    #     Windows Small Business Server 2003
+    WIN_NET_BUSINESS = GuestOS.send(:new, 'WIN_NET_BUSINESS')
+
+    # @!attribute [rw] win_net_standard_64
+    #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+    #     Windows Server 2003, Standard Edition (64 bit)
+    WIN_NET_STANDARD_64 = GuestOS.send(:new, 'WIN_NET_STANDARD_64')
+
+    # @!attribute [rw] win_net_enterprise_64
+    #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+    #     Windows Server 2003, Enterprise Edition (64 bit)
+    WIN_NET_ENTERPRISE_64 = GuestOS.send(:new, 'WIN_NET_ENTERPRISE_64')
+
+    # @!attribute [rw] win_longhorn
+    #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+    #     Windows Longhorn (experimental)
+    WIN_LONGHORN = GuestOS.send(:new, 'WIN_LONGHORN')
+
+    # @!attribute [rw] win_longhorn_64
+    #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+    #     Windows Longhorn (64 bit) (experimental)
+    WIN_LONGHORN_64 = GuestOS.send(:new, 'WIN_LONGHORN_64')
+
+    # @!attribute [rw] win_net_datacenter_64
+    #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+    #     Windows Server 2003, Datacenter Edition (64 bit) (experimental)
+    WIN_NET_DATACENTER_64 = GuestOS.send(:new, 'WIN_NET_DATACENTER_64')
+
+    # @!attribute [rw] win_vista
+    #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+    #     Windows Vista
+    WIN_VISTA = GuestOS.send(:new, 'WIN_VISTA')
+
+    # @!attribute [rw] win_vista_64
+    #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+    #     Windows Vista (64 bit)
+    WIN_VISTA_64 = GuestOS.send(:new, 'WIN_VISTA_64')
+
+    # @!attribute [rw] windows_7
+    #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+    #     Windows 7
+    WINDOWS_7 = GuestOS.send(:new, 'WINDOWS_7')
+
+    # @!attribute [rw] windows_7_64
+    #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+    #     Windows 7 (64 bit)
+    WINDOWS_7_64 = GuestOS.send(:new, 'WINDOWS_7_64')
+
+    # @!attribute [rw] windows_7_server_64
+    #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+    #     Windows Server 2008 R2 (64 bit)
+    WINDOWS_7_SERVER_64 = GuestOS.send(:new, 'WINDOWS_7_SERVER_64')
+
+    # @!attribute [rw] windows_8
+    #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+    #     Windows 8
+    WINDOWS_8 = GuestOS.send(:new, 'WINDOWS_8')
+
+    # @!attribute [rw] windows_8_64
+    #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+    #     Windows 8 (64 bit)
+    WINDOWS_8_64 = GuestOS.send(:new, 'WINDOWS_8_64')
+
+    # @!attribute [rw] windows_8_server_64
+    #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+    #     Windows 8 Server (64 bit)
+    WINDOWS_8_SERVER_64 = GuestOS.send(:new, 'WINDOWS_8_SERVER_64')
+
+    # @!attribute [rw] windows_9
+    #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+    #     Windows 10
+    WINDOWS_9 = GuestOS.send(:new, 'WINDOWS_9')
+
+    # @!attribute [rw] windows_9_64
+    #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+    #     Windows 10 (64 bit)
+    WINDOWS_9_64 = GuestOS.send(:new, 'WINDOWS_9_64')
+
+    # @!attribute [rw] windows_9_server_64
+    #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+    #     Windows 10 Server (64 bit)
+    WINDOWS_9_SERVER_64 = GuestOS.send(:new, 'WINDOWS_9_SERVER_64')
+
+    # @!attribute [rw] windows_hyperv
+    #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+    #     Windows Hyper-V
+    WINDOWS_HYPERV = GuestOS.send(:new, 'WINDOWS_HYPERV')
+
+    # @!attribute [rw] freebsd
+    #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+    #     FreeBSD
+    FREEBSD = GuestOS.send(:new, 'FREEBSD')
+
+    # @!attribute [rw] freebsd_64
+    #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+    #     FreeBSD x64
+    FREEBSD_64 = GuestOS.send(:new, 'FREEBSD_64')
+
+    # @!attribute [rw] redhat
+    #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+    #     Red Hat Linux 2.1
+    REDHAT = GuestOS.send(:new, 'REDHAT')
+
+    # @!attribute [rw] rhel_2
+    #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+    #     Red Hat Enterprise Linux 2
+    RHEL_2 = GuestOS.send(:new, 'RHEL_2')
+
+    # @!attribute [rw] rhel_3
+    #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+    #     Red Hat Enterprise Linux 3
+    RHEL_3 = GuestOS.send(:new, 'RHEL_3')
+
+    # @!attribute [rw] rhel_3_64
+    #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+    #     Red Hat Enterprise Linux 3 (64 bit)
+    RHEL_3_64 = GuestOS.send(:new, 'RHEL_3_64')
+
+    # @!attribute [rw] rhel_4
+    #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+    #     Red Hat Enterprise Linux 4
+    RHEL_4 = GuestOS.send(:new, 'RHEL_4')
+
+    # @!attribute [rw] rhel_4_64
+    #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+    #     Red Hat Enterprise Linux 4 (64 bit)
+    RHEL_4_64 = GuestOS.send(:new, 'RHEL_4_64')
+
+    # @!attribute [rw] rhel_5
+    #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+    #     Red Hat Enterprise Linux 5
+    RHEL_5 = GuestOS.send(:new, 'RHEL_5')
+
+    # @!attribute [rw] rhel_5_64
+    #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+    #     Red Hat Enterprise Linux 5 (64 bit) (experimental)
+    RHEL_5_64 = GuestOS.send(:new, 'RHEL_5_64')
+
+    # @!attribute [rw] rhel_6
+    #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+    #     Red Hat Enterprise Linux 6
+    RHEL_6 = GuestOS.send(:new, 'RHEL_6')
+
+    # @!attribute [rw] rhel_6_64
+    #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+    #     Red Hat Enterprise Linux 6 (64 bit)
+    RHEL_6_64 = GuestOS.send(:new, 'RHEL_6_64')
+
+    # @!attribute [rw] rhel_7
+    #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+    #     Red Hat Enterprise Linux 7
+    RHEL_7 = GuestOS.send(:new, 'RHEL_7')
+
+    # @!attribute [rw] rhel_7_64
+    #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+    #     Red Hat Enterprise Linux 7 (64 bit)
+    RHEL_7_64 = GuestOS.send(:new, 'RHEL_7_64')
+
+    # @!attribute [rw] centos
+    #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+    #     CentOS 4/5
+    CENTOS = GuestOS.send(:new, 'CENTOS')
+
+    # @!attribute [rw] centos_64
+    #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+    #     CentOS 4/5 (64-bit)
+    CENTOS_64 = GuestOS.send(:new, 'CENTOS_64')
+
+    # @!attribute [rw] centos_6
+    #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+    #     CentOS 6
+    CENTOS_6 = GuestOS.send(:new, 'CENTOS_6')
+
+    # @!attribute [rw] centos_6_64
+    #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+    #     CentOS 6 (64-bit)
+    CENTOS_6_64 = GuestOS.send(:new, 'CENTOS_6_64')
+
+    # @!attribute [rw] centos_7
+    #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+    #     CentOS 7
+    CENTOS_7 = GuestOS.send(:new, 'CENTOS_7')
+
+    # @!attribute [rw] centos_7_64
+    #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+    #     CentOS 7 (64-bit)
+    CENTOS_7_64 = GuestOS.send(:new, 'CENTOS_7_64')
+
+    # @!attribute [rw] oracle_linux
+    #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+    #     Oracle Linux 4/5
+    ORACLE_LINUX = GuestOS.send(:new, 'ORACLE_LINUX')
+
+    # @!attribute [rw] oracle_linux_64
+    #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+    #     Oracle Linux 4/5 (64-bit)
+    ORACLE_LINUX_64 = GuestOS.send(:new, 'ORACLE_LINUX_64')
+
+    # @!attribute [rw] oracle_linux_6
+    #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+    #     Oracle Linux 6
+    ORACLE_LINUX_6 = GuestOS.send(:new, 'ORACLE_LINUX_6')
+
+    # @!attribute [rw] oracle_linux_6_64
+    #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+    #     Oracle Linux 6 (64-bit)
+    ORACLE_LINUX_6_64 = GuestOS.send(:new, 'ORACLE_LINUX_6_64')
+
+    # @!attribute [rw] oracle_linux_7
+    #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+    #     Oracle Linux 7
+    ORACLE_LINUX_7 = GuestOS.send(:new, 'ORACLE_LINUX_7')
+
+    # @!attribute [rw] oracle_linux_7_64
+    #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+    #     Oracle Linux 7 (64-bit)
+    ORACLE_LINUX_7_64 = GuestOS.send(:new, 'ORACLE_LINUX_7_64')
+
+    # @!attribute [rw] suse
+    #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+    #     Suse Linux
+    SUSE = GuestOS.send(:new, 'SUSE')
+
+    # @!attribute [rw] suse_64
+    #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+    #     Suse Linux (64 bit)
+    SUSE_64 = GuestOS.send(:new, 'SUSE_64')
+
+    # @!attribute [rw] sles
+    #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+    #     Suse Linux Enterprise Server 9
+    SLES = GuestOS.send(:new, 'SLES')
+
+    # @!attribute [rw] sles_64
+    #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+    #     Suse Linux Enterprise Server 9 (64 bit)
+    SLES_64 = GuestOS.send(:new, 'SLES_64')
+
+    # @!attribute [rw] sles_10
+    #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+    #     Suse linux Enterprise Server 10
+    SLES_10 = GuestOS.send(:new, 'SLES_10')
+
+    # @!attribute [rw] sles_10_64
+    #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+    #     Suse Linux Enterprise Server 10 (64 bit) (experimental)
+    SLES_10_64 = GuestOS.send(:new, 'SLES_10_64')
+
+    # @!attribute [rw] sles_11
+    #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+    #     Suse linux Enterprise Server 11
+    SLES_11 = GuestOS.send(:new, 'SLES_11')
+
+    # @!attribute [rw] sles_11_64
+    #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+    #     Suse Linux Enterprise Server 11 (64 bit)
+    SLES_11_64 = GuestOS.send(:new, 'SLES_11_64')
+
+    # @!attribute [rw] sles_12
+    #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+    #     Suse linux Enterprise Server 12
+    SLES_12 = GuestOS.send(:new, 'SLES_12')
+
+    # @!attribute [rw] sles_12_64
+    #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+    #     Suse Linux Enterprise Server 12 (64 bit)
+    SLES_12_64 = GuestOS.send(:new, 'SLES_12_64')
+
+    # @!attribute [rw] nld_9
+    #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+    #     Novell Linux Desktop 9
+    NLD_9 = GuestOS.send(:new, 'NLD_9')
+
+    # @!attribute [rw] oes
+    #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+    #     Open Enterprise Server
+    OES = GuestOS.send(:new, 'OES')
+
+    # @!attribute [rw] sjds
+    #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+    #     Sun Java Desktop System
+    SJDS = GuestOS.send(:new, 'SJDS')
+
+    # @!attribute [rw] mandrake
+    #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+    #     Mandrake Linux
+    MANDRAKE = GuestOS.send(:new, 'MANDRAKE')
+
+    # @!attribute [rw] mandriva
+    #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+    #     Mandriva Linux
+    MANDRIVA = GuestOS.send(:new, 'MANDRIVA')
+
+    # @!attribute [rw] mandriva_64
+    #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+    #     Mandriva Linux (64 bit)
+    MANDRIVA_64 = GuestOS.send(:new, 'MANDRIVA_64')
+
+    # @!attribute [rw] turbo_linux
+    #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+    #     Turbolinux
+    TURBO_LINUX = GuestOS.send(:new, 'TURBO_LINUX')
+
+    # @!attribute [rw] turbo_linux_64
+    #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+    #     Turbolinux (64 bit)
+    TURBO_LINUX_64 = GuestOS.send(:new, 'TURBO_LINUX_64')
+
+    # @!attribute [rw] ubuntu
+    #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+    #     Ubuntu Linux
+    UBUNTU = GuestOS.send(:new, 'UBUNTU')
+
+    # @!attribute [rw] ubuntu_64
+    #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+    #     Ubuntu Linux (64 bit)
+    UBUNTU_64 = GuestOS.send(:new, 'UBUNTU_64')
+
+    # @!attribute [rw] debian_4
+    #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+    #     Debian GNU/Linux 4
+    DEBIAN_4 = GuestOS.send(:new, 'DEBIAN_4')
+
+    # @!attribute [rw] debian_4_64
+    #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+    #     Debian GNU/Linux 4 (64 bit)
+    DEBIAN_4_64 = GuestOS.send(:new, 'DEBIAN_4_64')
+
+    # @!attribute [rw] debian_5
+    #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+    #     Debian GNU/Linux 5
+    DEBIAN_5 = GuestOS.send(:new, 'DEBIAN_5')
+
+    # @!attribute [rw] debian_5_64
+    #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+    #     Debian GNU/Linux 5 (64 bit)
+    DEBIAN_5_64 = GuestOS.send(:new, 'DEBIAN_5_64')
+
+    # @!attribute [rw] debian_6
+    #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+    #     Debian GNU/Linux 6
+    DEBIAN_6 = GuestOS.send(:new, 'DEBIAN_6')
+
+    # @!attribute [rw] debian_6_64
+    #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+    #     Debian GNU/Linux 6 (64 bit)
+    DEBIAN_6_64 = GuestOS.send(:new, 'DEBIAN_6_64')
+
+    # @!attribute [rw] debian_7
+    #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+    #     Debian GNU/Linux 7
+    DEBIAN_7 = GuestOS.send(:new, 'DEBIAN_7')
+
+    # @!attribute [rw] debian_7_64
+    #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+    #     Debian GNU/Linux 7 (64 bit)
+    DEBIAN_7_64 = GuestOS.send(:new, 'DEBIAN_7_64')
+
+    # @!attribute [rw] debian_8
+    #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+    #     Debian GNU/Linux 8
+    DEBIAN_8 = GuestOS.send(:new, 'DEBIAN_8')
+
+    # @!attribute [rw] debian_8_64
+    #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+    #     Debian GNU/Linux 8 (64 bit)
+    DEBIAN_8_64 = GuestOS.send(:new, 'DEBIAN_8_64')
+
+    # @!attribute [rw] debian_9
+    #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+    #     Debian GNU/Linux 9
+    DEBIAN_9 = GuestOS.send(:new, 'DEBIAN_9')
+
+    # @!attribute [rw] debian_9_64
+    #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+    #     Debian GNU/Linux 9 (64 bit)
+    DEBIAN_9_64 = GuestOS.send(:new, 'DEBIAN_9_64')
+
+    # @!attribute [rw] debian_10
+    #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+    #     Debian GNU/Linux 10
+    DEBIAN_10 = GuestOS.send(:new, 'DEBIAN_10')
+
+    # @!attribute [rw] debian_10_64
+    #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+    #     Debian GNU/Linux 10 (64 bit)
+    DEBIAN_10_64 = GuestOS.send(:new, 'DEBIAN_10_64')
+
+    # @!attribute [rw] asianux_3
+    #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+    #     Asianux Server 3
+    ASIANUX_3 = GuestOS.send(:new, 'ASIANUX_3')
+
+    # @!attribute [rw] asianux_3_64
+    #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+    #     Asianux Server 3 (64 bit)
+    ASIANUX_3_64 = GuestOS.send(:new, 'ASIANUX_3_64')
+
+    # @!attribute [rw] asianux_4
+    #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+    #     Asianux Server 4
+    ASIANUX_4 = GuestOS.send(:new, 'ASIANUX_4')
+
+    # @!attribute [rw] asianux_4_64
+    #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+    #     Asianux Server 4 (64 bit)
+    ASIANUX_4_64 = GuestOS.send(:new, 'ASIANUX_4_64')
+
+    # @!attribute [rw] asianux_5_64
+    #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+    #     Asianux Server 5 (64 bit)
+    ASIANUX_5_64 = GuestOS.send(:new, 'ASIANUX_5_64')
+
+    # @!attribute [rw] asianux_7_64
+    #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+    #     Asianux Server 7 (64 bit)
+    ASIANUX_7_64 = GuestOS.send(:new, 'ASIANUX_7_64')
+
+    # @!attribute [rw] opensuse
+    #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+    #     OpenSUSE Linux
+    OPENSUSE = GuestOS.send(:new, 'OPENSUSE')
+
+    # @!attribute [rw] opensuse_64
+    #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+    #     OpenSUSE Linux (64 bit)
+    OPENSUSE_64 = GuestOS.send(:new, 'OPENSUSE_64')
+
+    # @!attribute [rw] fedora
+    #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+    #     Fedora Linux
+    FEDORA = GuestOS.send(:new, 'FEDORA')
+
+    # @!attribute [rw] fedora_64
+    #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+    #     Fedora Linux (64 bit)
+    FEDORA_64 = GuestOS.send(:new, 'FEDORA_64')
+
+    # @!attribute [rw] coreos_64
+    #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+    #     CoreOS Linux (64 bit)
+    COREOS_64 = GuestOS.send(:new, 'COREOS_64')
+
+    # @!attribute [rw] vmware_photon_64
+    #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+    #     VMware Photon (64 bit)
+    VMWARE_PHOTON_64 = GuestOS.send(:new, 'VMWARE_PHOTON_64')
+
+    # @!attribute [rw] other_24x_linux
+    #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+    #     Linux 2.4x Kernel
+    OTHER_24X_LINUX = GuestOS.send(:new, 'OTHER_24X_LINUX')
+
+    # @!attribute [rw] other_24x_linux_64
+    #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+    #     Linux 2.4x Kernel (64 bit) (experimental)
+    OTHER_24X_LINUX_64 = GuestOS.send(:new, 'OTHER_24X_LINUX_64')
+
+    # @!attribute [rw] other_26x_linux
+    #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+    #     Linux 2.6x Kernel
+    OTHER_26X_LINUX = GuestOS.send(:new, 'OTHER_26X_LINUX')
+
+    # @!attribute [rw] other_26x_linux_64
+    #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+    #     Linux 2.6x Kernel (64 bit) (experimental)
+    OTHER_26X_LINUX_64 = GuestOS.send(:new, 'OTHER_26X_LINUX_64')
+
+    # @!attribute [rw] other_3x_linux
+    #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+    #     Linux 3.x Kernel
+    OTHER_3X_LINUX = GuestOS.send(:new, 'OTHER_3X_LINUX')
+
+    # @!attribute [rw] other_3x_linux_64
+    #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+    #     Linux 3.x Kernel (64 bit)
+    OTHER_3X_LINUX_64 = GuestOS.send(:new, 'OTHER_3X_LINUX_64')
+
+    # @!attribute [rw] other_linux
+    #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+    #     Linux 2.2x Kernel
+    OTHER_LINUX = GuestOS.send(:new, 'OTHER_LINUX')
+
+    # @!attribute [rw] generic_linux
+    #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+    #     Other Linux
+    GENERIC_LINUX = GuestOS.send(:new, 'GENERIC_LINUX')
+
+    # @!attribute [rw] other_linux_64
+    #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+    #     Linux (64 bit) (experimental)
+    OTHER_LINUX_64 = GuestOS.send(:new, 'OTHER_LINUX_64')
+
+    # @!attribute [rw] solaris_6
+    #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+    #     Solaris 6
+    SOLARIS_6 = GuestOS.send(:new, 'SOLARIS_6')
+
+    # @!attribute [rw] solaris_7
+    #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+    #     Solaris 7
+    SOLARIS_7 = GuestOS.send(:new, 'SOLARIS_7')
+
+    # @!attribute [rw] solaris_8
+    #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+    #     Solaris 8
+    SOLARIS_8 = GuestOS.send(:new, 'SOLARIS_8')
+
+    # @!attribute [rw] solaris_9
+    #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+    #     Solaris 9
+    SOLARIS_9 = GuestOS.send(:new, 'SOLARIS_9')
+
+    # @!attribute [rw] solaris_10
+    #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+    #     Solaris 10 (32 bit) (experimental)
+    SOLARIS_10 = GuestOS.send(:new, 'SOLARIS_10')
+
+    # @!attribute [rw] solaris_10_64
+    #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+    #     Solaris 10 (64 bit) (experimental)
+    SOLARIS_10_64 = GuestOS.send(:new, 'SOLARIS_10_64')
+
+    # @!attribute [rw] solaris_11_64
+    #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+    #     Solaris 11 (64 bit)
+    SOLARIS_11_64 = GuestOS.send(:new, 'SOLARIS_11_64')
+
+    # @!attribute [rw] o_s2
+    #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+    #     OS/2
+    O_S2 = GuestOS.send(:new, 'O_S2')
+
+    # @!attribute [rw] ecomstation
+    #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+    #     eComStation 1.x
+    ECOMSTATION = GuestOS.send(:new, 'ECOMSTATION')
+
+    # @!attribute [rw] ecomstation_2
+    #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+    #     eComStation 2.0
+    ECOMSTATION_2 = GuestOS.send(:new, 'ECOMSTATION_2')
+
+    # @!attribute [rw] netware_4
+    #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+    #     Novell NetWare 4
+    NETWARE_4 = GuestOS.send(:new, 'NETWARE_4')
+
+    # @!attribute [rw] netware_5
+    #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+    #     Novell NetWare 5.1
+    NETWARE_5 = GuestOS.send(:new, 'NETWARE_5')
+
+    # @!attribute [rw] netware_6
+    #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+    #     Novell NetWare 6.x
+    NETWARE_6 = GuestOS.send(:new, 'NETWARE_6')
+
+    # @!attribute [rw] openserver_5
+    #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+    #     SCO OpenServer 5
+    OPENSERVER_5 = GuestOS.send(:new, 'OPENSERVER_5')
+
+    # @!attribute [rw] openserver_6
+    #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+    #     SCO OpenServer 6
+    OPENSERVER_6 = GuestOS.send(:new, 'OPENSERVER_6')
+
+    # @!attribute [rw] unixware_7
+    #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+    #     SCO UnixWare 7
+    UNIXWARE_7 = GuestOS.send(:new, 'UNIXWARE_7')
+
+    # @!attribute [rw] darwin
+    #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+    #     Mac OS 10.5
+    DARWIN = GuestOS.send(:new, 'DARWIN')
+
+    # @!attribute [rw] darwin_64
+    #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+    #     Mac OS 10.5 (64 bit)
+    DARWIN_64 = GuestOS.send(:new, 'DARWIN_64')
+
+    # @!attribute [rw] darwin_10
+    #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+    #     Mac OS 10.6
+    DARWIN_10 = GuestOS.send(:new, 'DARWIN_10')
+
+    # @!attribute [rw] darwin_10_64
+    #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+    #     Mac OS 10.6 (64 bit)
+    DARWIN_10_64 = GuestOS.send(:new, 'DARWIN_10_64')
+
+    # @!attribute [rw] darwin_11
+    #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+    #     Mac OS 10.7
+    DARWIN_11 = GuestOS.send(:new, 'DARWIN_11')
+
+    # @!attribute [rw] darwin_11_64
+    #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+    #     Mac OS 10.7 (64 bit)
+    DARWIN_11_64 = GuestOS.send(:new, 'DARWIN_11_64')
+
+    # @!attribute [rw] darwin_12_64
+    #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+    #     Mac OS 10.8 (64 bit)
+    DARWIN_12_64 = GuestOS.send(:new, 'DARWIN_12_64')
+
+    # @!attribute [rw] darwin_13_64
+    #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+    #     Mac OS 10.9 (64 bit)
+    DARWIN_13_64 = GuestOS.send(:new, 'DARWIN_13_64')
+
+    # @!attribute [rw] darwin_14_64
+    #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+    #     Mac OS 10.10 (64 bit)
+    DARWIN_14_64 = GuestOS.send(:new, 'DARWIN_14_64')
+
+    # @!attribute [rw] darwin_15_64
+    #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+    #     Mac OS 10.11 (64 bit)
+    DARWIN_15_64 = GuestOS.send(:new, 'DARWIN_15_64')
+
+    # @!attribute [rw] darwin_16_64
+    #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+    #     Mac OS 10.12 (64 bit)
+    DARWIN_16_64 = GuestOS.send(:new, 'DARWIN_16_64')
+
+    # @!attribute [rw] vmkernel
+    #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+    #     VMware ESX 4
+    VMKERNEL = GuestOS.send(:new, 'VMKERNEL')
+
+    # @!attribute [rw] vmkernel_5
+    #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+    #     VMware ESX 5
+    VMKERNEL_5 = GuestOS.send(:new, 'VMKERNEL_5')
+
+    # @!attribute [rw] vmkernel_6
+    #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+    #     VMware ESX 6
+    VMKERNEL_6 = GuestOS.send(:new, 'VMKERNEL_6')
+
+    # @!attribute [rw] vmkernel_65
+    #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+    #     VMware ESX 6.5
+    VMKERNEL_65 = GuestOS.send(:new, 'VMKERNEL_65')
+
+    # @!attribute [rw] other
+    #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+    #     Other Operating System
+    OTHER = GuestOS.send(:new, 'OTHER')
+
+    # @!attribute [rw] other_64
+    #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+    #     Other Operating System (64 bit) (experimental)
+    OTHER_64 = GuestOS.send(:new, 'OTHER_64')
+  end
 end

--- a/client/sdk/com/vmware/vcenter/vm/hardware.rb
+++ b/client/sdk/com/vmware/vcenter/vm/hardware.rb
@@ -1,5 +1,6 @@
 #---------------------------------------------------------------------------
-# Copyright 2016 VMware, Inc.  All rights reserved.
+# Copyright 2017 VMware, Inc.  All rights reserved.
+#
 # AUTO GENERATED FILE -- DO NOT MODIFY!
 #
 # vAPI type descriptors for package com.vmware.vcenter.vm.hardware.
@@ -8,6222 +9,5920 @@ require 'vapi'
 
 # declare the module hierarchy before we use the shorthand syntax below
 module Com
-    module Vmware
-        module Vcenter
-            module Vm
-                module Hardware
-                end
-            end
+  module Vmware
+    module Vcenter
+      module Vm
+        module Hardware
         end
+      end
     end
+  end
 end
 
 # The  ``com.vmware.vcenter.vm.hardware``   package  provides  classs  for managing the virtual hardware configuration and state of a virtual machine. This includes  methods  for reading and manipulating virtual device configuration and for querying the runtime state of the devices.
 module Com::Vmware::Vcenter::Vm::Hardware
+  # The  ``Com::Vmware::Vcenter::VM::Hardware::Boot``   class  provides  methods  for configuring the settings used when booting a virtual machine.
+  class BootService < VAPI::Bindings::VapiService
+    # static metamodel definitions
+    SERVICE_ID = VAPI::Core::ServiceIdentifier.new('com.vmware.vcenter.vm.hardware.boot')
 
-    # The  ``Com::Vmware::Vcenter::Vm::Hardware::Boot``   class  provides  methods  for configuring the settings used when booting a virtual machine.
-    class BootService < VAPI::Bindings::VapiService
+    GET_INFO = VAPI::Bindings::OperationInfo.new(
+      VAPI::Core::OperationIdentifier.new('get', SERVICE_ID),
+      VAPI::Bindings::OperationInputType.new(
+        'vm' => VAPI::Bindings::IdType.new('VirtualMachine')
+      ),
+      VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::VM::Hardware::Boot::Info'),
+      {
+        'com.vmware.vapi.std.errors.error' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Error'),
+        'com.vmware.vapi.std.errors.not_found' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::NotFound'),
+        'com.vmware.vapi.std.errors.resource_inaccessible' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::ResourceInaccessible'),
+        'com.vmware.vapi.std.errors.service_unavailable' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::ServiceUnavailable'),
+        'com.vmware.vapi.std.errors.unauthenticated' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Unauthenticated'),
+        'com.vmware.vapi.std.errors.unauthorized' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Unauthorized')
+      },
+      [],
+      []
+    )
 
-        protected
+    UPDATE_INFO = VAPI::Bindings::OperationInfo.new(
+      VAPI::Core::OperationIdentifier.new('update', SERVICE_ID),
+      VAPI::Bindings::OperationInputType.new(
+        'vm' => VAPI::Bindings::IdType.new('VirtualMachine'),
+        'spec' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::VM::Hardware::Boot::UpdateSpec')
+      ),
+      VAPI::Bindings::VoidType.instance,
+      {
+        'com.vmware.vapi.std.errors.error' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Error'),
+        'com.vmware.vapi.std.errors.not_found' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::NotFound'),
+        'com.vmware.vapi.std.errors.invalid_argument' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::InvalidArgument'),
+        'com.vmware.vapi.std.errors.resource_busy' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::ResourceBusy'),
+        'com.vmware.vapi.std.errors.resource_inaccessible' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::ResourceInaccessible'),
+        'com.vmware.vapi.std.errors.service_unavailable' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::ServiceUnavailable'),
+        'com.vmware.vapi.std.errors.unauthenticated' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Unauthenticated'),
+        'com.vmware.vapi.std.errors.unauthorized' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Unauthorized')
+      },
+      [],
+      []
+    )
 
-        # static metamodel definitions
-        @@service_id = VAPI::Core::ServiceIdentifier.new('com.vmware.vcenter.vm.hardware.boot')
+    SERVICE_INFO = VAPI::Bindings::ServiceInfo.new(
+      SERVICE_ID,
+      'get' => GET_INFO,
+      'update' => UPDATE_INFO
+    )
 
-        @@get_info = VAPI::Bindings::OperationInfo.new(
-            VAPI::Core::OperationIdentifier.new('get', @@service_id),
-            VAPI::Bindings::OperationInputType.new({
-                'vm' => VAPI::Bindings::IdType.new(resource_types='VirtualMachine'),
-            }),
-            VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::Vm::Hardware::Boot::Info'),
-            {
-                'com.vmware.vapi.std.errors.error' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Error'),
-                'com.vmware.vapi.std.errors.not_found' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::NotFound'),
-                'com.vmware.vapi.std.errors.resource_inaccessible' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::ResourceInaccessible'),
-                'com.vmware.vapi.std.errors.service_unavailable' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::ServiceUnavailable'),
-                'com.vmware.vapi.std.errors.unauthenticated' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Unauthenticated'),
-                'com.vmware.vapi.std.errors.unauthorized' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Unauthorized'),
-
-            },
-            [],
-            [])
-        @@update_info = VAPI::Bindings::OperationInfo.new(
-            VAPI::Core::OperationIdentifier.new('update', @@service_id),
-            VAPI::Bindings::OperationInputType.new({
-                'vm' => VAPI::Bindings::IdType.new(resource_types='VirtualMachine'),
-                'spec' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::Vm::Hardware::Boot::UpdateSpec'),
-            }),
-            VAPI::Bindings::VoidType.instance,
-            {
-                'com.vmware.vapi.std.errors.error' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Error'),
-                'com.vmware.vapi.std.errors.not_found' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::NotFound'),
-                'com.vmware.vapi.std.errors.invalid_argument' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::InvalidArgument'),
-                'com.vmware.vapi.std.errors.resource_busy' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::ResourceBusy'),
-                'com.vmware.vapi.std.errors.resource_inaccessible' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::ResourceInaccessible'),
-                'com.vmware.vapi.std.errors.service_unavailable' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::ServiceUnavailable'),
-                'com.vmware.vapi.std.errors.unauthenticated' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Unauthenticated'),
-                'com.vmware.vapi.std.errors.unauthorized' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Unauthorized'),
-
-            },
-            [],
-            [])
-
-        @@service_info = VAPI::Bindings::ServiceInfo.new(@@service_id, {
-            'get' => @@get_info,
-            'update' => @@update_info,
-        })
-
-        public
-
-        # Constructs a new instance.
-        #
-        # @param config [VAPI::Bindings::StubConfig] A hash with the api provider details.
-        def initialize(config)
-            super(config, @@service_info)
-        end
-
-
-        # Returns the boot-related settings of a virtual machine.
-        #
-        # @param vm [String]
-        #     Virtual machine identifier.
-        # @return [Com::Vmware::Vcenter::Vm::Hardware::Boot::Info]
-        #     Boot-related settings of the virtual machine.
-        # @raise [Com::Vmware::Vapi::Std::Errors::Error]
-        #     if the system reports an error while responding to the request.
-        # @raise [Com::Vmware::Vapi::Std::Errors::NotFound]
-        #     if the virtual machine is not found.
-        # @raise [Com::Vmware::Vapi::Std::Errors::ResourceInaccessible]
-        #     if the virtual machine's configuration state cannot be accessed.
-        # @raise [Com::Vmware::Vapi::Std::Errors::ServiceUnavailable]
-        #     if the system is unable to communicate with a service to complete the request.
-        # @raise [Com::Vmware::Vapi::Std::Errors::Unauthenticated]
-        #     if the user can not be authenticated.
-        # @raise [Com::Vmware::Vapi::Std::Errors::Unauthorized]
-        #     if the user doesn't have the required privileges.
-        def get(vm)
-            invoke_with_info(@@get_info, {
-                'vm' => vm,
-            })
-        end
-
-
-        # Updates the boot-related settings of a virtual machine.
-        #
-        # @param vm [String]
-        #     Virtual machine identifier.
-        # @param spec [Com::Vmware::Vcenter::Vm::Hardware::Boot::UpdateSpec]
-        #     Specification for updating the boot-related settings of the virtual machine.
-        # @return [Void]
-        # @raise [Com::Vmware::Vapi::Std::Errors::Error]
-        #     if the system reports an error while responding to the request.
-        # @raise [Com::Vmware::Vapi::Std::Errors::NotFound]
-        #     if the virtual machine is not found.
-        # @raise [Com::Vmware::Vapi::Std::Errors::InvalidArgument]
-        #     if one of the provided settings is not permitted; for example, specifying a negative value for  ``delay`` .
-        # @raise [Com::Vmware::Vapi::Std::Errors::ResourceBusy]
-        #     if the virtual machine is busy performing another operation.
-        # @raise [Com::Vmware::Vapi::Std::Errors::ResourceInaccessible]
-        #     if the virtual machine's configuration state cannot be accessed.
-        # @raise [Com::Vmware::Vapi::Std::Errors::ServiceUnavailable]
-        #     if the system is unable to communicate with a service to complete the request.
-        # @raise [Com::Vmware::Vapi::Std::Errors::Unauthenticated]
-        #     if the user can not be authenticated.
-        # @raise [Com::Vmware::Vapi::Std::Errors::Unauthorized]
-        #     if the user doesn't have the required privileges.
-        def update(vm, spec)
-            invoke_with_info(@@update_info, {
-                'vm' => vm,
-                'spec' => spec,
-            })
-        end
-
-
-
-        # The  ``Com::Vmware::Vcenter::Vm::Hardware::Boot::Info``   class  contains information about the virtual machine boot process.
-        # @!attribute [rw] type
-        #     @return [Com::Vmware::Vcenter::Vm::Hardware::Boot::Type]
-        #     Firmware type used by the virtual machine.
-        # @!attribute [rw] efi_legacy_boot
-        #     @return [Boolean]
-        #     Flag indicating whether to use EFI legacy boot mode.
-        #     This  field  is optional and it is only relevant when the value of  ``type``  is   :attr:`Com::Vmware::Vcenter::Vm::Hardware::Boot::Type.EFI`  .
-        # @!attribute [rw] network_protocol
-        #     @return [Com::Vmware::Vcenter::Vm::Hardware::Boot::NetworkProtocol]
-        #     Protocol to use when attempting to boot the virtual machine over the network.
-        #     This  field  is optional and it is only relevant when the value of  ``type``  is   :attr:`Com::Vmware::Vcenter::Vm::Hardware::Boot::Type.EFI`  .
-        # @!attribute [rw] delay
-        #     @return [Fixnum]
-        #     Delay in milliseconds before beginning the firmware boot process when the virtual machine is powered on. This delay may be used to provide a time window for users to connect to the virtual machine console and enter BIOS setup mode.
-        # @!attribute [rw] retry_
-        #     @return [Boolean]
-        #     Flag indicating whether the virtual machine will automatically retry the boot process after a failure.
-        # @!attribute [rw] retry_delay
-        #     @return [Fixnum]
-        #     Delay in milliseconds before retrying the boot process after a failure; applicable only when   :attr:`Com::Vmware::Vcenter::Vm::Hardware::Boot::Info.retry_`   is true.
-        # @!attribute [rw] enter_setup_mode
-        #     @return [Boolean]
-        #     Flag indicating whether the firmware boot process will automatically enter setup mode the next time the virtual machine boots. Note that this flag will automatically be reset to false once the virtual machine enters setup mode.
-        class Info < VAPI::Bindings::VapiStruct
-
-            class << self
-                # Holds (gets or creates) the binding type metadata for this structure type.
-                # @scope class
-                # @return [VAPI::Bindings::StructType] the binding type
-                def binding_type
-                    @binding_type ||= VAPI::Bindings::StructType.new(
-                        'com.vmware.vcenter.vm.hardware.boot.info',
-                        {
-                            'type' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::Vm::Hardware::Boot::Type'),
-                            'efi_legacy_boot' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::BooleanType.instance),
-                            'network_protocol' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::Vm::Hardware::Boot::NetworkProtocol')),
-                            'delay' => VAPI::Bindings::IntegerType.instance,
-                            'retry' => VAPI::Bindings::BooleanType.instance,
-                            'retry_delay' => VAPI::Bindings::IntegerType.instance,
-                            'enter_setup_mode' => VAPI::Bindings::BooleanType.instance,
-                        },
-                        Info,
-                        false,
-                        nil)
-                end
-            end
-
-            attr_accessor :type,
-                          :efi_legacy_boot,
-                          :network_protocol,
-                          :delay,
-                          :retry_,
-                          :retry_delay,
-                          :enter_setup_mode
-
-            # Constructs a new instance.
-            # @param ruby_values [Hash] a map of initial property values (optional)
-            # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
-            def initialize(ruby_values=nil, struct_value=nil)
-                super(self.class.binding_type, ruby_values, struct_value)
-            end
-        end
-
-
-        # The  ``Com::Vmware::Vcenter::Vm::Hardware::Boot::CreateSpec``   class  describes settings used when booting a virtual machine.
-        # @!attribute [rw] type
-        #     @return [Com::Vmware::Vcenter::Vm::Hardware::Boot::Type, nil]
-        #     Firmware type to be used by the virtual machine.
-        #     If  nil , defaults to value that is recommended for the guest OS and is supported for the virtual hardware version.
-        # @!attribute [rw] efi_legacy_boot
-        #     @return [Boolean, nil]
-        #     Flag indicating whether to use EFI legacy boot mode.
-        #     If  nil , defaults to value that is recommended for the guest OS and is supported for the virtual hardware version.
-        # @!attribute [rw] network_protocol
-        #     @return [Com::Vmware::Vcenter::Vm::Hardware::Boot::NetworkProtocol, nil]
-        #     Protocol to use when attempting to boot the virtual machine over the network.
-        #     If  nil , defaults to a system defined default value.
-        # @!attribute [rw] delay
-        #     @return [Fixnum, nil]
-        #     Delay in milliseconds before beginning the firmware boot process when the virtual machine is powered on. This delay may be used to provide a time window for users to connect to the virtual machine console and enter BIOS setup mode.
-        #     If  nil , default value is 0.
-        # @!attribute [rw] retry_
-        #     @return [Boolean, nil]
-        #     Flag indicating whether the virtual machine should automatically retry the boot process after a failure.
-        #     If  nil , default value is false.
-        # @!attribute [rw] retry_delay
-        #     @return [Fixnum, nil]
-        #     Delay in milliseconds before retrying the boot process after a failure; applicable only when   :attr:`Com::Vmware::Vcenter::Vm::Hardware::Boot::Info.retry_`   is true.
-        #     If  nil , default value is 10000.
-        # @!attribute [rw] enter_setup_mode
-        #     @return [Boolean, nil]
-        #     Flag indicating whether the firmware boot process should automatically enter setup mode the next time the virtual machine boots. Note that this flag will automatically be reset to false once the virtual machine enters setup mode.
-        #     If  nil , the value is unchanged.
-        class CreateSpec < VAPI::Bindings::VapiStruct
-
-            class << self
-                # Holds (gets or creates) the binding type metadata for this structure type.
-                # @scope class
-                # @return [VAPI::Bindings::StructType] the binding type
-                def binding_type
-                    @binding_type ||= VAPI::Bindings::StructType.new(
-                        'com.vmware.vcenter.vm.hardware.boot.create_spec',
-                        {
-                            'type' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::Vm::Hardware::Boot::Type')),
-                            'efi_legacy_boot' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::BooleanType.instance),
-                            'network_protocol' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::Vm::Hardware::Boot::NetworkProtocol')),
-                            'delay' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::IntegerType.instance),
-                            'retry' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::BooleanType.instance),
-                            'retry_delay' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::IntegerType.instance),
-                            'enter_setup_mode' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::BooleanType.instance),
-                        },
-                        CreateSpec,
-                        false,
-                        nil)
-                end
-            end
-
-            attr_accessor :type,
-                          :efi_legacy_boot,
-                          :network_protocol,
-                          :delay,
-                          :retry_,
-                          :retry_delay,
-                          :enter_setup_mode
-
-            # Constructs a new instance.
-            # @param ruby_values [Hash] a map of initial property values (optional)
-            # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
-            def initialize(ruby_values=nil, struct_value=nil)
-                super(self.class.binding_type, ruby_values, struct_value)
-            end
-        end
-
-
-        # The  ``Com::Vmware::Vcenter::Vm::Hardware::Boot::UpdateSpec``   class  describes the updates to the settings used when booting a virtual machine.
-        # @!attribute [rw] type
-        #     @return [Com::Vmware::Vcenter::Vm::Hardware::Boot::Type, nil]
-        #     Firmware type to be used by the virtual machine.
-        #     If  nil , the value is unchanged.
-        # @!attribute [rw] efi_legacy_boot
-        #     @return [Boolean, nil]
-        #     Flag indicating whether to use EFI legacy boot mode.
-        #     If  nil , the value is unchanged.
-        # @!attribute [rw] network_protocol
-        #     @return [Com::Vmware::Vcenter::Vm::Hardware::Boot::NetworkProtocol, nil]
-        #     Protocol to use when attempting to boot the virtual machine over the network.
-        #     If  nil , the value is unchanged.
-        # @!attribute [rw] delay
-        #     @return [Fixnum, nil]
-        #     Delay in milliseconds before beginning the firmware boot process when the virtual machine is powered on. This delay may be used to provide a time window for users to connect to the virtual machine console and enter BIOS setup mode.
-        #     If  nil , the value is unchanged.
-        # @!attribute [rw] retry_
-        #     @return [Boolean, nil]
-        #     Flag indicating whether the virtual machine should automatically retry the boot process after a failure.
-        #     If  nil , the value is unchanged.
-        # @!attribute [rw] retry_delay
-        #     @return [Fixnum, nil]
-        #     Delay in milliseconds before retrying the boot process after a failure; applicable only when   :attr:`Com::Vmware::Vcenter::Vm::Hardware::Boot::Info.retry_`   is true.
-        #     If  nil , the value is unchanged.
-        # @!attribute [rw] enter_setup_mode
-        #     @return [Boolean, nil]
-        #     Flag indicating whether the firmware boot process should automatically enter setup mode the next time the virtual machine boots. Note that this flag will automatically be reset to false once the virtual machine enters setup mode.
-        #     If  nil , the value is unchanged.
-        class UpdateSpec < VAPI::Bindings::VapiStruct
-
-            class << self
-                # Holds (gets or creates) the binding type metadata for this structure type.
-                # @scope class
-                # @return [VAPI::Bindings::StructType] the binding type
-                def binding_type
-                    @binding_type ||= VAPI::Bindings::StructType.new(
-                        'com.vmware.vcenter.vm.hardware.boot.update_spec',
-                        {
-                            'type' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::Vm::Hardware::Boot::Type')),
-                            'efi_legacy_boot' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::BooleanType.instance),
-                            'network_protocol' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::Vm::Hardware::Boot::NetworkProtocol')),
-                            'delay' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::IntegerType.instance),
-                            'retry' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::BooleanType.instance),
-                            'retry_delay' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::IntegerType.instance),
-                            'enter_setup_mode' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::BooleanType.instance),
-                        },
-                        UpdateSpec,
-                        false,
-                        nil)
-                end
-            end
-
-            attr_accessor :type,
-                          :efi_legacy_boot,
-                          :network_protocol,
-                          :delay,
-                          :retry_,
-                          :retry_delay,
-                          :enter_setup_mode
-
-            # Constructs a new instance.
-            # @param ruby_values [Hash] a map of initial property values (optional)
-            # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
-            def initialize(ruby_values=nil, struct_value=nil)
-                super(self.class.binding_type, ruby_values, struct_value)
-            end
-        end
-
-
-
-        # The  ``Com::Vmware::Vcenter::Vm::Hardware::Boot::Type``   enumerated type  defines the valid firmware types for a virtual machine.
-        # @!attribute [rw] bios
-        #     @return [Com::Vmware::Vcenter::Vm::Hardware::Boot::Type]
-        #     Basic Input/Output System (BIOS) firmware.
-        # @!attribute [rw] efi
-        #     @return [Com::Vmware::Vcenter::Vm::Hardware::Boot::Type]
-        #     Extensible Firmware Interface (EFI) firmware.
-        class Type < VAPI::Bindings::VapiEnum
-
-            class << self
-                # Holds (gets or creates) the binding type metadata for this enumeration type.
-                # @scope class
-                # @return [VAPI::Bindings::EnumType] the binding type
-                def binding_type
-                    @binding_type ||= VAPI::Bindings::EnumType.new(
-                        'com.vmware.vcenter.vm.hardware.boot.type',
-                        Type)
-                end
-
-                # Converts from a string value (perhaps off the wire) to an instance
-                # of this enum type.
-                # @param value [String] the actual value of the enum instance
-                # @return [Type] the instance found for the value, otherwise
-                #         an unknown instance will be built for the value
-                def from_string(value)
-                    begin
-                        const_get(value)
-                    rescue NameError
-                        Type.new('UNKNOWN', value)
-                    end
-                end
-            end
-
-            private
-
-            # Constructs a new instance.
-            # @param value [String] the actual value of the enum instance
-            # @param unknown [String] the unknown value when value is 'UKNOWN'
-            def initialize(value, unknown=nil)
-                super(self.class.binding_type, value, unknown)
-            end
-
-            public
-
-            # @!attribute [rw] bios
-            #     @return [Com::Vmware::Vcenter::Vm::Hardware::Boot::Type]
-            #     Basic Input/Output System (BIOS) firmware.
-            BIOS = Type.new('BIOS')
-
-            # @!attribute [rw] efi
-            #     @return [Com::Vmware::Vcenter::Vm::Hardware::Boot::Type]
-            #     Extensible Firmware Interface (EFI) firmware.
-            EFI = Type.new('EFI')
-
-        end
-
-
-        # The  ``Com::Vmware::Vcenter::Vm::Hardware::Boot::NetworkProtocol``   enumerated type  defines the valid network boot protocols supported when booting a virtual machine with   :attr:`Com::Vmware::Vcenter::Vm::Hardware::Boot::Type.EFI`   firmware over the network.
-        # @!attribute [rw] ip_v4
-        #     @return [Com::Vmware::Vcenter::Vm::Hardware::Boot::NetworkProtocol]
-        #     PXE or Apple NetBoot over IPv4.
-        # @!attribute [rw] ip_v6
-        #     @return [Com::Vmware::Vcenter::Vm::Hardware::Boot::NetworkProtocol]
-        #     PXE over IPv6.
-        class NetworkProtocol < VAPI::Bindings::VapiEnum
-
-            class << self
-                # Holds (gets or creates) the binding type metadata for this enumeration type.
-                # @scope class
-                # @return [VAPI::Bindings::EnumType] the binding type
-                def binding_type
-                    @binding_type ||= VAPI::Bindings::EnumType.new(
-                        'com.vmware.vcenter.vm.hardware.boot.network_protocol',
-                        NetworkProtocol)
-                end
-
-                # Converts from a string value (perhaps off the wire) to an instance
-                # of this enum type.
-                # @param value [String] the actual value of the enum instance
-                # @return [NetworkProtocol] the instance found for the value, otherwise
-                #         an unknown instance will be built for the value
-                def from_string(value)
-                    begin
-                        const_get(value)
-                    rescue NameError
-                        NetworkProtocol.new('UNKNOWN', value)
-                    end
-                end
-            end
-
-            private
-
-            # Constructs a new instance.
-            # @param value [String] the actual value of the enum instance
-            # @param unknown [String] the unknown value when value is 'UKNOWN'
-            def initialize(value, unknown=nil)
-                super(self.class.binding_type, value, unknown)
-            end
-
-            public
-
-            # @!attribute [rw] ip_v4
-            #     @return [Com::Vmware::Vcenter::Vm::Hardware::Boot::NetworkProtocol]
-            #     PXE or Apple NetBoot over IPv4.
-            IP_V4 = NetworkProtocol.new('IP_V4')
-
-            # @!attribute [rw] ip_v6
-            #     @return [Com::Vmware::Vcenter::Vm::Hardware::Boot::NetworkProtocol]
-            #     PXE over IPv6.
-            IP_V6 = NetworkProtocol.new('IP_V6')
-
-        end
-
-
+    # Constructs a new instance.
+    #
+    # @param config [VAPI::Bindings::StubConfig] A hash with the api provider details.
+    def initialize(config)
+      super(config, SERVICE_INFO)
     end
 
-
-    # The  ``Com::Vmware::Vcenter::Vm::Hardware::Cdrom``   class  provides  methods  for configuring the virtual CD-ROM devices of a virtual machine.
-    class Cdrom < VAPI::Bindings::VapiService
-
-        protected
-
-        # static metamodel definitions
-        @@service_id = VAPI::Core::ServiceIdentifier.new('com.vmware.vcenter.vm.hardware.cdrom')
-
-        @@list_info = VAPI::Bindings::OperationInfo.new(
-            VAPI::Core::OperationIdentifier.new('list', @@service_id),
-            VAPI::Bindings::OperationInputType.new({
-                'vm' => VAPI::Bindings::IdType.new(resource_types='VirtualMachine'),
-            }),
-            VAPI::Bindings::ListType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::Vm::Hardware::Cdrom::Summary')),
-            {
-                'com.vmware.vapi.std.errors.error' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Error'),
-                'com.vmware.vapi.std.errors.not_found' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::NotFound'),
-                'com.vmware.vapi.std.errors.resource_inaccessible' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::ResourceInaccessible'),
-                'com.vmware.vapi.std.errors.service_unavailable' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::ServiceUnavailable'),
-                'com.vmware.vapi.std.errors.unauthenticated' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Unauthenticated'),
-                'com.vmware.vapi.std.errors.unauthorized' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Unauthorized'),
-
-            },
-            [],
-            [])
-        @@get_info = VAPI::Bindings::OperationInfo.new(
-            VAPI::Core::OperationIdentifier.new('get', @@service_id),
-            VAPI::Bindings::OperationInputType.new({
-                'vm' => VAPI::Bindings::IdType.new(resource_types='VirtualMachine'),
-                'cdrom' => VAPI::Bindings::IdType.new(resource_types='com.vmware.vcenter.vm.hardware.Cdrom'),
-            }),
-            VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::Vm::Hardware::Cdrom::Info'),
-            {
-                'com.vmware.vapi.std.errors.error' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Error'),
-                'com.vmware.vapi.std.errors.not_found' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::NotFound'),
-                'com.vmware.vapi.std.errors.resource_inaccessible' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::ResourceInaccessible'),
-                'com.vmware.vapi.std.errors.service_unavailable' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::ServiceUnavailable'),
-                'com.vmware.vapi.std.errors.unauthenticated' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Unauthenticated'),
-                'com.vmware.vapi.std.errors.unauthorized' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Unauthorized'),
-
-            },
-            [],
-            [])
-        @@create_info = VAPI::Bindings::OperationInfo.new(
-            VAPI::Core::OperationIdentifier.new('create', @@service_id),
-            VAPI::Bindings::OperationInputType.new({
-                'vm' => VAPI::Bindings::IdType.new(resource_types='VirtualMachine'),
-                'spec' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::Vm::Hardware::Cdrom::CreateSpec'),
-            }),
-            VAPI::Bindings::IdType.new(resource_types='com.vmware.vcenter.vm.hardware.Cdrom'),
-            {
-                'com.vmware.vapi.std.errors.error' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Error'),
-                'com.vmware.vapi.std.errors.not_found' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::NotFound'),
-                'com.vmware.vapi.std.errors.not_allowed_in_current_state' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::NotAllowedInCurrentState'),
-                'com.vmware.vapi.std.errors.unable_to_allocate_resource' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::UnableToAllocateResource'),
-                'com.vmware.vapi.std.errors.resource_in_use' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::ResourceInUse'),
-                'com.vmware.vapi.std.errors.invalid_argument' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::InvalidArgument'),
-                'com.vmware.vapi.std.errors.resource_busy' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::ResourceBusy'),
-                'com.vmware.vapi.std.errors.resource_inaccessible' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::ResourceInaccessible'),
-                'com.vmware.vapi.std.errors.service_unavailable' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::ServiceUnavailable'),
-                'com.vmware.vapi.std.errors.unauthenticated' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Unauthenticated'),
-                'com.vmware.vapi.std.errors.unauthorized' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Unauthorized'),
-                'com.vmware.vapi.std.errors.unsupported' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Unsupported'),
-
-            },
-            [],
-            [])
-        @@update_info = VAPI::Bindings::OperationInfo.new(
-            VAPI::Core::OperationIdentifier.new('update', @@service_id),
-            VAPI::Bindings::OperationInputType.new({
-                'vm' => VAPI::Bindings::IdType.new(resource_types='VirtualMachine'),
-                'cdrom' => VAPI::Bindings::IdType.new(resource_types='com.vmware.vcenter.vm.hardware.Cdrom'),
-                'spec' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::Vm::Hardware::Cdrom::UpdateSpec'),
-            }),
-            VAPI::Bindings::VoidType.instance,
-            {
-                'com.vmware.vapi.std.errors.error' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Error'),
-                'com.vmware.vapi.std.errors.not_found' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::NotFound'),
-                'com.vmware.vapi.std.errors.not_allowed_in_current_state' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::NotAllowedInCurrentState'),
-                'com.vmware.vapi.std.errors.resource_busy' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::ResourceBusy'),
-                'com.vmware.vapi.std.errors.resource_inaccessible' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::ResourceInaccessible'),
-                'com.vmware.vapi.std.errors.service_unavailable' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::ServiceUnavailable'),
-                'com.vmware.vapi.std.errors.unauthenticated' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Unauthenticated'),
-                'com.vmware.vapi.std.errors.unauthorized' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Unauthorized'),
-
-            },
-            [],
-            [])
-        @@delete_info = VAPI::Bindings::OperationInfo.new(
-            VAPI::Core::OperationIdentifier.new('delete', @@service_id),
-            VAPI::Bindings::OperationInputType.new({
-                'vm' => VAPI::Bindings::IdType.new(resource_types='VirtualMachine'),
-                'cdrom' => VAPI::Bindings::IdType.new(resource_types='com.vmware.vcenter.vm.hardware.Cdrom'),
-            }),
-            VAPI::Bindings::VoidType.instance,
-            {
-                'com.vmware.vapi.std.errors.error' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Error'),
-                'com.vmware.vapi.std.errors.not_found' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::NotFound'),
-                'com.vmware.vapi.std.errors.not_allowed_in_current_state' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::NotAllowedInCurrentState'),
-                'com.vmware.vapi.std.errors.resource_busy' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::ResourceBusy'),
-                'com.vmware.vapi.std.errors.resource_inaccessible' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::ResourceInaccessible'),
-                'com.vmware.vapi.std.errors.service_unavailable' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::ServiceUnavailable'),
-                'com.vmware.vapi.std.errors.unauthenticated' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Unauthenticated'),
-                'com.vmware.vapi.std.errors.unauthorized' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Unauthorized'),
-
-            },
-            [],
-            [])
-        @@connect_info = VAPI::Bindings::OperationInfo.new(
-            VAPI::Core::OperationIdentifier.new('connect', @@service_id),
-            VAPI::Bindings::OperationInputType.new({
-                'vm' => VAPI::Bindings::IdType.new(resource_types='VirtualMachine'),
-                'cdrom' => VAPI::Bindings::IdType.new(resource_types='com.vmware.vcenter.vm.hardware.Cdrom'),
-            }),
-            VAPI::Bindings::VoidType.instance,
-            {
-                'com.vmware.vapi.std.errors.error' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Error'),
-                'com.vmware.vapi.std.errors.not_found' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::NotFound'),
-                'com.vmware.vapi.std.errors.already_in_desired_state' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::AlreadyInDesiredState'),
-                'com.vmware.vapi.std.errors.not_allowed_in_current_state' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::NotAllowedInCurrentState'),
-                'com.vmware.vapi.std.errors.resource_busy' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::ResourceBusy'),
-                'com.vmware.vapi.std.errors.resource_inaccessible' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::ResourceInaccessible'),
-                'com.vmware.vapi.std.errors.service_unavailable' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::ServiceUnavailable'),
-                'com.vmware.vapi.std.errors.unauthenticated' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Unauthenticated'),
-                'com.vmware.vapi.std.errors.unauthorized' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Unauthorized'),
-
-            },
-            [],
-            [])
-        @@disconnect_info = VAPI::Bindings::OperationInfo.new(
-            VAPI::Core::OperationIdentifier.new('disconnect', @@service_id),
-            VAPI::Bindings::OperationInputType.new({
-                'vm' => VAPI::Bindings::IdType.new(resource_types='VirtualMachine'),
-                'cdrom' => VAPI::Bindings::IdType.new(resource_types='com.vmware.vcenter.vm.hardware.Cdrom'),
-            }),
-            VAPI::Bindings::VoidType.instance,
-            {
-                'com.vmware.vapi.std.errors.error' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Error'),
-                'com.vmware.vapi.std.errors.not_found' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::NotFound'),
-                'com.vmware.vapi.std.errors.already_in_desired_state' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::AlreadyInDesiredState'),
-                'com.vmware.vapi.std.errors.not_allowed_in_current_state' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::NotAllowedInCurrentState'),
-                'com.vmware.vapi.std.errors.resource_busy' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::ResourceBusy'),
-                'com.vmware.vapi.std.errors.resource_inaccessible' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::ResourceInaccessible'),
-                'com.vmware.vapi.std.errors.service_unavailable' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::ServiceUnavailable'),
-                'com.vmware.vapi.std.errors.unauthenticated' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Unauthenticated'),
-                'com.vmware.vapi.std.errors.unauthorized' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Unauthorized'),
-
-            },
-            [],
-            [])
-
-        @@service_info = VAPI::Bindings::ServiceInfo.new(@@service_id, {
-            'list' => @@list_info,
-            'get' => @@get_info,
-            'create' => @@create_info,
-            'update' => @@update_info,
-            'delete' => @@delete_info,
-            'connect' => @@connect_info,
-            'disconnect' => @@disconnect_info,
-        })
-
-        public
-
-        # Constructs a new instance.
-        #
-        # @param config [VAPI::Bindings::StubConfig] A hash with the api provider details.
-        def initialize(config)
-            super(config, @@service_info)
-        end
-
-        RESOURCE_TYPE = 'com.vmware.vcenter.vm.hardware.Cdrom'
-
-
-        # Returns commonly used information about the virtual CD-ROM devices belonging to the virtual machine.
-        #
-        # @param vm [String]
-        #     Virtual machine identifier.
-        # @return [Array<Com::Vmware::Vcenter::Vm::Hardware::Cdrom::Summary>]
-        #     List of commonly used information about virtual CD-ROM devices.
-        # @raise [Com::Vmware::Vapi::Std::Errors::Error]
-        #     if the system reports an error while responding to the request.
-        # @raise [Com::Vmware::Vapi::Std::Errors::NotFound]
-        #     if the virtual machine is not found.
-        # @raise [Com::Vmware::Vapi::Std::Errors::ResourceInaccessible]
-        #     if the virtual machine's configuration state cannot be accessed.
-        # @raise [Com::Vmware::Vapi::Std::Errors::ServiceUnavailable]
-        #     if the system is unable to communicate with a service to complete the request.
-        # @raise [Com::Vmware::Vapi::Std::Errors::Unauthenticated]
-        #     if the user can not be authenticated.
-        # @raise [Com::Vmware::Vapi::Std::Errors::Unauthorized]
-        #     if the user doesn't have the required privileges.
-        def list(vm)
-            invoke_with_info(@@list_info, {
-                'vm' => vm,
-            })
-        end
-
-
-        # Returns information about a virtual CD-ROM device.
-        #
-        # @param vm [String]
-        #     Virtual machine identifier.
-        # @param cdrom [String]
-        #     Virtual CD-ROM device identifier.
-        # @return [Com::Vmware::Vcenter::Vm::Hardware::Cdrom::Info]
-        #     Information about the specified virtual CD-ROM device.
-        # @raise [Com::Vmware::Vapi::Std::Errors::Error]
-        #     if the system reports an error while responding to the request.
-        # @raise [Com::Vmware::Vapi::Std::Errors::NotFound]
-        #     if the virtual machine or virtual CD-ROM device is not found.
-        # @raise [Com::Vmware::Vapi::Std::Errors::ResourceInaccessible]
-        #     if the virtual machine's configuration state cannot be accessed.
-        # @raise [Com::Vmware::Vapi::Std::Errors::ServiceUnavailable]
-        #     if the system is unable to communicate with a service to complete the request.
-        # @raise [Com::Vmware::Vapi::Std::Errors::Unauthenticated]
-        #     if the user can not be authenticated.
-        # @raise [Com::Vmware::Vapi::Std::Errors::Unauthorized]
-        #     if the user doesn't have the required privileges.
-        def get(vm, cdrom)
-            invoke_with_info(@@get_info, {
-                'vm' => vm,
-                'cdrom' => cdrom,
-            })
-        end
-
-
-        # Adds a virtual CD-ROM device to the virtual machine.
-        #
-        # @param vm [String]
-        #     Virtual machine identifier.
-        # @param spec [Com::Vmware::Vcenter::Vm::Hardware::Cdrom::CreateSpec]
-        #     Specification for the new virtual CD-ROM device.
-        # @return [String]
-        #     Virtual CD-ROM device identifier.
-        # @raise [Com::Vmware::Vapi::Std::Errors::Error]
-        #     if the system reported that the CD-ROM device was created but was unable to confirm the creation because the identifier of the new device could not be determined.
-        # @raise [Com::Vmware::Vapi::Std::Errors::Error]
-        #     if the system reports an error while responding to the request.
-        # @raise [Com::Vmware::Vapi::Std::Errors::NotFound]
-        #     if the virtual machine is not found.
-        # @raise [Com::Vmware::Vapi::Std::Errors::NotAllowedInCurrentState]
-        #     if the virtual machine is suspended or if the virtual machine is powered on and virtual CD-ROM type is IDE.
-        # @raise [Com::Vmware::Vapi::Std::Errors::UnableToAllocateResource]
-        #     if the specified storage address is unavailable; for example, if the SCSI adapter requested does not exist.
-        # @raise [Com::Vmware::Vapi::Std::Errors::ResourceInUse]
-        #     if the specified storage address is in use.
-        # @raise [Com::Vmware::Vapi::Std::Errors::InvalidArgument]
-        #     if the specified storage address is out of bounds.
-        # @raise [Com::Vmware::Vapi::Std::Errors::ResourceBusy]
-        #     if the virtual machine is busy performing another operation.
-        # @raise [Com::Vmware::Vapi::Std::Errors::ResourceInaccessible]
-        #     if the virtual machine's configuration state cannot be accessed.
-        # @raise [Com::Vmware::Vapi::Std::Errors::ServiceUnavailable]
-        #     if the system is unable to communicate with a service to complete the request.
-        # @raise [Com::Vmware::Vapi::Std::Errors::Unauthenticated]
-        #     if the user can not be authenticated.
-        # @raise [Com::Vmware::Vapi::Std::Errors::Unauthorized]
-        #     if the user doesn't have the required privileges.
-        # @raise [Com::Vmware::Vapi::Std::Errors::Unsupported]
-        #     if the guest operating system of the virtual machine is not supported and  spec  includes  nil   fields  that default to guest-specific values.
-        def create(vm, spec)
-            invoke_with_info(@@create_info, {
-                'vm' => vm,
-                'spec' => spec,
-            })
-        end
-
-
-        # Updates the configuration of a virtual CD-ROM device.
-        #
-        # @param vm [String]
-        #     Virtual machine identifier.
-        # @param cdrom [String]
-        #     Virtual CD-ROM device identifier.
-        # @param spec [Com::Vmware::Vcenter::Vm::Hardware::Cdrom::UpdateSpec]
-        #     Specification for updating the virtual CD-ROM device.
-        # @return [Void]
-        # @raise [Com::Vmware::Vapi::Std::Errors::Error]
-        #     if the system reports an error while responding to the request.
-        # @raise [Com::Vmware::Vapi::Std::Errors::NotFound]
-        #     if the virtual machine or virtual CD-ROM device is not found.
-        # @raise [Com::Vmware::Vapi::Std::Errors::NotAllowedInCurrentState]
-        #     if one or more of the  fields  specified in the  ``spec``   parameter  cannot be modified due to the current power state of the virtual machine or the connection state of the virtual CD-ROM device.
-        # @raise [Com::Vmware::Vapi::Std::Errors::ResourceBusy]
-        #     if the virtual machine is busy performing another operation.
-        # @raise [Com::Vmware::Vapi::Std::Errors::ResourceInaccessible]
-        #     if the virtual machine's configuration state cannot be accessed.
-        # @raise [Com::Vmware::Vapi::Std::Errors::ServiceUnavailable]
-        #     if the system is unable to communicate with a service to complete the request.
-        # @raise [Com::Vmware::Vapi::Std::Errors::Unauthenticated]
-        #     if the user can not be authenticated.
-        # @raise [Com::Vmware::Vapi::Std::Errors::Unauthorized]
-        #     if the user doesn't have the required privileges.
-        def update(vm, cdrom, spec)
-            invoke_with_info(@@update_info, {
-                'vm' => vm,
-                'cdrom' => cdrom,
-                'spec' => spec,
-            })
-        end
-
-
-        # Removes a virtual CD-ROM device from the virtual machine.
-        #
-        # @param vm [String]
-        #     Virtual machine identifier.
-        # @param cdrom [String]
-        #     Virtual CD-ROM device identifier.
-        # @return [Void]
-        # @raise [Com::Vmware::Vapi::Std::Errors::Error]
-        #     if the system reports an error while responding to the request.
-        # @raise [Com::Vmware::Vapi::Std::Errors::NotFound]
-        #     if the virtual machine or virtual CD-ROM device is not found.
-        # @raise [Com::Vmware::Vapi::Std::Errors::NotAllowedInCurrentState]
-        #     if the virtual machine is suspended or if the virtual machine is powered on and virtual CD-ROM type is IDE.
-        # @raise [Com::Vmware::Vapi::Std::Errors::ResourceBusy]
-        #     if the virtual machine is busy performing another operation.
-        # @raise [Com::Vmware::Vapi::Std::Errors::ResourceInaccessible]
-        #     if the virtual machine's configuration state cannot be accessed.
-        # @raise [Com::Vmware::Vapi::Std::Errors::ServiceUnavailable]
-        #     if the system is unable to communicate with a service to complete the request.
-        # @raise [Com::Vmware::Vapi::Std::Errors::Unauthenticated]
-        #     if the user can not be authenticated.
-        # @raise [Com::Vmware::Vapi::Std::Errors::Unauthorized]
-        #     if the user doesn't have the required privileges.
-        def delete(vm, cdrom)
-            invoke_with_info(@@delete_info, {
-                'vm' => vm,
-                'cdrom' => cdrom,
-            })
-        end
-
-
-        # Connects a virtual CD-ROM device of a powered-on virtual machine to its backing. Connecting the virtual device makes the backing accessible from the perspective of the guest operating system.  
-        # 
-        #  For a powered-off virtual machine, the   :func:`Com::Vmware::Vcenter::Vm::Hardware::Cdrom.update`    method  may be used to configure the virtual CD-ROM device to start in the connected state when the virtual machine is powered on.
-        #
-        # @param vm [String]
-        #     Virtual machine identifier.
-        # @param cdrom [String]
-        #     Virtual CD-ROM device identifier.
-        # @return [Void]
-        # @raise [Com::Vmware::Vapi::Std::Errors::Error]
-        #     if the system reports an error while responding to the request.
-        # @raise [Com::Vmware::Vapi::Std::Errors::NotFound]
-        #     if the virtual machine or virtual CD-ROM device is not found.
-        # @raise [Com::Vmware::Vapi::Std::Errors::AlreadyInDesiredState]
-        #     if the virtual CD-ROM device is already connected.
-        # @raise [Com::Vmware::Vapi::Std::Errors::NotAllowedInCurrentState]
-        #     if the virtual machine is not powered on.
-        # @raise [Com::Vmware::Vapi::Std::Errors::ResourceBusy]
-        #     if the virtual machine is busy performing another operation.
-        # @raise [Com::Vmware::Vapi::Std::Errors::ResourceInaccessible]
-        #     if the virtual machine's configuration state cannot be accessed.
-        # @raise [Com::Vmware::Vapi::Std::Errors::ServiceUnavailable]
-        #     if the system is unable to communicate with a service to complete the request.
-        # @raise [Com::Vmware::Vapi::Std::Errors::Unauthenticated]
-        #     if the user can not be authenticated.
-        # @raise [Com::Vmware::Vapi::Std::Errors::Unauthorized]
-        #     if the user doesn't have the required privileges.
-        def connect(vm, cdrom)
-            invoke_with_info(@@connect_info, {
-                'vm' => vm,
-                'cdrom' => cdrom,
-            })
-        end
-
-
-        # Disconnects a virtual CD-ROM device of a powered-on virtual machine from its backing. The virtual device is still present and its backing configuration is unchanged, but from the perspective of the guest operating system, the CD-ROM device is not connected to its backing resource.  
-        # 
-        #  For a powered-off virtual machine, the   :func:`Com::Vmware::Vcenter::Vm::Hardware::Cdrom.update`    method  may be used to configure the virtual CD-ROM device to start in the disconnected state when the virtual machine is powered on.
-        #
-        # @param vm [String]
-        #     Virtual machine identifier.
-        # @param cdrom [String]
-        #     Virtual CD-ROM device identifier.
-        # @return [Void]
-        # @raise [Com::Vmware::Vapi::Std::Errors::Error]
-        #     if the system reports an error while responding to the request.
-        # @raise [Com::Vmware::Vapi::Std::Errors::NotFound]
-        #     if the virtual machine or virtual CD-ROM device is not found.
-        # @raise [Com::Vmware::Vapi::Std::Errors::AlreadyInDesiredState]
-        #     if the virtual CD-ROM device is already disconnected.
-        # @raise [Com::Vmware::Vapi::Std::Errors::NotAllowedInCurrentState]
-        #     if the virtual machine is not powered on.
-        # @raise [Com::Vmware::Vapi::Std::Errors::ResourceBusy]
-        #     if the virtual machine is busy performing another operation.
-        # @raise [Com::Vmware::Vapi::Std::Errors::ResourceInaccessible]
-        #     if the virtual machine's configuration state cannot be accessed.
-        # @raise [Com::Vmware::Vapi::Std::Errors::ServiceUnavailable]
-        #     if the system is unable to communicate with a service to complete the request.
-        # @raise [Com::Vmware::Vapi::Std::Errors::Unauthenticated]
-        #     if the user can not be authenticated.
-        # @raise [Com::Vmware::Vapi::Std::Errors::Unauthorized]
-        #     if the user doesn't have the required privileges.
-        def disconnect(vm, cdrom)
-            invoke_with_info(@@disconnect_info, {
-                'vm' => vm,
-                'cdrom' => cdrom,
-            })
-        end
-
-
-
-        # The  ``Com::Vmware::Vcenter::Vm::Hardware::Cdrom::BackingInfo``   class  contains information about the physical resource backing a virtual CD-ROM device.
-        # @!attribute [rw] type
-        #     @return [Com::Vmware::Vcenter::Vm::Hardware::Cdrom::BackingType]
-        #     Backing type for the virtual CD-ROM device.
-        # @!attribute [rw] iso_file
-        #     @return [String]
-        #     Path of the image file backing the virtual CD-ROM device.
-        #     This  field  is optional and it is only relevant when the value of  ``type``  is   :attr:`Com::Vmware::Vcenter::Vm::Hardware::Cdrom::BackingType.ISO_FILE`  .
-        # @!attribute [rw] host_device
-        #     @return [String, nil]
-        #     Name of the host device backing the virtual CD-ROM device.  
-        #     This  field  will be  nil  if  ``autoDetect``  is true and the virtual CD-ROM device is not connected or no suitable device is available on the host.
-        # @!attribute [rw] auto_detect
-        #     @return [Boolean]
-        #     Flag indicating whether the virtual CD-ROM device is configured to automatically detect a suitable host device.
-        #     This  field  is optional and it is only relevant when the value of  ``type``  is   :attr:`Com::Vmware::Vcenter::Vm::Hardware::Cdrom::BackingType.HOST_DEVICE`  .
-        # @!attribute [rw] device_access_type
-        #     @return [Com::Vmware::Vcenter::Vm::Hardware::Cdrom::DeviceAccessType]
-        #     Access type for the device backing.
-        #     This  field  is optional and it is only relevant when the value of  ``type``  is one of   :attr:`Com::Vmware::Vcenter::Vm::Hardware::Cdrom::BackingType.HOST_DEVICE`   or   :attr:`Com::Vmware::Vcenter::Vm::Hardware::Cdrom::BackingType.CLIENT_DEVICE`  .
-        class BackingInfo < VAPI::Bindings::VapiStruct
-
-            class << self
-                # Holds (gets or creates) the binding type metadata for this structure type.
-                # @scope class
-                # @return [VAPI::Bindings::StructType] the binding type
-                def binding_type
-                    @binding_type ||= VAPI::Bindings::StructType.new(
-                        'com.vmware.vcenter.vm.hardware.cdrom.backing_info',
-                        {
-                            'type' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::Vm::Hardware::Cdrom::BackingType'),
-                            'iso_file' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::StringType.instance),
-                            'host_device' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::StringType.instance),
-                            'auto_detect' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::BooleanType.instance),
-                            'device_access_type' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::Vm::Hardware::Cdrom::DeviceAccessType')),
-                        },
-                        BackingInfo,
-                        false,
-                        nil)
-                end
-            end
-
-            attr_accessor :type,
-                          :iso_file,
-                          :host_device,
-                          :auto_detect,
-                          :device_access_type
-
-            # Constructs a new instance.
-            # @param ruby_values [Hash] a map of initial property values (optional)
-            # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
-            def initialize(ruby_values=nil, struct_value=nil)
-                super(self.class.binding_type, ruby_values, struct_value)
-            end
-        end
-
-
-        # The  ``Com::Vmware::Vcenter::Vm::Hardware::Cdrom::BackingSpec``   class  provides a specification of the physical resource backing a virtual CD-ROM device.
-        # @!attribute [rw] type
-        #     @return [Com::Vmware::Vcenter::Vm::Hardware::Cdrom::BackingType]
-        #     Backing type for the virtual CD-ROM device.
-        # @!attribute [rw] iso_file
-        #     @return [String]
-        #     Path of the image file that should be used as the virtual CD-ROM device backing.
-        #     This  field  is optional and it is only relevant when the value of  ``type``  is   :attr:`Com::Vmware::Vcenter::Vm::Hardware::Cdrom::BackingType.ISO_FILE`  .
-        # @!attribute [rw] host_device
-        #     @return [String, nil]
-        #     Name of the device that should be used as the virtual CD-ROM device backing.
-        #     If  nil , the virtual CD-ROM device will be configured to automatically detect a suitable host device.
-        # @!attribute [rw] device_access_type
-        #     @return [Com::Vmware::Vcenter::Vm::Hardware::Cdrom::DeviceAccessType, nil]
-        #     Access type for the device backing.
-        #     If  nil , defaults to   :attr:`Com::Vmware::Vcenter::Vm::Hardware::Cdrom::DeviceAccessType.EMULATION`  .
-        class BackingSpec < VAPI::Bindings::VapiStruct
-
-            class << self
-                # Holds (gets or creates) the binding type metadata for this structure type.
-                # @scope class
-                # @return [VAPI::Bindings::StructType] the binding type
-                def binding_type
-                    @binding_type ||= VAPI::Bindings::StructType.new(
-                        'com.vmware.vcenter.vm.hardware.cdrom.backing_spec',
-                        {
-                            'type' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::Vm::Hardware::Cdrom::BackingType'),
-                            'iso_file' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::StringType.instance),
-                            'host_device' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::StringType.instance),
-                            'device_access_type' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::Vm::Hardware::Cdrom::DeviceAccessType')),
-                        },
-                        BackingSpec,
-                        false,
-                        nil)
-                end
-            end
-
-            attr_accessor :type,
-                          :iso_file,
-                          :host_device,
-                          :device_access_type
-
-            # Constructs a new instance.
-            # @param ruby_values [Hash] a map of initial property values (optional)
-            # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
-            def initialize(ruby_values=nil, struct_value=nil)
-                super(self.class.binding_type, ruby_values, struct_value)
-            end
-        end
-
-
-        # The  ``Com::Vmware::Vcenter::Vm::Hardware::Cdrom::Info``   class  contains information about a virtual CD-ROM device.
-        # @!attribute [rw] type
-        #     @return [Com::Vmware::Vcenter::Vm::Hardware::Cdrom::HostBusAdapterType]
-        #     Type of host bus adapter to which the device is attached.
-        # @!attribute [rw] label
-        #     @return [String]
-        #     Device label.
-        # @!attribute [rw] ide
-        #     @return [Com::Vmware::Vcenter::Vm::Hardware::IdeAddressInfo]
-        #     Address of device attached to a virtual IDE adapter.
-        #     This  field  is optional and it is only relevant when the value of  ``type``  is   :attr:`Com::Vmware::Vcenter::Vm::Hardware::Cdrom::HostBusAdapterType.IDE`  .
-        # @!attribute [rw] sata
-        #     @return [Com::Vmware::Vcenter::Vm::Hardware::SataAddressInfo]
-        #     Address of device attached to a virtual SATA adapter.
-        #     This  field  is optional and it is only relevant when the value of  ``type``  is   :attr:`Com::Vmware::Vcenter::Vm::Hardware::Cdrom::HostBusAdapterType.SATA`  .
-        # @!attribute [rw] backing
-        #     @return [Com::Vmware::Vcenter::Vm::Hardware::Cdrom::BackingInfo]
-        #     Physical resource backing for the virtual CD-ROM device.
-        class Info < VAPI::Bindings::VapiStruct
-
-            class << self
-                # Holds (gets or creates) the binding type metadata for this structure type.
-                # @scope class
-                # @return [VAPI::Bindings::StructType] the binding type
-                def binding_type
-                    @binding_type ||= VAPI::Bindings::StructType.new(
-                        'com.vmware.vcenter.vm.hardware.cdrom.info',
-                        {
-                            'type' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::Vm::Hardware::Cdrom::HostBusAdapterType'),
-                            'label' => VAPI::Bindings::StringType.instance,
-                            'ide' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::Vm::Hardware::IdeAddressInfo')),
-                            'sata' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::Vm::Hardware::SataAddressInfo')),
-                            'backing' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::Vm::Hardware::Cdrom::BackingInfo'),
-                            'state' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::Vm::Hardware::ConnectionState'),
-                            'start_connected' => VAPI::Bindings::BooleanType.instance,
-                            'allow_guest_control' => VAPI::Bindings::BooleanType.instance,
-                        },
-                        Info,
-                        false,
-                        nil)
-                end
-            end
-
-            attr_accessor :type,
-                          :label,
-                          :ide,
-                          :sata,
-                          :backing,
-                          :state,
-                          :start_connected,
-                          :allow_guest_control
-
-            # Constructs a new instance.
-            # @param ruby_values [Hash] a map of initial property values (optional)
-            # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
-            def initialize(ruby_values=nil, struct_value=nil)
-                super(self.class.binding_type, ruby_values, struct_value)
-            end
-        end
-
-
-        # The  ``Com::Vmware::Vcenter::Vm::Hardware::Cdrom::CreateSpec``   class  provides a specification for the configuration of a newly-created virtual CD-ROM device.
-        # @!attribute [rw] type
-        #     @return [Com::Vmware::Vcenter::Vm::Hardware::Cdrom::HostBusAdapterType, nil]
-        #     Type of host bus adapter to which the device should be attached.
-        #     If  nil , guest-specific default values will be used
-        # @!attribute [rw] ide
-        #     @return [Com::Vmware::Vcenter::Vm::Hardware::IdeAddressSpec, nil]
-        #     Address for attaching the device to a virtual IDE adapter.
-        #     If  nil , the server will choose an available address; if none is available, the request will fail.
-        # @!attribute [rw] sata
-        #     @return [Com::Vmware::Vcenter::Vm::Hardware::SataAddressSpec, nil]
-        #     Address for attaching the device to a virtual SATA adapter.
-        #     If  nil , the server will choose an available address; if none is available, the request will fail.
-        # @!attribute [rw] backing
-        #     @return [Com::Vmware::Vcenter::Vm::Hardware::Cdrom::BackingSpec, nil]
-        #     Physical resource backing for the virtual CD-ROM device.
-        #     If  nil , defaults to automatic detection of a suitable host device.
-        class CreateSpec < VAPI::Bindings::VapiStruct
-
-            class << self
-                # Holds (gets or creates) the binding type metadata for this structure type.
-                # @scope class
-                # @return [VAPI::Bindings::StructType] the binding type
-                def binding_type
-                    @binding_type ||= VAPI::Bindings::StructType.new(
-                        'com.vmware.vcenter.vm.hardware.cdrom.create_spec',
-                        {
-                            'type' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::Vm::Hardware::Cdrom::HostBusAdapterType')),
-                            'ide' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::Vm::Hardware::IdeAddressSpec')),
-                            'sata' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::Vm::Hardware::SataAddressSpec')),
-                            'backing' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::Vm::Hardware::Cdrom::BackingSpec')),
-                            'start_connected' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::BooleanType.instance),
-                            'allow_guest_control' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::BooleanType.instance),
-                        },
-                        CreateSpec,
-                        false,
-                        nil)
-                end
-            end
-
-            attr_accessor :type,
-                          :ide,
-                          :sata,
-                          :backing,
-                          :start_connected,
-                          :allow_guest_control
-
-            # Constructs a new instance.
-            # @param ruby_values [Hash] a map of initial property values (optional)
-            # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
-            def initialize(ruby_values=nil, struct_value=nil)
-                super(self.class.binding_type, ruby_values, struct_value)
-            end
-        end
-
-
-        # The  ``Com::Vmware::Vcenter::Vm::Hardware::Cdrom::UpdateSpec``   class  describes the updates to be made to the configuration of a virtual CD-ROM device.
-        # @!attribute [rw] backing
-        #     @return [Com::Vmware::Vcenter::Vm::Hardware::Cdrom::BackingSpec, nil]
-        #     Physical resource backing for the virtual CD-ROM device.  
-        #     
-        #      This  field  may only be modified if the virtual machine is not powered on or the virtual CD-ROM device is not connected.
-        #     If  nil , the value is unchanged.
-        class UpdateSpec < VAPI::Bindings::VapiStruct
-
-            class << self
-                # Holds (gets or creates) the binding type metadata for this structure type.
-                # @scope class
-                # @return [VAPI::Bindings::StructType] the binding type
-                def binding_type
-                    @binding_type ||= VAPI::Bindings::StructType.new(
-                        'com.vmware.vcenter.vm.hardware.cdrom.update_spec',
-                        {
-                            'backing' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::Vm::Hardware::Cdrom::BackingSpec')),
-                            'start_connected' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::BooleanType.instance),
-                            'allow_guest_control' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::BooleanType.instance),
-                        },
-                        UpdateSpec,
-                        false,
-                        nil)
-                end
-            end
-
-            attr_accessor :backing,
-                          :start_connected,
-                          :allow_guest_control
-
-            # Constructs a new instance.
-            # @param ruby_values [Hash] a map of initial property values (optional)
-            # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
-            def initialize(ruby_values=nil, struct_value=nil)
-                super(self.class.binding_type, ruby_values, struct_value)
-            end
-        end
-
-
-        # The  ``Com::Vmware::Vcenter::Vm::Hardware::Cdrom::Summary``   class  contains commonly used information about a virtual CD-ROM device.
-        # @!attribute [rw] cdrom
-        #     @return [String]
-        #     Identifier of the virtual CD-ROM device.
-        class Summary < VAPI::Bindings::VapiStruct
-
-            class << self
-                # Holds (gets or creates) the binding type metadata for this structure type.
-                # @scope class
-                # @return [VAPI::Bindings::StructType] the binding type
-                def binding_type
-                    @binding_type ||= VAPI::Bindings::StructType.new(
-                        'com.vmware.vcenter.vm.hardware.cdrom.summary',
-                        {
-                            'cdrom' => VAPI::Bindings::IdType.new(resource_types='com.vmware.vcenter.vm.hardware.Cdrom'),
-                        },
-                        Summary,
-                        false,
-                        nil)
-                end
-            end
-
-            attr_accessor :cdrom
-
-            # Constructs a new instance.
-            # @param ruby_values [Hash] a map of initial property values (optional)
-            # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
-            def initialize(ruby_values=nil, struct_value=nil)
-                super(self.class.binding_type, ruby_values, struct_value)
-            end
-        end
-
-
-
-        # The  ``Com::Vmware::Vcenter::Vm::Hardware::Cdrom::HostBusAdapterType``   enumerated type  defines the valid types of host bus adapters that may be used for attaching a Cdrom to a virtual machine.
-        # @!attribute [rw] ide
-        #     @return [Com::Vmware::Vcenter::Vm::Hardware::Cdrom::HostBusAdapterType]
-        #     Cdrom is attached to an IDE adapter.
-        # @!attribute [rw] sata
-        #     @return [Com::Vmware::Vcenter::Vm::Hardware::Cdrom::HostBusAdapterType]
-        #     Cdrom is attached to a SATA adapter.
-        class HostBusAdapterType < VAPI::Bindings::VapiEnum
-
-            class << self
-                # Holds (gets or creates) the binding type metadata for this enumeration type.
-                # @scope class
-                # @return [VAPI::Bindings::EnumType] the binding type
-                def binding_type
-                    @binding_type ||= VAPI::Bindings::EnumType.new(
-                        'com.vmware.vcenter.vm.hardware.cdrom.host_bus_adapter_type',
-                        HostBusAdapterType)
-                end
-
-                # Converts from a string value (perhaps off the wire) to an instance
-                # of this enum type.
-                # @param value [String] the actual value of the enum instance
-                # @return [HostBusAdapterType] the instance found for the value, otherwise
-                #         an unknown instance will be built for the value
-                def from_string(value)
-                    begin
-                        const_get(value)
-                    rescue NameError
-                        HostBusAdapterType.new('UNKNOWN', value)
-                    end
-                end
-            end
-
-            private
-
-            # Constructs a new instance.
-            # @param value [String] the actual value of the enum instance
-            # @param unknown [String] the unknown value when value is 'UKNOWN'
-            def initialize(value, unknown=nil)
-                super(self.class.binding_type, value, unknown)
-            end
-
-            public
-
-            # @!attribute [rw] ide
-            #     @return [Com::Vmware::Vcenter::Vm::Hardware::Cdrom::HostBusAdapterType]
-            #     Cdrom is attached to an IDE adapter.
-            IDE = HostBusAdapterType.new('IDE')
-
-            # @!attribute [rw] sata
-            #     @return [Com::Vmware::Vcenter::Vm::Hardware::Cdrom::HostBusAdapterType]
-            #     Cdrom is attached to a SATA adapter.
-            SATA = HostBusAdapterType.new('SATA')
-
-        end
-
-
-        # The  ``Com::Vmware::Vcenter::Vm::Hardware::Cdrom::BackingType``   enumerated type  defines the valid backing types for a virtual CD-ROM device.
-        # @!attribute [rw] iso_file
-        #     @return [Com::Vmware::Vcenter::Vm::Hardware::Cdrom::BackingType]
-        #     Virtual CD-ROM device is backed by an ISO file.
-        # @!attribute [rw] host_device
-        #     @return [Com::Vmware::Vcenter::Vm::Hardware::Cdrom::BackingType]
-        #     Virtual CD-ROM device is backed by a device on the host where the virtual machine is running.
-        # @!attribute [rw] client_device
-        #     @return [Com::Vmware::Vcenter::Vm::Hardware::Cdrom::BackingType]
-        #     Virtual CD-ROM device is backed by a device on the client that is connected to the virtual machine console.
-        class BackingType < VAPI::Bindings::VapiEnum
-
-            class << self
-                # Holds (gets or creates) the binding type metadata for this enumeration type.
-                # @scope class
-                # @return [VAPI::Bindings::EnumType] the binding type
-                def binding_type
-                    @binding_type ||= VAPI::Bindings::EnumType.new(
-                        'com.vmware.vcenter.vm.hardware.cdrom.backing_type',
-                        BackingType)
-                end
-
-                # Converts from a string value (perhaps off the wire) to an instance
-                # of this enum type.
-                # @param value [String] the actual value of the enum instance
-                # @return [BackingType] the instance found for the value, otherwise
-                #         an unknown instance will be built for the value
-                def from_string(value)
-                    begin
-                        const_get(value)
-                    rescue NameError
-                        BackingType.new('UNKNOWN', value)
-                    end
-                end
-            end
-
-            private
-
-            # Constructs a new instance.
-            # @param value [String] the actual value of the enum instance
-            # @param unknown [String] the unknown value when value is 'UKNOWN'
-            def initialize(value, unknown=nil)
-                super(self.class.binding_type, value, unknown)
-            end
-
-            public
-
-            # @!attribute [rw] iso_file
-            #     @return [Com::Vmware::Vcenter::Vm::Hardware::Cdrom::BackingType]
-            #     Virtual CD-ROM device is backed by an ISO file.
-            ISO_FILE = BackingType.new('ISO_FILE')
-
-            # @!attribute [rw] host_device
-            #     @return [Com::Vmware::Vcenter::Vm::Hardware::Cdrom::BackingType]
-            #     Virtual CD-ROM device is backed by a device on the host where the virtual machine is running.
-            HOST_DEVICE = BackingType.new('HOST_DEVICE')
-
-            # @!attribute [rw] client_device
-            #     @return [Com::Vmware::Vcenter::Vm::Hardware::Cdrom::BackingType]
-            #     Virtual CD-ROM device is backed by a device on the client that is connected to the virtual machine console.
-            CLIENT_DEVICE = BackingType.new('CLIENT_DEVICE')
-
-        end
-
-
-        # The  ``Com::Vmware::Vcenter::Vm::Hardware::Cdrom::DeviceAccessType``   enumerated type  defines the valid device access types for a physical device packing of a virtual CD-ROM device.
-        # @!attribute [rw] emulation
-        #     @return [Com::Vmware::Vcenter::Vm::Hardware::Cdrom::DeviceAccessType]
-        #     ATAPI or SCSI device emulation.
-        # @!attribute [rw] passthru
-        #     @return [Com::Vmware::Vcenter::Vm::Hardware::Cdrom::DeviceAccessType]
-        #     Raw passthru device access.
-        # @!attribute [rw] passthru_exclusive
-        #     @return [Com::Vmware::Vcenter::Vm::Hardware::Cdrom::DeviceAccessType]
-        #     Raw passthru device access, with exclusive access to the device.
-        class DeviceAccessType < VAPI::Bindings::VapiEnum
-
-            class << self
-                # Holds (gets or creates) the binding type metadata for this enumeration type.
-                # @scope class
-                # @return [VAPI::Bindings::EnumType] the binding type
-                def binding_type
-                    @binding_type ||= VAPI::Bindings::EnumType.new(
-                        'com.vmware.vcenter.vm.hardware.cdrom.device_access_type',
-                        DeviceAccessType)
-                end
-
-                # Converts from a string value (perhaps off the wire) to an instance
-                # of this enum type.
-                # @param value [String] the actual value of the enum instance
-                # @return [DeviceAccessType] the instance found for the value, otherwise
-                #         an unknown instance will be built for the value
-                def from_string(value)
-                    begin
-                        const_get(value)
-                    rescue NameError
-                        DeviceAccessType.new('UNKNOWN', value)
-                    end
-                end
-            end
-
-            private
-
-            # Constructs a new instance.
-            # @param value [String] the actual value of the enum instance
-            # @param unknown [String] the unknown value when value is 'UKNOWN'
-            def initialize(value, unknown=nil)
-                super(self.class.binding_type, value, unknown)
-            end
-
-            public
-
-            # @!attribute [rw] emulation
-            #     @return [Com::Vmware::Vcenter::Vm::Hardware::Cdrom::DeviceAccessType]
-            #     ATAPI or SCSI device emulation.
-            EMULATION = DeviceAccessType.new('EMULATION')
-
-            # @!attribute [rw] passthru
-            #     @return [Com::Vmware::Vcenter::Vm::Hardware::Cdrom::DeviceAccessType]
-            #     Raw passthru device access.
-            PASSTHRU = DeviceAccessType.new('PASSTHRU')
-
-            # @!attribute [rw] passthru_exclusive
-            #     @return [Com::Vmware::Vcenter::Vm::Hardware::Cdrom::DeviceAccessType]
-            #     Raw passthru device access, with exclusive access to the device.
-            PASSTHRU_EXCLUSIVE = DeviceAccessType.new('PASSTHRU_EXCLUSIVE')
-
-        end
-
-
+    # Returns the boot-related settings of a virtual machine.
+    #
+    # @param vm [String]
+    #     Virtual machine identifier.
+    # @return [Com::Vmware::Vcenter::VM::Hardware::Boot::Info]
+    #     Boot-related settings of the virtual machine.
+    # @raise [Com::Vmware::Vapi::Std::Errors::Error]
+    #     if the system reports an error while responding to the request.
+    # @raise [Com::Vmware::Vapi::Std::Errors::NotFound]
+    #     if the virtual machine is not found.
+    # @raise [Com::Vmware::Vapi::Std::Errors::ResourceInaccessible]
+    #     if the virtual machine's configuration state cannot be accessed.
+    # @raise [Com::Vmware::Vapi::Std::Errors::ServiceUnavailable]
+    #     if the system is unable to communicate with a service to complete the request.
+    # @raise [Com::Vmware::Vapi::Std::Errors::Unauthenticated]
+    #     if the user can not be authenticated.
+    # @raise [Com::Vmware::Vapi::Std::Errors::Unauthorized]
+    #     if the user doesn't have the required privileges.
+    def get(vm)
+      invoke_with_info(GET_INFO,
+                       'vm' => vm)
     end
 
-
-    # The  ``Com::Vmware::Vcenter::Vm::Hardware::Cpu``   class  provides  methods  for configuring the CPU settings of a virtual machine.
-    class Cpu < VAPI::Bindings::VapiService
-
-        protected
-
-        # static metamodel definitions
-        @@service_id = VAPI::Core::ServiceIdentifier.new('com.vmware.vcenter.vm.hardware.cpu')
-
-        @@get_info = VAPI::Bindings::OperationInfo.new(
-            VAPI::Core::OperationIdentifier.new('get', @@service_id),
-            VAPI::Bindings::OperationInputType.new({
-                'vm' => VAPI::Bindings::IdType.new(resource_types='VirtualMachine'),
-            }),
-            VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::Vm::Hardware::Cpu::Info'),
-            {
-                'com.vmware.vapi.std.errors.error' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Error'),
-                'com.vmware.vapi.std.errors.not_found' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::NotFound'),
-                'com.vmware.vapi.std.errors.resource_inaccessible' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::ResourceInaccessible'),
-                'com.vmware.vapi.std.errors.service_unavailable' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::ServiceUnavailable'),
-                'com.vmware.vapi.std.errors.unauthenticated' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Unauthenticated'),
-                'com.vmware.vapi.std.errors.unauthorized' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Unauthorized'),
-
-            },
-            [],
-            [])
-        @@update_info = VAPI::Bindings::OperationInfo.new(
-            VAPI::Core::OperationIdentifier.new('update', @@service_id),
-            VAPI::Bindings::OperationInputType.new({
-                'vm' => VAPI::Bindings::IdType.new(resource_types='VirtualMachine'),
-                'spec' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::Vm::Hardware::Cpu::UpdateSpec'),
-            }),
-            VAPI::Bindings::VoidType.instance,
-            {
-                'com.vmware.vapi.std.errors.error' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Error'),
-                'com.vmware.vapi.std.errors.not_found' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::NotFound'),
-                'com.vmware.vapi.std.errors.invalid_argument' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::InvalidArgument'),
-                'com.vmware.vapi.std.errors.not_allowed_in_current_state' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::NotAllowedInCurrentState'),
-                'com.vmware.vapi.std.errors.resource_busy' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::ResourceBusy'),
-                'com.vmware.vapi.std.errors.resource_inaccessible' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::ResourceInaccessible'),
-                'com.vmware.vapi.std.errors.service_unavailable' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::ServiceUnavailable'),
-                'com.vmware.vapi.std.errors.unauthenticated' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Unauthenticated'),
-                'com.vmware.vapi.std.errors.unauthorized' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Unauthorized'),
-
-            },
-            [],
-            [])
-
-        @@service_info = VAPI::Bindings::ServiceInfo.new(@@service_id, {
-            'get' => @@get_info,
-            'update' => @@update_info,
-        })
-
-        public
-
-        # Constructs a new instance.
-        #
-        # @param config [VAPI::Bindings::StubConfig] A hash with the api provider details.
-        def initialize(config)
-            super(config, @@service_info)
-        end
-
-
-        # Returns the CPU-related settings of a virtual machine.
-        #
-        # @param vm [String]
-        #     Virtual machine identifier.
-        # @return [Com::Vmware::Vcenter::Vm::Hardware::Cpu::Info]
-        #     CPU-related settings of the virtual machine.
-        # @raise [Com::Vmware::Vapi::Std::Errors::Error]
-        #     if the system reports an error while responding to the request.
-        # @raise [Com::Vmware::Vapi::Std::Errors::NotFound]
-        #     if the virtual machine is not found.
-        # @raise [Com::Vmware::Vapi::Std::Errors::ResourceInaccessible]
-        #     if the virtual machine's configuration state cannot be accessed.
-        # @raise [Com::Vmware::Vapi::Std::Errors::ServiceUnavailable]
-        #     if the system is unable to communicate with a service to complete the request.
-        # @raise [Com::Vmware::Vapi::Std::Errors::Unauthenticated]
-        #     if the user can not be authenticated.
-        # @raise [Com::Vmware::Vapi::Std::Errors::Unauthorized]
-        #     if the user doesn't have the required privileges.
-        def get(vm)
-            invoke_with_info(@@get_info, {
-                'vm' => vm,
-            })
-        end
-
-
-        # Updates the CPU-related settings of a virtual machine.
-        #
-        # @param vm [String]
-        #     Virtual machine identifier.
-        # @param spec [Com::Vmware::Vcenter::Vm::Hardware::Cpu::UpdateSpec]
-        #     Specification for updating the CPU-related settings of the virtual machine.
-        # @return [Void]
-        # @raise [Com::Vmware::Vapi::Std::Errors::Error]
-        #     if the system reports an error while responding to the request.
-        # @raise [Com::Vmware::Vapi::Std::Errors::NotFound]
-        #     if the virtual machine is not found.
-        # @raise [Com::Vmware::Vapi::Std::Errors::InvalidArgument]
-        #     if one of the provided settings is not permitted; for example, specifying a negative value for  ``count`` .
-        # @raise [Com::Vmware::Vapi::Std::Errors::NotAllowedInCurrentState]
-        #     if  ``hotAddEnabled``  or  ``hotRemoveEnabled``  is specified and the virtual machine is not powered off.
-        # @raise [Com::Vmware::Vapi::Std::Errors::NotAllowedInCurrentState]
-        #     if  ``count``  is specified and is greater than  ``count`` ,  ``hotAddEnabled``  is false, and the virtual machine is not powered off.
-        # @raise [Com::Vmware::Vapi::Std::Errors::NotAllowedInCurrentState]
-        #     if  ``count``  is specified and is less than  ``count`` ,  ``hotRemoveEnabled``  is false, and the virtual machine is not powered off.
-        # @raise [Com::Vmware::Vapi::Std::Errors::ResourceBusy]
-        #     if the virtual machine is busy performing another operation.
-        # @raise [Com::Vmware::Vapi::Std::Errors::ResourceInaccessible]
-        #     if the virtual machine's configuration state cannot be accessed.
-        # @raise [Com::Vmware::Vapi::Std::Errors::ServiceUnavailable]
-        #     if the system is unable to communicate with a service to complete the request.
-        # @raise [Com::Vmware::Vapi::Std::Errors::Unauthenticated]
-        #     if the user can not be authenticated.
-        # @raise [Com::Vmware::Vapi::Std::Errors::Unauthorized]
-        #     if the user doesn't have the required privileges.
-        def update(vm, spec)
-            invoke_with_info(@@update_info, {
-                'vm' => vm,
-                'spec' => spec,
-            })
-        end
-
-
-
-        # The  ``Com::Vmware::Vcenter::Vm::Hardware::Cpu::Info``   class  contains CPU-related information about a virtual machine.
-        # @!attribute [rw] count
-        #     @return [Fixnum]
-        #     Number of CPU cores.
-        # @!attribute [rw] cores_per_socket
-        #     @return [Fixnum]
-        #     Number of CPU cores per socket.
-        # @!attribute [rw] hot_add_enabled
-        #     @return [Boolean]
-        #     Flag indicating whether adding CPUs while the virtual machine is running is enabled.
-        # @!attribute [rw] hot_remove_enabled
-        #     @return [Boolean]
-        #     Flag indicating whether removing CPUs while the virtual machine is running is enabled.
-        class Info < VAPI::Bindings::VapiStruct
-
-            class << self
-                # Holds (gets or creates) the binding type metadata for this structure type.
-                # @scope class
-                # @return [VAPI::Bindings::StructType] the binding type
-                def binding_type
-                    @binding_type ||= VAPI::Bindings::StructType.new(
-                        'com.vmware.vcenter.vm.hardware.cpu.info',
-                        {
-                            'count' => VAPI::Bindings::IntegerType.instance,
-                            'cores_per_socket' => VAPI::Bindings::IntegerType.instance,
-                            'hot_add_enabled' => VAPI::Bindings::BooleanType.instance,
-                            'hot_remove_enabled' => VAPI::Bindings::BooleanType.instance,
-                        },
-                        Info,
-                        false,
-                        nil)
-                end
-            end
-
-            attr_accessor :count,
-                          :cores_per_socket,
-                          :hot_add_enabled,
-                          :hot_remove_enabled
-
-            # Constructs a new instance.
-            # @param ruby_values [Hash] a map of initial property values (optional)
-            # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
-            def initialize(ruby_values=nil, struct_value=nil)
-                super(self.class.binding_type, ruby_values, struct_value)
-            end
-        end
-
-
-        # The  ``Com::Vmware::Vcenter::Vm::Hardware::Cpu::UpdateSpec``   class  describes the updates to be made to the CPU-related settings of a virtual machine.
-        # @!attribute [rw] count
-        #     @return [Fixnum, nil]
-        #     New number of CPU cores. The number of CPU cores in the virtual machine must be a multiple of the number of cores per socket.  
-        #     
-        #      The supported range of CPU counts is constrained by the configured guest operating system and virtual hardware version of the virtual machine.  
-        #     
-        #      If the virtual machine is running, the number of CPU cores may only be increased if   :attr:`Com::Vmware::Vcenter::Vm::Hardware::Cpu::Info.hot_add_enabled`   is true, and may only be decreased if   :attr:`Com::Vmware::Vcenter::Vm::Hardware::Cpu::Info.hot_remove_enabled`   is true.
-        #     If  nil , the value is unchanged.
-        # @!attribute [rw] cores_per_socket
-        #     @return [Fixnum, nil]
-        #     New number of CPU cores per socket. The number of CPU cores in the virtual machine must be a multiple of the number of cores per socket.
-        #     If  nil , the value is unchanged.
-        # @!attribute [rw] hot_add_enabled
-        #     @return [Boolean, nil]
-        #     Flag indicating whether adding CPUs while the virtual machine is running is enabled.  
-        #     
-        #      This  field  may only be modified if the virtual machine is powered off.
-        #     If  nil , the value is unchanged.
-        # @!attribute [rw] hot_remove_enabled
-        #     @return [Boolean, nil]
-        #     Flag indicating whether removing CPUs while the virtual machine is running is enabled.  
-        #     
-        #      This  field  may only be modified if the virtual machine is powered off.
-        #     If  nil , the value is unchanged.
-        class UpdateSpec < VAPI::Bindings::VapiStruct
-
-            class << self
-                # Holds (gets or creates) the binding type metadata for this structure type.
-                # @scope class
-                # @return [VAPI::Bindings::StructType] the binding type
-                def binding_type
-                    @binding_type ||= VAPI::Bindings::StructType.new(
-                        'com.vmware.vcenter.vm.hardware.cpu.update_spec',
-                        {
-                            'count' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::IntegerType.instance),
-                            'cores_per_socket' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::IntegerType.instance),
-                            'hot_add_enabled' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::BooleanType.instance),
-                            'hot_remove_enabled' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::BooleanType.instance),
-                        },
-                        UpdateSpec,
-                        false,
-                        nil)
-                end
-            end
-
-            attr_accessor :count,
-                          :cores_per_socket,
-                          :hot_add_enabled,
-                          :hot_remove_enabled
-
-            # Constructs a new instance.
-            # @param ruby_values [Hash] a map of initial property values (optional)
-            # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
-            def initialize(ruby_values=nil, struct_value=nil)
-                super(self.class.binding_type, ruby_values, struct_value)
-            end
-        end
-
-
+    # Updates the boot-related settings of a virtual machine.
+    #
+    # @param vm [String]
+    #     Virtual machine identifier.
+    # @param spec [Com::Vmware::Vcenter::VM::Hardware::Boot::UpdateSpec]
+    #     Specification for updating the boot-related settings of the virtual machine.
+    # @return [Void]
+    # @raise [Com::Vmware::Vapi::Std::Errors::Error]
+    #     if the system reports an error while responding to the request.
+    # @raise [Com::Vmware::Vapi::Std::Errors::NotFound]
+    #     if the virtual machine is not found.
+    # @raise [Com::Vmware::Vapi::Std::Errors::InvalidArgument]
+    #     if one of the provided settings is not permitted; for example, specifying a negative value for  ``delay`` .
+    # @raise [Com::Vmware::Vapi::Std::Errors::ResourceBusy]
+    #     if the virtual machine is busy performing another operation.
+    # @raise [Com::Vmware::Vapi::Std::Errors::ResourceInaccessible]
+    #     if the virtual machine's configuration state cannot be accessed.
+    # @raise [Com::Vmware::Vapi::Std::Errors::ServiceUnavailable]
+    #     if the system is unable to communicate with a service to complete the request.
+    # @raise [Com::Vmware::Vapi::Std::Errors::Unauthenticated]
+    #     if the user can not be authenticated.
+    # @raise [Com::Vmware::Vapi::Std::Errors::Unauthorized]
+    #     if the user doesn't have the required privileges.
+    def update(vm, spec)
+      invoke_with_info(UPDATE_INFO,
+                       'vm' => vm,
+                       'spec' => spec)
     end
 
-
-    # The  ``Com::Vmware::Vcenter::Vm::Hardware::Disk``   class  provides  methods  for configuring the virtual disks of a virtual machine. A virtual disk has a backing such as a VMDK file. The backing has an independent lifecycle from the virtual machine when it is detached from the virtual machine. The   :func:`Com::Vmware::Vcenter::Vm::Hardware::Disk.create`    method  provides the ability to create a new virtual disk. When creating a virtual disk, a new VMDK file may be created or an existing VMDK file may used as a backing. Once a VMDK file is associated with a virtual machine, its lifecycle will be bound to the virtual machine. In other words, it will be deleted when the virtual machine is deleted. The   :func:`Com::Vmware::Vcenter::Vm::Hardware::Disk.delete`    method  provides the ability to detach a VMDK file from the virtual machine. The   :func:`Com::Vmware::Vcenter::Vm::Hardware::Disk.delete`    method  does not delete the VMDK file that backs the virtual disk. Once detached, the VMDK file will not be destroyed when the virtual machine to which it was associated is deleted.
-    class Disk < VAPI::Bindings::VapiService
-
-        protected
-
-        # static metamodel definitions
-        @@service_id = VAPI::Core::ServiceIdentifier.new('com.vmware.vcenter.vm.hardware.disk')
-
-        @@list_info = VAPI::Bindings::OperationInfo.new(
-            VAPI::Core::OperationIdentifier.new('list', @@service_id),
-            VAPI::Bindings::OperationInputType.new({
-                'vm' => VAPI::Bindings::IdType.new(resource_types='VirtualMachine'),
-            }),
-            VAPI::Bindings::ListType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::Vm::Hardware::Disk::Summary')),
-            {
-                'com.vmware.vapi.std.errors.error' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Error'),
-                'com.vmware.vapi.std.errors.not_found' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::NotFound'),
-                'com.vmware.vapi.std.errors.resource_inaccessible' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::ResourceInaccessible'),
-                'com.vmware.vapi.std.errors.service_unavailable' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::ServiceUnavailable'),
-                'com.vmware.vapi.std.errors.unauthenticated' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Unauthenticated'),
-                'com.vmware.vapi.std.errors.unauthorized' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Unauthorized'),
-
-            },
-            [],
-            [])
-        @@get_info = VAPI::Bindings::OperationInfo.new(
-            VAPI::Core::OperationIdentifier.new('get', @@service_id),
-            VAPI::Bindings::OperationInputType.new({
-                'vm' => VAPI::Bindings::IdType.new(resource_types='VirtualMachine'),
-                'disk' => VAPI::Bindings::IdType.new(resource_types='com.vmware.vcenter.vm.hardware.Disk'),
-            }),
-            VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::Vm::Hardware::Disk::Info'),
-            {
-                'com.vmware.vapi.std.errors.error' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Error'),
-                'com.vmware.vapi.std.errors.not_found' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::NotFound'),
-                'com.vmware.vapi.std.errors.resource_inaccessible' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::ResourceInaccessible'),
-                'com.vmware.vapi.std.errors.service_unavailable' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::ServiceUnavailable'),
-                'com.vmware.vapi.std.errors.unauthenticated' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Unauthenticated'),
-                'com.vmware.vapi.std.errors.unauthorized' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Unauthorized'),
-
-            },
-            [],
-            [])
-        @@create_info = VAPI::Bindings::OperationInfo.new(
-            VAPI::Core::OperationIdentifier.new('create', @@service_id),
-            VAPI::Bindings::OperationInputType.new({
-                'vm' => VAPI::Bindings::IdType.new(resource_types='VirtualMachine'),
-                'spec' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::Vm::Hardware::Disk::CreateSpec'),
-            }),
-            VAPI::Bindings::IdType.new(resource_types='com.vmware.vcenter.vm.hardware.Disk'),
-            {
-                'com.vmware.vapi.std.errors.error' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Error'),
-                'com.vmware.vapi.std.errors.not_found' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::NotFound'),
-                'com.vmware.vapi.std.errors.not_allowed_in_current_state' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::NotAllowedInCurrentState'),
-                'com.vmware.vapi.std.errors.unable_to_allocate_resource' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::UnableToAllocateResource'),
-                'com.vmware.vapi.std.errors.resource_in_use' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::ResourceInUse'),
-                'com.vmware.vapi.std.errors.invalid_argument' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::InvalidArgument'),
-                'com.vmware.vapi.std.errors.resource_busy' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::ResourceBusy'),
-                'com.vmware.vapi.std.errors.resource_inaccessible' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::ResourceInaccessible'),
-                'com.vmware.vapi.std.errors.service_unavailable' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::ServiceUnavailable'),
-                'com.vmware.vapi.std.errors.unauthenticated' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Unauthenticated'),
-                'com.vmware.vapi.std.errors.unauthorized' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Unauthorized'),
-                'com.vmware.vapi.std.errors.unsupported' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Unsupported'),
-
-            },
-            [],
-            [])
-        @@update_info = VAPI::Bindings::OperationInfo.new(
-            VAPI::Core::OperationIdentifier.new('update', @@service_id),
-            VAPI::Bindings::OperationInputType.new({
-                'vm' => VAPI::Bindings::IdType.new(resource_types='VirtualMachine'),
-                'disk' => VAPI::Bindings::IdType.new(resource_types='com.vmware.vcenter.vm.hardware.Disk'),
-                'spec' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::Vm::Hardware::Disk::UpdateSpec'),
-            }),
-            VAPI::Bindings::VoidType.instance,
-            {
-                'com.vmware.vapi.std.errors.error' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Error'),
-                'com.vmware.vapi.std.errors.not_found' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::NotFound'),
-                'com.vmware.vapi.std.errors.not_allowed_in_current_state' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::NotAllowedInCurrentState'),
-                'com.vmware.vapi.std.errors.resource_busy' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::ResourceBusy'),
-                'com.vmware.vapi.std.errors.resource_inaccessible' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::ResourceInaccessible'),
-                'com.vmware.vapi.std.errors.service_unavailable' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::ServiceUnavailable'),
-                'com.vmware.vapi.std.errors.unauthenticated' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Unauthenticated'),
-                'com.vmware.vapi.std.errors.unauthorized' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Unauthorized'),
-
-            },
-            [],
-            [])
-        @@delete_info = VAPI::Bindings::OperationInfo.new(
-            VAPI::Core::OperationIdentifier.new('delete', @@service_id),
-            VAPI::Bindings::OperationInputType.new({
-                'vm' => VAPI::Bindings::IdType.new(resource_types='VirtualMachine'),
-                'disk' => VAPI::Bindings::IdType.new(resource_types='com.vmware.vcenter.vm.hardware.Disk'),
-            }),
-            VAPI::Bindings::VoidType.instance,
-            {
-                'com.vmware.vapi.std.errors.error' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Error'),
-                'com.vmware.vapi.std.errors.not_found' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::NotFound'),
-                'com.vmware.vapi.std.errors.not_allowed_in_current_state' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::NotAllowedInCurrentState'),
-                'com.vmware.vapi.std.errors.resource_busy' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::ResourceBusy'),
-                'com.vmware.vapi.std.errors.resource_inaccessible' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::ResourceInaccessible'),
-                'com.vmware.vapi.std.errors.service_unavailable' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::ServiceUnavailable'),
-                'com.vmware.vapi.std.errors.unauthenticated' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Unauthenticated'),
-                'com.vmware.vapi.std.errors.unauthorized' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Unauthorized'),
-
-            },
-            [],
-            [])
-
-        @@service_info = VAPI::Bindings::ServiceInfo.new(@@service_id, {
-            'list' => @@list_info,
-            'get' => @@get_info,
-            'create' => @@create_info,
-            'update' => @@update_info,
-            'delete' => @@delete_info,
-        })
-
-        public
-
-        # Constructs a new instance.
-        #
-        # @param config [VAPI::Bindings::StubConfig] A hash with the api provider details.
-        def initialize(config)
-            super(config, @@service_info)
-        end
-
-        RESOURCE_TYPE = 'com.vmware.vcenter.vm.hardware.Disk'
-
-
-        # Returns commonly used information about the virtual disks belonging to the virtual machine.
-        #
-        # @param vm [String]
-        #     Virtual machine identifier.
-        # @return [Array<Com::Vmware::Vcenter::Vm::Hardware::Disk::Summary>]
-        #     List of commonly used information about the virtual disks.
-        # @raise [Com::Vmware::Vapi::Std::Errors::Error]
-        #     if the system reports an error while responding to the request.
-        # @raise [Com::Vmware::Vapi::Std::Errors::NotFound]
-        #     if the virtual machine is not found.
-        # @raise [Com::Vmware::Vapi::Std::Errors::ResourceInaccessible]
-        #     if the virtual machine's configuration state cannot be accessed.
-        # @raise [Com::Vmware::Vapi::Std::Errors::ServiceUnavailable]
-        #     if the system is unable to communicate with a service to complete the request.
-        # @raise [Com::Vmware::Vapi::Std::Errors::Unauthenticated]
-        #     if the user can not be authenticated.
-        # @raise [Com::Vmware::Vapi::Std::Errors::Unauthorized]
-        #     if the user doesn't have the required privileges.
-        def list(vm)
-            invoke_with_info(@@list_info, {
-                'vm' => vm,
-            })
-        end
-
-
-        # Returns information about a virtual disk.
-        #
-        # @param vm [String]
-        #     Virtual machine identifier.
-        # @param disk [String]
-        #     Virtual disk identifier.
-        # @return [Com::Vmware::Vcenter::Vm::Hardware::Disk::Info]
-        #     Information about the specified virtual disk.
-        # @raise [Com::Vmware::Vapi::Std::Errors::Error]
-        #     if the system reports an error while responding to the request.
-        # @raise [Com::Vmware::Vapi::Std::Errors::NotFound]
-        #     if the virtual machine or virtual disk is not found.
-        # @raise [Com::Vmware::Vapi::Std::Errors::ResourceInaccessible]
-        #     if the virtual machine's configuration state cannot be accessed.
-        # @raise [Com::Vmware::Vapi::Std::Errors::ServiceUnavailable]
-        #     if the system is unable to communicate with a service to complete the request.
-        # @raise [Com::Vmware::Vapi::Std::Errors::Unauthenticated]
-        #     if the user can not be authenticated.
-        # @raise [Com::Vmware::Vapi::Std::Errors::Unauthorized]
-        #     if the user doesn't have the required privileges.
-        def get(vm, disk)
-            invoke_with_info(@@get_info, {
-                'vm' => vm,
-                'disk' => disk,
-            })
-        end
-
-
-        # Adds a virtual disk to the virtual machine. While adding the virtual disk, a new VMDK file may be created or an existing VMDK file may be used to back the virtual disk.
-        #
-        # @param vm [String]
-        #     Virtual machine identifier.
-        # @param spec [Com::Vmware::Vcenter::Vm::Hardware::Disk::CreateSpec]
-        #     Specification for the new virtual disk.
-        # @return [String]
-        #     Virtual disk identifier.
-        # @raise [Com::Vmware::Vapi::Std::Errors::Error]
-        #     if system reported that the disk device was created but was unable to confirm the creation because the identifier of the new device could not be determined.
-        # @raise [Com::Vmware::Vapi::Std::Errors::Error]
-        #     if the system reports an error while responding to the request.
-        # @raise [Com::Vmware::Vapi::Std::Errors::NotFound]
-        #     if the virtual machine is not found.
-        # @raise [Com::Vmware::Vapi::Std::Errors::NotAllowedInCurrentState]
-        #     if the virtual machine is suspended or if the virtual machine is powered on and virtual disk type is IDE.
-        # @raise [Com::Vmware::Vapi::Std::Errors::UnableToAllocateResource]
-        #     if the specified storage address is unavailable; for example, if the SCSI adapter requested does not exist.
-        # @raise [Com::Vmware::Vapi::Std::Errors::ResourceInUse]
-        #     if the specified storage address is in use.
-        # @raise [Com::Vmware::Vapi::Std::Errors::InvalidArgument]
-        #     if the specified storage address is out of bounds.
-        # @raise [Com::Vmware::Vapi::Std::Errors::ResourceBusy]
-        #     if the virtual machine is busy performing another operation.
-        # @raise [Com::Vmware::Vapi::Std::Errors::ResourceInaccessible]
-        #     if the virtual machine's configuration state cannot be accessed.
-        # @raise [Com::Vmware::Vapi::Std::Errors::ServiceUnavailable]
-        #     if the system is unable to communicate with a service to complete the request.
-        # @raise [Com::Vmware::Vapi::Std::Errors::Unauthenticated]
-        #     if the user can not be authenticated.
-        # @raise [Com::Vmware::Vapi::Std::Errors::Unauthorized]
-        #     if the user doesn't have the required privileges.
-        # @raise [Com::Vmware::Vapi::Std::Errors::Unsupported]
-        #     if the guest operating system of the virtual machine is not supported and  spec  includes  nil   fields  that default to guest-specific values.
-        def create(vm, spec)
-            invoke_with_info(@@create_info, {
-                'vm' => vm,
-                'spec' => spec,
-            })
-        end
-
-
-        # Updates the configuration of a virtual disk. An update  method  can be used to detach the existing VMDK file and attach another VMDK file to the virtual machine.
-        #
-        # @param vm [String]
-        #     Virtual machine identifier.
-        # @param disk [String]
-        #     Virtual disk identifier.
-        # @param spec [Com::Vmware::Vcenter::Vm::Hardware::Disk::UpdateSpec]
-        #     Specification for updating the virtual disk.
-        # @return [Void]
-        # @raise [Com::Vmware::Vapi::Std::Errors::Error]
-        #     if the system reports an error while responding to the request.
-        # @raise [Com::Vmware::Vapi::Std::Errors::NotFound]
-        #     if the virtual machine or virtual disk is not found.
-        # @raise [Com::Vmware::Vapi::Std::Errors::NotAllowedInCurrentState]
-        #     if one or more of the  fields  specified in the  ``spec``   parameter  cannot be modified due to the current power state of the virtual machine or the connection state of the virtual disk.
-        # @raise [Com::Vmware::Vapi::Std::Errors::ResourceBusy]
-        #     if the virtual machine is busy performing another operation.
-        # @raise [Com::Vmware::Vapi::Std::Errors::ResourceInaccessible]
-        #     if the virtual machine's configuration state cannot be accessed.
-        # @raise [Com::Vmware::Vapi::Std::Errors::ServiceUnavailable]
-        #     if the system is unable to communicate with a service to complete the request.
-        # @raise [Com::Vmware::Vapi::Std::Errors::Unauthenticated]
-        #     if the user can not be authenticated.
-        # @raise [Com::Vmware::Vapi::Std::Errors::Unauthorized]
-        #     if the user doesn't have the required privileges.
-        def update(vm, disk, spec)
-            invoke_with_info(@@update_info, {
-                'vm' => vm,
-                'disk' => disk,
-                'spec' => spec,
-            })
-        end
-
-
-        # Removes a virtual disk from the virtual machine. This  method  does not destroy the VMDK file that backs the virtual disk. It only detaches the VMDK file from the virtual machine. Once detached, the VMDK file will not be destroyed when the virtual machine to which it was associated is deleted.
-        #
-        # @param vm [String]
-        #     Virtual machine identifier.
-        # @param disk [String]
-        #     Virtual disk identifier.
-        # @return [Void]
-        # @raise [Com::Vmware::Vapi::Std::Errors::Error]
-        #     if the system reports an error while responding to the request.
-        # @raise [Com::Vmware::Vapi::Std::Errors::NotFound]
-        #     if the virtual machine or virtual disk is not found.
-        # @raise [Com::Vmware::Vapi::Std::Errors::NotAllowedInCurrentState]
-        #     if the virtual machine is suspended or if the virtual machine is powered on and virtual disk type is IDE.
-        # @raise [Com::Vmware::Vapi::Std::Errors::ResourceBusy]
-        #     if the virtual machine is busy performing another operation.
-        # @raise [Com::Vmware::Vapi::Std::Errors::ResourceInaccessible]
-        #     if the virtual machine's configuration state cannot be accessed.
-        # @raise [Com::Vmware::Vapi::Std::Errors::ServiceUnavailable]
-        #     if the system is unable to communicate with a service to complete the request.
-        # @raise [Com::Vmware::Vapi::Std::Errors::Unauthenticated]
-        #     if the user can not be authenticated.
-        # @raise [Com::Vmware::Vapi::Std::Errors::Unauthorized]
-        #     if the user doesn't have the required privileges.
-        def delete(vm, disk)
-            invoke_with_info(@@delete_info, {
-                'vm' => vm,
-                'disk' => disk,
-            })
-        end
-
-
-
-        # The  ``Com::Vmware::Vcenter::Vm::Hardware::Disk::BackingInfo``   class  contains information about the physical resource backing a virtual disk.
-        # @!attribute [rw] type
-        #     @return [Com::Vmware::Vcenter::Vm::Hardware::Disk::BackingType]
-        #     Backing type for the virtual disk.
-        # @!attribute [rw] vmdk_file
-        #     @return [String]
-        #     Path of the VMDK file backing the virtual disk.
-        #     This  field  is optional and it is only relevant when the value of  ``type``  is   :attr:`Com::Vmware::Vcenter::Vm::Hardware::Disk::BackingType.VMDK_FILE`  .
-        class BackingInfo < VAPI::Bindings::VapiStruct
-
-            class << self
-                # Holds (gets or creates) the binding type metadata for this structure type.
-                # @scope class
-                # @return [VAPI::Bindings::StructType] the binding type
-                def binding_type
-                    @binding_type ||= VAPI::Bindings::StructType.new(
-                        'com.vmware.vcenter.vm.hardware.disk.backing_info',
-                        {
-                            'type' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::Vm::Hardware::Disk::BackingType'),
-                            'vmdk_file' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::StringType.instance),
-                        },
-                        BackingInfo,
-                        false,
-                        nil)
-                end
-            end
-
-            attr_accessor :type,
-                          :vmdk_file
-
-            # Constructs a new instance.
-            # @param ruby_values [Hash] a map of initial property values (optional)
-            # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
-            def initialize(ruby_values=nil, struct_value=nil)
-                super(self.class.binding_type, ruby_values, struct_value)
-            end
-        end
-
-
-        # The  ``Com::Vmware::Vcenter::Vm::Hardware::Disk::BackingSpec``   class  provides a specification of the physical resource backing a virtual disk.
-        # @!attribute [rw] type
-        #     @return [Com::Vmware::Vcenter::Vm::Hardware::Disk::BackingType]
-        #     Backing type for the virtual disk.
-        # @!attribute [rw] vmdk_file
-        #     @return [String]
-        #     Path of the VMDK file backing the virtual disk.
-        #     This  field  is optional and it is only relevant when the value of  ``type``  is   :attr:`Com::Vmware::Vcenter::Vm::Hardware::Disk::BackingType.VMDK_FILE`  .
-        class BackingSpec < VAPI::Bindings::VapiStruct
-
-            class << self
-                # Holds (gets or creates) the binding type metadata for this structure type.
-                # @scope class
-                # @return [VAPI::Bindings::StructType] the binding type
-                def binding_type
-                    @binding_type ||= VAPI::Bindings::StructType.new(
-                        'com.vmware.vcenter.vm.hardware.disk.backing_spec',
-                        {
-                            'type' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::Vm::Hardware::Disk::BackingType'),
-                            'vmdk_file' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::StringType.instance),
-                        },
-                        BackingSpec,
-                        false,
-                        nil)
-                end
-            end
-
-            attr_accessor :type,
-                          :vmdk_file
-
-            # Constructs a new instance.
-            # @param ruby_values [Hash] a map of initial property values (optional)
-            # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
-            def initialize(ruby_values=nil, struct_value=nil)
-                super(self.class.binding_type, ruby_values, struct_value)
-            end
-        end
-
-
-        # The  ``Com::Vmware::Vcenter::Vm::Hardware::Disk::VmdkCreateSpec``   class  provides a specification for creating a new VMDK file to be used as a backing for a virtual disk. The virtual disk will be stored in the same directory as the virtual machine's configuration file.
-        # @!attribute [rw] name
-        #     @return [String, nil]
-        #     Base name of the VMDK file. The name should not include the '.vmdk' file extension.
-        #     If  nil , a name (derived from the name of the virtual machine) will be chosen by the server.
-        # @!attribute [rw] capacity
-        #     @return [Fixnum, nil]
-        #     Capacity of the virtual disk backing in bytes.
-        #     If  nil , defaults to a guest-specific capacity.
-        class VmdkCreateSpec < VAPI::Bindings::VapiStruct
-
-            class << self
-                # Holds (gets or creates) the binding type metadata for this structure type.
-                # @scope class
-                # @return [VAPI::Bindings::StructType] the binding type
-                def binding_type
-                    @binding_type ||= VAPI::Bindings::StructType.new(
-                        'com.vmware.vcenter.vm.hardware.disk.vmdk_create_spec',
-                        {
-                            'name' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::StringType.instance),
-                            'capacity' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::IntegerType.instance),
-                        },
-                        VmdkCreateSpec,
-                        false,
-                        nil)
-                end
-            end
-
-            attr_accessor :name,
-                          :capacity
-
-            # Constructs a new instance.
-            # @param ruby_values [Hash] a map of initial property values (optional)
-            # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
-            def initialize(ruby_values=nil, struct_value=nil)
-                super(self.class.binding_type, ruby_values, struct_value)
-            end
-        end
-
-
-        # The  ``Com::Vmware::Vcenter::Vm::Hardware::Disk::Info``   class  contains information about a virtual disk.
-        # @!attribute [rw] label
-        #     @return [String]
-        #     Device label.
-        # @!attribute [rw] type
-        #     @return [Com::Vmware::Vcenter::Vm::Hardware::Disk::HostBusAdapterType]
-        #     Type of host bus adapter to which the device is attached.
-        # @!attribute [rw] ide
-        #     @return [Com::Vmware::Vcenter::Vm::Hardware::IdeAddressInfo]
-        #     Address of device attached to a virtual IDE adapter.
-        #     Workaround for PR1459646
-        # @!attribute [rw] scsi
-        #     @return [Com::Vmware::Vcenter::Vm::Hardware::ScsiAddressInfo]
-        #     Address of device attached to a virtual SCSI adapter.
-        #     Workaround for PR1459646
-        # @!attribute [rw] sata
-        #     @return [Com::Vmware::Vcenter::Vm::Hardware::SataAddressInfo]
-        #     Address of device attached to a virtual SATA adapter.
-        #     Workaround for PR1459646
-        # @!attribute [rw] backing
-        #     @return [Com::Vmware::Vcenter::Vm::Hardware::Disk::BackingInfo]
-        #     Physical resource backing for the virtual disk.
-        # @!attribute [rw] capacity
-        #     @return [Fixnum, nil]
-        #     Capacity of the virtual disk in bytes.
-        #     If  nil , virtual disk is inaccessible or disk capacity is 0.
-        class Info < VAPI::Bindings::VapiStruct
-
-            class << self
-                # Holds (gets or creates) the binding type metadata for this structure type.
-                # @scope class
-                # @return [VAPI::Bindings::StructType] the binding type
-                def binding_type
-                    @binding_type ||= VAPI::Bindings::StructType.new(
-                        'com.vmware.vcenter.vm.hardware.disk.info',
-                        {
-                            'label' => VAPI::Bindings::StringType.instance,
-                            'type' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::Vm::Hardware::Disk::HostBusAdapterType'),
-                            'ide' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::Vm::Hardware::IdeAddressInfo')),
-                            'scsi' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::Vm::Hardware::ScsiAddressInfo')),
-                            'sata' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::Vm::Hardware::SataAddressInfo')),
-                            'backing' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::Vm::Hardware::Disk::BackingInfo'),
-                            'capacity' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::IntegerType.instance),
-                        },
-                        Info,
-                        false,
-                        nil)
-                end
-            end
-
-            attr_accessor :label,
-                          :type,
-                          :ide,
-                          :scsi,
-                          :sata,
-                          :backing,
-                          :capacity
-
-            # Constructs a new instance.
-            # @param ruby_values [Hash] a map of initial property values (optional)
-            # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
-            def initialize(ruby_values=nil, struct_value=nil)
-                super(self.class.binding_type, ruby_values, struct_value)
-            end
-        end
-
-
-        # The  ``Com::Vmware::Vcenter::Vm::Hardware::Disk::CreateSpec``   class  provides a specification for the configuration of a newly-created virtual disk.
-        # @!attribute [rw] type
-        #     @return [Com::Vmware::Vcenter::Vm::Hardware::Disk::HostBusAdapterType, nil]
-        #     Type of host bus adapter to which the device should be attached.
-        #     If  nil , guest-specific default values will be used
-        # @!attribute [rw] ide
-        #     @return [Com::Vmware::Vcenter::Vm::Hardware::IdeAddressSpec, nil]
-        #     Address for attaching the device to a virtual IDE adapter.
-        #     If  nil , the server will choose an available address; if none is available, the request will fail.
-        # @!attribute [rw] scsi
-        #     @return [Com::Vmware::Vcenter::Vm::Hardware::ScsiAddressSpec, nil]
-        #     Address for attaching the device to a virtual SCSI adapter.
-        #     If  nil , the server will choose an available address; if none is available, the request will fail.
-        # @!attribute [rw] sata
-        #     @return [Com::Vmware::Vcenter::Vm::Hardware::SataAddressSpec, nil]
-        #     Address for attaching the device to a virtual SATA adapter.
-        #     If  nil , the server will choose an available address; if none is available, the request will fail.
-        # @!attribute [rw] backing
-        #     @return [Com::Vmware::Vcenter::Vm::Hardware::Disk::BackingSpec, nil]
-        #     Existing physical resource backing for the virtual disk. Exactly one of  ``backing``  or  ``newVmdk``  must be specified.
-        #     If  nil , the virtual disk will not be connected to an existing backing.
-        # @!attribute [rw] new_vmdk
-        #     @return [Com::Vmware::Vcenter::Vm::Hardware::Disk::VmdkCreateSpec, nil]
-        #     Specification for creating a new VMDK backing for the virtual disk. Exactly one of  ``backing``  or  ``newVmdk``  must be specified.
-        #     If  nil , a new VMDK backing will not be created.
-        class CreateSpec < VAPI::Bindings::VapiStruct
-
-            class << self
-                # Holds (gets or creates) the binding type metadata for this structure type.
-                # @scope class
-                # @return [VAPI::Bindings::StructType] the binding type
-                def binding_type
-                    @binding_type ||= VAPI::Bindings::StructType.new(
-                        'com.vmware.vcenter.vm.hardware.disk.create_spec',
-                        {
-                            'type' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::Vm::Hardware::Disk::HostBusAdapterType')),
-                            'ide' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::Vm::Hardware::IdeAddressSpec')),
-                            'scsi' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::Vm::Hardware::ScsiAddressSpec')),
-                            'sata' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::Vm::Hardware::SataAddressSpec')),
-                            'backing' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::Vm::Hardware::Disk::BackingSpec')),
-                            'new_vmdk' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::Vm::Hardware::Disk::VmdkCreateSpec')),
-                        },
-                        CreateSpec,
-                        false,
-                        nil)
-                end
-            end
-
-            attr_accessor :type,
-                          :ide,
-                          :scsi,
-                          :sata,
-                          :backing,
-                          :new_vmdk
-
-            # Constructs a new instance.
-            # @param ruby_values [Hash] a map of initial property values (optional)
-            # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
-            def initialize(ruby_values=nil, struct_value=nil)
-                super(self.class.binding_type, ruby_values, struct_value)
-            end
-        end
-
-
-        # The  ``Com::Vmware::Vcenter::Vm::Hardware::Disk::UpdateSpec``   class  describes the updates to be made to the configuration of a virtual disk.
-        # @!attribute [rw] backing
-        #     @return [Com::Vmware::Vcenter::Vm::Hardware::Disk::BackingSpec, nil]
-        #     Physical resource backing for the virtual disk.  
-        #     
-        #      This  field  may only be modified if the virtual machine is not powered on.
-        #     If  nil , the value is unchanged.
-        class UpdateSpec < VAPI::Bindings::VapiStruct
-
-            class << self
-                # Holds (gets or creates) the binding type metadata for this structure type.
-                # @scope class
-                # @return [VAPI::Bindings::StructType] the binding type
-                def binding_type
-                    @binding_type ||= VAPI::Bindings::StructType.new(
-                        'com.vmware.vcenter.vm.hardware.disk.update_spec',
-                        {
-                            'backing' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::Vm::Hardware::Disk::BackingSpec')),
-                        },
-                        UpdateSpec,
-                        false,
-                        nil)
-                end
-            end
-
-            attr_accessor :backing
-
-            # Constructs a new instance.
-            # @param ruby_values [Hash] a map of initial property values (optional)
-            # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
-            def initialize(ruby_values=nil, struct_value=nil)
-                super(self.class.binding_type, ruby_values, struct_value)
-            end
-        end
-
-
-        # The  ``Com::Vmware::Vcenter::Vm::Hardware::Disk::Summary``   class  contains commonly used information about a virtual disk.
-        # @!attribute [rw] disk
-        #     @return [String]
-        #     Identifier of the virtual Disk.
-        class Summary < VAPI::Bindings::VapiStruct
-
-            class << self
-                # Holds (gets or creates) the binding type metadata for this structure type.
-                # @scope class
-                # @return [VAPI::Bindings::StructType] the binding type
-                def binding_type
-                    @binding_type ||= VAPI::Bindings::StructType.new(
-                        'com.vmware.vcenter.vm.hardware.disk.summary',
-                        {
-                            'disk' => VAPI::Bindings::IdType.new(resource_types='com.vmware.vcenter.vm.hardware.Disk'),
-                        },
-                        Summary,
-                        false,
-                        nil)
-                end
-            end
-
-            attr_accessor :disk
-
-            # Constructs a new instance.
-            # @param ruby_values [Hash] a map of initial property values (optional)
-            # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
-            def initialize(ruby_values=nil, struct_value=nil)
-                super(self.class.binding_type, ruby_values, struct_value)
-            end
-        end
-
-
-
-        # The  ``Com::Vmware::Vcenter::Vm::Hardware::Disk::HostBusAdapterType``   enumerated type  defines the valid types of host bus adapters that may be used for attaching a virtual storage device to a virtual machine.
-        # @!attribute [rw] ide
-        #     @return [Com::Vmware::Vcenter::Vm::Hardware::Disk::HostBusAdapterType]
-        #     Disk is attached to an IDE adapter.
-        # @!attribute [rw] scsi
-        #     @return [Com::Vmware::Vcenter::Vm::Hardware::Disk::HostBusAdapterType]
-        #     Disk is attached to a SCSI adapter.
-        # @!attribute [rw] sata
-        #     @return [Com::Vmware::Vcenter::Vm::Hardware::Disk::HostBusAdapterType]
-        #     Disk is attached to a SATA adapter.
-        class HostBusAdapterType < VAPI::Bindings::VapiEnum
-
-            class << self
-                # Holds (gets or creates) the binding type metadata for this enumeration type.
-                # @scope class
-                # @return [VAPI::Bindings::EnumType] the binding type
-                def binding_type
-                    @binding_type ||= VAPI::Bindings::EnumType.new(
-                        'com.vmware.vcenter.vm.hardware.disk.host_bus_adapter_type',
-                        HostBusAdapterType)
-                end
-
-                # Converts from a string value (perhaps off the wire) to an instance
-                # of this enum type.
-                # @param value [String] the actual value of the enum instance
-                # @return [HostBusAdapterType] the instance found for the value, otherwise
-                #         an unknown instance will be built for the value
-                def from_string(value)
-                    begin
-                        const_get(value)
-                    rescue NameError
-                        HostBusAdapterType.new('UNKNOWN', value)
-                    end
-                end
-            end
-
-            private
-
-            # Constructs a new instance.
-            # @param value [String] the actual value of the enum instance
-            # @param unknown [String] the unknown value when value is 'UKNOWN'
-            def initialize(value, unknown=nil)
-                super(self.class.binding_type, value, unknown)
-            end
-
-            public
-
-            # @!attribute [rw] ide
-            #     @return [Com::Vmware::Vcenter::Vm::Hardware::Disk::HostBusAdapterType]
-            #     Disk is attached to an IDE adapter.
-            IDE = HostBusAdapterType.new('IDE')
-
-            # @!attribute [rw] scsi
-            #     @return [Com::Vmware::Vcenter::Vm::Hardware::Disk::HostBusAdapterType]
-            #     Disk is attached to a SCSI adapter.
-            SCSI = HostBusAdapterType.new('SCSI')
-
-            # @!attribute [rw] sata
-            #     @return [Com::Vmware::Vcenter::Vm::Hardware::Disk::HostBusAdapterType]
-            #     Disk is attached to a SATA adapter.
-            SATA = HostBusAdapterType.new('SATA')
-
-        end
-
-
-        # The  ``Com::Vmware::Vcenter::Vm::Hardware::Disk::BackingType``   enumerated type  defines the valid backing types for a virtual disk.
-        # @!attribute [rw] vmdk_file
-        #     @return [Com::Vmware::Vcenter::Vm::Hardware::Disk::BackingType]
-        #     Virtual disk is backed by a VMDK file.
-        class BackingType < VAPI::Bindings::VapiEnum
-
-            class << self
-                # Holds (gets or creates) the binding type metadata for this enumeration type.
-                # @scope class
-                # @return [VAPI::Bindings::EnumType] the binding type
-                def binding_type
-                    @binding_type ||= VAPI::Bindings::EnumType.new(
-                        'com.vmware.vcenter.vm.hardware.disk.backing_type',
-                        BackingType)
-                end
-
-                # Converts from a string value (perhaps off the wire) to an instance
-                # of this enum type.
-                # @param value [String] the actual value of the enum instance
-                # @return [BackingType] the instance found for the value, otherwise
-                #         an unknown instance will be built for the value
-                def from_string(value)
-                    begin
-                        const_get(value)
-                    rescue NameError
-                        BackingType.new('UNKNOWN', value)
-                    end
-                end
-            end
-
-            private
-
-            # Constructs a new instance.
-            # @param value [String] the actual value of the enum instance
-            # @param unknown [String] the unknown value when value is 'UKNOWN'
-            def initialize(value, unknown=nil)
-                super(self.class.binding_type, value, unknown)
-            end
-
-            public
-
-            # @!attribute [rw] vmdk_file
-            #     @return [Com::Vmware::Vcenter::Vm::Hardware::Disk::BackingType]
-            #     Virtual disk is backed by a VMDK file.
-            VMDK_FILE = BackingType.new('VMDK_FILE')
-
-        end
-
-
-    end
-
-
-    # The  ``Com::Vmware::Vcenter::Vm::Hardware::Ethernet``   class  provides  methods  for configuring the virtual Ethernet adapters of a virtual machine.
-    class Ethernet < VAPI::Bindings::VapiService
-
-        protected
-
-        # static metamodel definitions
-        @@service_id = VAPI::Core::ServiceIdentifier.new('com.vmware.vcenter.vm.hardware.ethernet')
-
-        @@list_info = VAPI::Bindings::OperationInfo.new(
-            VAPI::Core::OperationIdentifier.new('list', @@service_id),
-            VAPI::Bindings::OperationInputType.new({
-                'vm' => VAPI::Bindings::IdType.new(resource_types='VirtualMachine'),
-            }),
-            VAPI::Bindings::ListType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::Vm::Hardware::Ethernet::Summary')),
-            {
-                'com.vmware.vapi.std.errors.error' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Error'),
-                'com.vmware.vapi.std.errors.not_found' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::NotFound'),
-                'com.vmware.vapi.std.errors.resource_inaccessible' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::ResourceInaccessible'),
-                'com.vmware.vapi.std.errors.service_unavailable' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::ServiceUnavailable'),
-                'com.vmware.vapi.std.errors.unauthenticated' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Unauthenticated'),
-                'com.vmware.vapi.std.errors.unauthorized' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Unauthorized'),
-
-            },
-            [],
-            [])
-        @@get_info = VAPI::Bindings::OperationInfo.new(
-            VAPI::Core::OperationIdentifier.new('get', @@service_id),
-            VAPI::Bindings::OperationInputType.new({
-                'vm' => VAPI::Bindings::IdType.new(resource_types='VirtualMachine'),
-                'nic' => VAPI::Bindings::IdType.new(resource_types='com.vmware.vcenter.vm.hardware.Ethernet'),
-            }),
-            VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::Vm::Hardware::Ethernet::Info'),
-            {
-                'com.vmware.vapi.std.errors.error' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Error'),
-                'com.vmware.vapi.std.errors.not_found' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::NotFound'),
-                'com.vmware.vapi.std.errors.resource_inaccessible' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::ResourceInaccessible'),
-                'com.vmware.vapi.std.errors.service_unavailable' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::ServiceUnavailable'),
-                'com.vmware.vapi.std.errors.unauthenticated' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Unauthenticated'),
-                'com.vmware.vapi.std.errors.unauthorized' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Unauthorized'),
-
-            },
-            [],
-            [])
-        @@create_info = VAPI::Bindings::OperationInfo.new(
-            VAPI::Core::OperationIdentifier.new('create', @@service_id),
-            VAPI::Bindings::OperationInputType.new({
-                'vm' => VAPI::Bindings::IdType.new(resource_types='VirtualMachine'),
-                'spec' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::Vm::Hardware::Ethernet::CreateSpec'),
-            }),
-            VAPI::Bindings::IdType.new(resource_types='com.vmware.vcenter.vm.hardware.Ethernet'),
-            {
-                'com.vmware.vapi.std.errors.error' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Error'),
-                'com.vmware.vapi.std.errors.not_found' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::NotFound'),
-                'com.vmware.vapi.std.errors.unable_to_allocate_resource' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::UnableToAllocateResource'),
-                'com.vmware.vapi.std.errors.invalid_argument' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::InvalidArgument'),
-                'com.vmware.vapi.std.errors.resource_busy' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::ResourceBusy'),
-                'com.vmware.vapi.std.errors.resource_inaccessible' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::ResourceInaccessible'),
-                'com.vmware.vapi.std.errors.service_unavailable' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::ServiceUnavailable'),
-                'com.vmware.vapi.std.errors.unauthenticated' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Unauthenticated'),
-                'com.vmware.vapi.std.errors.unauthorized' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Unauthorized'),
-                'com.vmware.vapi.std.errors.unsupported' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Unsupported'),
-
-            },
-            [],
-            [])
-        @@update_info = VAPI::Bindings::OperationInfo.new(
-            VAPI::Core::OperationIdentifier.new('update', @@service_id),
-            VAPI::Bindings::OperationInputType.new({
-                'vm' => VAPI::Bindings::IdType.new(resource_types='VirtualMachine'),
-                'nic' => VAPI::Bindings::IdType.new(resource_types='com.vmware.vcenter.vm.hardware.Ethernet'),
-                'spec' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::Vm::Hardware::Ethernet::UpdateSpec'),
-            }),
-            VAPI::Bindings::VoidType.instance,
-            {
-                'com.vmware.vapi.std.errors.error' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Error'),
-                'com.vmware.vapi.std.errors.invalid_argument' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::InvalidArgument'),
-                'com.vmware.vapi.std.errors.not_found' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::NotFound'),
-                'com.vmware.vapi.std.errors.resource_busy' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::ResourceBusy'),
-                'com.vmware.vapi.std.errors.resource_inaccessible' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::ResourceInaccessible'),
-                'com.vmware.vapi.std.errors.service_unavailable' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::ServiceUnavailable'),
-                'com.vmware.vapi.std.errors.unauthenticated' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Unauthenticated'),
-                'com.vmware.vapi.std.errors.unauthorized' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Unauthorized'),
-
-            },
-            [],
-            [])
-        @@delete_info = VAPI::Bindings::OperationInfo.new(
-            VAPI::Core::OperationIdentifier.new('delete', @@service_id),
-            VAPI::Bindings::OperationInputType.new({
-                'vm' => VAPI::Bindings::IdType.new(resource_types='VirtualMachine'),
-                'nic' => VAPI::Bindings::IdType.new(resource_types='com.vmware.vcenter.vm.hardware.Ethernet'),
-            }),
-            VAPI::Bindings::VoidType.instance,
-            {
-                'com.vmware.vapi.std.errors.error' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Error'),
-                'com.vmware.vapi.std.errors.not_found' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::NotFound'),
-                'com.vmware.vapi.std.errors.resource_busy' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::ResourceBusy'),
-                'com.vmware.vapi.std.errors.resource_inaccessible' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::ResourceInaccessible'),
-                'com.vmware.vapi.std.errors.service_unavailable' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::ServiceUnavailable'),
-                'com.vmware.vapi.std.errors.unauthenticated' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Unauthenticated'),
-                'com.vmware.vapi.std.errors.unauthorized' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Unauthorized'),
-
-            },
-            [],
-            [])
-        @@connect_info = VAPI::Bindings::OperationInfo.new(
-            VAPI::Core::OperationIdentifier.new('connect', @@service_id),
-            VAPI::Bindings::OperationInputType.new({
-                'vm' => VAPI::Bindings::IdType.new(resource_types='VirtualMachine'),
-                'nic' => VAPI::Bindings::IdType.new(resource_types='com.vmware.vcenter.vm.hardware.Ethernet'),
-            }),
-            VAPI::Bindings::VoidType.instance,
-            {
-                'com.vmware.vapi.std.errors.error' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Error'),
-                'com.vmware.vapi.std.errors.not_found' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::NotFound'),
-                'com.vmware.vapi.std.errors.already_in_desired_state' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::AlreadyInDesiredState'),
-                'com.vmware.vapi.std.errors.not_allowed_in_current_state' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::NotAllowedInCurrentState'),
-                'com.vmware.vapi.std.errors.resource_busy' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::ResourceBusy'),
-                'com.vmware.vapi.std.errors.resource_inaccessible' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::ResourceInaccessible'),
-                'com.vmware.vapi.std.errors.service_unavailable' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::ServiceUnavailable'),
-                'com.vmware.vapi.std.errors.unauthenticated' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Unauthenticated'),
-                'com.vmware.vapi.std.errors.unauthorized' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Unauthorized'),
-
-            },
-            [],
-            [])
-        @@disconnect_info = VAPI::Bindings::OperationInfo.new(
-            VAPI::Core::OperationIdentifier.new('disconnect', @@service_id),
-            VAPI::Bindings::OperationInputType.new({
-                'vm' => VAPI::Bindings::IdType.new(resource_types='VirtualMachine'),
-                'nic' => VAPI::Bindings::IdType.new(resource_types='com.vmware.vcenter.vm.hardware.Ethernet'),
-            }),
-            VAPI::Bindings::VoidType.instance,
-            {
-                'com.vmware.vapi.std.errors.error' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Error'),
-                'com.vmware.vapi.std.errors.not_found' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::NotFound'),
-                'com.vmware.vapi.std.errors.already_in_desired_state' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::AlreadyInDesiredState'),
-                'com.vmware.vapi.std.errors.not_allowed_in_current_state' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::NotAllowedInCurrentState'),
-                'com.vmware.vapi.std.errors.resource_busy' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::ResourceBusy'),
-                'com.vmware.vapi.std.errors.resource_inaccessible' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::ResourceInaccessible'),
-                'com.vmware.vapi.std.errors.service_unavailable' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::ServiceUnavailable'),
-                'com.vmware.vapi.std.errors.unauthenticated' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Unauthenticated'),
-                'com.vmware.vapi.std.errors.unauthorized' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Unauthorized'),
-
-            },
-            [],
-            [])
-
-        @@service_info = VAPI::Bindings::ServiceInfo.new(@@service_id, {
-            'list' => @@list_info,
-            'get' => @@get_info,
-            'create' => @@create_info,
-            'update' => @@update_info,
-            'delete' => @@delete_info,
-            'connect' => @@connect_info,
-            'disconnect' => @@disconnect_info,
-        })
-
-        public
-
-        # Constructs a new instance.
-        #
-        # @param config [VAPI::Bindings::StubConfig] A hash with the api provider details.
-        def initialize(config)
-            super(config, @@service_info)
-        end
-
-        RESOURCE_TYPE = 'com.vmware.vcenter.vm.hardware.Ethernet'
-
-
-        # Returns commonly used information about the virtual Ethernet adapters belonging to the virtual machine.
-        #
-        # @param vm [String]
-        #     Virtual machine identifier.
-        # @return [Array<Com::Vmware::Vcenter::Vm::Hardware::Ethernet::Summary>]
-        #     List of commonly used information about virtual Ethernet adapters.
-        # @raise [Com::Vmware::Vapi::Std::Errors::Error]
-        #     if the system reports an error while responding to the request.
-        # @raise [Com::Vmware::Vapi::Std::Errors::NotFound]
-        #     if the virtual machine is not found.
-        # @raise [Com::Vmware::Vapi::Std::Errors::ResourceInaccessible]
-        #     if the virtual machine's configuration state cannot be accessed.
-        # @raise [Com::Vmware::Vapi::Std::Errors::ServiceUnavailable]
-        #     if the system is unable to communicate with a service to complete the request.
-        # @raise [Com::Vmware::Vapi::Std::Errors::Unauthenticated]
-        #     if the user can not be authenticated.
-        # @raise [Com::Vmware::Vapi::Std::Errors::Unauthorized]
-        #     if the user doesn't have the required privileges.
-        def list(vm)
-            invoke_with_info(@@list_info, {
-                'vm' => vm,
-            })
-        end
-
-
-        # Returns information about a virtual Ethernet adapter.
-        #
-        # @param vm [String]
-        #     Virtual machine identifier.
-        # @param nic [String]
-        #     Virtual Ethernet adapter identifier.
-        # @return [Com::Vmware::Vcenter::Vm::Hardware::Ethernet::Info]
-        #     Information about the specified virtual Ethernet adapter.
-        # @raise [Com::Vmware::Vapi::Std::Errors::Error]
-        #     if the system reports an error while responding to the request.
-        # @raise [Com::Vmware::Vapi::Std::Errors::NotFound]
-        #     if the virtual machine or virtual Ethernet adapter is not found.
-        # @raise [Com::Vmware::Vapi::Std::Errors::ResourceInaccessible]
-        #     if the virtual machine's configuration state cannot be accessed.
-        # @raise [Com::Vmware::Vapi::Std::Errors::ServiceUnavailable]
-        #     if the system is unable to communicate with a service to complete the request.
-        # @raise [Com::Vmware::Vapi::Std::Errors::Unauthenticated]
-        #     if the user can not be authenticated.
-        # @raise [Com::Vmware::Vapi::Std::Errors::Unauthorized]
-        #     if the user doesn't have the required privileges.
-        def get(vm, nic)
-            invoke_with_info(@@get_info, {
-                'vm' => vm,
-                'nic' => nic,
-            })
-        end
-
-
-        # Adds a virtual Ethernet adapter to the virtual machine.
-        #
-        # @param vm [String]
-        #     Virtual machine identifier.
-        # @param spec [Com::Vmware::Vcenter::Vm::Hardware::Ethernet::CreateSpec]
-        #     Specification for the new virtual Ethernet adapter.
-        # @return [String]
-        #     Virtual Ethernet adapter identifier.
-        # @raise [Com::Vmware::Vapi::Std::Errors::Error]
-        #     if the system reported that the Ethernet adapter was created but was unable to confirm the creation because the identifier of the new adapter could not be determined.
-        # @raise [Com::Vmware::Vapi::Std::Errors::Error]
-        #     if the system reports an error while responding to the request.
-        # @raise [Com::Vmware::Vapi::Std::Errors::NotFound]
-        #     if the virtual machine or network backing is not found.
-        # @raise [Com::Vmware::Vapi::Std::Errors::UnableToAllocateResource]
-        #     if the virtual machine already has the maximum number of supported Ethernet adapters.
-        # @raise [Com::Vmware::Vapi::Std::Errors::InvalidArgument]
-        #     if the specified PCI address is out of bounds, HOST_DEVICE is specified as the type, or a backing cannot be found in the case that backing is left  nil .
-        # @raise [Com::Vmware::Vapi::Std::Errors::ResourceBusy]
-        #     if the virtual machine is busy performing another operation.
-        # @raise [Com::Vmware::Vapi::Std::Errors::ResourceInaccessible]
-        #     if the virtual machine's configuration state cannot be accessed.
-        # @raise [Com::Vmware::Vapi::Std::Errors::ServiceUnavailable]
-        #     if the system is unable to communicate with a service to complete the request.
-        # @raise [Com::Vmware::Vapi::Std::Errors::Unauthenticated]
-        #     if the user can not be authenticated.
-        # @raise [Com::Vmware::Vapi::Std::Errors::Unauthorized]
-        #     if the user doesn't have the required privileges.
-        # @raise [Com::Vmware::Vapi::Std::Errors::Unsupported]
-        #     if the guest operating system of the virtual machine is not supported and  spec  includes  nil   fields  that default to guest-specific values.
-        def create(vm, spec)
-            invoke_with_info(@@create_info, {
-                'vm' => vm,
-                'spec' => spec,
-            })
-        end
-
-
-        # Updates the configuration of a virtual Ethernet adapter.
-        #
-        # @param vm [String]
-        #     Virtual machine identifier.
-        # @param nic [String]
-        #     Virtual Ethernet adapter identifier.
-        # @param spec [Com::Vmware::Vcenter::Vm::Hardware::Ethernet::UpdateSpec]
-        #     Specification for updating the virtual Ethernet adapter.
-        # @return [Void]
-        # @raise [Com::Vmware::Vapi::Std::Errors::Error]
-        #     if the system reports an error while responding to the request.
-        # @raise [Com::Vmware::Vapi::Std::Errors::InvalidArgument]
-        #     if HOST_DEVICE is specified as the type.
-        # @raise [Com::Vmware::Vapi::Std::Errors::NotFound]
-        #     if the virtual machine, virtual Ethernet adapter, or backing network is not found.
-        # @raise [Com::Vmware::Vapi::Std::Errors::ResourceBusy]
-        #     if the virtual machine is busy performing another operation.
-        # @raise [Com::Vmware::Vapi::Std::Errors::ResourceInaccessible]
-        #     if the virtual machine's configuration state cannot be accessed.
-        # @raise [Com::Vmware::Vapi::Std::Errors::ServiceUnavailable]
-        #     if the system is unable to communicate with a service to complete the request.
-        # @raise [Com::Vmware::Vapi::Std::Errors::Unauthenticated]
-        #     if the user can not be authenticated.
-        # @raise [Com::Vmware::Vapi::Std::Errors::Unauthorized]
-        #     if the user doesn't have the required privileges.
-        def update(vm, nic, spec)
-            invoke_with_info(@@update_info, {
-                'vm' => vm,
-                'nic' => nic,
-                'spec' => spec,
-            })
-        end
-
-
-        # Removes a virtual Ethernet adapter from the virtual machine.
-        #
-        # @param vm [String]
-        #     Virtual machine identifier.
-        # @param nic [String]
-        #     Virtual Ethernet adapter identifier.
-        # @return [Void]
-        # @raise [Com::Vmware::Vapi::Std::Errors::Error]
-        #     if the system reports an error while responding to the request.
-        # @raise [Com::Vmware::Vapi::Std::Errors::NotFound]
-        #     if the virtual machine or virtual Ethernet adapter is not found.
-        # @raise [Com::Vmware::Vapi::Std::Errors::ResourceBusy]
-        #     if the virtual machine is busy performing another operation.
-        # @raise [Com::Vmware::Vapi::Std::Errors::ResourceInaccessible]
-        #     if the virtual machine's configuration state cannot be accessed.
-        # @raise [Com::Vmware::Vapi::Std::Errors::ServiceUnavailable]
-        #     if the system is unable to communicate with a service to complete the request.
-        # @raise [Com::Vmware::Vapi::Std::Errors::Unauthenticated]
-        #     if the user can not be authenticated.
-        # @raise [Com::Vmware::Vapi::Std::Errors::Unauthorized]
-        #     if the user doesn't have the required privileges.
-        def delete(vm, nic)
-            invoke_with_info(@@delete_info, {
-                'vm' => vm,
-                'nic' => nic,
-            })
-        end
-
-
-        # Connects a virtual Ethernet adapter of a powered-on virtual machine to its backing. Connecting the virtual device makes the backing accessible from the perspective of the guest operating system.  
-        # 
-        #  For a powered-off virtual machine, the   :func:`Com::Vmware::Vcenter::Vm::Hardware::Ethernet.update`    method  may be used to configure the virtual Ethernet adapter to start in the connected state when the virtual machine is powered on.
-        #
-        # @param vm [String]
-        #     Virtual machine identifier.
-        # @param nic [String]
-        #     Virtual Ethernet adapter identifier.
-        # @return [Void]
-        # @raise [Com::Vmware::Vapi::Std::Errors::Error]
-        #     if the system reports an error while responding to the request.
-        # @raise [Com::Vmware::Vapi::Std::Errors::NotFound]
-        #     if the virtual machine or virtual Ethernet adapter is not found.
-        # @raise [Com::Vmware::Vapi::Std::Errors::AlreadyInDesiredState]
-        #     if the virtual Ethernet adapter is already connected.
-        # @raise [Com::Vmware::Vapi::Std::Errors::NotAllowedInCurrentState]
-        #     if the virtual machine is not powered on.
-        # @raise [Com::Vmware::Vapi::Std::Errors::ResourceBusy]
-        #     if the virtual machine is busy performing another operation.
-        # @raise [Com::Vmware::Vapi::Std::Errors::ResourceInaccessible]
-        #     if the virtual machine's configuration state cannot be accessed.
-        # @raise [Com::Vmware::Vapi::Std::Errors::ServiceUnavailable]
-        #     if the system is unable to communicate with a service to complete the request.
-        # @raise [Com::Vmware::Vapi::Std::Errors::Unauthenticated]
-        #     if the user can not be authenticated.
-        # @raise [Com::Vmware::Vapi::Std::Errors::Unauthorized]
-        #     if the user doesn't have the required privileges.
-        def connect(vm, nic)
-            invoke_with_info(@@connect_info, {
-                'vm' => vm,
-                'nic' => nic,
-            })
-        end
-
-
-        # Disconnects a virtual Ethernet adapter of a powered-on virtual machine from its backing. The virtual device is still present and its backing configuration is unchanged, but from the perspective of the guest operating system, the Ethernet adapter is not connected to its backing resource.  
-        # 
-        #  For a powered-off virtual machine, the   :func:`Com::Vmware::Vcenter::Vm::Hardware::Ethernet.update`    method  may be used to configure the virtual Ethernet adapter to start in the disconnected state when the virtual machine is powered on.
-        #
-        # @param vm [String]
-        #     Virtual machine identifier.
-        # @param nic [String]
-        #     Virtual Ethernet adapter identifier.
-        # @return [Void]
-        # @raise [Com::Vmware::Vapi::Std::Errors::Error]
-        #     if the system reports an error while responding to the request.
-        # @raise [Com::Vmware::Vapi::Std::Errors::NotFound]
-        #     if the virtual machine or virtual Ethernet adapter is not found.
-        # @raise [Com::Vmware::Vapi::Std::Errors::AlreadyInDesiredState]
-        #     if the virtual Ethernet adapter is already disconnected.
-        # @raise [Com::Vmware::Vapi::Std::Errors::NotAllowedInCurrentState]
-        #     if the virtual machine is not powered on.
-        # @raise [Com::Vmware::Vapi::Std::Errors::ResourceBusy]
-        #     if the virtual machine is busy performing another operation.
-        # @raise [Com::Vmware::Vapi::Std::Errors::ResourceInaccessible]
-        #     if the virtual machine's configuration state cannot be accessed.
-        # @raise [Com::Vmware::Vapi::Std::Errors::ServiceUnavailable]
-        #     if the system is unable to communicate with a service to complete the request.
-        # @raise [Com::Vmware::Vapi::Std::Errors::Unauthenticated]
-        #     if the user can not be authenticated.
-        # @raise [Com::Vmware::Vapi::Std::Errors::Unauthorized]
-        #     if the user doesn't have the required privileges.
-        def disconnect(vm, nic)
-            invoke_with_info(@@disconnect_info, {
-                'vm' => vm,
-                'nic' => nic,
-            })
-        end
-
-
-
-        # The  ``Com::Vmware::Vcenter::Vm::Hardware::Ethernet::BackingInfo``   class  contains information about the physical resource backing a virtual Ethernet adapter.
-        # @!attribute [rw] type
-        #     @return [Com::Vmware::Vcenter::Vm::Hardware::Ethernet::BackingType]
-        #     Backing type for the virtual Ethernet adapter.
-        # @!attribute [rw] network
-        #     @return [String, nil]
-        #     Identifier of the network backing the virtual Ethernet adapter.
-        #     If  nil , the identifier of the network backing could not be determined.
-        # @!attribute [rw] network_name
-        #     @return [String]
-        #     Name of the standard portgroup backing the virtual Ethernet adapter.
-        #     This  field  is optional and it is only relevant when the value of  ``type``  is   :attr:`Com::Vmware::Vcenter::Vm::Hardware::Ethernet::BackingType.STANDARD_PORTGROUP`  .
-        # @!attribute [rw] host_device
-        #     @return [String]
-        #     Name of the device backing the virtual Ethernet adapter.
-        #     This  field  is optional and it is only relevant when the value of  ``type``  is   :attr:`Com::Vmware::Vcenter::Vm::Hardware::Ethernet::BackingType.HOST_DEVICE`  .
-        # @!attribute [rw] distributed_switch_uuid
-        #     @return [String]
-        #     UUID of the distributed virtual switch that backs the virtual Ethernet adapter.
-        #     This  field  is optional and it is only relevant when the value of  ``type``  is   :attr:`Com::Vmware::Vcenter::Vm::Hardware::Ethernet::BackingType.DISTRIBUTED_PORTGROUP`  .
-        # @!attribute [rw] distributed_port
-        #     @return [String, nil]
-        #     Key of the distributed virtual port that backs the virtual Ethernet adapter.
-        #     This  field  will be  nil  if the virtual Ethernet device is not bound to a distributed virtual port; this can happen if the virtual machine is powered off or the virtual Ethernet device is not connected.
-        # @!attribute [rw] connection_cookie
-        #     @return [Fixnum, nil]
-        #     Server-generated cookie that identifies the connection to the port. This ookie may be used to verify that the virtual machine is the rightful owner of the port.
-        #     This  field  will be  nil  if the virtual Ethernet device is not bound to a distributed virtual port; this can happen if the virtual machine is powered off or the virtual Ethernet device is not connected.
-        # @!attribute [rw] opaque_network_type
-        #     @return [String]
-        #     Type of the opaque network that backs the virtual Ethernet adapter.
-        #     This  field  is optional and it is only relevant when the value of  ``type``  is   :attr:`Com::Vmware::Vcenter::Vm::Hardware::Ethernet::BackingType.OPAQUE_NETWORK`  .
-        # @!attribute [rw] opaque_network_id
-        #     @return [String]
-        #     Identifier of the opaque network that backs the virtual Ethernet adapter.
-        #     This  field  is optional and it is only relevant when the value of  ``type``  is   :attr:`Com::Vmware::Vcenter::Vm::Hardware::Ethernet::BackingType.OPAQUE_NETWORK`  .
-        class BackingInfo < VAPI::Bindings::VapiStruct
-
-            class << self
-                # Holds (gets or creates) the binding type metadata for this structure type.
-                # @scope class
-                # @return [VAPI::Bindings::StructType] the binding type
-                def binding_type
-                    @binding_type ||= VAPI::Bindings::StructType.new(
-                        'com.vmware.vcenter.vm.hardware.ethernet.backing_info',
-                        {
-                            'type' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::Vm::Hardware::Ethernet::BackingType'),
-                            'network' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::IdType.new),
-                            'network_name' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::StringType.instance),
-                            'host_device' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::StringType.instance),
-                            'distributed_switch_uuid' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::StringType.instance),
-                            'distributed_port' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::StringType.instance),
-                            'connection_cookie' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::IntegerType.instance),
-                            'opaque_network_type' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::StringType.instance),
-                            'opaque_network_id' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::StringType.instance),
-                        },
-                        BackingInfo,
-                        false,
-                        nil)
-                end
-            end
-
-            attr_accessor :type,
-                          :network,
-                          :network_name,
-                          :host_device,
-                          :distributed_switch_uuid,
-                          :distributed_port,
-                          :connection_cookie,
-                          :opaque_network_type,
-                          :opaque_network_id
-
-            # Constructs a new instance.
-            # @param ruby_values [Hash] a map of initial property values (optional)
-            # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
-            def initialize(ruby_values=nil, struct_value=nil)
-                super(self.class.binding_type, ruby_values, struct_value)
-            end
-        end
-
-
-        # The  ``Com::Vmware::Vcenter::Vm::Hardware::Ethernet::BackingSpec``   class  provides a specification of the physical resource that backs a virtual Ethernet adapter.
-        # @!attribute [rw] type
-        #     @return [Com::Vmware::Vcenter::Vm::Hardware::Ethernet::BackingType]
-        #     Backing type for the virtual Ethernet adapter.
-        # @!attribute [rw] network
-        #     @return [String]
-        #     Identifier of the network that backs the virtual Ethernet adapter.
-        #     This  field  is optional and it is only relevant when the value of  ``type``  is one of   :attr:`Com::Vmware::Vcenter::Vm::Hardware::Ethernet::BackingType.STANDARD_PORTGROUP`  ,   :attr:`Com::Vmware::Vcenter::Vm::Hardware::Ethernet::BackingType.DISTRIBUTED_PORTGROUP`  , or   :attr:`Com::Vmware::Vcenter::Vm::Hardware::Ethernet::BackingType.OPAQUE_NETWORK`  .
-        # @!attribute [rw] distributed_port
-        #     @return [String, nil]
-        #     Key of the distributed virtual port that backs the virtual Ethernet adapter. Depending on the type of the Portgroup, the port may be specified using this field. If the portgroup type is early-binding (also known as static), a port is assigned when the Ethernet adapter is configured to use the port. The port may be either automatically or specifically assigned based on the value of this  field . If the portgroup type is ephemeral, the port is created and assigned to a virtual machine when it is powered on and the Ethernet adapter is connected. This  field  cannot be specified as no free ports exist before use.
-        #     May be used to specify a port when the network specified on the  ``network``   field  is a static or early binding distributed portgroup. If  nil , the port will be automatically assigned to the Ethernet adapter based on the policy embodied by the portgroup type.
-        class BackingSpec < VAPI::Bindings::VapiStruct
-
-            class << self
-                # Holds (gets or creates) the binding type metadata for this structure type.
-                # @scope class
-                # @return [VAPI::Bindings::StructType] the binding type
-                def binding_type
-                    @binding_type ||= VAPI::Bindings::StructType.new(
-                        'com.vmware.vcenter.vm.hardware.ethernet.backing_spec',
-                        {
-                            'type' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::Vm::Hardware::Ethernet::BackingType'),
-                            'network' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::IdType.new),
-                            'distributed_port' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::StringType.instance),
-                        },
-                        BackingSpec,
-                        false,
-                        nil)
-                end
-            end
-
-            attr_accessor :type,
-                          :network,
-                          :distributed_port
-
-            # Constructs a new instance.
-            # @param ruby_values [Hash] a map of initial property values (optional)
-            # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
-            def initialize(ruby_values=nil, struct_value=nil)
-                super(self.class.binding_type, ruby_values, struct_value)
-            end
-        end
-
-
-        # The  ``Com::Vmware::Vcenter::Vm::Hardware::Ethernet::Info``   class  contains information about a virtual Ethernet adapter.
-        # @!attribute [rw] label
-        #     @return [String]
-        #     Device label.
-        # @!attribute [rw] type
-        #     @return [Com::Vmware::Vcenter::Vm::Hardware::Ethernet::EmulationType]
-        #     Ethernet adapter emulation type.
-        # @!attribute [rw] upt_compatibility_enabled
-        #     @return [Boolean]
-        #     Flag indicating whether Universal Pass-Through (UPT) compatibility is enabled on this virtual Ethernet adapter.
-        #     This  field  is optional and it is only relevant when the value of  ``type``  is   :attr:`Com::Vmware::Vcenter::Vm::Hardware::Ethernet::EmulationType.VMXNET3`  .
-        # @!attribute [rw] mac_type
-        #     @return [Com::Vmware::Vcenter::Vm::Hardware::Ethernet::MacAddressType]
-        #     MAC address type.
-        # @!attribute [rw] mac_address
-        #     @return [String, nil]
-        #     MAC address.
-        #     May be  nil  if   :attr:`Com::Vmware::Vcenter::Vm::Hardware::Ethernet::Info.mac_type`   is   :attr:`Com::Vmware::Vcenter::Vm::Hardware::Ethernet::MacAddressType.MANUAL`   and has not been specified, or if   :attr:`Com::Vmware::Vcenter::Vm::Hardware::Ethernet::Info.mac_type`   is   :attr:`Com::Vmware::Vcenter::Vm::Hardware::Ethernet::MacAddressType.GENERATED`   and the virtual machine has never been powered on since the Ethernet adapter was created.
-        # @!attribute [rw] pci_slot_number
-        #     @return [Fixnum, nil]
-        #     Address of the virtual Ethernet adapter on the PCI bus. If the PCI address is invalid, the server will change it when the VM is started or as the device is hot added.
-        #     May be  nil  if the virtual machine has never been powered on since the adapter was created.
-        # @!attribute [rw] wake_on_lan_enabled
-        #     @return [Boolean]
-        #     Flag indicating whether wake-on-LAN is enabled on this virtual Ethernet adapter.
-        # @!attribute [rw] backing
-        #     @return [Com::Vmware::Vcenter::Vm::Hardware::Ethernet::BackingInfo]
-        #     Physical resource backing for the virtual Ethernet adapter.
-        class Info < VAPI::Bindings::VapiStruct
-
-            class << self
-                # Holds (gets or creates) the binding type metadata for this structure type.
-                # @scope class
-                # @return [VAPI::Bindings::StructType] the binding type
-                def binding_type
-                    @binding_type ||= VAPI::Bindings::StructType.new(
-                        'com.vmware.vcenter.vm.hardware.ethernet.info',
-                        {
-                            'label' => VAPI::Bindings::StringType.instance,
-                            'type' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::Vm::Hardware::Ethernet::EmulationType'),
-                            'upt_compatibility_enabled' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::BooleanType.instance),
-                            'mac_type' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::Vm::Hardware::Ethernet::MacAddressType'),
-                            'mac_address' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::StringType.instance),
-                            'pci_slot_number' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::IntegerType.instance),
-                            'wake_on_lan_enabled' => VAPI::Bindings::BooleanType.instance,
-                            'backing' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::Vm::Hardware::Ethernet::BackingInfo'),
-                            'state' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::Vm::Hardware::ConnectionState'),
-                            'start_connected' => VAPI::Bindings::BooleanType.instance,
-                            'allow_guest_control' => VAPI::Bindings::BooleanType.instance,
-                        },
-                        Info,
-                        false,
-                        nil)
-                end
-            end
-
-            attr_accessor :label,
-                          :type,
-                          :upt_compatibility_enabled,
-                          :mac_type,
-                          :mac_address,
-                          :pci_slot_number,
-                          :wake_on_lan_enabled,
-                          :backing,
-                          :state,
-                          :start_connected,
-                          :allow_guest_control
-
-            # Constructs a new instance.
-            # @param ruby_values [Hash] a map of initial property values (optional)
-            # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
-            def initialize(ruby_values=nil, struct_value=nil)
-                super(self.class.binding_type, ruby_values, struct_value)
-            end
-        end
-
-
-        # The  ``Com::Vmware::Vcenter::Vm::Hardware::Ethernet::CreateSpec``   class  provides a specification for the configuration of a newly-created virtual Ethernet adapter.
-        # @!attribute [rw] type
-        #     @return [Com::Vmware::Vcenter::Vm::Hardware::Ethernet::EmulationType, nil]
-        #     Ethernet adapter emulation type.
-        #     If  nil , defaults to a guest-specific type.
-        # @!attribute [rw] upt_compatibility_enabled
-        #     @return [Boolean, nil]
-        #     Flag indicating whether Universal Pass-Through (UPT) compatibility is enabled on this virtual Ethernet adapter.
-        #     If  nil , defaults to false.
-        # @!attribute [rw] mac_type
-        #     @return [Com::Vmware::Vcenter::Vm::Hardware::Ethernet::MacAddressType, nil]
-        #     MAC address type.
-        #     If  nil , defaults to   :attr:`Com::Vmware::Vcenter::Vm::Hardware::Ethernet::MacAddressType.GENERATED`  .
-        # @!attribute [rw] mac_address
-        #     @return [String]
-        #     MAC address.
-        #     Workaround for PR1459647
-        # @!attribute [rw] pci_slot_number
-        #     @return [Fixnum, nil]
-        #     Address of the virtual Ethernet adapter on the PCI bus. If the PCI address is invalid, the server will change when it the VM is started or as the device is hot added.
-        #     If  nil , the server will choose an available address when the virtual machine is powered on.
-        # @!attribute [rw] wake_on_lan_enabled
-        #     @return [Boolean, nil]
-        #     Flag indicating whether wake-on-LAN is enabled on this virtual Ethernet adapter.
-        #     Defaults to false if  nil .
-        # @!attribute [rw] backing
-        #     @return [Com::Vmware::Vcenter::Vm::Hardware::Ethernet::BackingSpec, nil]
-        #     Physical resource backing for the virtual Ethernet adapter.
-        #     If  nil , the system may try to find an appropriate backing. If one is not found, the request will fail.
-        class CreateSpec < VAPI::Bindings::VapiStruct
-
-            class << self
-                # Holds (gets or creates) the binding type metadata for this structure type.
-                # @scope class
-                # @return [VAPI::Bindings::StructType] the binding type
-                def binding_type
-                    @binding_type ||= VAPI::Bindings::StructType.new(
-                        'com.vmware.vcenter.vm.hardware.ethernet.create_spec',
-                        {
-                            'type' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::Vm::Hardware::Ethernet::EmulationType')),
-                            'upt_compatibility_enabled' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::BooleanType.instance),
-                            'mac_type' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::Vm::Hardware::Ethernet::MacAddressType')),
-                            'mac_address' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::StringType.instance),
-                            'pci_slot_number' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::IntegerType.instance),
-                            'wake_on_lan_enabled' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::BooleanType.instance),
-                            'backing' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::Vm::Hardware::Ethernet::BackingSpec')),
-                            'start_connected' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::BooleanType.instance),
-                            'allow_guest_control' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::BooleanType.instance),
-                        },
-                        CreateSpec,
-                        false,
-                        nil)
-                end
-            end
-
-            attr_accessor :type,
-                          :upt_compatibility_enabled,
-                          :mac_type,
-                          :mac_address,
-                          :pci_slot_number,
-                          :wake_on_lan_enabled,
-                          :backing,
-                          :start_connected,
-                          :allow_guest_control
-
-            # Constructs a new instance.
-            # @param ruby_values [Hash] a map of initial property values (optional)
-            # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
-            def initialize(ruby_values=nil, struct_value=nil)
-                super(self.class.binding_type, ruby_values, struct_value)
-            end
-        end
-
-
-        # The  ``Com::Vmware::Vcenter::Vm::Hardware::Ethernet::UpdateSpec``   class  describes the updates to be made to the configuration of a virtual Ethernet adapter.
-        # @!attribute [rw] upt_compatibility_enabled
-        #     @return [Boolean, nil]
-        #     Flag indicating whether Universal Pass-Through (UPT) compatibility should be enabled on this virtual Ethernet adapter.  
-        #     
-        #      This  field  may be modified at any time, and changes will be applied the next time the virtual machine is powered on.
-        #     If  nil , the value is unchanged. Must be  nil  if the emulation type of the virtual Ethernet adapter is not   :attr:`Com::Vmware::Vcenter::Vm::Hardware::Ethernet::EmulationType.VMXNET3`  .
-        # @!attribute [rw] mac_type
-        #     @return [Com::Vmware::Vcenter::Vm::Hardware::Ethernet::MacAddressType, nil]
-        #     MAC address type.  
-        #     
-        #      This  field  may be modified at any time, and changes will be applied the next time the virtual machine is powered on.
-        #     If  nil , the value is unchanged.
-        # @!attribute [rw] mac_address
-        #     @return [String, nil]
-        #     MAC address.  
-        #     
-        #      This  field  may be modified at any time, and changes will be applied the next time the virtual machine is powered on.
-        #     If  nil , the value is unchanged. Must be specified if   :attr:`Com::Vmware::Vcenter::Vm::Hardware::Ethernet::UpdateSpec.mac_type`   is   :attr:`Com::Vmware::Vcenter::Vm::Hardware::Ethernet::MacAddressType.MANUAL`  . Must be  nil  if the MAC address type is not   :attr:`Com::Vmware::Vcenter::Vm::Hardware::Ethernet::MacAddressType.MANUAL`  .
-        # @!attribute [rw] wake_on_lan_enabled
-        #     @return [Boolean, nil]
-        #     Flag indicating whether wake-on-LAN shoud be enabled on this virtual Ethernet adapter.  
-        #     
-        #      This  field  may be modified at any time, and changes will be applied the next time the virtual machine is powered on.
-        #     If  nil , the value is unchanged.
-        # @!attribute [rw] backing
-        #     @return [Com::Vmware::Vcenter::Vm::Hardware::Ethernet::BackingSpec, nil]
-        #     Physical resource backing for the virtual Ethernet adapter.  
-        #     
-        #      This  field  may be modified at any time, and changes will be applied the next time the virtual machine is powered on.
-        #     If  nil , the value is unchanged.
-        class UpdateSpec < VAPI::Bindings::VapiStruct
-
-            class << self
-                # Holds (gets or creates) the binding type metadata for this structure type.
-                # @scope class
-                # @return [VAPI::Bindings::StructType] the binding type
-                def binding_type
-                    @binding_type ||= VAPI::Bindings::StructType.new(
-                        'com.vmware.vcenter.vm.hardware.ethernet.update_spec',
-                        {
-                            'upt_compatibility_enabled' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::BooleanType.instance),
-                            'mac_type' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::Vm::Hardware::Ethernet::MacAddressType')),
-                            'mac_address' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::StringType.instance),
-                            'wake_on_lan_enabled' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::BooleanType.instance),
-                            'backing' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::Vm::Hardware::Ethernet::BackingSpec')),
-                            'start_connected' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::BooleanType.instance),
-                            'allow_guest_control' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::BooleanType.instance),
-                        },
-                        UpdateSpec,
-                        false,
-                        nil)
-                end
-            end
-
-            attr_accessor :upt_compatibility_enabled,
-                          :mac_type,
-                          :mac_address,
-                          :wake_on_lan_enabled,
-                          :backing,
-                          :start_connected,
-                          :allow_guest_control
-
-            # Constructs a new instance.
-            # @param ruby_values [Hash] a map of initial property values (optional)
-            # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
-            def initialize(ruby_values=nil, struct_value=nil)
-                super(self.class.binding_type, ruby_values, struct_value)
-            end
-        end
-
-
-        # The  ``Com::Vmware::Vcenter::Vm::Hardware::Ethernet::Summary``   class  contains commonly used information about a virtual Ethernet adapter.
-        # @!attribute [rw] nic
-        #     @return [String]
-        #     Identifier of the virtual Ethernet adapter.
-        class Summary < VAPI::Bindings::VapiStruct
-
-            class << self
-                # Holds (gets or creates) the binding type metadata for this structure type.
-                # @scope class
-                # @return [VAPI::Bindings::StructType] the binding type
-                def binding_type
-                    @binding_type ||= VAPI::Bindings::StructType.new(
-                        'com.vmware.vcenter.vm.hardware.ethernet.summary',
-                        {
-                            'nic' => VAPI::Bindings::IdType.new(resource_types='com.vmware.vcenter.vm.hardware.Ethernet'),
-                        },
-                        Summary,
-                        false,
-                        nil)
-                end
-            end
-
-            attr_accessor :nic
-
-            # Constructs a new instance.
-            # @param ruby_values [Hash] a map of initial property values (optional)
-            # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
-            def initialize(ruby_values=nil, struct_value=nil)
-                super(self.class.binding_type, ruby_values, struct_value)
-            end
-        end
-
-
-
-        # The  ``Com::Vmware::Vcenter::Vm::Hardware::Ethernet::EmulationType``   enumerated type  defines the valid emulation types for a virtual Ethernet adapter.
-        # @!attribute [rw] e1000
-        #     @return [Com::Vmware::Vcenter::Vm::Hardware::Ethernet::EmulationType]
-        #     E1000 ethernet adapter.
-        # @!attribute [rw] e1000e
-        #     @return [Com::Vmware::Vcenter::Vm::Hardware::Ethernet::EmulationType]
-        #     E1000e ethernet adapter.
-        # @!attribute [rw] pcne_t32
-        #     @return [Com::Vmware::Vcenter::Vm::Hardware::Ethernet::EmulationType]
-        #     AMD Lance PCNet32 Ethernet adapter.
-        # @!attribute [rw] vmxnet
-        #     @return [Com::Vmware::Vcenter::Vm::Hardware::Ethernet::EmulationType]
-        #     VMware Vmxnet virtual Ethernet adapter.
-        # @!attribute [rw] vmxne_t2
-        #     @return [Com::Vmware::Vcenter::Vm::Hardware::Ethernet::EmulationType]
-        #     VMware Vmxnet2 virtual Ethernet adapter.
-        # @!attribute [rw] vmxne_t3
-        #     @return [Com::Vmware::Vcenter::Vm::Hardware::Ethernet::EmulationType]
-        #     VMware Vmxnet3 virtual Ethernet adapter.
-        class EmulationType < VAPI::Bindings::VapiEnum
-
-            class << self
-                # Holds (gets or creates) the binding type metadata for this enumeration type.
-                # @scope class
-                # @return [VAPI::Bindings::EnumType] the binding type
-                def binding_type
-                    @binding_type ||= VAPI::Bindings::EnumType.new(
-                        'com.vmware.vcenter.vm.hardware.ethernet.emulation_type',
-                        EmulationType)
-                end
-
-                # Converts from a string value (perhaps off the wire) to an instance
-                # of this enum type.
-                # @param value [String] the actual value of the enum instance
-                # @return [EmulationType] the instance found for the value, otherwise
-                #         an unknown instance will be built for the value
-                def from_string(value)
-                    begin
-                        const_get(value)
-                    rescue NameError
-                        EmulationType.new('UNKNOWN', value)
-                    end
-                end
-            end
-
-            private
-
-            # Constructs a new instance.
-            # @param value [String] the actual value of the enum instance
-            # @param unknown [String] the unknown value when value is 'UKNOWN'
-            def initialize(value, unknown=nil)
-                super(self.class.binding_type, value, unknown)
-            end
-
-            public
-
-            # @!attribute [rw] e1000
-            #     @return [Com::Vmware::Vcenter::Vm::Hardware::Ethernet::EmulationType]
-            #     E1000 ethernet adapter.
-            E1000 = EmulationType.new('E1000')
-
-            # @!attribute [rw] e1000e
-            #     @return [Com::Vmware::Vcenter::Vm::Hardware::Ethernet::EmulationType]
-            #     E1000e ethernet adapter.
-            E1000E = EmulationType.new('E1000E')
-
-            # @!attribute [rw] pcne_t32
-            #     @return [Com::Vmware::Vcenter::Vm::Hardware::Ethernet::EmulationType]
-            #     AMD Lance PCNet32 Ethernet adapter.
-            PCNE_T32 = EmulationType.new('PCNE_T32')
-
-            # @!attribute [rw] vmxnet
-            #     @return [Com::Vmware::Vcenter::Vm::Hardware::Ethernet::EmulationType]
-            #     VMware Vmxnet virtual Ethernet adapter.
-            VMXNET = EmulationType.new('VMXNET')
-
-            # @!attribute [rw] vmxne_t2
-            #     @return [Com::Vmware::Vcenter::Vm::Hardware::Ethernet::EmulationType]
-            #     VMware Vmxnet2 virtual Ethernet adapter.
-            VMXNE_T2 = EmulationType.new('VMXNE_T2')
-
-            # @!attribute [rw] vmxne_t3
-            #     @return [Com::Vmware::Vcenter::Vm::Hardware::Ethernet::EmulationType]
-            #     VMware Vmxnet3 virtual Ethernet adapter.
-            VMXNE_T3 = EmulationType.new('VMXNE_T3')
-
-        end
-
-
-        # The  ``Com::Vmware::Vcenter::Vm::Hardware::Ethernet::MacAddressType``   enumerated type  defines the valid MAC address origins for a virtual Ethernet adapter.
-        # @!attribute [rw] manual
-        #     @return [Com::Vmware::Vcenter::Vm::Hardware::Ethernet::MacAddressType]
-        #     MAC address is assigned statically.
-        # @!attribute [rw] generated
-        #     @return [Com::Vmware::Vcenter::Vm::Hardware::Ethernet::MacAddressType]
-        #     MAC address is generated automatically.
-        # @!attribute [rw] assigned
-        #     @return [Com::Vmware::Vcenter::Vm::Hardware::Ethernet::MacAddressType]
-        #     MAC address is assigned by vCenter Server.
-        class MacAddressType < VAPI::Bindings::VapiEnum
-
-            class << self
-                # Holds (gets or creates) the binding type metadata for this enumeration type.
-                # @scope class
-                # @return [VAPI::Bindings::EnumType] the binding type
-                def binding_type
-                    @binding_type ||= VAPI::Bindings::EnumType.new(
-                        'com.vmware.vcenter.vm.hardware.ethernet.mac_address_type',
-                        MacAddressType)
-                end
-
-                # Converts from a string value (perhaps off the wire) to an instance
-                # of this enum type.
-                # @param value [String] the actual value of the enum instance
-                # @return [MacAddressType] the instance found for the value, otherwise
-                #         an unknown instance will be built for the value
-                def from_string(value)
-                    begin
-                        const_get(value)
-                    rescue NameError
-                        MacAddressType.new('UNKNOWN', value)
-                    end
-                end
-            end
-
-            private
-
-            # Constructs a new instance.
-            # @param value [String] the actual value of the enum instance
-            # @param unknown [String] the unknown value when value is 'UKNOWN'
-            def initialize(value, unknown=nil)
-                super(self.class.binding_type, value, unknown)
-            end
-
-            public
-
-            # @!attribute [rw] manual
-            #     @return [Com::Vmware::Vcenter::Vm::Hardware::Ethernet::MacAddressType]
-            #     MAC address is assigned statically.
-            MANUAL = MacAddressType.new('MANUAL')
-
-            # @!attribute [rw] generated
-            #     @return [Com::Vmware::Vcenter::Vm::Hardware::Ethernet::MacAddressType]
-            #     MAC address is generated automatically.
-            GENERATED = MacAddressType.new('GENERATED')
-
-            # @!attribute [rw] assigned
-            #     @return [Com::Vmware::Vcenter::Vm::Hardware::Ethernet::MacAddressType]
-            #     MAC address is assigned by vCenter Server.
-            ASSIGNED = MacAddressType.new('ASSIGNED')
-
-        end
-
-
-        # The  ``Com::Vmware::Vcenter::Vm::Hardware::Ethernet::BackingType``   enumerated type  defines the valid backing types for a virtual Ethernet adapter.
-        # @!attribute [rw] standard_portgroup
-        #     @return [Com::Vmware::Vcenter::Vm::Hardware::Ethernet::BackingType]
-        #     vSphere standard portgroup network backing.
-        # @!attribute [rw] host_device
-        #     @return [Com::Vmware::Vcenter::Vm::Hardware::Ethernet::BackingType]
-        #     Legacy host device network backing. Imported VMs may have virtual Ethernet adapters with this type of backing, but this type of backing cannot be used to create or to update a virtual Ethernet adapter.
-        # @!attribute [rw] distributed_portgroup
-        #     @return [Com::Vmware::Vcenter::Vm::Hardware::Ethernet::BackingType]
-        #     Distributed virtual switch backing.
-        # @!attribute [rw] opaque_network
-        #     @return [Com::Vmware::Vcenter::Vm::Hardware::Ethernet::BackingType]
-        #     Opaque network backing.
-        class BackingType < VAPI::Bindings::VapiEnum
-
-            class << self
-                # Holds (gets or creates) the binding type metadata for this enumeration type.
-                # @scope class
-                # @return [VAPI::Bindings::EnumType] the binding type
-                def binding_type
-                    @binding_type ||= VAPI::Bindings::EnumType.new(
-                        'com.vmware.vcenter.vm.hardware.ethernet.backing_type',
-                        BackingType)
-                end
-
-                # Converts from a string value (perhaps off the wire) to an instance
-                # of this enum type.
-                # @param value [String] the actual value of the enum instance
-                # @return [BackingType] the instance found for the value, otherwise
-                #         an unknown instance will be built for the value
-                def from_string(value)
-                    begin
-                        const_get(value)
-                    rescue NameError
-                        BackingType.new('UNKNOWN', value)
-                    end
-                end
-            end
-
-            private
-
-            # Constructs a new instance.
-            # @param value [String] the actual value of the enum instance
-            # @param unknown [String] the unknown value when value is 'UKNOWN'
-            def initialize(value, unknown=nil)
-                super(self.class.binding_type, value, unknown)
-            end
-
-            public
-
-            # @!attribute [rw] standard_portgroup
-            #     @return [Com::Vmware::Vcenter::Vm::Hardware::Ethernet::BackingType]
-            #     vSphere standard portgroup network backing.
-            STANDARD_PORTGROUP = BackingType.new('STANDARD_PORTGROUP')
-
-            # @!attribute [rw] host_device
-            #     @return [Com::Vmware::Vcenter::Vm::Hardware::Ethernet::BackingType]
-            #     Legacy host device network backing. Imported VMs may have virtual Ethernet adapters with this type of backing, but this type of backing cannot be used to create or to update a virtual Ethernet adapter.
-            HOST_DEVICE = BackingType.new('HOST_DEVICE')
-
-            # @!attribute [rw] distributed_portgroup
-            #     @return [Com::Vmware::Vcenter::Vm::Hardware::Ethernet::BackingType]
-            #     Distributed virtual switch backing.
-            DISTRIBUTED_PORTGROUP = BackingType.new('DISTRIBUTED_PORTGROUP')
-
-            # @!attribute [rw] opaque_network
-            #     @return [Com::Vmware::Vcenter::Vm::Hardware::Ethernet::BackingType]
-            #     Opaque network backing.
-            OPAQUE_NETWORK = BackingType.new('OPAQUE_NETWORK')
-
-        end
-
-
-    end
-
-
-    # The  ``Com::Vmware::Vcenter::Vm::Hardware::Floppy``   class  provides  methods  for configuring the virtual floppy drives of a virtual machine.
-    class Floppy < VAPI::Bindings::VapiService
-
-        protected
-
-        # static metamodel definitions
-        @@service_id = VAPI::Core::ServiceIdentifier.new('com.vmware.vcenter.vm.hardware.floppy')
-
-        @@list_info = VAPI::Bindings::OperationInfo.new(
-            VAPI::Core::OperationIdentifier.new('list', @@service_id),
-            VAPI::Bindings::OperationInputType.new({
-                'vm' => VAPI::Bindings::IdType.new(resource_types='VirtualMachine'),
-            }),
-            VAPI::Bindings::ListType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::Vm::Hardware::Floppy::Summary')),
-            {
-                'com.vmware.vapi.std.errors.error' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Error'),
-                'com.vmware.vapi.std.errors.not_found' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::NotFound'),
-                'com.vmware.vapi.std.errors.resource_inaccessible' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::ResourceInaccessible'),
-                'com.vmware.vapi.std.errors.service_unavailable' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::ServiceUnavailable'),
-                'com.vmware.vapi.std.errors.unauthenticated' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Unauthenticated'),
-                'com.vmware.vapi.std.errors.unauthorized' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Unauthorized'),
-
-            },
-            [],
-            [])
-        @@get_info = VAPI::Bindings::OperationInfo.new(
-            VAPI::Core::OperationIdentifier.new('get', @@service_id),
-            VAPI::Bindings::OperationInputType.new({
-                'vm' => VAPI::Bindings::IdType.new(resource_types='VirtualMachine'),
-                'floppy' => VAPI::Bindings::IdType.new(resource_types='com.vmware.vcenter.vm.hardware.Floppy'),
-            }),
-            VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::Vm::Hardware::Floppy::Info'),
-            {
-                'com.vmware.vapi.std.errors.error' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Error'),
-                'com.vmware.vapi.std.errors.not_found' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::NotFound'),
-                'com.vmware.vapi.std.errors.resource_inaccessible' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::ResourceInaccessible'),
-                'com.vmware.vapi.std.errors.service_unavailable' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::ServiceUnavailable'),
-                'com.vmware.vapi.std.errors.unauthenticated' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Unauthenticated'),
-                'com.vmware.vapi.std.errors.unauthorized' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Unauthorized'),
-
-            },
-            [],
-            [])
-        @@create_info = VAPI::Bindings::OperationInfo.new(
-            VAPI::Core::OperationIdentifier.new('create', @@service_id),
-            VAPI::Bindings::OperationInputType.new({
-                'vm' => VAPI::Bindings::IdType.new(resource_types='VirtualMachine'),
-                'spec' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::Vm::Hardware::Floppy::CreateSpec'),
-            }),
-            VAPI::Bindings::IdType.new(resource_types='com.vmware.vcenter.vm.hardware.Floppy'),
-            {
-                'com.vmware.vapi.std.errors.error' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Error'),
-                'com.vmware.vapi.std.errors.not_found' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::NotFound'),
-                'com.vmware.vapi.std.errors.not_allowed_in_current_state' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::NotAllowedInCurrentState'),
-                'com.vmware.vapi.std.errors.unable_to_allocate_resource' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::UnableToAllocateResource'),
-                'com.vmware.vapi.std.errors.resource_busy' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::ResourceBusy'),
-                'com.vmware.vapi.std.errors.resource_inaccessible' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::ResourceInaccessible'),
-                'com.vmware.vapi.std.errors.service_unavailable' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::ServiceUnavailable'),
-                'com.vmware.vapi.std.errors.unauthenticated' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Unauthenticated'),
-                'com.vmware.vapi.std.errors.unauthorized' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Unauthorized'),
-
-            },
-            [],
-            [])
-        @@update_info = VAPI::Bindings::OperationInfo.new(
-            VAPI::Core::OperationIdentifier.new('update', @@service_id),
-            VAPI::Bindings::OperationInputType.new({
-                'vm' => VAPI::Bindings::IdType.new(resource_types='VirtualMachine'),
-                'floppy' => VAPI::Bindings::IdType.new(resource_types='com.vmware.vcenter.vm.hardware.Floppy'),
-                'spec' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::Vm::Hardware::Floppy::UpdateSpec'),
-            }),
-            VAPI::Bindings::VoidType.instance,
-            {
-                'com.vmware.vapi.std.errors.error' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Error'),
-                'com.vmware.vapi.std.errors.not_found' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::NotFound'),
-                'com.vmware.vapi.std.errors.not_allowed_in_current_state' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::NotAllowedInCurrentState'),
-                'com.vmware.vapi.std.errors.resource_busy' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::ResourceBusy'),
-                'com.vmware.vapi.std.errors.resource_inaccessible' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::ResourceInaccessible'),
-                'com.vmware.vapi.std.errors.service_unavailable' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::ServiceUnavailable'),
-                'com.vmware.vapi.std.errors.unauthenticated' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Unauthenticated'),
-                'com.vmware.vapi.std.errors.unauthorized' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Unauthorized'),
-
-            },
-            [],
-            [])
-        @@delete_info = VAPI::Bindings::OperationInfo.new(
-            VAPI::Core::OperationIdentifier.new('delete', @@service_id),
-            VAPI::Bindings::OperationInputType.new({
-                'vm' => VAPI::Bindings::IdType.new(resource_types='VirtualMachine'),
-                'floppy' => VAPI::Bindings::IdType.new(resource_types='com.vmware.vcenter.vm.hardware.Floppy'),
-            }),
-            VAPI::Bindings::VoidType.instance,
-            {
-                'com.vmware.vapi.std.errors.error' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Error'),
-                'com.vmware.vapi.std.errors.not_found' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::NotFound'),
-                'com.vmware.vapi.std.errors.not_allowed_in_current_state' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::NotAllowedInCurrentState'),
-                'com.vmware.vapi.std.errors.resource_busy' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::ResourceBusy'),
-                'com.vmware.vapi.std.errors.resource_inaccessible' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::ResourceInaccessible'),
-                'com.vmware.vapi.std.errors.service_unavailable' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::ServiceUnavailable'),
-                'com.vmware.vapi.std.errors.unauthenticated' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Unauthenticated'),
-                'com.vmware.vapi.std.errors.unauthorized' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Unauthorized'),
-
-            },
-            [],
-            [])
-        @@connect_info = VAPI::Bindings::OperationInfo.new(
-            VAPI::Core::OperationIdentifier.new('connect', @@service_id),
-            VAPI::Bindings::OperationInputType.new({
-                'vm' => VAPI::Bindings::IdType.new(resource_types='VirtualMachine'),
-                'floppy' => VAPI::Bindings::IdType.new(resource_types='com.vmware.vcenter.vm.hardware.Floppy'),
-            }),
-            VAPI::Bindings::VoidType.instance,
-            {
-                'com.vmware.vapi.std.errors.error' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Error'),
-                'com.vmware.vapi.std.errors.not_found' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::NotFound'),
-                'com.vmware.vapi.std.errors.already_in_desired_state' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::AlreadyInDesiredState'),
-                'com.vmware.vapi.std.errors.not_allowed_in_current_state' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::NotAllowedInCurrentState'),
-                'com.vmware.vapi.std.errors.resource_busy' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::ResourceBusy'),
-                'com.vmware.vapi.std.errors.resource_inaccessible' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::ResourceInaccessible'),
-                'com.vmware.vapi.std.errors.service_unavailable' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::ServiceUnavailable'),
-                'com.vmware.vapi.std.errors.unauthenticated' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Unauthenticated'),
-                'com.vmware.vapi.std.errors.unauthorized' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Unauthorized'),
-
-            },
-            [],
-            [])
-        @@disconnect_info = VAPI::Bindings::OperationInfo.new(
-            VAPI::Core::OperationIdentifier.new('disconnect', @@service_id),
-            VAPI::Bindings::OperationInputType.new({
-                'vm' => VAPI::Bindings::IdType.new(resource_types='VirtualMachine'),
-                'floppy' => VAPI::Bindings::IdType.new(resource_types='com.vmware.vcenter.vm.hardware.Floppy'),
-            }),
-            VAPI::Bindings::VoidType.instance,
-            {
-                'com.vmware.vapi.std.errors.error' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Error'),
-                'com.vmware.vapi.std.errors.not_found' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::NotFound'),
-                'com.vmware.vapi.std.errors.already_in_desired_state' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::AlreadyInDesiredState'),
-                'com.vmware.vapi.std.errors.not_allowed_in_current_state' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::NotAllowedInCurrentState'),
-                'com.vmware.vapi.std.errors.resource_busy' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::ResourceBusy'),
-                'com.vmware.vapi.std.errors.resource_inaccessible' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::ResourceInaccessible'),
-                'com.vmware.vapi.std.errors.service_unavailable' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::ServiceUnavailable'),
-                'com.vmware.vapi.std.errors.unauthenticated' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Unauthenticated'),
-                'com.vmware.vapi.std.errors.unauthorized' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Unauthorized'),
-
-            },
-            [],
-            [])
-
-        @@service_info = VAPI::Bindings::ServiceInfo.new(@@service_id, {
-            'list' => @@list_info,
-            'get' => @@get_info,
-            'create' => @@create_info,
-            'update' => @@update_info,
-            'delete' => @@delete_info,
-            'connect' => @@connect_info,
-            'disconnect' => @@disconnect_info,
-        })
-
-        public
-
-        # Constructs a new instance.
-        #
-        # @param config [VAPI::Bindings::StubConfig] A hash with the api provider details.
-        def initialize(config)
-            super(config, @@service_info)
-        end
-
-        RESOURCE_TYPE = 'com.vmware.vcenter.vm.hardware.Floppy'
-
-
-        # Returns commonly used information about the virtual floppy drives belonging to the virtual machine.
-        #
-        # @param vm [String]
-        #     Virtual machine identifier.
-        # @return [Array<Com::Vmware::Vcenter::Vm::Hardware::Floppy::Summary>]
-        #     List of commonly used information about virtual floppy drives.
-        # @raise [Com::Vmware::Vapi::Std::Errors::Error]
-        #     if the system reports an error while responding to the request.
-        # @raise [Com::Vmware::Vapi::Std::Errors::NotFound]
-        #     if the virtual machine is not found.
-        # @raise [Com::Vmware::Vapi::Std::Errors::ResourceInaccessible]
-        #     if the virtual machine's configuration state cannot be accessed.
-        # @raise [Com::Vmware::Vapi::Std::Errors::ServiceUnavailable]
-        #     if the system is unable to communicate with a service to complete the request.
-        # @raise [Com::Vmware::Vapi::Std::Errors::Unauthenticated]
-        #     if the user can not be authenticated.
-        # @raise [Com::Vmware::Vapi::Std::Errors::Unauthorized]
-        #     if the user doesn't have the required privileges.
-        def list(vm)
-            invoke_with_info(@@list_info, {
-                'vm' => vm,
-            })
-        end
-
-
-        # Returns information about a virtual floppy drive.
-        #
-        # @param vm [String]
-        #     Virtual machine identifier.
-        # @param floppy [String]
-        #     Virtual floppy drive identifier.
-        # @return [Com::Vmware::Vcenter::Vm::Hardware::Floppy::Info]
-        #     Information about the specified virtual floppy drive.
-        # @raise [Com::Vmware::Vapi::Std::Errors::Error]
-        #     if the system reports an error while responding to the request.
-        # @raise [Com::Vmware::Vapi::Std::Errors::NotFound]
-        #     if the virtual machine or virtual floppy drive is not found.
-        # @raise [Com::Vmware::Vapi::Std::Errors::ResourceInaccessible]
-        #     if the virtual machine's configuration state cannot be accessed.
-        # @raise [Com::Vmware::Vapi::Std::Errors::ServiceUnavailable]
-        #     if the system is unable to communicate with a service to complete the request.
-        # @raise [Com::Vmware::Vapi::Std::Errors::Unauthenticated]
-        #     if the user can not be authenticated.
-        # @raise [Com::Vmware::Vapi::Std::Errors::Unauthorized]
-        #     if the user doesn't have the required privileges.
-        def get(vm, floppy)
-            invoke_with_info(@@get_info, {
-                'vm' => vm,
-                'floppy' => floppy,
-            })
-        end
-
-
-        # Adds a virtual floppy drive to the virtual machine.
-        #
-        # @param vm [String]
-        #     Virtual machine identifier.
-        # @param spec [Com::Vmware::Vcenter::Vm::Hardware::Floppy::CreateSpec]
-        #     Specification for the new virtual floppy drive.
-        # @return [String]
-        #     Virtual floppy drive identifier.
-        # @raise [Com::Vmware::Vapi::Std::Errors::Error]
-        #     if the system reported that the floppy device was created but was unable to confirm the creation because the identifier of the new device could not be determined.
-        # @raise [Com::Vmware::Vapi::Std::Errors::Error]
-        #     if the system reports an error while responding to the request.
-        # @raise [Com::Vmware::Vapi::Std::Errors::NotFound]
-        #     if the virtual machine is not found.
-        # @raise [Com::Vmware::Vapi::Std::Errors::NotAllowedInCurrentState]
-        #     if the virtual machine is not powered off.
-        # @raise [Com::Vmware::Vapi::Std::Errors::UnableToAllocateResource]
-        #     if the virtual machine already has the maximum number of supported floppy drives.
-        # @raise [Com::Vmware::Vapi::Std::Errors::ResourceBusy]
-        #     if the virtual machine is busy performing another operation.
-        # @raise [Com::Vmware::Vapi::Std::Errors::ResourceInaccessible]
-        #     if the virtual machine's configuration state cannot be accessed.
-        # @raise [Com::Vmware::Vapi::Std::Errors::ServiceUnavailable]
-        #     if the system is unable to communicate with a service to complete the request.
-        # @raise [Com::Vmware::Vapi::Std::Errors::Unauthenticated]
-        #     if the user can not be authenticated.
-        # @raise [Com::Vmware::Vapi::Std::Errors::Unauthorized]
-        #     if the user doesn't have the required privileges.
-        def create(vm, spec)
-            invoke_with_info(@@create_info, {
-                'vm' => vm,
-                'spec' => spec,
-            })
-        end
-
-
-        # Updates the configuration of a virtual floppy drive.
-        #
-        # @param vm [String]
-        #     Virtual machine identifier.
-        # @param floppy [String]
-        #     Virtual floppy drive identifier.
-        # @param spec [Com::Vmware::Vcenter::Vm::Hardware::Floppy::UpdateSpec]
-        #     Specification for updating the virtual floppy drive.
-        # @return [Void]
-        # @raise [Com::Vmware::Vapi::Std::Errors::Error]
-        #     if the system reports an error while responding to the request.
-        # @raise [Com::Vmware::Vapi::Std::Errors::NotFound]
-        #     if the virtual machine or virtual floppy drive is not found.
-        # @raise [Com::Vmware::Vapi::Std::Errors::NotAllowedInCurrentState]
-        #     if one or more of the  fields  specified in the  ``spec``   parameter  cannot be modified due to the current power state of the virtual machine or the connection state of the virtual floppy drive.
-        # @raise [Com::Vmware::Vapi::Std::Errors::ResourceBusy]
-        #     if the virtual machine is busy performing another operation.
-        # @raise [Com::Vmware::Vapi::Std::Errors::ResourceInaccessible]
-        #     if the virtual machine's configuration state cannot be accessed.
-        # @raise [Com::Vmware::Vapi::Std::Errors::ServiceUnavailable]
-        #     if the system is unable to communicate with a service to complete the request.
-        # @raise [Com::Vmware::Vapi::Std::Errors::Unauthenticated]
-        #     if the user can not be authenticated.
-        # @raise [Com::Vmware::Vapi::Std::Errors::Unauthorized]
-        #     if the user doesn't have the required privileges.
-        def update(vm, floppy, spec)
-            invoke_with_info(@@update_info, {
-                'vm' => vm,
-                'floppy' => floppy,
-                'spec' => spec,
-            })
-        end
-
-
-        # Removes a virtual floppy drive from the virtual machine.
-        #
-        # @param vm [String]
-        #     Virtual machine identifier.
-        # @param floppy [String]
-        #     Virtual floppy drive identifier.
-        # @return [Void]
-        # @raise [Com::Vmware::Vapi::Std::Errors::Error]
-        #     if the system reports an error while responding to the request.
-        # @raise [Com::Vmware::Vapi::Std::Errors::NotFound]
-        #     if the virtual machine or virtual floppy drive is not found.
-        # @raise [Com::Vmware::Vapi::Std::Errors::NotAllowedInCurrentState]
-        #     if the virtual machine is not powered off.
-        # @raise [Com::Vmware::Vapi::Std::Errors::ResourceBusy]
-        #     if the virtual machine is busy performing another operation.
-        # @raise [Com::Vmware::Vapi::Std::Errors::ResourceInaccessible]
-        #     if the virtual machine's configuration state cannot be accessed.
-        # @raise [Com::Vmware::Vapi::Std::Errors::ServiceUnavailable]
-        #     if the system is unable to communicate with a service to complete the request.
-        # @raise [Com::Vmware::Vapi::Std::Errors::Unauthenticated]
-        #     if the user can not be authenticated.
-        # @raise [Com::Vmware::Vapi::Std::Errors::Unauthorized]
-        #     if the user doesn't have the required privileges.
-        def delete(vm, floppy)
-            invoke_with_info(@@delete_info, {
-                'vm' => vm,
-                'floppy' => floppy,
-            })
-        end
-
-
-        # Connects a virtual floppy drive of a powered-on virtual machine to its backing. Connecting the virtual device makes the backing accessible from the perspective of the guest operating system.  
-        # 
-        #  For a powered-off virtual machine, the   :func:`Com::Vmware::Vcenter::Vm::Hardware::Floppy.update`    method  may be used to configure the virtual floppy drive to start in the connected state when the virtual machine is powered on.
-        #
-        # @param vm [String]
-        #     Virtual machine identifier.
-        # @param floppy [String]
-        #     Virtual floppy drive identifier.
-        # @return [Void]
-        # @raise [Com::Vmware::Vapi::Std::Errors::Error]
-        #     if the system reports an error while responding to the request.
-        # @raise [Com::Vmware::Vapi::Std::Errors::NotFound]
-        #     if the virtual machine or virtual floppy drive is not found.
-        # @raise [Com::Vmware::Vapi::Std::Errors::AlreadyInDesiredState]
-        #     if the virtual floppy drive is already connected.
-        # @raise [Com::Vmware::Vapi::Std::Errors::NotAllowedInCurrentState]
-        #     if the virtual machine is not powered on.
-        # @raise [Com::Vmware::Vapi::Std::Errors::ResourceBusy]
-        #     if the virtual machine is busy performing another operation.
-        # @raise [Com::Vmware::Vapi::Std::Errors::ResourceInaccessible]
-        #     if the virtual machine's configuration state cannot be accessed.
-        # @raise [Com::Vmware::Vapi::Std::Errors::ServiceUnavailable]
-        #     if the system is unable to communicate with a service to complete the request.
-        # @raise [Com::Vmware::Vapi::Std::Errors::Unauthenticated]
-        #     if the user can not be authenticated.
-        # @raise [Com::Vmware::Vapi::Std::Errors::Unauthorized]
-        #     if the user doesn't have the required privileges.
-        def connect(vm, floppy)
-            invoke_with_info(@@connect_info, {
-                'vm' => vm,
-                'floppy' => floppy,
-            })
-        end
-
-
-        # Disconnects a virtual floppy drive of a powered-on virtual machine from its backing. The virtual device is still present and its backing configuration is unchanged, but from the perspective of the guest operating system, the floppy drive is not connected to its backing resource.  
-        # 
-        #  For a powered-off virtual machine, the   :func:`Com::Vmware::Vcenter::Vm::Hardware::Floppy.update`    method  may be used to configure the virtual floppy floppy to start in the disconnected state when the virtual machine is powered on.
-        #
-        # @param vm [String]
-        #     Virtual machine identifier.
-        # @param floppy [String]
-        #     Virtual floppy drive identifier.
-        # @return [Void]
-        # @raise [Com::Vmware::Vapi::Std::Errors::Error]
-        #     if the system reports an error while responding to the request.
-        # @raise [Com::Vmware::Vapi::Std::Errors::NotFound]
-        #     if the virtual machine or virtual floppy drive is not found.
-        # @raise [Com::Vmware::Vapi::Std::Errors::AlreadyInDesiredState]
-        #     if the virtual floppy drive is already disconnected.
-        # @raise [Com::Vmware::Vapi::Std::Errors::NotAllowedInCurrentState]
-        #     if the virtual machine is not powered on.
-        # @raise [Com::Vmware::Vapi::Std::Errors::ResourceBusy]
-        #     if the virtual machine is busy performing another operation.
-        # @raise [Com::Vmware::Vapi::Std::Errors::ResourceInaccessible]
-        #     if the virtual machine's configuration state cannot be accessed.
-        # @raise [Com::Vmware::Vapi::Std::Errors::ServiceUnavailable]
-        #     if the system is unable to communicate with a service to complete the request.
-        # @raise [Com::Vmware::Vapi::Std::Errors::Unauthenticated]
-        #     if the user can not be authenticated.
-        # @raise [Com::Vmware::Vapi::Std::Errors::Unauthorized]
-        #     if the user doesn't have the required privileges.
-        def disconnect(vm, floppy)
-            invoke_with_info(@@disconnect_info, {
-                'vm' => vm,
-                'floppy' => floppy,
-            })
-        end
-
-
-
-        # The  ``Com::Vmware::Vcenter::Vm::Hardware::Floppy::BackingInfo``   class  contains information about the physical resource backing a virtual floppy drive.
-        # @!attribute [rw] type
-        #     @return [Com::Vmware::Vcenter::Vm::Hardware::Floppy::BackingType]
-        #     Backing type for the virtual floppy drive.
-        # @!attribute [rw] image_file
-        #     @return [String]
-        #     Path of the image file backing the virtual floppy drive.
-        #     This  field  is optional and it is only relevant when the value of  ``type``  is   :attr:`Com::Vmware::Vcenter::Vm::Hardware::Floppy::BackingType.IMAGE_FILE`  .
-        # @!attribute [rw] host_device
-        #     @return [String, nil]
-        #     Name of the host device backing the virtual floppy drive.  
-        #     This  field  will be  nil  if  ``autoDetect``  is true and the virtual floppy drive is not connected or no suitable device is available on the host.
-        # @!attribute [rw] auto_detect
-        #     @return [Boolean]
-        #     Flag indicating whether the virtual floppy drive is configured to automatically detect a suitable host device.
-        #     This  field  is optional and it is only relevant when the value of  ``type``  is   :attr:`Com::Vmware::Vcenter::Vm::Hardware::Floppy::BackingType.HOST_DEVICE`  .
-        class BackingInfo < VAPI::Bindings::VapiStruct
-
-            class << self
-                # Holds (gets or creates) the binding type metadata for this structure type.
-                # @scope class
-                # @return [VAPI::Bindings::StructType] the binding type
-                def binding_type
-                    @binding_type ||= VAPI::Bindings::StructType.new(
-                        'com.vmware.vcenter.vm.hardware.floppy.backing_info',
-                        {
-                            'type' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::Vm::Hardware::Floppy::BackingType'),
-                            'image_file' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::StringType.instance),
-                            'host_device' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::StringType.instance),
-                            'auto_detect' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::BooleanType.instance),
-                        },
-                        BackingInfo,
-                        false,
-                        nil)
-                end
-            end
-
-            attr_accessor :type,
-                          :image_file,
-                          :host_device,
-                          :auto_detect
-
-            # Constructs a new instance.
-            # @param ruby_values [Hash] a map of initial property values (optional)
-            # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
-            def initialize(ruby_values=nil, struct_value=nil)
-                super(self.class.binding_type, ruby_values, struct_value)
-            end
-        end
-
-
-        # The  ``Com::Vmware::Vcenter::Vm::Hardware::Floppy::BackingSpec``   class  provides a specification of the physical resource backing a virtual floppy drive.
-        # @!attribute [rw] type
-        #     @return [Com::Vmware::Vcenter::Vm::Hardware::Floppy::BackingType]
-        #     Backing type for the virtual floppy drive.
-        # @!attribute [rw] image_file
-        #     @return [String]
-        #     Path of the image file that should be used as the virtual floppy drive backing.
-        #     This  field  is optional and it is only relevant when the value of  ``type``  is   :attr:`Com::Vmware::Vcenter::Vm::Hardware::Floppy::BackingType.IMAGE_FILE`  .
-        # @!attribute [rw] host_device
-        #     @return [String, nil]
-        #     Name of the device that should be used as the virtual floppy drive backing.
-        #     If  nil , the virtual floppy drive will be configured to automatically detect a suitable host device.
-        class BackingSpec < VAPI::Bindings::VapiStruct
-
-            class << self
-                # Holds (gets or creates) the binding type metadata for this structure type.
-                # @scope class
-                # @return [VAPI::Bindings::StructType] the binding type
-                def binding_type
-                    @binding_type ||= VAPI::Bindings::StructType.new(
-                        'com.vmware.vcenter.vm.hardware.floppy.backing_spec',
-                        {
-                            'type' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::Vm::Hardware::Floppy::BackingType'),
-                            'image_file' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::StringType.instance),
-                            'host_device' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::StringType.instance),
-                        },
-                        BackingSpec,
-                        false,
-                        nil)
-                end
-            end
-
-            attr_accessor :type,
-                          :image_file,
-                          :host_device
-
-            # Constructs a new instance.
-            # @param ruby_values [Hash] a map of initial property values (optional)
-            # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
-            def initialize(ruby_values=nil, struct_value=nil)
-                super(self.class.binding_type, ruby_values, struct_value)
-            end
-        end
-
-
-        # The  ``Com::Vmware::Vcenter::Vm::Hardware::Floppy::Info``   class  contains information about a virtual floppy drive.
-        # @!attribute [rw] label
-        #     @return [String]
-        #     Device label.
-        # @!attribute [rw] backing
-        #     @return [Com::Vmware::Vcenter::Vm::Hardware::Floppy::BackingInfo]
-        #     Physical resource backing for the virtual floppy drive.
-        class Info < VAPI::Bindings::VapiStruct
-
-            class << self
-                # Holds (gets or creates) the binding type metadata for this structure type.
-                # @scope class
-                # @return [VAPI::Bindings::StructType] the binding type
-                def binding_type
-                    @binding_type ||= VAPI::Bindings::StructType.new(
-                        'com.vmware.vcenter.vm.hardware.floppy.info',
-                        {
-                            'label' => VAPI::Bindings::StringType.instance,
-                            'backing' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::Vm::Hardware::Floppy::BackingInfo'),
-                            'state' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::Vm::Hardware::ConnectionState'),
-                            'start_connected' => VAPI::Bindings::BooleanType.instance,
-                            'allow_guest_control' => VAPI::Bindings::BooleanType.instance,
-                        },
-                        Info,
-                        false,
-                        nil)
-                end
-            end
-
-            attr_accessor :label,
-                          :backing,
-                          :state,
-                          :start_connected,
-                          :allow_guest_control
-
-            # Constructs a new instance.
-            # @param ruby_values [Hash] a map of initial property values (optional)
-            # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
-            def initialize(ruby_values=nil, struct_value=nil)
-                super(self.class.binding_type, ruby_values, struct_value)
-            end
-        end
-
-
-        # The  ``Com::Vmware::Vcenter::Vm::Hardware::Floppy::CreateSpec``   class  provides a specification for the configuration of a newly-created virtual floppy drive.
-        # @!attribute [rw] backing
-        #     @return [Com::Vmware::Vcenter::Vm::Hardware::Floppy::BackingSpec, nil]
-        #     Physical resource backing for the virtual floppy drive.
-        #     If  nil , defaults to automatic detection of a suitable host device.
-        class CreateSpec < VAPI::Bindings::VapiStruct
-
-            class << self
-                # Holds (gets or creates) the binding type metadata for this structure type.
-                # @scope class
-                # @return [VAPI::Bindings::StructType] the binding type
-                def binding_type
-                    @binding_type ||= VAPI::Bindings::StructType.new(
-                        'com.vmware.vcenter.vm.hardware.floppy.create_spec',
-                        {
-                            'backing' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::Vm::Hardware::Floppy::BackingSpec')),
-                            'start_connected' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::BooleanType.instance),
-                            'allow_guest_control' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::BooleanType.instance),
-                        },
-                        CreateSpec,
-                        false,
-                        nil)
-                end
-            end
-
-            attr_accessor :backing,
-                          :start_connected,
-                          :allow_guest_control
-
-            # Constructs a new instance.
-            # @param ruby_values [Hash] a map of initial property values (optional)
-            # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
-            def initialize(ruby_values=nil, struct_value=nil)
-                super(self.class.binding_type, ruby_values, struct_value)
-            end
-        end
-
-
-        # The  ``Com::Vmware::Vcenter::Vm::Hardware::Floppy::UpdateSpec``   class  describes the updates to be made to the configuration of a virtual floppy drive.
-        # @!attribute [rw] backing
-        #     @return [Com::Vmware::Vcenter::Vm::Hardware::Floppy::BackingSpec, nil]
-        #     Physical resource backing for the virtual floppy drive.  
-        #     
-        #      This  field  may only be modified if the virtual machine is not powered on or the virtual floppy drive is not connected.
-        #     If  nil , the value is unchanged.
-        class UpdateSpec < VAPI::Bindings::VapiStruct
-
-            class << self
-                # Holds (gets or creates) the binding type metadata for this structure type.
-                # @scope class
-                # @return [VAPI::Bindings::StructType] the binding type
-                def binding_type
-                    @binding_type ||= VAPI::Bindings::StructType.new(
-                        'com.vmware.vcenter.vm.hardware.floppy.update_spec',
-                        {
-                            'backing' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::Vm::Hardware::Floppy::BackingSpec')),
-                            'start_connected' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::BooleanType.instance),
-                            'allow_guest_control' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::BooleanType.instance),
-                        },
-                        UpdateSpec,
-                        false,
-                        nil)
-                end
-            end
-
-            attr_accessor :backing,
-                          :start_connected,
-                          :allow_guest_control
-
-            # Constructs a new instance.
-            # @param ruby_values [Hash] a map of initial property values (optional)
-            # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
-            def initialize(ruby_values=nil, struct_value=nil)
-                super(self.class.binding_type, ruby_values, struct_value)
-            end
-        end
-
-
-        # The  ``Com::Vmware::Vcenter::Vm::Hardware::Floppy::Summary``   class  contains commonly used information about a virtual floppy drive.
-        # @!attribute [rw] floppy
-        #     @return [String]
-        #     Identifier of the virtual floppy drive.
-        class Summary < VAPI::Bindings::VapiStruct
-
-            class << self
-                # Holds (gets or creates) the binding type metadata for this structure type.
-                # @scope class
-                # @return [VAPI::Bindings::StructType] the binding type
-                def binding_type
-                    @binding_type ||= VAPI::Bindings::StructType.new(
-                        'com.vmware.vcenter.vm.hardware.floppy.summary',
-                        {
-                            'floppy' => VAPI::Bindings::IdType.new(resource_types='com.vmware.vcenter.vm.hardware.Floppy'),
-                        },
-                        Summary,
-                        false,
-                        nil)
-                end
-            end
-
-            attr_accessor :floppy
-
-            # Constructs a new instance.
-            # @param ruby_values [Hash] a map of initial property values (optional)
-            # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
-            def initialize(ruby_values=nil, struct_value=nil)
-                super(self.class.binding_type, ruby_values, struct_value)
-            end
-        end
-
-
-
-        # The  ``Com::Vmware::Vcenter::Vm::Hardware::Floppy::BackingType``   enumerated type  defines the valid backing types for a virtual floppy drive.
-        # @!attribute [rw] image_file
-        #     @return [Com::Vmware::Vcenter::Vm::Hardware::Floppy::BackingType]
-        #     Virtual floppy drive is backed by an image file.
-        # @!attribute [rw] host_device
-        #     @return [Com::Vmware::Vcenter::Vm::Hardware::Floppy::BackingType]
-        #     Virtual floppy drive is backed by a device on the host where the virtual machine is running.
-        # @!attribute [rw] client_device
-        #     @return [Com::Vmware::Vcenter::Vm::Hardware::Floppy::BackingType]
-        #     Virtual floppy drive is backed by a device on the client that is connected to the virtual machine console.
-        class BackingType < VAPI::Bindings::VapiEnum
-
-            class << self
-                # Holds (gets or creates) the binding type metadata for this enumeration type.
-                # @scope class
-                # @return [VAPI::Bindings::EnumType] the binding type
-                def binding_type
-                    @binding_type ||= VAPI::Bindings::EnumType.new(
-                        'com.vmware.vcenter.vm.hardware.floppy.backing_type',
-                        BackingType)
-                end
-
-                # Converts from a string value (perhaps off the wire) to an instance
-                # of this enum type.
-                # @param value [String] the actual value of the enum instance
-                # @return [BackingType] the instance found for the value, otherwise
-                #         an unknown instance will be built for the value
-                def from_string(value)
-                    begin
-                        const_get(value)
-                    rescue NameError
-                        BackingType.new('UNKNOWN', value)
-                    end
-                end
-            end
-
-            private
-
-            # Constructs a new instance.
-            # @param value [String] the actual value of the enum instance
-            # @param unknown [String] the unknown value when value is 'UKNOWN'
-            def initialize(value, unknown=nil)
-                super(self.class.binding_type, value, unknown)
-            end
-
-            public
-
-            # @!attribute [rw] image_file
-            #     @return [Com::Vmware::Vcenter::Vm::Hardware::Floppy::BackingType]
-            #     Virtual floppy drive is backed by an image file.
-            IMAGE_FILE = BackingType.new('IMAGE_FILE')
-
-            # @!attribute [rw] host_device
-            #     @return [Com::Vmware::Vcenter::Vm::Hardware::Floppy::BackingType]
-            #     Virtual floppy drive is backed by a device on the host where the virtual machine is running.
-            HOST_DEVICE = BackingType.new('HOST_DEVICE')
-
-            # @!attribute [rw] client_device
-            #     @return [Com::Vmware::Vcenter::Vm::Hardware::Floppy::BackingType]
-            #     Virtual floppy drive is backed by a device on the client that is connected to the virtual machine console.
-            CLIENT_DEVICE = BackingType.new('CLIENT_DEVICE')
-
-        end
-
-
-    end
-
-
-    # The  ``Com::Vmware::Vcenter::Vm::Hardware::Memory``   class  provides  methods  for configuring the memory settings of a virtual machine.
-    class Memory < VAPI::Bindings::VapiService
-
-        protected
-
-        # static metamodel definitions
-        @@service_id = VAPI::Core::ServiceIdentifier.new('com.vmware.vcenter.vm.hardware.memory')
-
-        @@get_info = VAPI::Bindings::OperationInfo.new(
-            VAPI::Core::OperationIdentifier.new('get', @@service_id),
-            VAPI::Bindings::OperationInputType.new({
-                'vm' => VAPI::Bindings::IdType.new(resource_types='VirtualMachine'),
-            }),
-            VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::Vm::Hardware::Memory::Info'),
-            {
-                'com.vmware.vapi.std.errors.error' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Error'),
-                'com.vmware.vapi.std.errors.not_found' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::NotFound'),
-                'com.vmware.vapi.std.errors.resource_inaccessible' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::ResourceInaccessible'),
-                'com.vmware.vapi.std.errors.service_unavailable' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::ServiceUnavailable'),
-                'com.vmware.vapi.std.errors.unauthenticated' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Unauthenticated'),
-                'com.vmware.vapi.std.errors.unauthorized' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Unauthorized'),
-
-            },
-            [],
-            [])
-        @@update_info = VAPI::Bindings::OperationInfo.new(
-            VAPI::Core::OperationIdentifier.new('update', @@service_id),
-            VAPI::Bindings::OperationInputType.new({
-                'vm' => VAPI::Bindings::IdType.new(resource_types='VirtualMachine'),
-                'spec' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::Vm::Hardware::Memory::UpdateSpec'),
-            }),
-            VAPI::Bindings::VoidType.instance,
-            {
-                'com.vmware.vapi.std.errors.error' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Error'),
-                'com.vmware.vapi.std.errors.not_found' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::NotFound'),
-                'com.vmware.vapi.std.errors.invalid_argument' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::InvalidArgument'),
-                'com.vmware.vapi.std.errors.not_allowed_in_current_state' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::NotAllowedInCurrentState'),
-                'com.vmware.vapi.std.errors.resource_busy' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::ResourceBusy'),
-                'com.vmware.vapi.std.errors.resource_inaccessible' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::ResourceInaccessible'),
-                'com.vmware.vapi.std.errors.service_unavailable' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::ServiceUnavailable'),
-                'com.vmware.vapi.std.errors.unauthenticated' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Unauthenticated'),
-                'com.vmware.vapi.std.errors.unauthorized' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Unauthorized'),
-
-            },
-            [],
-            [])
-
-        @@service_info = VAPI::Bindings::ServiceInfo.new(@@service_id, {
-            'get' => @@get_info,
-            'update' => @@update_info,
-        })
-
-        public
-
-        # Constructs a new instance.
-        #
-        # @param config [VAPI::Bindings::StubConfig] A hash with the api provider details.
-        def initialize(config)
-            super(config, @@service_info)
-        end
-
-
-        # Returns the memory-related settings of a virtual machine.
-        #
-        # @param vm [String]
-        #     Virtual machine identifier.
-        # @return [Com::Vmware::Vcenter::Vm::Hardware::Memory::Info]
-        #     Memory-related settings of the virtual machine.
-        # @raise [Com::Vmware::Vapi::Std::Errors::Error]
-        #     if the system reports an error while responding to the request.
-        # @raise [Com::Vmware::Vapi::Std::Errors::NotFound]
-        #     if the virtual machine is not found.
-        # @raise [Com::Vmware::Vapi::Std::Errors::ResourceInaccessible]
-        #     if the virtual machine's configuration state cannot be accessed.
-        # @raise [Com::Vmware::Vapi::Std::Errors::ServiceUnavailable]
-        #     if the system is unable to communicate with a service to complete the request.
-        # @raise [Com::Vmware::Vapi::Std::Errors::Unauthenticated]
-        #     if the user can not be authenticated.
-        # @raise [Com::Vmware::Vapi::Std::Errors::Unauthorized]
-        #     if the user doesn't have the required privileges.
-        def get(vm)
-            invoke_with_info(@@get_info, {
-                'vm' => vm,
-            })
-        end
-
-
-        # Updates the memory-related settings of a virtual machine.
-        #
-        # @param vm [String]
-        #     Virtual machine identifier.
-        # @param spec [Com::Vmware::Vcenter::Vm::Hardware::Memory::UpdateSpec]
-        #     Specification for updating the memory-related settings of the virtual machine.
-        # @return [Void]
-        # @raise [Com::Vmware::Vapi::Std::Errors::Error]
-        #     if the system reports an error while responding to the request.
-        # @raise [Com::Vmware::Vapi::Std::Errors::NotFound]
-        #     if the virtual machine is not found.
-        # @raise [Com::Vmware::Vapi::Std::Errors::InvalidArgument]
-        #     if one of the provided settings is not permitted; for example, specifying a negative value for  ``sizeMiB`` .
-        # @raise [Com::Vmware::Vapi::Std::Errors::NotAllowedInCurrentState]
-        #     if  ``hotAddEnabled``  is specified and the virtual machine is not powered off.
-        # @raise [Com::Vmware::Vapi::Std::Errors::NotAllowedInCurrentState]
-        #     if  ``sizeMiB``  is specified,  ``hotAddEnabled``  is false, and the virtual machine is not powered off.
-        # @raise [Com::Vmware::Vapi::Std::Errors::ResourceBusy]
-        #     if the virtual machine is busy performing another operation.
-        # @raise [Com::Vmware::Vapi::Std::Errors::ResourceInaccessible]
-        #     if the virtual machine's configuration state cannot be accessed.
-        # @raise [Com::Vmware::Vapi::Std::Errors::ServiceUnavailable]
-        #     if the system is unable to communicate with a service to complete the request.
-        # @raise [Com::Vmware::Vapi::Std::Errors::Unauthenticated]
-        #     if the user can not be authenticated.
-        # @raise [Com::Vmware::Vapi::Std::Errors::Unauthorized]
-        #     if the user doesn't have the required privileges.
-        def update(vm, spec)
-            invoke_with_info(@@update_info, {
-                'vm' => vm,
-                'spec' => spec,
-            })
-        end
-
-
-
-        # The  ``Com::Vmware::Vcenter::Vm::Hardware::Memory::Info``   class  contains memory-related information about a virtual machine.
-        # @!attribute [rw] size_MiB
-        #     @return [Fixnum]
-        #     Memory size in mebibytes.
-        # @!attribute [rw] hot_add_enabled
-        #     @return [Boolean]
-        #     Flag indicating whether adding memory while the virtual machine is running is enabled.  
-        #     
-        #      Some guest operating systems may consume more resources or perform less efficiently when they run on hardware that supports adding memory while the machine is running.
-        # @!attribute [rw] hot_add_increment_size_MiB
-        #     @return [Fixnum, nil]
-        #     The granularity, in mebibytes, at which memory can be added to a running virtual machine.  
-        #     
-        #      When adding memory to a running virtual machine, the amount of memory added must be at least   :attr:`Com::Vmware::Vcenter::Vm::Hardware::Memory::Info.hot_add_increment_size_MiB`   and the total memory size of the virtual machine must be a multiple of {\@link>hotAddIncrementSize}.
-        #     Only set when   :attr:`Com::Vmware::Vcenter::Vm::Hardware::Memory::Info.hot_add_enabled`   is true and the virtual machine is running.
-        # @!attribute [rw] hot_add_limit_MiB
-        #     @return [Fixnum, nil]
-        #     The maximum amount of memory, in mebibytes, that can be added to a running virtual machine.
-        #     Only set when   :attr:`Com::Vmware::Vcenter::Vm::Hardware::Memory::Info.hot_add_enabled`   is true and the virtual machine is running.
-        class Info < VAPI::Bindings::VapiStruct
-
-            class << self
-                # Holds (gets or creates) the binding type metadata for this structure type.
-                # @scope class
-                # @return [VAPI::Bindings::StructType] the binding type
-                def binding_type
-                    @binding_type ||= VAPI::Bindings::StructType.new(
-                        'com.vmware.vcenter.vm.hardware.memory.info',
-                        {
-                            'size_MiB' => VAPI::Bindings::IntegerType.instance,
-                            'hot_add_enabled' => VAPI::Bindings::BooleanType.instance,
-                            'hot_add_increment_size_MiB' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::IntegerType.instance),
-                            'hot_add_limit_MiB' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::IntegerType.instance),
-                        },
-                        Info,
-                        false,
-                        nil)
-                end
-            end
-
-            attr_accessor :size_MiB,
-                          :hot_add_enabled,
-                          :hot_add_increment_size_MiB,
-                          :hot_add_limit_MiB
-
-            # Constructs a new instance.
-            # @param ruby_values [Hash] a map of initial property values (optional)
-            # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
-            def initialize(ruby_values=nil, struct_value=nil)
-                super(self.class.binding_type, ruby_values, struct_value)
-            end
-        end
-
-
-        # The  ``Com::Vmware::Vcenter::Vm::Hardware::Memory::UpdateSpec``   class  describes the updates to be made to the memory-related settings of a virtual machine.
-        # @!attribute [rw] size_MiB
-        #     @return [Fixnum, nil]
-        #     New memory size in mebibytes.  
-        #     
-        #      The supported range of memory sizes is constrained by the configured guest operating system and virtual hardware version of the virtual machine.  
-        #     
-        #      If the virtual machine is running, this value may only be changed if   :attr:`Com::Vmware::Vcenter::Vm::Hardware::Memory::Info.hot_add_enabled`   is true, and the new memory size must satisfy the constraints specified by   :attr:`Com::Vmware::Vcenter::Vm::Hardware::Memory::Info.hot_add_increment_size_MiB`   and   :attr:`Com::Vmware::Vcenter::Vm::Hardware::Memory::Info.hot_add_limit_MiB`  .
-        #     If  nil , the value is unchanged.
-        # @!attribute [rw] hot_add_enabled
-        #     @return [Boolean, nil]
-        #     Flag indicating whether adding memory while the virtual machine is running should be enabled.  
-        #     
-        #      Some guest operating systems may consume more resources or perform less efficiently when they run on hardware that supports adding memory while the machine is running.  
-        #     
-        #      This  field  may only be modified if the virtual machine is not powered on.
-        #     If  nil , the value is unchanged.
-        class UpdateSpec < VAPI::Bindings::VapiStruct
-
-            class << self
-                # Holds (gets or creates) the binding type metadata for this structure type.
-                # @scope class
-                # @return [VAPI::Bindings::StructType] the binding type
-                def binding_type
-                    @binding_type ||= VAPI::Bindings::StructType.new(
-                        'com.vmware.vcenter.vm.hardware.memory.update_spec',
-                        {
-                            'size_MiB' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::IntegerType.instance),
-                            'hot_add_enabled' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::BooleanType.instance),
-                        },
-                        UpdateSpec,
-                        false,
-                        nil)
-                end
-            end
-
-            attr_accessor :size_MiB,
-                          :hot_add_enabled
-
-            # Constructs a new instance.
-            # @param ruby_values [Hash] a map of initial property values (optional)
-            # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
-            def initialize(ruby_values=nil, struct_value=nil)
-                super(self.class.binding_type, ruby_values, struct_value)
-            end
-        end
-
-
-    end
-
-
-    # The  ``Com::Vmware::Vcenter::Vm::Hardware::Parallel``   class  provides  methods  for configuring the virtual parallel ports of a virtual machine.
-    class Parallel < VAPI::Bindings::VapiService
-
-        protected
-
-        # static metamodel definitions
-        @@service_id = VAPI::Core::ServiceIdentifier.new('com.vmware.vcenter.vm.hardware.parallel')
-
-        @@list_info = VAPI::Bindings::OperationInfo.new(
-            VAPI::Core::OperationIdentifier.new('list', @@service_id),
-            VAPI::Bindings::OperationInputType.new({
-                'vm' => VAPI::Bindings::IdType.new(resource_types='VirtualMachine'),
-            }),
-            VAPI::Bindings::ListType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::Vm::Hardware::Parallel::Summary')),
-            {
-                'com.vmware.vapi.std.errors.error' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Error'),
-                'com.vmware.vapi.std.errors.not_found' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::NotFound'),
-                'com.vmware.vapi.std.errors.resource_inaccessible' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::ResourceInaccessible'),
-                'com.vmware.vapi.std.errors.service_unavailable' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::ServiceUnavailable'),
-                'com.vmware.vapi.std.errors.unauthenticated' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Unauthenticated'),
-                'com.vmware.vapi.std.errors.unauthorized' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Unauthorized'),
-
-            },
-            [],
-            [])
-        @@get_info = VAPI::Bindings::OperationInfo.new(
-            VAPI::Core::OperationIdentifier.new('get', @@service_id),
-            VAPI::Bindings::OperationInputType.new({
-                'vm' => VAPI::Bindings::IdType.new(resource_types='VirtualMachine'),
-                'port' => VAPI::Bindings::IdType.new(resource_types='com.vmware.vcenter.vm.hardware.ParallelPort'),
-            }),
-            VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::Vm::Hardware::Parallel::Info'),
-            {
-                'com.vmware.vapi.std.errors.error' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Error'),
-                'com.vmware.vapi.std.errors.not_found' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::NotFound'),
-                'com.vmware.vapi.std.errors.resource_inaccessible' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::ResourceInaccessible'),
-                'com.vmware.vapi.std.errors.service_unavailable' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::ServiceUnavailable'),
-                'com.vmware.vapi.std.errors.unauthenticated' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Unauthenticated'),
-                'com.vmware.vapi.std.errors.unauthorized' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Unauthorized'),
-
-            },
-            [],
-            [])
-        @@create_info = VAPI::Bindings::OperationInfo.new(
-            VAPI::Core::OperationIdentifier.new('create', @@service_id),
-            VAPI::Bindings::OperationInputType.new({
-                'vm' => VAPI::Bindings::IdType.new(resource_types='VirtualMachine'),
-                'spec' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::Vm::Hardware::Parallel::CreateSpec'),
-            }),
-            VAPI::Bindings::IdType.new(resource_types='com.vmware.vcenter.vm.hardware.ParallelPort'),
-            {
-                'com.vmware.vapi.std.errors.error' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Error'),
-                'com.vmware.vapi.std.errors.not_found' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::NotFound'),
-                'com.vmware.vapi.std.errors.not_allowed_in_current_state' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::NotAllowedInCurrentState'),
-                'com.vmware.vapi.std.errors.unable_to_allocate_resource' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::UnableToAllocateResource'),
-                'com.vmware.vapi.std.errors.resource_busy' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::ResourceBusy'),
-                'com.vmware.vapi.std.errors.resource_inaccessible' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::ResourceInaccessible'),
-                'com.vmware.vapi.std.errors.service_unavailable' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::ServiceUnavailable'),
-                'com.vmware.vapi.std.errors.unauthenticated' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Unauthenticated'),
-                'com.vmware.vapi.std.errors.unauthorized' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Unauthorized'),
-
-            },
-            [],
-            [])
-        @@update_info = VAPI::Bindings::OperationInfo.new(
-            VAPI::Core::OperationIdentifier.new('update', @@service_id),
-            VAPI::Bindings::OperationInputType.new({
-                'vm' => VAPI::Bindings::IdType.new(resource_types='VirtualMachine'),
-                'port' => VAPI::Bindings::IdType.new(resource_types='com.vmware.vcenter.vm.hardware.ParallelPort'),
-                'spec' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::Vm::Hardware::Parallel::UpdateSpec'),
-            }),
-            VAPI::Bindings::VoidType.instance,
-            {
-                'com.vmware.vapi.std.errors.error' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Error'),
-                'com.vmware.vapi.std.errors.not_found' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::NotFound'),
-                'com.vmware.vapi.std.errors.not_allowed_in_current_state' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::NotAllowedInCurrentState'),
-                'com.vmware.vapi.std.errors.resource_busy' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::ResourceBusy'),
-                'com.vmware.vapi.std.errors.resource_inaccessible' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::ResourceInaccessible'),
-                'com.vmware.vapi.std.errors.service_unavailable' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::ServiceUnavailable'),
-                'com.vmware.vapi.std.errors.unauthenticated' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Unauthenticated'),
-                'com.vmware.vapi.std.errors.unauthorized' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Unauthorized'),
-
-            },
-            [],
-            [])
-        @@delete_info = VAPI::Bindings::OperationInfo.new(
-            VAPI::Core::OperationIdentifier.new('delete', @@service_id),
-            VAPI::Bindings::OperationInputType.new({
-                'vm' => VAPI::Bindings::IdType.new(resource_types='VirtualMachine'),
-                'port' => VAPI::Bindings::IdType.new(resource_types='com.vmware.vcenter.vm.hardware.ParallelPort'),
-            }),
-            VAPI::Bindings::VoidType.instance,
-            {
-                'com.vmware.vapi.std.errors.error' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Error'),
-                'com.vmware.vapi.std.errors.not_found' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::NotFound'),
-                'com.vmware.vapi.std.errors.not_allowed_in_current_state' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::NotAllowedInCurrentState'),
-                'com.vmware.vapi.std.errors.resource_busy' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::ResourceBusy'),
-                'com.vmware.vapi.std.errors.resource_inaccessible' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::ResourceInaccessible'),
-                'com.vmware.vapi.std.errors.service_unavailable' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::ServiceUnavailable'),
-                'com.vmware.vapi.std.errors.unauthenticated' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Unauthenticated'),
-                'com.vmware.vapi.std.errors.unauthorized' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Unauthorized'),
-
-            },
-            [],
-            [])
-        @@connect_info = VAPI::Bindings::OperationInfo.new(
-            VAPI::Core::OperationIdentifier.new('connect', @@service_id),
-            VAPI::Bindings::OperationInputType.new({
-                'vm' => VAPI::Bindings::IdType.new(resource_types='VirtualMachine'),
-                'port' => VAPI::Bindings::IdType.new(resource_types='com.vmware.vcenter.vm.hardware.ParallelPort'),
-            }),
-            VAPI::Bindings::VoidType.instance,
-            {
-                'com.vmware.vapi.std.errors.error' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Error'),
-                'com.vmware.vapi.std.errors.not_found' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::NotFound'),
-                'com.vmware.vapi.std.errors.already_in_desired_state' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::AlreadyInDesiredState'),
-                'com.vmware.vapi.std.errors.not_allowed_in_current_state' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::NotAllowedInCurrentState'),
-                'com.vmware.vapi.std.errors.resource_busy' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::ResourceBusy'),
-                'com.vmware.vapi.std.errors.resource_inaccessible' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::ResourceInaccessible'),
-                'com.vmware.vapi.std.errors.service_unavailable' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::ServiceUnavailable'),
-                'com.vmware.vapi.std.errors.unauthenticated' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Unauthenticated'),
-                'com.vmware.vapi.std.errors.unauthorized' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Unauthorized'),
-
-            },
-            [],
-            [])
-        @@disconnect_info = VAPI::Bindings::OperationInfo.new(
-            VAPI::Core::OperationIdentifier.new('disconnect', @@service_id),
-            VAPI::Bindings::OperationInputType.new({
-                'vm' => VAPI::Bindings::IdType.new(resource_types='VirtualMachine'),
-                'port' => VAPI::Bindings::IdType.new(resource_types='com.vmware.vcenter.vm.hardware.ParallelPort'),
-            }),
-            VAPI::Bindings::VoidType.instance,
-            {
-                'com.vmware.vapi.std.errors.error' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Error'),
-                'com.vmware.vapi.std.errors.not_found' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::NotFound'),
-                'com.vmware.vapi.std.errors.already_in_desired_state' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::AlreadyInDesiredState'),
-                'com.vmware.vapi.std.errors.not_allowed_in_current_state' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::NotAllowedInCurrentState'),
-                'com.vmware.vapi.std.errors.resource_busy' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::ResourceBusy'),
-                'com.vmware.vapi.std.errors.resource_inaccessible' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::ResourceInaccessible'),
-                'com.vmware.vapi.std.errors.service_unavailable' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::ServiceUnavailable'),
-                'com.vmware.vapi.std.errors.unauthenticated' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Unauthenticated'),
-                'com.vmware.vapi.std.errors.unauthorized' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Unauthorized'),
-
-            },
-            [],
-            [])
-
-        @@service_info = VAPI::Bindings::ServiceInfo.new(@@service_id, {
-            'list' => @@list_info,
-            'get' => @@get_info,
-            'create' => @@create_info,
-            'update' => @@update_info,
-            'delete' => @@delete_info,
-            'connect' => @@connect_info,
-            'disconnect' => @@disconnect_info,
-        })
-
-        public
-
-        # Constructs a new instance.
-        #
-        # @param config [VAPI::Bindings::StubConfig] A hash with the api provider details.
-        def initialize(config)
-            super(config, @@service_info)
-        end
-
-        RESOURCE_TYPE = 'com.vmware.vcenter.vm.hardware.ParallelPort'
-
-
-        # Returns commonly used information about the virtual parallel ports belonging to the virtual machine.
-        #
-        # @param vm [String]
-        #     Virtual machine identifier.
-        # @return [Array<Com::Vmware::Vcenter::Vm::Hardware::Parallel::Summary>]
-        #     List of commonly used information about virtual parallel ports.
-        # @raise [Com::Vmware::Vapi::Std::Errors::Error]
-        #     if the system reports an error while responding to the request.
-        # @raise [Com::Vmware::Vapi::Std::Errors::NotFound]
-        #     if the virtual machine is not found.
-        # @raise [Com::Vmware::Vapi::Std::Errors::ResourceInaccessible]
-        #     if the virtual machine's configuration state cannot be accessed.
-        # @raise [Com::Vmware::Vapi::Std::Errors::ServiceUnavailable]
-        #     if the system is unable to communicate with a service to complete the request.
-        # @raise [Com::Vmware::Vapi::Std::Errors::Unauthenticated]
-        #     if the user can not be authenticated.
-        # @raise [Com::Vmware::Vapi::Std::Errors::Unauthorized]
-        #     if the user doesn't have the required privileges.
-        def list(vm)
-            invoke_with_info(@@list_info, {
-                'vm' => vm,
-            })
-        end
-
-
-        # Returns information about a virtual parallel port.
-        #
-        # @param vm [String]
-        #     Virtual machine identifier.
-        # @param port [String]
-        #     Virtual parallel port identifier.
-        # @return [Com::Vmware::Vcenter::Vm::Hardware::Parallel::Info]
-        #     Information about the specified virtual parallel port.
-        # @raise [Com::Vmware::Vapi::Std::Errors::Error]
-        #     if the system reports an error while responding to the request.
-        # @raise [Com::Vmware::Vapi::Std::Errors::NotFound]
-        #     if the virtual machine or virtual parallel port is not found.
-        # @raise [Com::Vmware::Vapi::Std::Errors::ResourceInaccessible]
-        #     if the virtual machine's configuration state cannot be accessed.
-        # @raise [Com::Vmware::Vapi::Std::Errors::ServiceUnavailable]
-        #     if the system is unable to communicate with a service to complete the request.
-        # @raise [Com::Vmware::Vapi::Std::Errors::Unauthenticated]
-        #     if the user can not be authenticated.
-        # @raise [Com::Vmware::Vapi::Std::Errors::Unauthorized]
-        #     if the user doesn't have the required privileges.
-        def get(vm, port)
-            invoke_with_info(@@get_info, {
-                'vm' => vm,
-                'port' => port,
-            })
-        end
-
-
-        # Adds a virtual parallel port to the virtual machine.
-        #
-        # @param vm [String]
-        #     Virtual machine identifier.
-        # @param spec [Com::Vmware::Vcenter::Vm::Hardware::Parallel::CreateSpec]
-        #     Specification for the new virtual parallel port.
-        # @return [String]
-        #     Virtual parallel port identifier.
-        # @raise [Com::Vmware::Vapi::Std::Errors::Error]
-        #     if the system reported that the parallel port device was created but was unable to confirm the creation because the identifier of the new device could not be determined.
-        # @raise [Com::Vmware::Vapi::Std::Errors::Error]
-        #     if the system reports an error while responding to the request.
-        # @raise [Com::Vmware::Vapi::Std::Errors::NotFound]
-        #     if the virtual machine is not found.
-        # @raise [Com::Vmware::Vapi::Std::Errors::NotAllowedInCurrentState]
-        #     if the virtual machine is not powered off.
-        # @raise [Com::Vmware::Vapi::Std::Errors::UnableToAllocateResource]
-        #     if the virtual machine already has the maximum number of supported parallel ports.
-        # @raise [Com::Vmware::Vapi::Std::Errors::ResourceBusy]
-        #     if the virtual machine is busy performing another operation.
-        # @raise [Com::Vmware::Vapi::Std::Errors::ResourceInaccessible]
-        #     if the virtual machine's configuration state cannot be accessed.
-        # @raise [Com::Vmware::Vapi::Std::Errors::ServiceUnavailable]
-        #     if the system is unable to communicate with a service to complete the request.
-        # @raise [Com::Vmware::Vapi::Std::Errors::Unauthenticated]
-        #     if the user can not be authenticated.
-        # @raise [Com::Vmware::Vapi::Std::Errors::Unauthorized]
-        #     if the user doesn't have the required privileges.
-        def create(vm, spec)
-            invoke_with_info(@@create_info, {
-                'vm' => vm,
-                'spec' => spec,
-            })
-        end
-
-
-        # Updates the configuration of a virtual parallel port.
-        #
-        # @param vm [String]
-        #     Virtual machine identifier.
-        # @param port [String]
-        #     Virtual parallel port identifier.
-        # @param spec [Com::Vmware::Vcenter::Vm::Hardware::Parallel::UpdateSpec]
-        #     Specification for updating the virtual parallel port.
-        # @return [Void]
-        # @raise [Com::Vmware::Vapi::Std::Errors::Error]
-        #     if the system reports an error while responding to the request.
-        # @raise [Com::Vmware::Vapi::Std::Errors::NotFound]
-        #     if the virtual machine or virtual parallel port is not found.
-        # @raise [Com::Vmware::Vapi::Std::Errors::NotAllowedInCurrentState]
-        #     if one or more of the  fields  specified in the  ``spec``   parameter  cannot be modified due to the current power state of the virtual machine or the connection state of the virtual parallel port.
-        # @raise [Com::Vmware::Vapi::Std::Errors::ResourceBusy]
-        #     if the virtual machine is busy performing another operation.
-        # @raise [Com::Vmware::Vapi::Std::Errors::ResourceInaccessible]
-        #     if the virtual machine's configuration state cannot be accessed.
-        # @raise [Com::Vmware::Vapi::Std::Errors::ServiceUnavailable]
-        #     if the system is unable to communicate with a service to complete the request.
-        # @raise [Com::Vmware::Vapi::Std::Errors::Unauthenticated]
-        #     if the user can not be authenticated.
-        # @raise [Com::Vmware::Vapi::Std::Errors::Unauthorized]
-        #     if the user doesn't have the required privileges.
-        def update(vm, port, spec)
-            invoke_with_info(@@update_info, {
-                'vm' => vm,
-                'port' => port,
-                'spec' => spec,
-            })
-        end
-
-
-        # Removes a virtual parallel port from the virtual machine.
-        #
-        # @param vm [String]
-        #     Virtual machine identifier.
-        # @param port [String]
-        #     Virtual parallel port identifier.
-        # @return [Void]
-        # @raise [Com::Vmware::Vapi::Std::Errors::Error]
-        #     if the system reports an error while responding to the request.
-        # @raise [Com::Vmware::Vapi::Std::Errors::NotFound]
-        #     if the virtual machine or virtual parallel port is not found.
-        # @raise [Com::Vmware::Vapi::Std::Errors::NotAllowedInCurrentState]
-        #     if the virtual machine is not powered off.
-        # @raise [Com::Vmware::Vapi::Std::Errors::ResourceBusy]
-        #     if the virtual machine is busy performing another operation.
-        # @raise [Com::Vmware::Vapi::Std::Errors::ResourceInaccessible]
-        #     if the virtual machine's configuration state cannot be accessed.
-        # @raise [Com::Vmware::Vapi::Std::Errors::ServiceUnavailable]
-        #     if the system is unable to communicate with a service to complete the request.
-        # @raise [Com::Vmware::Vapi::Std::Errors::Unauthenticated]
-        #     if the user can not be authenticated.
-        # @raise [Com::Vmware::Vapi::Std::Errors::Unauthorized]
-        #     if the user doesn't have the required privileges.
-        def delete(vm, port)
-            invoke_with_info(@@delete_info, {
-                'vm' => vm,
-                'port' => port,
-            })
-        end
-
-
-        # Connects a virtual parallel port of a powered-on virtual machine to its backing. Connecting the virtual device makes the backing accessible from the perspective of the guest operating system.  
-        # 
-        #  For a powered-off virtual machine, the   :func:`Com::Vmware::Vcenter::Vm::Hardware::Parallel.update`    method  may be used to configure the virtual parallel port to start in the connected state when the virtual machine is powered on.
-        #
-        # @param vm [String]
-        #     Virtual machine identifier.
-        # @param port [String]
-        #     Virtual parallel port identifier.
-        # @return [Void]
-        # @raise [Com::Vmware::Vapi::Std::Errors::Error]
-        #     if the system reports an error while responding to the request.
-        # @raise [Com::Vmware::Vapi::Std::Errors::NotFound]
-        #     if the virtual machine or virtual parallel port is not found.
-        # @raise [Com::Vmware::Vapi::Std::Errors::AlreadyInDesiredState]
-        #     if the virtual parallel port is already connected.
-        # @raise [Com::Vmware::Vapi::Std::Errors::NotAllowedInCurrentState]
-        #     if the virtual machine is not powered on.
-        # @raise [Com::Vmware::Vapi::Std::Errors::ResourceBusy]
-        #     if the virtual machine is busy performing another operation.
-        # @raise [Com::Vmware::Vapi::Std::Errors::ResourceInaccessible]
-        #     if the virtual machine's configuration state cannot be accessed.
-        # @raise [Com::Vmware::Vapi::Std::Errors::ServiceUnavailable]
-        #     if the system is unable to communicate with a service to complete the request.
-        # @raise [Com::Vmware::Vapi::Std::Errors::Unauthenticated]
-        #     if the user can not be authenticated.
-        # @raise [Com::Vmware::Vapi::Std::Errors::Unauthorized]
-        #     if the user doesn't have the required privileges.
-        def connect(vm, port)
-            invoke_with_info(@@connect_info, {
-                'vm' => vm,
-                'port' => port,
-            })
-        end
-
-
-        # Disconnects a virtual parallel port of a powered-on virtual machine from its backing. The virtual device is still present and its backing configuration is unchanged, but from the perspective of the guest operating system, the parallel port is not connected to its backing.  
-        # 
-        #  For a powered-off virtual machine, the   :func:`Com::Vmware::Vcenter::Vm::Hardware::Parallel.update`    method  may be used to configure the virtual parallel port to start in the disconnected state when the virtual machine is powered on.
-        #
-        # @param vm [String]
-        #     Virtual machine identifier.
-        # @param port [String]
-        #     Virtual parallel port identifier.
-        # @return [Void]
-        # @raise [Com::Vmware::Vapi::Std::Errors::Error]
-        #     if the system reports an error while responding to the request.
-        # @raise [Com::Vmware::Vapi::Std::Errors::NotFound]
-        #     if the virtual machine or virtual parallel port is not found.
-        # @raise [Com::Vmware::Vapi::Std::Errors::AlreadyInDesiredState]
-        #     if the virtual parallel port is already disconnected.
-        # @raise [Com::Vmware::Vapi::Std::Errors::NotAllowedInCurrentState]
-        #     if the virtual machine is not powered on.
-        # @raise [Com::Vmware::Vapi::Std::Errors::ResourceBusy]
-        #     if the virtual machine is busy performing another operation.
-        # @raise [Com::Vmware::Vapi::Std::Errors::ResourceInaccessible]
-        #     if the virtual machine's configuration state cannot be accessed.
-        # @raise [Com::Vmware::Vapi::Std::Errors::ServiceUnavailable]
-        #     if the system is unable to communicate with a service to complete the request.
-        # @raise [Com::Vmware::Vapi::Std::Errors::Unauthenticated]
-        #     if the user can not be authenticated.
-        # @raise [Com::Vmware::Vapi::Std::Errors::Unauthorized]
-        #     if the user doesn't have the required privileges.
-        def disconnect(vm, port)
-            invoke_with_info(@@disconnect_info, {
-                'vm' => vm,
-                'port' => port,
-            })
-        end
-
-
-
-        # The  ``Com::Vmware::Vcenter::Vm::Hardware::Parallel::BackingInfo``   class  contains information about the physical resource backing a virtual parallel port.
-        # @!attribute [rw] type
-        #     @return [Com::Vmware::Vcenter::Vm::Hardware::Parallel::BackingType]
-        #     Backing type for the virtual parallel port.
-        # @!attribute [rw] file
-        #     @return [String]
-        #     Path of the file backing the virtual parallel port.
-        #     This  field  is optional and it is only relevant when the value of  ``type``  is   :attr:`Com::Vmware::Vcenter::Vm::Hardware::Parallel::BackingType.FILE`  .
-        # @!attribute [rw] host_device
-        #     @return [String, nil]
-        #     Name of the device backing the virtual parallel port.  
-        #     This  field  will be  nil  if  ``autoDetect``  is true and the virtual parallel port is not connected or no suitable device is available on the host.
-        # @!attribute [rw] auto_detect
-        #     @return [Boolean]
-        #     Flag indicating whether the virtual parallel port is configured to automatically detect a suitable host device.
-        #     This  field  is optional and it is only relevant when the value of  ``type``  is   :attr:`Com::Vmware::Vcenter::Vm::Hardware::Parallel::BackingType.HOST_DEVICE`  .
-        class BackingInfo < VAPI::Bindings::VapiStruct
-
-            class << self
-                # Holds (gets or creates) the binding type metadata for this structure type.
-                # @scope class
-                # @return [VAPI::Bindings::StructType] the binding type
-                def binding_type
-                    @binding_type ||= VAPI::Bindings::StructType.new(
-                        'com.vmware.vcenter.vm.hardware.parallel.backing_info',
-                        {
-                            'type' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::Vm::Hardware::Parallel::BackingType'),
-                            'file' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::StringType.instance),
-                            'host_device' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::StringType.instance),
-                            'auto_detect' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::BooleanType.instance),
-                        },
-                        BackingInfo,
-                        false,
-                        nil)
-                end
-            end
-
-            attr_accessor :type,
-                          :file,
-                          :host_device,
-                          :auto_detect
-
-            # Constructs a new instance.
-            # @param ruby_values [Hash] a map of initial property values (optional)
-            # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
-            def initialize(ruby_values=nil, struct_value=nil)
-                super(self.class.binding_type, ruby_values, struct_value)
-            end
-        end
-
-
-        # The  ``Com::Vmware::Vcenter::Vm::Hardware::Parallel::BackingSpec``   class  provides a specification of the physical resource backing a virtual parallel port.
-        # @!attribute [rw] type
-        #     @return [Com::Vmware::Vcenter::Vm::Hardware::Parallel::BackingType]
-        #     Backing type for the virtual parallel port.
-        # @!attribute [rw] file
-        #     @return [String]
-        #     Path of the file that should be used as the virtual parallel port backing.
-        #     This  field  is optional and it is only relevant when the value of  ``type``  is   :attr:`Com::Vmware::Vcenter::Vm::Hardware::Parallel::BackingType.FILE`  .
-        # @!attribute [rw] host_device
-        #     @return [String, nil]
-        #     Name of the device that should be used as the virtual parallel port backing.
-        #     If  nil , the virtual parallel port will be configured to automatically detect a suitable host device.
-        class BackingSpec < VAPI::Bindings::VapiStruct
-
-            class << self
-                # Holds (gets or creates) the binding type metadata for this structure type.
-                # @scope class
-                # @return [VAPI::Bindings::StructType] the binding type
-                def binding_type
-                    @binding_type ||= VAPI::Bindings::StructType.new(
-                        'com.vmware.vcenter.vm.hardware.parallel.backing_spec',
-                        {
-                            'type' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::Vm::Hardware::Parallel::BackingType'),
-                            'file' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::StringType.instance),
-                            'host_device' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::StringType.instance),
-                        },
-                        BackingSpec,
-                        false,
-                        nil)
-                end
-            end
-
-            attr_accessor :type,
-                          :file,
-                          :host_device
-
-            # Constructs a new instance.
-            # @param ruby_values [Hash] a map of initial property values (optional)
-            # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
-            def initialize(ruby_values=nil, struct_value=nil)
-                super(self.class.binding_type, ruby_values, struct_value)
-            end
-        end
-
-
-        # The  ``Com::Vmware::Vcenter::Vm::Hardware::Parallel::Info``   class  contains information about a virtual parallel port.
-        # @!attribute [rw] label
-        #     @return [String]
-        #     Device label.
-        # @!attribute [rw] backing
-        #     @return [Com::Vmware::Vcenter::Vm::Hardware::Parallel::BackingInfo]
-        #     Physical resource backing for the virtual parallel port.
-        class Info < VAPI::Bindings::VapiStruct
-
-            class << self
-                # Holds (gets or creates) the binding type metadata for this structure type.
-                # @scope class
-                # @return [VAPI::Bindings::StructType] the binding type
-                def binding_type
-                    @binding_type ||= VAPI::Bindings::StructType.new(
-                        'com.vmware.vcenter.vm.hardware.parallel.info',
-                        {
-                            'label' => VAPI::Bindings::StringType.instance,
-                            'backing' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::Vm::Hardware::Parallel::BackingInfo'),
-                            'state' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::Vm::Hardware::ConnectionState'),
-                            'start_connected' => VAPI::Bindings::BooleanType.instance,
-                            'allow_guest_control' => VAPI::Bindings::BooleanType.instance,
-                        },
-                        Info,
-                        false,
-                        nil)
-                end
-            end
-
-            attr_accessor :label,
-                          :backing,
-                          :state,
-                          :start_connected,
-                          :allow_guest_control
-
-            # Constructs a new instance.
-            # @param ruby_values [Hash] a map of initial property values (optional)
-            # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
-            def initialize(ruby_values=nil, struct_value=nil)
-                super(self.class.binding_type, ruby_values, struct_value)
-            end
-        end
-
-
-        # The  ``Com::Vmware::Vcenter::Vm::Hardware::Parallel::CreateSpec``   class  provides a specification for the configuration of a newly-created virtual parallel port.
-        # @!attribute [rw] backing
-        #     @return [Com::Vmware::Vcenter::Vm::Hardware::Parallel::BackingSpec, nil]
-        #     Physical resource backing for the virtual parallel port.
-        #     If  nil , defaults to automatic detection of a suitable host device.
-        class CreateSpec < VAPI::Bindings::VapiStruct
-
-            class << self
-                # Holds (gets or creates) the binding type metadata for this structure type.
-                # @scope class
-                # @return [VAPI::Bindings::StructType] the binding type
-                def binding_type
-                    @binding_type ||= VAPI::Bindings::StructType.new(
-                        'com.vmware.vcenter.vm.hardware.parallel.create_spec',
-                        {
-                            'backing' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::Vm::Hardware::Parallel::BackingSpec')),
-                            'start_connected' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::BooleanType.instance),
-                            'allow_guest_control' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::BooleanType.instance),
-                        },
-                        CreateSpec,
-                        false,
-                        nil)
-                end
-            end
-
-            attr_accessor :backing,
-                          :start_connected,
-                          :allow_guest_control
-
-            # Constructs a new instance.
-            # @param ruby_values [Hash] a map of initial property values (optional)
-            # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
-            def initialize(ruby_values=nil, struct_value=nil)
-                super(self.class.binding_type, ruby_values, struct_value)
-            end
-        end
-
-
-        # The  ``Com::Vmware::Vcenter::Vm::Hardware::Parallel::UpdateSpec``   class  describes the updates to be made to the configuration of a virtual parallel port.
-        # @!attribute [rw] backing
-        #     @return [Com::Vmware::Vcenter::Vm::Hardware::Parallel::BackingSpec, nil]
-        #     Physical resource backing for the virtual parallel port.  
-        #     
-        #      This  field  may only be modified if the virtual machine is not powered on or the virtual parallel port is not connected.
-        #     If  nil , the value is unchanged.
-        class UpdateSpec < VAPI::Bindings::VapiStruct
-
-            class << self
-                # Holds (gets or creates) the binding type metadata for this structure type.
-                # @scope class
-                # @return [VAPI::Bindings::StructType] the binding type
-                def binding_type
-                    @binding_type ||= VAPI::Bindings::StructType.new(
-                        'com.vmware.vcenter.vm.hardware.parallel.update_spec',
-                        {
-                            'backing' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::Vm::Hardware::Parallel::BackingSpec')),
-                            'start_connected' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::BooleanType.instance),
-                            'allow_guest_control' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::BooleanType.instance),
-                        },
-                        UpdateSpec,
-                        false,
-                        nil)
-                end
-            end
-
-            attr_accessor :backing,
-                          :start_connected,
-                          :allow_guest_control
-
-            # Constructs a new instance.
-            # @param ruby_values [Hash] a map of initial property values (optional)
-            # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
-            def initialize(ruby_values=nil, struct_value=nil)
-                super(self.class.binding_type, ruby_values, struct_value)
-            end
-        end
-
-
-        # The  ``Com::Vmware::Vcenter::Vm::Hardware::Parallel::Summary``   class  contains commonly used information about a virtual parallel port.
-        # @!attribute [rw] port
-        #     @return [String]
-        #     Identifier of the virtual parallel port.
-        class Summary < VAPI::Bindings::VapiStruct
-
-            class << self
-                # Holds (gets or creates) the binding type metadata for this structure type.
-                # @scope class
-                # @return [VAPI::Bindings::StructType] the binding type
-                def binding_type
-                    @binding_type ||= VAPI::Bindings::StructType.new(
-                        'com.vmware.vcenter.vm.hardware.parallel.summary',
-                        {
-                            'port' => VAPI::Bindings::IdType.new(resource_types='com.vmware.vcenter.vm.hardware.ParallelPort'),
-                        },
-                        Summary,
-                        false,
-                        nil)
-                end
-            end
-
-            attr_accessor :port
-
-            # Constructs a new instance.
-            # @param ruby_values [Hash] a map of initial property values (optional)
-            # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
-            def initialize(ruby_values=nil, struct_value=nil)
-                super(self.class.binding_type, ruby_values, struct_value)
-            end
-        end
-
-
-
-        # The  ``Com::Vmware::Vcenter::Vm::Hardware::Parallel::BackingType``   enumerated type  defines the valid backing types for a virtual parallel port.
-        # @!attribute [rw] file
-        #     @return [Com::Vmware::Vcenter::Vm::Hardware::Parallel::BackingType]
-        #     Virtual parallel port is backed by a file.
-        # @!attribute [rw] host_device
-        #     @return [Com::Vmware::Vcenter::Vm::Hardware::Parallel::BackingType]
-        #     Virtual parallel port is backed by a device on the host where the virtual machine is running.
-        class BackingType < VAPI::Bindings::VapiEnum
-
-            class << self
-                # Holds (gets or creates) the binding type metadata for this enumeration type.
-                # @scope class
-                # @return [VAPI::Bindings::EnumType] the binding type
-                def binding_type
-                    @binding_type ||= VAPI::Bindings::EnumType.new(
-                        'com.vmware.vcenter.vm.hardware.parallel.backing_type',
-                        BackingType)
-                end
-
-                # Converts from a string value (perhaps off the wire) to an instance
-                # of this enum type.
-                # @param value [String] the actual value of the enum instance
-                # @return [BackingType] the instance found for the value, otherwise
-                #         an unknown instance will be built for the value
-                def from_string(value)
-                    begin
-                        const_get(value)
-                    rescue NameError
-                        BackingType.new('UNKNOWN', value)
-                    end
-                end
-            end
-
-            private
-
-            # Constructs a new instance.
-            # @param value [String] the actual value of the enum instance
-            # @param unknown [String] the unknown value when value is 'UKNOWN'
-            def initialize(value, unknown=nil)
-                super(self.class.binding_type, value, unknown)
-            end
-
-            public
-
-            # @!attribute [rw] file
-            #     @return [Com::Vmware::Vcenter::Vm::Hardware::Parallel::BackingType]
-            #     Virtual parallel port is backed by a file.
-            FILE = BackingType.new('FILE')
-
-            # @!attribute [rw] host_device
-            #     @return [Com::Vmware::Vcenter::Vm::Hardware::Parallel::BackingType]
-            #     Virtual parallel port is backed by a device on the host where the virtual machine is running.
-            HOST_DEVICE = BackingType.new('HOST_DEVICE')
-
-        end
-
-
-    end
-
-
-    # The  ``Com::Vmware::Vcenter::Vm::Hardware::Serial``   class  provides  methods  for configuring the virtual serial ports of a virtual machine.
-    class Serial < VAPI::Bindings::VapiService
-
-        protected
-
-        # static metamodel definitions
-        @@service_id = VAPI::Core::ServiceIdentifier.new('com.vmware.vcenter.vm.hardware.serial')
-
-        @@list_info = VAPI::Bindings::OperationInfo.new(
-            VAPI::Core::OperationIdentifier.new('list', @@service_id),
-            VAPI::Bindings::OperationInputType.new({
-                'vm' => VAPI::Bindings::IdType.new(resource_types='VirtualMachine'),
-            }),
-            VAPI::Bindings::ListType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::Vm::Hardware::Serial::Summary')),
-            {
-                'com.vmware.vapi.std.errors.error' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Error'),
-                'com.vmware.vapi.std.errors.not_found' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::NotFound'),
-                'com.vmware.vapi.std.errors.resource_inaccessible' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::ResourceInaccessible'),
-                'com.vmware.vapi.std.errors.service_unavailable' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::ServiceUnavailable'),
-                'com.vmware.vapi.std.errors.unauthenticated' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Unauthenticated'),
-                'com.vmware.vapi.std.errors.unauthorized' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Unauthorized'),
-
-            },
-            [],
-            [])
-        @@get_info = VAPI::Bindings::OperationInfo.new(
-            VAPI::Core::OperationIdentifier.new('get', @@service_id),
-            VAPI::Bindings::OperationInputType.new({
-                'vm' => VAPI::Bindings::IdType.new(resource_types='VirtualMachine'),
-                'port' => VAPI::Bindings::IdType.new(resource_types='com.vmware.vcenter.vm.hardware.SerialPort'),
-            }),
-            VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::Vm::Hardware::Serial::Info'),
-            {
-                'com.vmware.vapi.std.errors.error' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Error'),
-                'com.vmware.vapi.std.errors.not_found' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::NotFound'),
-                'com.vmware.vapi.std.errors.resource_inaccessible' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::ResourceInaccessible'),
-                'com.vmware.vapi.std.errors.service_unavailable' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::ServiceUnavailable'),
-                'com.vmware.vapi.std.errors.unauthenticated' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Unauthenticated'),
-                'com.vmware.vapi.std.errors.unauthorized' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Unauthorized'),
-
-            },
-            [],
-            [])
-        @@create_info = VAPI::Bindings::OperationInfo.new(
-            VAPI::Core::OperationIdentifier.new('create', @@service_id),
-            VAPI::Bindings::OperationInputType.new({
-                'vm' => VAPI::Bindings::IdType.new(resource_types='VirtualMachine'),
-                'spec' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::Vm::Hardware::Serial::CreateSpec'),
-            }),
-            VAPI::Bindings::IdType.new(resource_types='com.vmware.vcenter.vm.hardware.SerialPort'),
-            {
-                'com.vmware.vapi.std.errors.error' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Error'),
-                'com.vmware.vapi.std.errors.not_found' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::NotFound'),
-                'com.vmware.vapi.std.errors.not_allowed_in_current_state' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::NotAllowedInCurrentState'),
-                'com.vmware.vapi.std.errors.unable_to_allocate_resource' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::UnableToAllocateResource'),
-                'com.vmware.vapi.std.errors.resource_busy' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::ResourceBusy'),
-                'com.vmware.vapi.std.errors.resource_inaccessible' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::ResourceInaccessible'),
-                'com.vmware.vapi.std.errors.service_unavailable' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::ServiceUnavailable'),
-                'com.vmware.vapi.std.errors.unauthenticated' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Unauthenticated'),
-                'com.vmware.vapi.std.errors.unauthorized' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Unauthorized'),
-
-            },
-            [],
-            [])
-        @@update_info = VAPI::Bindings::OperationInfo.new(
-            VAPI::Core::OperationIdentifier.new('update', @@service_id),
-            VAPI::Bindings::OperationInputType.new({
-                'vm' => VAPI::Bindings::IdType.new(resource_types='VirtualMachine'),
-                'port' => VAPI::Bindings::IdType.new(resource_types='com.vmware.vcenter.vm.hardware.SerialPort'),
-                'spec' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::Vm::Hardware::Serial::UpdateSpec'),
-            }),
-            VAPI::Bindings::VoidType.instance,
-            {
-                'com.vmware.vapi.std.errors.error' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Error'),
-                'com.vmware.vapi.std.errors.not_found' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::NotFound'),
-                'com.vmware.vapi.std.errors.not_allowed_in_current_state' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::NotAllowedInCurrentState'),
-                'com.vmware.vapi.std.errors.resource_busy' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::ResourceBusy'),
-                'com.vmware.vapi.std.errors.resource_inaccessible' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::ResourceInaccessible'),
-                'com.vmware.vapi.std.errors.service_unavailable' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::ServiceUnavailable'),
-                'com.vmware.vapi.std.errors.unauthenticated' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Unauthenticated'),
-                'com.vmware.vapi.std.errors.unauthorized' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Unauthorized'),
-
-            },
-            [],
-            [])
-        @@delete_info = VAPI::Bindings::OperationInfo.new(
-            VAPI::Core::OperationIdentifier.new('delete', @@service_id),
-            VAPI::Bindings::OperationInputType.new({
-                'vm' => VAPI::Bindings::IdType.new(resource_types='VirtualMachine'),
-                'port' => VAPI::Bindings::IdType.new(resource_types='com.vmware.vcenter.vm.hardware.SerialPort'),
-            }),
-            VAPI::Bindings::VoidType.instance,
-            {
-                'com.vmware.vapi.std.errors.error' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Error'),
-                'com.vmware.vapi.std.errors.not_found' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::NotFound'),
-                'com.vmware.vapi.std.errors.not_allowed_in_current_state' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::NotAllowedInCurrentState'),
-                'com.vmware.vapi.std.errors.resource_busy' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::ResourceBusy'),
-                'com.vmware.vapi.std.errors.resource_inaccessible' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::ResourceInaccessible'),
-                'com.vmware.vapi.std.errors.service_unavailable' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::ServiceUnavailable'),
-                'com.vmware.vapi.std.errors.unauthenticated' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Unauthenticated'),
-                'com.vmware.vapi.std.errors.unauthorized' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Unauthorized'),
-
-            },
-            [],
-            [])
-        @@connect_info = VAPI::Bindings::OperationInfo.new(
-            VAPI::Core::OperationIdentifier.new('connect', @@service_id),
-            VAPI::Bindings::OperationInputType.new({
-                'vm' => VAPI::Bindings::IdType.new(resource_types='VirtualMachine'),
-                'port' => VAPI::Bindings::IdType.new(resource_types='com.vmware.vcenter.vm.hardware.SerialPort'),
-            }),
-            VAPI::Bindings::VoidType.instance,
-            {
-                'com.vmware.vapi.std.errors.error' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Error'),
-                'com.vmware.vapi.std.errors.not_found' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::NotFound'),
-                'com.vmware.vapi.std.errors.already_in_desired_state' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::AlreadyInDesiredState'),
-                'com.vmware.vapi.std.errors.not_allowed_in_current_state' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::NotAllowedInCurrentState'),
-                'com.vmware.vapi.std.errors.resource_busy' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::ResourceBusy'),
-                'com.vmware.vapi.std.errors.resource_inaccessible' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::ResourceInaccessible'),
-                'com.vmware.vapi.std.errors.service_unavailable' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::ServiceUnavailable'),
-                'com.vmware.vapi.std.errors.unauthenticated' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Unauthenticated'),
-                'com.vmware.vapi.std.errors.unauthorized' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Unauthorized'),
-
-            },
-            [],
-            [])
-        @@disconnect_info = VAPI::Bindings::OperationInfo.new(
-            VAPI::Core::OperationIdentifier.new('disconnect', @@service_id),
-            VAPI::Bindings::OperationInputType.new({
-                'vm' => VAPI::Bindings::IdType.new(resource_types='VirtualMachine'),
-                'port' => VAPI::Bindings::IdType.new(resource_types='com.vmware.vcenter.vm.hardware.SerialPort'),
-            }),
-            VAPI::Bindings::VoidType.instance,
-            {
-                'com.vmware.vapi.std.errors.error' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Error'),
-                'com.vmware.vapi.std.errors.not_found' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::NotFound'),
-                'com.vmware.vapi.std.errors.already_in_desired_state' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::AlreadyInDesiredState'),
-                'com.vmware.vapi.std.errors.not_allowed_in_current_state' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::NotAllowedInCurrentState'),
-                'com.vmware.vapi.std.errors.resource_busy' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::ResourceBusy'),
-                'com.vmware.vapi.std.errors.resource_inaccessible' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::ResourceInaccessible'),
-                'com.vmware.vapi.std.errors.service_unavailable' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::ServiceUnavailable'),
-                'com.vmware.vapi.std.errors.unauthenticated' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Unauthenticated'),
-                'com.vmware.vapi.std.errors.unauthorized' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Unauthorized'),
-
-            },
-            [],
-            [])
-
-        @@service_info = VAPI::Bindings::ServiceInfo.new(@@service_id, {
-            'list' => @@list_info,
-            'get' => @@get_info,
-            'create' => @@create_info,
-            'update' => @@update_info,
-            'delete' => @@delete_info,
-            'connect' => @@connect_info,
-            'disconnect' => @@disconnect_info,
-        })
-
-        public
-
-        # Constructs a new instance.
-        #
-        # @param config [VAPI::Bindings::StubConfig] A hash with the api provider details.
-        def initialize(config)
-            super(config, @@service_info)
-        end
-
-        RESOURCE_TYPE = 'com.vmware.vcenter.vm.hardware.SerialPort'
-
-
-        # Returns commonly used information about the virtual serial ports belonging to the virtual machine.
-        #
-        # @param vm [String]
-        #     Virtual machine identifier.
-        # @return [Array<Com::Vmware::Vcenter::Vm::Hardware::Serial::Summary>]
-        #     List of commonly used information about virtual serial ports.
-        # @raise [Com::Vmware::Vapi::Std::Errors::Error]
-        #     if the system reports an error while responding to the request.
-        # @raise [Com::Vmware::Vapi::Std::Errors::NotFound]
-        #     if the virtual machine is not found.
-        # @raise [Com::Vmware::Vapi::Std::Errors::ResourceInaccessible]
-        #     if the virtual machine's configuration state cannot be accessed.
-        # @raise [Com::Vmware::Vapi::Std::Errors::ServiceUnavailable]
-        #     if the system is unable to communicate with a service to complete the request.
-        # @raise [Com::Vmware::Vapi::Std::Errors::Unauthenticated]
-        #     if the user can not be authenticated.
-        # @raise [Com::Vmware::Vapi::Std::Errors::Unauthorized]
-        #     if the user doesn't have the required privileges.
-        def list(vm)
-            invoke_with_info(@@list_info, {
-                'vm' => vm,
-            })
-        end
-
-
-        # Returns information about a virtual serial port.
-        #
-        # @param vm [String]
-        #     Virtual machine identifier.
-        # @param port [String]
-        #     Virtual serial port identifier.
-        # @return [Com::Vmware::Vcenter::Vm::Hardware::Serial::Info]
-        #     Information about the specified virtual serial port.
-        # @raise [Com::Vmware::Vapi::Std::Errors::Error]
-        #     if the system reports an error while responding to the request.
-        # @raise [Com::Vmware::Vapi::Std::Errors::NotFound]
-        #     if the virtual machine or virtual serial port is not found.
-        # @raise [Com::Vmware::Vapi::Std::Errors::ResourceInaccessible]
-        #     if the virtual machine's configuration state cannot be accessed.
-        # @raise [Com::Vmware::Vapi::Std::Errors::ServiceUnavailable]
-        #     if the system is unable to communicate with a service to complete the request.
-        # @raise [Com::Vmware::Vapi::Std::Errors::Unauthenticated]
-        #     if the user can not be authenticated.
-        # @raise [Com::Vmware::Vapi::Std::Errors::Unauthorized]
-        #     if the user doesn't have the required privileges.
-        def get(vm, port)
-            invoke_with_info(@@get_info, {
-                'vm' => vm,
-                'port' => port,
-            })
-        end
-
-
-        # Adds a virtual serial port to the virtual machine.
-        #
-        # @param vm [String]
-        #     Virtual machine identifier.
-        # @param spec [Com::Vmware::Vcenter::Vm::Hardware::Serial::CreateSpec]
-        #     Specification for the new virtual serial port.
-        # @return [String]
-        #     Virtual serial port identifier.
-        # @raise [Com::Vmware::Vapi::Std::Errors::Error]
-        #     if the system reported that the serial port device was created but was unable to confirm the creation because the identifier of the new device could not be determined.
-        # @raise [Com::Vmware::Vapi::Std::Errors::Error]
-        #     if the system reports an error while responding to the request.
-        # @raise [Com::Vmware::Vapi::Std::Errors::NotFound]
-        #     if the virtual machine is not found.
-        # @raise [Com::Vmware::Vapi::Std::Errors::NotAllowedInCurrentState]
-        #     if the virtual machine is not powered off.
-        # @raise [Com::Vmware::Vapi::Std::Errors::UnableToAllocateResource]
-        #     if the virtual machine already has the maximum number of supported serial ports.
-        # @raise [Com::Vmware::Vapi::Std::Errors::ResourceBusy]
-        #     if the virtual machine is busy performing another operation.
-        # @raise [Com::Vmware::Vapi::Std::Errors::ResourceInaccessible]
-        #     if the virtual machine's configuration state cannot be accessed.
-        # @raise [Com::Vmware::Vapi::Std::Errors::ServiceUnavailable]
-        #     if the system is unable to communicate with a service to complete the request.
-        # @raise [Com::Vmware::Vapi::Std::Errors::Unauthenticated]
-        #     if the user can not be authenticated.
-        # @raise [Com::Vmware::Vapi::Std::Errors::Unauthorized]
-        #     if the user doesn't have the required privileges.
-        def create(vm, spec)
-            invoke_with_info(@@create_info, {
-                'vm' => vm,
-                'spec' => spec,
-            })
-        end
-
-
-        # Updates the configuration of a virtual serial port.
-        #
-        # @param vm [String]
-        #     Virtual machine identifier.
-        # @param port [String]
-        #     Virtual serial port identifier.
-        # @param spec [Com::Vmware::Vcenter::Vm::Hardware::Serial::UpdateSpec]
-        #     Specification for updating the virtual serial port.
-        # @return [Void]
-        # @raise [Com::Vmware::Vapi::Std::Errors::Error]
-        #     if the system reports an error while responding to the request.
-        # @raise [Com::Vmware::Vapi::Std::Errors::NotFound]
-        #     if the virtual machine or virtual serial port is not found.
-        # @raise [Com::Vmware::Vapi::Std::Errors::NotAllowedInCurrentState]
-        #     if one or more of the  fields  specified in the  ``spec``   parameter  cannot be modified due to the current power state of the virtual machine or the connection state of the virtual serial port.
-        # @raise [Com::Vmware::Vapi::Std::Errors::ResourceBusy]
-        #     if the virtual machine is busy performing another operation.
-        # @raise [Com::Vmware::Vapi::Std::Errors::ResourceInaccessible]
-        #     if the virtual machine's configuration state cannot be accessed.
-        # @raise [Com::Vmware::Vapi::Std::Errors::ServiceUnavailable]
-        #     if the system is unable to communicate with a service to complete the request.
-        # @raise [Com::Vmware::Vapi::Std::Errors::Unauthenticated]
-        #     if the user can not be authenticated.
-        # @raise [Com::Vmware::Vapi::Std::Errors::Unauthorized]
-        #     if the user doesn't have the required privileges.
-        def update(vm, port, spec)
-            invoke_with_info(@@update_info, {
-                'vm' => vm,
-                'port' => port,
-                'spec' => spec,
-            })
-        end
-
-
-        # Removes a virtual serial port from the virtual machine.
-        #
-        # @param vm [String]
-        #     Virtual machine identifier.
-        # @param port [String]
-        #     Virtual serial port identifier.
-        # @return [Void]
-        # @raise [Com::Vmware::Vapi::Std::Errors::Error]
-        #     if the system reports an error while responding to the request.
-        # @raise [Com::Vmware::Vapi::Std::Errors::NotFound]
-        #     if the virtual machine or virtual serial port is not found.
-        # @raise [Com::Vmware::Vapi::Std::Errors::NotAllowedInCurrentState]
-        #     if the virtual machine is not powered off.
-        # @raise [Com::Vmware::Vapi::Std::Errors::ResourceBusy]
-        #     if the virtual machine is busy performing another operation.
-        # @raise [Com::Vmware::Vapi::Std::Errors::ResourceInaccessible]
-        #     if the virtual machine's configuration state cannot be accessed.
-        # @raise [Com::Vmware::Vapi::Std::Errors::ServiceUnavailable]
-        #     if the system is unable to communicate with a service to complete the request.
-        # @raise [Com::Vmware::Vapi::Std::Errors::Unauthenticated]
-        #     if the user can not be authenticated.
-        # @raise [Com::Vmware::Vapi::Std::Errors::Unauthorized]
-        #     if the user doesn't have the required privileges.
-        def delete(vm, port)
-            invoke_with_info(@@delete_info, {
-                'vm' => vm,
-                'port' => port,
-            })
-        end
-
-
-        # Connects a virtual serial port of a powered-on virtual machine to its backing. Connecting the virtual device makes the backing accessible from the perspective of the guest operating system.  
-        # 
-        #  For a powered-off virtual machine, the   :func:`Com::Vmware::Vcenter::Vm::Hardware::Serial.update`    method  may be used to configure the virtual serial port to start in the connected state when the virtual machine is powered on.
-        #
-        # @param vm [String]
-        #     Virtual machine identifier.
-        # @param port [String]
-        #     Virtual serial port identifier.
-        # @return [Void]
-        # @raise [Com::Vmware::Vapi::Std::Errors::Error]
-        #     if the system reports an error while responding to the request.
-        # @raise [Com::Vmware::Vapi::Std::Errors::NotFound]
-        #     if the virtual machine or virtual serial port is not found.
-        # @raise [Com::Vmware::Vapi::Std::Errors::AlreadyInDesiredState]
-        #     if the virtual serial port is already connected.
-        # @raise [Com::Vmware::Vapi::Std::Errors::NotAllowedInCurrentState]
-        #     if the virtual machine is not powered on.
-        # @raise [Com::Vmware::Vapi::Std::Errors::ResourceBusy]
-        #     if the virtual machine is busy performing another operation.
-        # @raise [Com::Vmware::Vapi::Std::Errors::ResourceInaccessible]
-        #     if the virtual machine's configuration state cannot be accessed.
-        # @raise [Com::Vmware::Vapi::Std::Errors::ServiceUnavailable]
-        #     if the system is unable to communicate with a service to complete the request.
-        # @raise [Com::Vmware::Vapi::Std::Errors::Unauthenticated]
-        #     if the user can not be authenticated.
-        # @raise [Com::Vmware::Vapi::Std::Errors::Unauthorized]
-        #     if the user doesn't have the required privileges.
-        def connect(vm, port)
-            invoke_with_info(@@connect_info, {
-                'vm' => vm,
-                'port' => port,
-            })
-        end
-
-
-        # Disconnects a virtual serial port of a powered-on virtual machine from its backing. The virtual device is still present and its backing configuration is unchanged, but from the perspective of the guest operating system, the serial port is not connected to its backing.  
-        # 
-        #  For a powered-off virtual machine, the   :func:`Com::Vmware::Vcenter::Vm::Hardware::Serial.update`    method  may be used to configure the virtual serial port to start in the disconnected state when the virtual machine is powered on.
-        #
-        # @param vm [String]
-        #     Virtual machine identifier.
-        # @param port [String]
-        #     Virtual serial port identifier.
-        # @return [Void]
-        # @raise [Com::Vmware::Vapi::Std::Errors::Error]
-        #     if the system reports an error while responding to the request.
-        # @raise [Com::Vmware::Vapi::Std::Errors::NotFound]
-        #     if the virtual machine or virtual serial port is not found.
-        # @raise [Com::Vmware::Vapi::Std::Errors::AlreadyInDesiredState]
-        #     if the virtual serial port is already disconnected.
-        # @raise [Com::Vmware::Vapi::Std::Errors::NotAllowedInCurrentState]
-        #     if the virtual machine is not powered on.
-        # @raise [Com::Vmware::Vapi::Std::Errors::ResourceBusy]
-        #     if the virtual machine is busy performing another operation.
-        # @raise [Com::Vmware::Vapi::Std::Errors::ResourceInaccessible]
-        #     if the virtual machine's configuration state cannot be accessed.
-        # @raise [Com::Vmware::Vapi::Std::Errors::ServiceUnavailable]
-        #     if the system is unable to communicate with a service to complete the request.
-        # @raise [Com::Vmware::Vapi::Std::Errors::Unauthenticated]
-        #     if the user can not be authenticated.
-        # @raise [Com::Vmware::Vapi::Std::Errors::Unauthorized]
-        #     if the user doesn't have the required privileges.
-        def disconnect(vm, port)
-            invoke_with_info(@@disconnect_info, {
-                'vm' => vm,
-                'port' => port,
-            })
-        end
-
-
-
-        # The  ``Com::Vmware::Vcenter::Vm::Hardware::Serial::BackingInfo``   class  contains information about the physical resource backing a virtual serial port.
-        # @!attribute [rw] type
-        #     @return [Com::Vmware::Vcenter::Vm::Hardware::Serial::BackingType]
-        #     Backing type for the virtual serial port.
-        # @!attribute [rw] file
-        #     @return [String]
-        #     Path of the file backing the virtual serial port.
-        #     This  field  is optional and it is only relevant when the value of  ``type``  is   :attr:`Com::Vmware::Vcenter::Vm::Hardware::Serial::BackingType.FILE`  .
-        # @!attribute [rw] host_device
-        #     @return [String, nil]
-        #     Name of the device backing the virtual serial port.  
-        #     This  field  will be  nil  if  ``autoDetect``  is true and the virtual serial port is not connected or no suitable device is available on the host.
-        # @!attribute [rw] auto_detect
-        #     @return [Boolean]
-        #     Flag indicating whether the virtual serial port is configured to automatically detect a suitable host device.
-        #     This  field  is optional and it is only relevant when the value of  ``type``  is   :attr:`Com::Vmware::Vcenter::Vm::Hardware::Serial::BackingType.HOST_DEVICE`  .
-        # @!attribute [rw] pipe
-        #     @return [String]
-        #     Name of the pipe backing the virtual serial port.
-        #     This  field  is optional and it is only relevant when the value of  ``type``  is one of   :attr:`Com::Vmware::Vcenter::Vm::Hardware::Serial::BackingType.PIPE_SERVER`   or   :attr:`Com::Vmware::Vcenter::Vm::Hardware::Serial::BackingType.PIPE_CLIENT`  .
-        # @!attribute [rw] no_rx_loss
-        #     @return [Boolean]
-        #     Flag that enables optimized data transfer over the pipe. When the value is true, the host buffers data to prevent data overrun. This allows the virtual machine to read all of the data transferred over the pipe with no data loss.
-        #     This  field  is optional and it is only relevant when the value of  ``type``  is one of   :attr:`Com::Vmware::Vcenter::Vm::Hardware::Serial::BackingType.PIPE_SERVER`   or   :attr:`Com::Vmware::Vcenter::Vm::Hardware::Serial::BackingType.PIPE_CLIENT`  .
-        # @!attribute [rw] network_location
-        #     @return [URI]
-        #     URI specifying the location of the network service backing the virtual serial port.  
-        #     
-        #       * If   :attr:`Com::Vmware::Vcenter::Vm::Hardware::Serial::BackingInfo.type`   is   :attr:`Com::Vmware::Vcenter::Vm::Hardware::Serial::BackingType.NETWORK_SERVER`  , this  field  is the location used by clients to connect to this server. The hostname part of the URI should either be empty or should specify the address of the host on which the virtual machine is running.
-        #        * If   :attr:`Com::Vmware::Vcenter::Vm::Hardware::Serial::BackingInfo.type`   is   :attr:`Com::Vmware::Vcenter::Vm::Hardware::Serial::BackingType.NETWORK_CLIENT`  , this  field  is the location used by the virtual machine to connect to the remote server.
-        #       
-        #     This  field  is optional and it is only relevant when the value of  ``type``  is one of   :attr:`Com::Vmware::Vcenter::Vm::Hardware::Serial::BackingType.NETWORK_SERVER`   or   :attr:`Com::Vmware::Vcenter::Vm::Hardware::Serial::BackingType.NETWORK_CLIENT`  .
-        # @!attribute [rw] proxy
-        #     @return [URI, nil]
-        #     Proxy service that provides network access to the network backing. If set, the virtual machine initiates a connection with the proxy service and forwards the traffic to the proxy.
-        #     If  nil , no proxy service is configured.
-        class BackingInfo < VAPI::Bindings::VapiStruct
-
-            class << self
-                # Holds (gets or creates) the binding type metadata for this structure type.
-                # @scope class
-                # @return [VAPI::Bindings::StructType] the binding type
-                def binding_type
-                    @binding_type ||= VAPI::Bindings::StructType.new(
-                        'com.vmware.vcenter.vm.hardware.serial.backing_info',
-                        {
-                            'type' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::Vm::Hardware::Serial::BackingType'),
-                            'file' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::StringType.instance),
-                            'host_device' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::StringType.instance),
-                            'auto_detect' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::BooleanType.instance),
-                            'pipe' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::StringType.instance),
-                            'no_rx_loss' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::BooleanType.instance),
-                            'network_location' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::URIType.instance),
-                            'proxy' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::URIType.instance),
-                        },
-                        BackingInfo,
-                        false,
-                        nil)
-                end
-            end
-
-            attr_accessor :type,
-                          :file,
-                          :host_device,
-                          :auto_detect,
-                          :pipe,
-                          :no_rx_loss,
-                          :network_location,
-                          :proxy
-
-            # Constructs a new instance.
-            # @param ruby_values [Hash] a map of initial property values (optional)
-            # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
-            def initialize(ruby_values=nil, struct_value=nil)
-                super(self.class.binding_type, ruby_values, struct_value)
-            end
-        end
-
-
-        # The  ``Com::Vmware::Vcenter::Vm::Hardware::Serial::BackingSpec``   class  provides a specification of the physical resource backing a virtual serial port.
-        # @!attribute [rw] type
-        #     @return [Com::Vmware::Vcenter::Vm::Hardware::Serial::BackingType]
-        #     Backing type for the virtual serial port.
-        # @!attribute [rw] file
-        #     @return [String]
-        #     Path of the file backing the virtual serial port.
-        #     This  field  is optional and it is only relevant when the value of  ``type``  is   :attr:`Com::Vmware::Vcenter::Vm::Hardware::Serial::BackingType.FILE`  .
-        # @!attribute [rw] host_device
-        #     @return [String, nil]
-        #     Name of the device backing the virtual serial port.  
-        #     If  nil , the virtual serial port will be configured to automatically detect a suitable host device.
-        # @!attribute [rw] pipe
-        #     @return [String]
-        #     Name of the pipe backing the virtual serial port.
-        #     This  field  is optional and it is only relevant when the value of  ``type``  is one of   :attr:`Com::Vmware::Vcenter::Vm::Hardware::Serial::BackingType.PIPE_SERVER`   or   :attr:`Com::Vmware::Vcenter::Vm::Hardware::Serial::BackingType.PIPE_CLIENT`  .
-        # @!attribute [rw] no_rx_loss
-        #     @return [Boolean, nil]
-        #     Flag that enables optimized data transfer over the pipe. When the value is true, the host buffers data to prevent data overrun. This allows the virtual machine to read all of the data transferred over the pipe with no data loss.
-        #     If  nil , defaults to  false .
-        # @!attribute [rw] network_location
-        #     @return [URI]
-        #     URI specifying the location of the network service backing the virtual serial port.  
-        #     
-        #       * If   :attr:`Com::Vmware::Vcenter::Vm::Hardware::Serial::BackingSpec.type`   is   :attr:`Com::Vmware::Vcenter::Vm::Hardware::Serial::BackingType.NETWORK_SERVER`  , this  field  is the location used by clients to connect to this server. The hostname part of the URI should either be empty or should specify the address of the host on which the virtual machine is running.
-        #        * If   :attr:`Com::Vmware::Vcenter::Vm::Hardware::Serial::BackingSpec.type`   is   :attr:`Com::Vmware::Vcenter::Vm::Hardware::Serial::BackingType.NETWORK_CLIENT`  , this  field  is the location used by the virtual machine to connect to the remote server.
-        #       
-        #     This  field  is optional and it is only relevant when the value of  ``type``  is one of   :attr:`Com::Vmware::Vcenter::Vm::Hardware::Serial::BackingType.NETWORK_SERVER`   or   :attr:`Com::Vmware::Vcenter::Vm::Hardware::Serial::BackingType.NETWORK_CLIENT`  .
-        # @!attribute [rw] proxy
-        #     @return [URI, nil]
-        #     Proxy service that provides network access to the network backing. If set, the virtual machine initiates a connection with the proxy service and forwards the traffic to the proxy.
-        #     If  nil , no proxy service should be used.
-        class BackingSpec < VAPI::Bindings::VapiStruct
-
-            class << self
-                # Holds (gets or creates) the binding type metadata for this structure type.
-                # @scope class
-                # @return [VAPI::Bindings::StructType] the binding type
-                def binding_type
-                    @binding_type ||= VAPI::Bindings::StructType.new(
-                        'com.vmware.vcenter.vm.hardware.serial.backing_spec',
-                        {
-                            'type' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::Vm::Hardware::Serial::BackingType'),
-                            'file' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::StringType.instance),
-                            'host_device' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::StringType.instance),
-                            'pipe' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::StringType.instance),
-                            'no_rx_loss' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::BooleanType.instance),
-                            'network_location' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::URIType.instance),
-                            'proxy' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::URIType.instance),
-                        },
-                        BackingSpec,
-                        false,
-                        nil)
-                end
-            end
-
-            attr_accessor :type,
-                          :file,
-                          :host_device,
-                          :pipe,
-                          :no_rx_loss,
-                          :network_location,
-                          :proxy
-
-            # Constructs a new instance.
-            # @param ruby_values [Hash] a map of initial property values (optional)
-            # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
-            def initialize(ruby_values=nil, struct_value=nil)
-                super(self.class.binding_type, ruby_values, struct_value)
-            end
-        end
-
-
-        # The  ``Com::Vmware::Vcenter::Vm::Hardware::Serial::Info``   class  contains information about a virtual serial port.
-        # @!attribute [rw] label
-        #     @return [String]
-        #     Device label.
-        # @!attribute [rw] yield_on_poll
-        #     @return [Boolean]
-        #     CPU yield behavior. If set to true, the virtual machine will periodically relinquish the processor if its sole task is polling the virtual serial port. The amount of time it takes to regain the processor will depend on the degree of other virtual machine activity on the host.
-        # @!attribute [rw] backing
-        #     @return [Com::Vmware::Vcenter::Vm::Hardware::Serial::BackingInfo]
-        #     Physical resource backing for the virtual serial port.
-        class Info < VAPI::Bindings::VapiStruct
-
-            class << self
-                # Holds (gets or creates) the binding type metadata for this structure type.
-                # @scope class
-                # @return [VAPI::Bindings::StructType] the binding type
-                def binding_type
-                    @binding_type ||= VAPI::Bindings::StructType.new(
-                        'com.vmware.vcenter.vm.hardware.serial.info',
-                        {
-                            'label' => VAPI::Bindings::StringType.instance,
-                            'yield_on_poll' => VAPI::Bindings::BooleanType.instance,
-                            'backing' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::Vm::Hardware::Serial::BackingInfo'),
-                            'state' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::Vm::Hardware::ConnectionState'),
-                            'start_connected' => VAPI::Bindings::BooleanType.instance,
-                            'allow_guest_control' => VAPI::Bindings::BooleanType.instance,
-                        },
-                        Info,
-                        false,
-                        nil)
-                end
-            end
-
-            attr_accessor :label,
-                          :yield_on_poll,
-                          :backing,
-                          :state,
-                          :start_connected,
-                          :allow_guest_control
-
-            # Constructs a new instance.
-            # @param ruby_values [Hash] a map of initial property values (optional)
-            # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
-            def initialize(ruby_values=nil, struct_value=nil)
-                super(self.class.binding_type, ruby_values, struct_value)
-            end
-        end
-
-
-        # The  ``Com::Vmware::Vcenter::Vm::Hardware::Serial::CreateSpec``   class  provides a specification for the configuration of a newly-created virtual serial port.
-        # @!attribute [rw] yield_on_poll
-        #     @return [Boolean, nil]
-        #     CPU yield behavior. If set to true, the virtual machine will periodically relinquish the processor if its sole task is polling the virtual serial port. The amount of time it takes to regain the processor will depend on the degree of other virtual machine activity on the host.
-        #     If  nil , defaults to false.
-        # @!attribute [rw] backing
-        #     @return [Com::Vmware::Vcenter::Vm::Hardware::Serial::BackingSpec, nil]
-        #     Physical resource backing for the virtual serial port.
-        #     If  nil , defaults to automatic detection of a suitable host device.
-        class CreateSpec < VAPI::Bindings::VapiStruct
-
-            class << self
-                # Holds (gets or creates) the binding type metadata for this structure type.
-                # @scope class
-                # @return [VAPI::Bindings::StructType] the binding type
-                def binding_type
-                    @binding_type ||= VAPI::Bindings::StructType.new(
-                        'com.vmware.vcenter.vm.hardware.serial.create_spec',
-                        {
-                            'yield_on_poll' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::BooleanType.instance),
-                            'backing' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::Vm::Hardware::Serial::BackingSpec')),
-                            'start_connected' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::BooleanType.instance),
-                            'allow_guest_control' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::BooleanType.instance),
-                        },
-                        CreateSpec,
-                        false,
-                        nil)
-                end
-            end
-
-            attr_accessor :yield_on_poll,
-                          :backing,
-                          :start_connected,
-                          :allow_guest_control
-
-            # Constructs a new instance.
-            # @param ruby_values [Hash] a map of initial property values (optional)
-            # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
-            def initialize(ruby_values=nil, struct_value=nil)
-                super(self.class.binding_type, ruby_values, struct_value)
-            end
-        end
-
-
-        # The  ``Com::Vmware::Vcenter::Vm::Hardware::Serial::UpdateSpec``   class  describes the updates to be made to the configuration of a virtual serial port.
-        # @!attribute [rw] yield_on_poll
-        #     @return [Boolean, nil]
-        #     CPU yield behavior. If set to true, the virtual machine will periodically relinquish the processor if its sole task is polling the virtual serial port. The amount of time it takes to regain the processor will depend on the degree of other virtual machine activity on the host.  
-        #     
-        #      This  field  may be modified at any time, and changes applied to a connected virtual serial port take effect immediately.
-        #     If  nil , the value is unchanged.
-        # @!attribute [rw] backing
-        #     @return [Com::Vmware::Vcenter::Vm::Hardware::Serial::BackingSpec, nil]
-        #     Physical resource backing for the virtual serial port.  
-        #     
-        #      This  field  may only be modified if the virtual machine is not powered on or the virtual serial port is not connected.
-        #     If  nil , the value is unchanged.
-        class UpdateSpec < VAPI::Bindings::VapiStruct
-
-            class << self
-                # Holds (gets or creates) the binding type metadata for this structure type.
-                # @scope class
-                # @return [VAPI::Bindings::StructType] the binding type
-                def binding_type
-                    @binding_type ||= VAPI::Bindings::StructType.new(
-                        'com.vmware.vcenter.vm.hardware.serial.update_spec',
-                        {
-                            'yield_on_poll' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::BooleanType.instance),
-                            'backing' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::Vm::Hardware::Serial::BackingSpec')),
-                            'start_connected' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::BooleanType.instance),
-                            'allow_guest_control' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::BooleanType.instance),
-                        },
-                        UpdateSpec,
-                        false,
-                        nil)
-                end
-            end
-
-            attr_accessor :yield_on_poll,
-                          :backing,
-                          :start_connected,
-                          :allow_guest_control
-
-            # Constructs a new instance.
-            # @param ruby_values [Hash] a map of initial property values (optional)
-            # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
-            def initialize(ruby_values=nil, struct_value=nil)
-                super(self.class.binding_type, ruby_values, struct_value)
-            end
-        end
-
-
-        # The  ``Com::Vmware::Vcenter::Vm::Hardware::Serial::Summary``   class  contains commonly used information about a virtual serial port.
-        # @!attribute [rw] port
-        #     @return [String]
-        #     Identifier of the virtual serial port.
-        class Summary < VAPI::Bindings::VapiStruct
-
-            class << self
-                # Holds (gets or creates) the binding type metadata for this structure type.
-                # @scope class
-                # @return [VAPI::Bindings::StructType] the binding type
-                def binding_type
-                    @binding_type ||= VAPI::Bindings::StructType.new(
-                        'com.vmware.vcenter.vm.hardware.serial.summary',
-                        {
-                            'port' => VAPI::Bindings::IdType.new(resource_types='com.vmware.vcenter.vm.hardware.SerialPort'),
-                        },
-                        Summary,
-                        false,
-                        nil)
-                end
-            end
-
-            attr_accessor :port
-
-            # Constructs a new instance.
-            # @param ruby_values [Hash] a map of initial property values (optional)
-            # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
-            def initialize(ruby_values=nil, struct_value=nil)
-                super(self.class.binding_type, ruby_values, struct_value)
-            end
-        end
-
-
-
-        # The  ``Com::Vmware::Vcenter::Vm::Hardware::Serial::BackingType``   enumerated type  defines the valid backing types for a virtual serial port.
-        # @!attribute [rw] file
-        #     @return [Com::Vmware::Vcenter::Vm::Hardware::Serial::BackingType]
-        #     Virtual serial port is backed by a file.
-        # @!attribute [rw] host_device
-        #     @return [Com::Vmware::Vcenter::Vm::Hardware::Serial::BackingType]
-        #     Virtual serial port is backed by a device on the host where the virtual machine is running.
-        # @!attribute [rw] pipe_server
-        #     @return [Com::Vmware::Vcenter::Vm::Hardware::Serial::BackingType]
-        #     Virtual serial port is backed by a named pipe server. The virtual machine will accept a connection from a host application or another virtual machine on the same host. This is useful for capturing debugging information sent through the virtual serial port.
-        # @!attribute [rw] pipe_client
-        #     @return [Com::Vmware::Vcenter::Vm::Hardware::Serial::BackingType]
-        #     Virtual serial port is backed by a named pipe client. The virtual machine will connect to the named pipe provided by a host application or another virtual machine on the same host. This is useful for capturing debugging information sent through the virtual serial port.
-        # @!attribute [rw] network_server
-        #     @return [Com::Vmware::Vcenter::Vm::Hardware::Serial::BackingType]
-        #     Virtual serial port is backed by a network server. This backing may be used to create a network-accessible serial port on the virtual machine, accepting a connection from a remote system.
-        # @!attribute [rw] network_client
-        #     @return [Com::Vmware::Vcenter::Vm::Hardware::Serial::BackingType]
-        #     Virtual serial port is backed by a network client. This backing may be used to create a network-accessible serial port on the virtual machine, initiating a connection to a remote system.
-        class BackingType < VAPI::Bindings::VapiEnum
-
-            class << self
-                # Holds (gets or creates) the binding type metadata for this enumeration type.
-                # @scope class
-                # @return [VAPI::Bindings::EnumType] the binding type
-                def binding_type
-                    @binding_type ||= VAPI::Bindings::EnumType.new(
-                        'com.vmware.vcenter.vm.hardware.serial.backing_type',
-                        BackingType)
-                end
-
-                # Converts from a string value (perhaps off the wire) to an instance
-                # of this enum type.
-                # @param value [String] the actual value of the enum instance
-                # @return [BackingType] the instance found for the value, otherwise
-                #         an unknown instance will be built for the value
-                def from_string(value)
-                    begin
-                        const_get(value)
-                    rescue NameError
-                        BackingType.new('UNKNOWN', value)
-                    end
-                end
-            end
-
-            private
-
-            # Constructs a new instance.
-            # @param value [String] the actual value of the enum instance
-            # @param unknown [String] the unknown value when value is 'UKNOWN'
-            def initialize(value, unknown=nil)
-                super(self.class.binding_type, value, unknown)
-            end
-
-            public
-
-            # @!attribute [rw] file
-            #     @return [Com::Vmware::Vcenter::Vm::Hardware::Serial::BackingType]
-            #     Virtual serial port is backed by a file.
-            FILE = BackingType.new('FILE')
-
-            # @!attribute [rw] host_device
-            #     @return [Com::Vmware::Vcenter::Vm::Hardware::Serial::BackingType]
-            #     Virtual serial port is backed by a device on the host where the virtual machine is running.
-            HOST_DEVICE = BackingType.new('HOST_DEVICE')
-
-            # @!attribute [rw] pipe_server
-            #     @return [Com::Vmware::Vcenter::Vm::Hardware::Serial::BackingType]
-            #     Virtual serial port is backed by a named pipe server. The virtual machine will accept a connection from a host application or another virtual machine on the same host. This is useful for capturing debugging information sent through the virtual serial port.
-            PIPE_SERVER = BackingType.new('PIPE_SERVER')
-
-            # @!attribute [rw] pipe_client
-            #     @return [Com::Vmware::Vcenter::Vm::Hardware::Serial::BackingType]
-            #     Virtual serial port is backed by a named pipe client. The virtual machine will connect to the named pipe provided by a host application or another virtual machine on the same host. This is useful for capturing debugging information sent through the virtual serial port.
-            PIPE_CLIENT = BackingType.new('PIPE_CLIENT')
-
-            # @!attribute [rw] network_server
-            #     @return [Com::Vmware::Vcenter::Vm::Hardware::Serial::BackingType]
-            #     Virtual serial port is backed by a network server. This backing may be used to create a network-accessible serial port on the virtual machine, accepting a connection from a remote system.
-            NETWORK_SERVER = BackingType.new('NETWORK_SERVER')
-
-            # @!attribute [rw] network_client
-            #     @return [Com::Vmware::Vcenter::Vm::Hardware::Serial::BackingType]
-            #     Virtual serial port is backed by a network client. This backing may be used to create a network-accessible serial port on the virtual machine, initiating a connection to a remote system.
-            NETWORK_CLIENT = BackingType.new('NETWORK_CLIENT')
-
-        end
-
-
-    end
-
-
-
-    # The  ``Com::Vmware::Vcenter::Vm::Hardware::IdeAddressInfo``   class  contains information about the address of a virtual device that is attached to a virtual IDE adapter of a virtual machine.
-    # @!attribute [rw] primary
+    # The  ``Com::Vmware::Vcenter::VM::Hardware::Boot::Info``   class  contains information about the virtual machine boot process.
+    # @!attribute [rw] type
+    #     @return [Com::Vmware::Vcenter::VM::Hardware::Boot::Type]
+    #     Firmware type used by the virtual machine.
+    # @!attribute [rw] efi_legacy_boot
     #     @return [Boolean]
-    #     Flag specifying whether the device is attached to the primary or secondary IDE adapter of the virtual machine.
-    # @!attribute [rw] master
+    #     Flag indicating whether to use EFI legacy boot mode.
+    #     This  field  is optional and it is only relevant when the value of  ``type``  is   :attr:`Com::Vmware::Vcenter::VM::Hardware::Boot::Type.EFI`  .
+    # @!attribute [rw] network_protocol
+    #     @return [Com::Vmware::Vcenter::VM::Hardware::Boot::NetworkProtocol]
+    #     Protocol to use when attempting to boot the virtual machine over the network.
+    #     This  field  is optional and it is only relevant when the value of  ``type``  is   :attr:`Com::Vmware::Vcenter::VM::Hardware::Boot::Type.EFI`  .
+    # @!attribute [rw] delay
+    #     @return [Fixnum]
+    #     Delay in milliseconds before beginning the firmware boot process when the virtual machine is powered on. This delay may be used to provide a time window for users to connect to the virtual machine console and enter BIOS setup mode.
+    # @!attribute [rw] retry_
     #     @return [Boolean]
-    #     Flag specifying whether the device is the master or slave device on the IDE adapter.
-    class IdeAddressInfo < VAPI::Bindings::VapiStruct
-
-        class << self
-            # Holds (gets or creates) the binding type metadata for this structure type.
-            # @scope class
-            # @return [VAPI::Bindings::StructType] the binding type
-            def binding_type
-                @binding_type ||= VAPI::Bindings::StructType.new(
-                    'com.vmware.vcenter.vm.hardware.ide_address_info',
-                    {
-                        'primary' => VAPI::Bindings::BooleanType.instance,
-                        'master' => VAPI::Bindings::BooleanType.instance,
-                    },
-                    IdeAddressInfo,
-                    false,
-                    nil)
-            end
+    #     Flag indicating whether the virtual machine will automatically retry the boot process after a failure.
+    # @!attribute [rw] retry_delay
+    #     @return [Fixnum]
+    #     Delay in milliseconds before retrying the boot process after a failure; applicable only when   :attr:`Com::Vmware::Vcenter::VM::Hardware::Boot::Info.retry_`   is true.
+    # @!attribute [rw] enter_setup_mode
+    #     @return [Boolean]
+    #     Flag indicating whether the firmware boot process will automatically enter setup mode the next time the virtual machine boots. Note that this flag will automatically be reset to false once the virtual machine enters setup mode.
+    class Info < VAPI::Bindings::VapiStruct
+      class << self
+        # Holds (gets or creates) the binding type metadata for this structure type.
+        # @scope class
+        # @return [VAPI::Bindings::StructType] the binding type
+        def binding_type
+          @binding_type ||= VAPI::Bindings::StructType.new(
+            'com.vmware.vcenter.vm.hardware.boot.info',
+            {
+              'type' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::VM::Hardware::Boot::Type'),
+              'efi_legacy_boot' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::BooleanType.instance),
+              'network_protocol' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::VM::Hardware::Boot::NetworkProtocol')),
+              'delay' => VAPI::Bindings::IntegerType.instance,
+              'retry' => VAPI::Bindings::BooleanType.instance,
+              'retry_delay' => VAPI::Bindings::IntegerType.instance,
+              'enter_setup_mode' => VAPI::Bindings::BooleanType.instance
+            },
+            Info,
+            false,
+            nil
+          )
         end
+      end
 
-        attr_accessor :primary,
-                      :master
+      attr_accessor :type,
+                    :efi_legacy_boot,
+                    :network_protocol,
+                    :delay,
+                    :retry_,
+                    :retry_delay,
+                    :enter_setup_mode
 
-        # Constructs a new instance.
-        # @param ruby_values [Hash] a map of initial property values (optional)
-        # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
-        def initialize(ruby_values=nil, struct_value=nil)
-            super(self.class.binding_type, ruby_values, struct_value)
-        end
+      # Constructs a new instance.
+      # @param ruby_values [Hash] a map of initial property values (optional)
+      # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
+      def initialize(ruby_values = nil, struct_value = nil)
+        super(self.class.binding_type, ruby_values, struct_value)
+      end
     end
 
-
-    # The  ``Com::Vmware::Vcenter::Vm::Hardware::ScsiAddressInfo``   class  contains information about the address of a virtual device that is attached to a virtual SCSI adapter of a virtual machine.
-    # @!attribute [rw] bus
-    #     @return [Fixnum]
-    #     Bus number of the adapter to which the device is attached.
-    # @!attribute [rw] unit
-    #     @return [Fixnum]
-    #     Unit number of the device.
-    class ScsiAddressInfo < VAPI::Bindings::VapiStruct
-
-        class << self
-            # Holds (gets or creates) the binding type metadata for this structure type.
-            # @scope class
-            # @return [VAPI::Bindings::StructType] the binding type
-            def binding_type
-                @binding_type ||= VAPI::Bindings::StructType.new(
-                    'com.vmware.vcenter.vm.hardware.scsi_address_info',
-                    {
-                        'bus' => VAPI::Bindings::IntegerType.instance,
-                        'unit' => VAPI::Bindings::IntegerType.instance,
-                    },
-                    ScsiAddressInfo,
-                    false,
-                    nil)
-            end
-        end
-
-        attr_accessor :bus,
-                      :unit
-
-        # Constructs a new instance.
-        # @param ruby_values [Hash] a map of initial property values (optional)
-        # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
-        def initialize(ruby_values=nil, struct_value=nil)
-            super(self.class.binding_type, ruby_values, struct_value)
-        end
-    end
-
-
-    # The  ``Com::Vmware::Vcenter::Vm::Hardware::SataAddressInfo``   class  contains information about the address of a virtual device that is attached to a virtual SATA adapter of a virtual machine.
-    # @!attribute [rw] bus
-    #     @return [Fixnum]
-    #     Bus number of the adapter to which the device is attached.
-    # @!attribute [rw] unit
-    #     @return [Fixnum]
-    #     Unit number of the device.
-    class SataAddressInfo < VAPI::Bindings::VapiStruct
-
-        class << self
-            # Holds (gets or creates) the binding type metadata for this structure type.
-            # @scope class
-            # @return [VAPI::Bindings::StructType] the binding type
-            def binding_type
-                @binding_type ||= VAPI::Bindings::StructType.new(
-                    'com.vmware.vcenter.vm.hardware.sata_address_info',
-                    {
-                        'bus' => VAPI::Bindings::IntegerType.instance,
-                        'unit' => VAPI::Bindings::IntegerType.instance,
-                    },
-                    SataAddressInfo,
-                    false,
-                    nil)
-            end
-        end
-
-        attr_accessor :bus,
-                      :unit
-
-        # Constructs a new instance.
-        # @param ruby_values [Hash] a map of initial property values (optional)
-        # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
-        def initialize(ruby_values=nil, struct_value=nil)
-            super(self.class.binding_type, ruby_values, struct_value)
-        end
-    end
-
-
-    # The  ``Com::Vmware::Vcenter::Vm::Hardware::IdeAddressSpec``   class  contains information for specifying the address of a virtual device that is attached to a virtual IDE adapter of a virtual machine.
-    # @!attribute [rw] primary
+    # The  ``Com::Vmware::Vcenter::VM::Hardware::Boot::CreateSpec``   class  describes settings used when booting a virtual machine.
+    # @!attribute [rw] type
+    #     @return [Com::Vmware::Vcenter::VM::Hardware::Boot::Type, nil]
+    #     Firmware type to be used by the virtual machine.
+    #     If  nil , defaults to value that is recommended for the guest OS and is supported for the virtual hardware version.
+    # @!attribute [rw] efi_legacy_boot
     #     @return [Boolean, nil]
-    #     Flag specifying whether the device should be attached to the primary or secondary IDE adapter of the virtual machine.
-    #     If  nil , the server will choose a adapter with an available connection. If no IDE connections are available, the request will be rejected.
-    # @!attribute [rw] master
-    #     @return [Boolean, nil]
-    #     Flag specifying whether the device should be the master or slave device on the IDE adapter.
-    #     If  nil , the server will choose an available connection type. If no IDE connections are available, the request will be rejected.
-    class IdeAddressSpec < VAPI::Bindings::VapiStruct
-
-        class << self
-            # Holds (gets or creates) the binding type metadata for this structure type.
-            # @scope class
-            # @return [VAPI::Bindings::StructType] the binding type
-            def binding_type
-                @binding_type ||= VAPI::Bindings::StructType.new(
-                    'com.vmware.vcenter.vm.hardware.ide_address_spec',
-                    {
-                        'primary' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::BooleanType.instance),
-                        'master' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::BooleanType.instance),
-                    },
-                    IdeAddressSpec,
-                    false,
-                    nil)
-            end
-        end
-
-        attr_accessor :primary,
-                      :master
-
-        # Constructs a new instance.
-        # @param ruby_values [Hash] a map of initial property values (optional)
-        # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
-        def initialize(ruby_values=nil, struct_value=nil)
-            super(self.class.binding_type, ruby_values, struct_value)
-        end
-    end
-
-
-    # The  ``Com::Vmware::Vcenter::Vm::Hardware::ScsiAddressSpec``   class  contains information for specifying the address of a virtual device that is attached to a virtual SCSI adapter of a virtual machine.
-    # @!attribute [rw] bus
-    #     @return [Fixnum]
-    #     Bus number of the adapter to which the device should be attached.
-    # @!attribute [rw] unit
+    #     Flag indicating whether to use EFI legacy boot mode.
+    #     If  nil , defaults to value that is recommended for the guest OS and is supported for the virtual hardware version.
+    # @!attribute [rw] network_protocol
+    #     @return [Com::Vmware::Vcenter::VM::Hardware::Boot::NetworkProtocol, nil]
+    #     Protocol to use when attempting to boot the virtual machine over the network.
+    #     If  nil , defaults to a system defined default value.
+    # @!attribute [rw] delay
     #     @return [Fixnum, nil]
-    #     Unit number of the device.
-    #     If  nil , the server will choose an available unit number on the specified adapter. If there are no available connections on the adapter, the request will be rejected.
-    class ScsiAddressSpec < VAPI::Bindings::VapiStruct
-
-        class << self
-            # Holds (gets or creates) the binding type metadata for this structure type.
-            # @scope class
-            # @return [VAPI::Bindings::StructType] the binding type
-            def binding_type
-                @binding_type ||= VAPI::Bindings::StructType.new(
-                    'com.vmware.vcenter.vm.hardware.scsi_address_spec',
-                    {
-                        'bus' => VAPI::Bindings::IntegerType.instance,
-                        'unit' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::IntegerType.instance),
-                    },
-                    ScsiAddressSpec,
-                    false,
-                    nil)
-            end
-        end
-
-        attr_accessor :bus,
-                      :unit
-
-        # Constructs a new instance.
-        # @param ruby_values [Hash] a map of initial property values (optional)
-        # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
-        def initialize(ruby_values=nil, struct_value=nil)
-            super(self.class.binding_type, ruby_values, struct_value)
-        end
-    end
-
-
-    # The  ``Com::Vmware::Vcenter::Vm::Hardware::SataAddressSpec``   class  contains information for specifying the address of a virtual device that is attached to a virtual SATA adapter of a virtual machine.
-    # @!attribute [rw] bus
-    #     @return [Fixnum]
-    #     Bus number of the adapter to which the device should be attached.
-    # @!attribute [rw] unit
+    #     Delay in milliseconds before beginning the firmware boot process when the virtual machine is powered on. This delay may be used to provide a time window for users to connect to the virtual machine console and enter BIOS setup mode.
+    #     If  nil , default value is 0.
+    # @!attribute [rw] retry_
+    #     @return [Boolean, nil]
+    #     Flag indicating whether the virtual machine should automatically retry the boot process after a failure.
+    #     If  nil , default value is false.
+    # @!attribute [rw] retry_delay
     #     @return [Fixnum, nil]
-    #     Unit number of the device.
-    #     If  nil , the server will choose an available unit number on the specified adapter. If there are no available connections on the adapter, the request will be rejected.
-    class SataAddressSpec < VAPI::Bindings::VapiStruct
-
-        class << self
-            # Holds (gets or creates) the binding type metadata for this structure type.
-            # @scope class
-            # @return [VAPI::Bindings::StructType] the binding type
-            def binding_type
-                @binding_type ||= VAPI::Bindings::StructType.new(
-                    'com.vmware.vcenter.vm.hardware.sata_address_spec',
-                    {
-                        'bus' => VAPI::Bindings::IntegerType.instance,
-                        'unit' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::IntegerType.instance),
-                    },
-                    SataAddressSpec,
-                    false,
-                    nil)
-            end
-        end
-
-        attr_accessor :bus,
-                      :unit
-
-        # Constructs a new instance.
-        # @param ruby_values [Hash] a map of initial property values (optional)
-        # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
-        def initialize(ruby_values=nil, struct_value=nil)
-            super(self.class.binding_type, ruby_values, struct_value)
-        end
-    end
-
-
-    # The  ``Com::Vmware::Vcenter::Vm::Hardware::ConnectionInfo``   class  provides information about the state and configuration of a removable virtual device.
-    # @!attribute [rw] state
-    #     @return [Com::Vmware::Vcenter::Vm::Hardware::ConnectionState]
-    #     Connection status of the virtual device.
-    # @!attribute [rw] start_connected
-    #     @return [Boolean]
-    #     Flag indicating whether the virtual device should be connected whenever the virtual machine is powered on.
-    # @!attribute [rw] allow_guest_control
-    #     @return [Boolean]
-    #     Flag indicating whether the guest can connect and disconnect the device.
-    class ConnectionInfo < VAPI::Bindings::VapiStruct
-
-        class << self
-            # Holds (gets or creates) the binding type metadata for this structure type.
-            # @scope class
-            # @return [VAPI::Bindings::StructType] the binding type
-            def binding_type
-                @binding_type ||= VAPI::Bindings::StructType.new(
-                    'com.vmware.vcenter.vm.hardware.connection_info',
-                    {
-                        'state' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::Vm::Hardware::ConnectionState'),
-                        'start_connected' => VAPI::Bindings::BooleanType.instance,
-                        'allow_guest_control' => VAPI::Bindings::BooleanType.instance,
-                    },
-                    ConnectionInfo,
-                    false,
-                    nil)
-            end
-        end
-
-        attr_accessor :state,
-                      :start_connected,
-                      :allow_guest_control
-
-        # Constructs a new instance.
-        # @param ruby_values [Hash] a map of initial property values (optional)
-        # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
-        def initialize(ruby_values=nil, struct_value=nil)
-            super(self.class.binding_type, ruby_values, struct_value)
-        end
-    end
-
-
-    # The  ``Com::Vmware::Vcenter::Vm::Hardware::ConnectionCreateSpec``   class  provides a specification for the configuration of a newly-created removable device.
-    # @!attribute [rw] start_connected
+    #     Delay in milliseconds before retrying the boot process after a failure; applicable only when   :attr:`Com::Vmware::Vcenter::VM::Hardware::Boot::Info.retry_`   is true.
+    #     If  nil , default value is 10000.
+    # @!attribute [rw] enter_setup_mode
     #     @return [Boolean, nil]
-    #     Flag indicating whether the virtual device should be connected whenever the virtual machine is powered on.
-    #     Defaults to false if  nil .
-    # @!attribute [rw] allow_guest_control
-    #     @return [Boolean, nil]
-    #     Flag indicating whether the guest can connect and disconnect the device.
-    #     Defaults to false if  nil .
-    class ConnectionCreateSpec < VAPI::Bindings::VapiStruct
-
-        class << self
-            # Holds (gets or creates) the binding type metadata for this structure type.
-            # @scope class
-            # @return [VAPI::Bindings::StructType] the binding type
-            def binding_type
-                @binding_type ||= VAPI::Bindings::StructType.new(
-                    'com.vmware.vcenter.vm.hardware.connection_create_spec',
-                    {
-                        'start_connected' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::BooleanType.instance),
-                        'allow_guest_control' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::BooleanType.instance),
-                    },
-                    ConnectionCreateSpec,
-                    false,
-                    nil)
-            end
-        end
-
-        attr_accessor :start_connected,
-                      :allow_guest_control
-
-        # Constructs a new instance.
-        # @param ruby_values [Hash] a map of initial property values (optional)
-        # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
-        def initialize(ruby_values=nil, struct_value=nil)
-            super(self.class.binding_type, ruby_values, struct_value)
-        end
-    end
-
-
-    # The  ``Com::Vmware::Vcenter::Vm::Hardware::ConnectionUpdateSpec``   class  describes the updates to be made to the configuration of a removable virtual device.
-    # @!attribute [rw] start_connected
-    #     @return [Boolean, nil]
-    #     Flag indicating whether the virtual device should be connected whenever the virtual machine is powered on.
+    #     Flag indicating whether the firmware boot process should automatically enter setup mode the next time the virtual machine boots. Note that this flag will automatically be reset to false once the virtual machine enters setup mode.
     #     If  nil , the value is unchanged.
-    # @!attribute [rw] allow_guest_control
-    #     @return [Boolean, nil]
-    #     Flag indicating whether the guest can connect and disconnect the device.
-    #     If  nil , the value is unchanged.
-    class ConnectionUpdateSpec < VAPI::Bindings::VapiStruct
-
-        class << self
-            # Holds (gets or creates) the binding type metadata for this structure type.
-            # @scope class
-            # @return [VAPI::Bindings::StructType] the binding type
-            def binding_type
-                @binding_type ||= VAPI::Bindings::StructType.new(
-                    'com.vmware.vcenter.vm.hardware.connection_update_spec',
-                    {
-                        'start_connected' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::BooleanType.instance),
-                        'allow_guest_control' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::BooleanType.instance),
-                    },
-                    ConnectionUpdateSpec,
-                    false,
-                    nil)
-            end
+    class CreateSpec < VAPI::Bindings::VapiStruct
+      class << self
+        # Holds (gets or creates) the binding type metadata for this structure type.
+        # @scope class
+        # @return [VAPI::Bindings::StructType] the binding type
+        def binding_type
+          @binding_type ||= VAPI::Bindings::StructType.new(
+            'com.vmware.vcenter.vm.hardware.boot.create_spec',
+            {
+              'type' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::VM::Hardware::Boot::Type')),
+              'efi_legacy_boot' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::BooleanType.instance),
+              'network_protocol' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::VM::Hardware::Boot::NetworkProtocol')),
+              'delay' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::IntegerType.instance),
+              'retry' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::BooleanType.instance),
+              'retry_delay' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::IntegerType.instance),
+              'enter_setup_mode' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::BooleanType.instance)
+            },
+            CreateSpec,
+            false,
+            nil
+          )
         end
+      end
 
-        attr_accessor :start_connected,
-                      :allow_guest_control
+      attr_accessor :type,
+                    :efi_legacy_boot,
+                    :network_protocol,
+                    :delay,
+                    :retry_,
+                    :retry_delay,
+                    :enter_setup_mode
 
-        # Constructs a new instance.
-        # @param ruby_values [Hash] a map of initial property values (optional)
-        # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
-        def initialize(ruby_values=nil, struct_value=nil)
-            super(self.class.binding_type, ruby_values, struct_value)
-        end
+      # Constructs a new instance.
+      # @param ruby_values [Hash] a map of initial property values (optional)
+      # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
+      def initialize(ruby_values = nil, struct_value = nil)
+        super(self.class.binding_type, ruby_values, struct_value)
+      end
     end
 
+    # The  ``Com::Vmware::Vcenter::VM::Hardware::Boot::UpdateSpec``   class  describes the updates to the settings used when booting a virtual machine.
+    # @!attribute [rw] type
+    #     @return [Com::Vmware::Vcenter::VM::Hardware::Boot::Type, nil]
+    #     Firmware type to be used by the virtual machine.
+    #     If  nil , the value is unchanged.
+    # @!attribute [rw] efi_legacy_boot
+    #     @return [Boolean, nil]
+    #     Flag indicating whether to use EFI legacy boot mode.
+    #     If  nil , the value is unchanged.
+    # @!attribute [rw] network_protocol
+    #     @return [Com::Vmware::Vcenter::VM::Hardware::Boot::NetworkProtocol, nil]
+    #     Protocol to use when attempting to boot the virtual machine over the network.
+    #     If  nil , the value is unchanged.
+    # @!attribute [rw] delay
+    #     @return [Fixnum, nil]
+    #     Delay in milliseconds before beginning the firmware boot process when the virtual machine is powered on. This delay may be used to provide a time window for users to connect to the virtual machine console and enter BIOS setup mode.
+    #     If  nil , the value is unchanged.
+    # @!attribute [rw] retry_
+    #     @return [Boolean, nil]
+    #     Flag indicating whether the virtual machine should automatically retry the boot process after a failure.
+    #     If  nil , the value is unchanged.
+    # @!attribute [rw] retry_delay
+    #     @return [Fixnum, nil]
+    #     Delay in milliseconds before retrying the boot process after a failure; applicable only when   :attr:`Com::Vmware::Vcenter::VM::Hardware::Boot::Info.retry_`   is true.
+    #     If  nil , the value is unchanged.
+    # @!attribute [rw] enter_setup_mode
+    #     @return [Boolean, nil]
+    #     Flag indicating whether the firmware boot process should automatically enter setup mode the next time the virtual machine boots. Note that this flag will automatically be reset to false once the virtual machine enters setup mode.
+    #     If  nil , the value is unchanged.
+    class UpdateSpec < VAPI::Bindings::VapiStruct
+      class << self
+        # Holds (gets or creates) the binding type metadata for this structure type.
+        # @scope class
+        # @return [VAPI::Bindings::StructType] the binding type
+        def binding_type
+          @binding_type ||= VAPI::Bindings::StructType.new(
+            'com.vmware.vcenter.vm.hardware.boot.update_spec',
+            {
+              'type' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::VM::Hardware::Boot::Type')),
+              'efi_legacy_boot' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::BooleanType.instance),
+              'network_protocol' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::VM::Hardware::Boot::NetworkProtocol')),
+              'delay' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::IntegerType.instance),
+              'retry' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::BooleanType.instance),
+              'retry_delay' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::IntegerType.instance),
+              'enter_setup_mode' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::BooleanType.instance)
+            },
+            UpdateSpec,
+            false,
+            nil
+          )
+        end
+      end
 
-    # The  ``Com::Vmware::Vcenter::Vm::Hardware::ConnectionState``   enumerated type  defines the valid states for a removable device that is configured to be connected.
-    # @!attribute [rw] connected
-    #     @return [Com::Vmware::Vcenter::Vm::Hardware::ConnectionState]
-    #     The device is connected and working correctly.
-    # @!attribute [rw] recoverable_error
-    #     @return [Com::Vmware::Vcenter::Vm::Hardware::ConnectionState]
-    #     Device connection failed due to a recoverable error; for example, the virtual device backing is currently in use by another virtual machine.
-    # @!attribute [rw] unrecoverable_error
-    #     @return [Com::Vmware::Vcenter::Vm::Hardware::ConnectionState]
-    #     Device connection failed due to an unrecoverable error; for example, the virtual device backing does not exist.
-    # @!attribute [rw] not_connected
-    #     @return [Com::Vmware::Vcenter::Vm::Hardware::ConnectionState]
-    #     The device is not connected.
-    # @!attribute [rw] unknown
-    #     @return [Com::Vmware::Vcenter::Vm::Hardware::ConnectionState]
-    #     The device status is unknown.
-    class ConnectionState < VAPI::Bindings::VapiEnum
+      attr_accessor :type,
+                    :efi_legacy_boot,
+                    :network_protocol,
+                    :delay,
+                    :retry_,
+                    :retry_delay,
+                    :enter_setup_mode
 
-        class << self
-            # Holds (gets or creates) the binding type metadata for this enumeration type.
-            # @scope class
-            # @return [VAPI::Bindings::EnumType] the binding type
-            def binding_type
-                @binding_type ||= VAPI::Bindings::EnumType.new(
-                    'com.vmware.vcenter.vm.hardware.connection_state',
-                    ConnectionState)
-            end
+      # Constructs a new instance.
+      # @param ruby_values [Hash] a map of initial property values (optional)
+      # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
+      def initialize(ruby_values = nil, struct_value = nil)
+        super(self.class.binding_type, ruby_values, struct_value)
+      end
+    end
 
-            # Converts from a string value (perhaps off the wire) to an instance
-            # of this enum type.
-            # @param value [String] the actual value of the enum instance
-            # @return [ConnectionState] the instance found for the value, otherwise
-            #         an unknown instance will be built for the value
-            def from_string(value)
-                begin
-                    const_get(value)
-                rescue NameError
-                    ConnectionState.new('UNKNOWN', value)
-                end
-            end
+    # The  ``Com::Vmware::Vcenter::VM::Hardware::Boot::Type``   enumerated type  defines the valid firmware types for a virtual machine.
+    # @!attribute [rw] bios
+    #     @return [Com::Vmware::Vcenter::VM::Hardware::Boot::Type]
+    #     Basic Input/Output System (BIOS) firmware.
+    # @!attribute [rw] efi
+    #     @return [Com::Vmware::Vcenter::VM::Hardware::Boot::Type]
+    #     Extensible Firmware Interface (EFI) firmware.
+    class Type < VAPI::Bindings::VapiEnum
+      class << self
+        # Holds (gets or creates) the binding type metadata for this enumeration type.
+        # @scope class
+        # @return [VAPI::Bindings::EnumType] the binding type
+        def binding_type
+          @binding_type ||= VAPI::Bindings::EnumType.new(
+            'com.vmware.vcenter.vm.hardware.boot.type',
+            Type
+          )
         end
 
-        private
-
-        # Constructs a new instance.
+        # Converts from a string value (perhaps off the wire) to an instance
+        # of this enum type.
         # @param value [String] the actual value of the enum instance
-        # @param unknown [String] the unknown value when value is 'UKNOWN'
-        def initialize(value, unknown=nil)
-            super(self.class.binding_type, value, unknown)
+        # @return [Type] the instance found for the value, otherwise
+        #         an unknown instance will be built for the value
+        def from_string(value)
+          const_get(value)
+        rescue NameError
+          Type.send(:new, 'UNKNOWN', value)
+        end
+      end
+
+      # Constructs a new instance.
+      # @param value [String] the actual value of the enum instance
+      # @param unknown [String] the unknown value when value is 'UKNOWN'
+      def initialize(value, unknown = nil)
+        super(self.class.binding_type, value, unknown)
+      end
+
+      private_class_method :new
+
+      # @!attribute [rw] bios
+      #     @return [Com::Vmware::Vcenter::VM::Hardware::Boot::Type]
+      #     Basic Input/Output System (BIOS) firmware.
+      BIOS = Type.send(:new, 'BIOS')
+
+      # @!attribute [rw] efi
+      #     @return [Com::Vmware::Vcenter::VM::Hardware::Boot::Type]
+      #     Extensible Firmware Interface (EFI) firmware.
+      EFI = Type.send(:new, 'EFI')
+    end
+    # The  ``Com::Vmware::Vcenter::VM::Hardware::Boot::NetworkProtocol``   enumerated type  defines the valid network boot protocols supported when booting a virtual machine with   :attr:`Com::Vmware::Vcenter::VM::Hardware::Boot::Type.EFI`   firmware over the network.
+    # @!attribute [rw] ip_v4
+    #     @return [Com::Vmware::Vcenter::VM::Hardware::Boot::NetworkProtocol]
+    #     PXE or Apple NetBoot over IPv4.
+    # @!attribute [rw] ip_v6
+    #     @return [Com::Vmware::Vcenter::VM::Hardware::Boot::NetworkProtocol]
+    #     PXE over IPv6.
+    class NetworkProtocol < VAPI::Bindings::VapiEnum
+      class << self
+        # Holds (gets or creates) the binding type metadata for this enumeration type.
+        # @scope class
+        # @return [VAPI::Bindings::EnumType] the binding type
+        def binding_type
+          @binding_type ||= VAPI::Bindings::EnumType.new(
+            'com.vmware.vcenter.vm.hardware.boot.network_protocol',
+            NetworkProtocol
+          )
         end
 
-        public
+        # Converts from a string value (perhaps off the wire) to an instance
+        # of this enum type.
+        # @param value [String] the actual value of the enum instance
+        # @return [NetworkProtocol] the instance found for the value, otherwise
+        #         an unknown instance will be built for the value
+        def from_string(value)
+          const_get(value)
+        rescue NameError
+          NetworkProtocol.send(:new, 'UNKNOWN', value)
+        end
+      end
 
-        # @!attribute [rw] connected
-        #     @return [Com::Vmware::Vcenter::Vm::Hardware::ConnectionState]
-        #     The device is connected and working correctly.
-        CONNECTED = ConnectionState.new('CONNECTED')
+      # Constructs a new instance.
+      # @param value [String] the actual value of the enum instance
+      # @param unknown [String] the unknown value when value is 'UKNOWN'
+      def initialize(value, unknown = nil)
+        super(self.class.binding_type, value, unknown)
+      end
 
-        # @!attribute [rw] recoverable_error
-        #     @return [Com::Vmware::Vcenter::Vm::Hardware::ConnectionState]
-        #     Device connection failed due to a recoverable error; for example, the virtual device backing is currently in use by another virtual machine.
-        RECOVERABLE_ERROR = ConnectionState.new('RECOVERABLE_ERROR')
+      private_class_method :new
 
-        # @!attribute [rw] unrecoverable_error
-        #     @return [Com::Vmware::Vcenter::Vm::Hardware::ConnectionState]
-        #     Device connection failed due to an unrecoverable error; for example, the virtual device backing does not exist.
-        UNRECOVERABLE_ERROR = ConnectionState.new('UNRECOVERABLE_ERROR')
+      # @!attribute [rw] ip_v4
+      #     @return [Com::Vmware::Vcenter::VM::Hardware::Boot::NetworkProtocol]
+      #     PXE or Apple NetBoot over IPv4.
+      IP_V4 = NetworkProtocol.send(:new, 'IP_V4')
 
-        # @!attribute [rw] not_connected
-        #     @return [Com::Vmware::Vcenter::Vm::Hardware::ConnectionState]
-        #     The device is not connected.
-        NOT_CONNECTED = ConnectionState.new('NOT_CONNECTED')
+      # @!attribute [rw] ip_v6
+      #     @return [Com::Vmware::Vcenter::VM::Hardware::Boot::NetworkProtocol]
+      #     PXE over IPv6.
+      IP_V6 = NetworkProtocol.send(:new, 'IP_V6')
+    end
+  end
+  # The  ``Com::Vmware::Vcenter::VM::Hardware::Cdrom``   class  provides  methods  for configuring the virtual CD-ROM devices of a virtual machine.
+  class Cdrom < VAPI::Bindings::VapiService
+    # static metamodel definitions
+    SERVICE_ID = VAPI::Core::ServiceIdentifier.new('com.vmware.vcenter.vm.hardware.cdrom')
 
-        # @!attribute [rw] unknown
-        #     @return [Com::Vmware::Vcenter::Vm::Hardware::ConnectionState]
-        #     The device status is unknown.
-        UNKNOWN = ConnectionState.new('UNKNOWN')
+    LIST_INFO = VAPI::Bindings::OperationInfo.new(
+      VAPI::Core::OperationIdentifier.new('list', SERVICE_ID),
+      VAPI::Bindings::OperationInputType.new(
+        'vm' => VAPI::Bindings::IdType.new('VirtualMachine')
+      ),
+      VAPI::Bindings::ListType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::VM::Hardware::Cdrom::Summary')),
+      {
+        'com.vmware.vapi.std.errors.error' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Error'),
+        'com.vmware.vapi.std.errors.not_found' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::NotFound'),
+        'com.vmware.vapi.std.errors.resource_inaccessible' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::ResourceInaccessible'),
+        'com.vmware.vapi.std.errors.service_unavailable' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::ServiceUnavailable'),
+        'com.vmware.vapi.std.errors.unauthenticated' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Unauthenticated'),
+        'com.vmware.vapi.std.errors.unauthorized' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Unauthorized')
+      },
+      [],
+      []
+    )
 
+    GET_INFO = VAPI::Bindings::OperationInfo.new(
+      VAPI::Core::OperationIdentifier.new('get', SERVICE_ID),
+      VAPI::Bindings::OperationInputType.new(
+        'vm' => VAPI::Bindings::IdType.new('VirtualMachine'),
+        'cdrom' => VAPI::Bindings::IdType.new('com.vmware.vcenter.vm.hardware.Cdrom')
+      ),
+      VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::VM::Hardware::Cdrom::Info'),
+      {
+        'com.vmware.vapi.std.errors.error' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Error'),
+        'com.vmware.vapi.std.errors.not_found' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::NotFound'),
+        'com.vmware.vapi.std.errors.resource_inaccessible' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::ResourceInaccessible'),
+        'com.vmware.vapi.std.errors.service_unavailable' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::ServiceUnavailable'),
+        'com.vmware.vapi.std.errors.unauthenticated' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Unauthenticated'),
+        'com.vmware.vapi.std.errors.unauthorized' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Unauthorized')
+      },
+      [],
+      []
+    )
+
+    CREATE_INFO = VAPI::Bindings::OperationInfo.new(
+      VAPI::Core::OperationIdentifier.new('create', SERVICE_ID),
+      VAPI::Bindings::OperationInputType.new(
+        'vm' => VAPI::Bindings::IdType.new('VirtualMachine'),
+        'spec' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::VM::Hardware::Cdrom::CreateSpec')
+      ),
+      VAPI::Bindings::IdType.new('com.vmware.vcenter.vm.hardware.Cdrom'),
+      {
+        'com.vmware.vapi.std.errors.error' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Error'),
+        'com.vmware.vapi.std.errors.not_found' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::NotFound'),
+        'com.vmware.vapi.std.errors.not_allowed_in_current_state' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::NotAllowedInCurrentState'),
+        'com.vmware.vapi.std.errors.unable_to_allocate_resource' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::UnableToAllocateResource'),
+        'com.vmware.vapi.std.errors.resource_in_use' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::ResourceInUse'),
+        'com.vmware.vapi.std.errors.invalid_argument' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::InvalidArgument'),
+        'com.vmware.vapi.std.errors.resource_busy' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::ResourceBusy'),
+        'com.vmware.vapi.std.errors.resource_inaccessible' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::ResourceInaccessible'),
+        'com.vmware.vapi.std.errors.service_unavailable' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::ServiceUnavailable'),
+        'com.vmware.vapi.std.errors.unauthenticated' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Unauthenticated'),
+        'com.vmware.vapi.std.errors.unauthorized' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Unauthorized'),
+        'com.vmware.vapi.std.errors.unsupported' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Unsupported')
+      },
+      [],
+      []
+    )
+
+    UPDATE_INFO = VAPI::Bindings::OperationInfo.new(
+      VAPI::Core::OperationIdentifier.new('update', SERVICE_ID),
+      VAPI::Bindings::OperationInputType.new(
+        'vm' => VAPI::Bindings::IdType.new('VirtualMachine'),
+        'cdrom' => VAPI::Bindings::IdType.new('com.vmware.vcenter.vm.hardware.Cdrom'),
+        'spec' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::VM::Hardware::Cdrom::UpdateSpec')
+      ),
+      VAPI::Bindings::VoidType.instance,
+      {
+        'com.vmware.vapi.std.errors.error' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Error'),
+        'com.vmware.vapi.std.errors.not_found' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::NotFound'),
+        'com.vmware.vapi.std.errors.not_allowed_in_current_state' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::NotAllowedInCurrentState'),
+        'com.vmware.vapi.std.errors.resource_busy' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::ResourceBusy'),
+        'com.vmware.vapi.std.errors.resource_inaccessible' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::ResourceInaccessible'),
+        'com.vmware.vapi.std.errors.service_unavailable' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::ServiceUnavailable'),
+        'com.vmware.vapi.std.errors.unauthenticated' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Unauthenticated'),
+        'com.vmware.vapi.std.errors.unauthorized' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Unauthorized')
+      },
+      [],
+      []
+    )
+
+    DELETE_INFO = VAPI::Bindings::OperationInfo.new(
+      VAPI::Core::OperationIdentifier.new('delete', SERVICE_ID),
+      VAPI::Bindings::OperationInputType.new(
+        'vm' => VAPI::Bindings::IdType.new('VirtualMachine'),
+        'cdrom' => VAPI::Bindings::IdType.new('com.vmware.vcenter.vm.hardware.Cdrom')
+      ),
+      VAPI::Bindings::VoidType.instance,
+      {
+        'com.vmware.vapi.std.errors.error' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Error'),
+        'com.vmware.vapi.std.errors.not_found' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::NotFound'),
+        'com.vmware.vapi.std.errors.not_allowed_in_current_state' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::NotAllowedInCurrentState'),
+        'com.vmware.vapi.std.errors.resource_busy' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::ResourceBusy'),
+        'com.vmware.vapi.std.errors.resource_inaccessible' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::ResourceInaccessible'),
+        'com.vmware.vapi.std.errors.service_unavailable' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::ServiceUnavailable'),
+        'com.vmware.vapi.std.errors.unauthenticated' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Unauthenticated'),
+        'com.vmware.vapi.std.errors.unauthorized' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Unauthorized')
+      },
+      [],
+      []
+    )
+
+    CONNECT_INFO = VAPI::Bindings::OperationInfo.new(
+      VAPI::Core::OperationIdentifier.new('connect', SERVICE_ID),
+      VAPI::Bindings::OperationInputType.new(
+        'vm' => VAPI::Bindings::IdType.new('VirtualMachine'),
+        'cdrom' => VAPI::Bindings::IdType.new('com.vmware.vcenter.vm.hardware.Cdrom')
+      ),
+      VAPI::Bindings::VoidType.instance,
+      {
+        'com.vmware.vapi.std.errors.error' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Error'),
+        'com.vmware.vapi.std.errors.not_found' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::NotFound'),
+        'com.vmware.vapi.std.errors.already_in_desired_state' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::AlreadyInDesiredState'),
+        'com.vmware.vapi.std.errors.not_allowed_in_current_state' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::NotAllowedInCurrentState'),
+        'com.vmware.vapi.std.errors.resource_busy' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::ResourceBusy'),
+        'com.vmware.vapi.std.errors.resource_inaccessible' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::ResourceInaccessible'),
+        'com.vmware.vapi.std.errors.service_unavailable' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::ServiceUnavailable'),
+        'com.vmware.vapi.std.errors.unauthenticated' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Unauthenticated'),
+        'com.vmware.vapi.std.errors.unauthorized' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Unauthorized')
+      },
+      [],
+      []
+    )
+
+    DISCONNECT_INFO = VAPI::Bindings::OperationInfo.new(
+      VAPI::Core::OperationIdentifier.new('disconnect', SERVICE_ID),
+      VAPI::Bindings::OperationInputType.new(
+        'vm' => VAPI::Bindings::IdType.new('VirtualMachine'),
+        'cdrom' => VAPI::Bindings::IdType.new('com.vmware.vcenter.vm.hardware.Cdrom')
+      ),
+      VAPI::Bindings::VoidType.instance,
+      {
+        'com.vmware.vapi.std.errors.error' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Error'),
+        'com.vmware.vapi.std.errors.not_found' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::NotFound'),
+        'com.vmware.vapi.std.errors.already_in_desired_state' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::AlreadyInDesiredState'),
+        'com.vmware.vapi.std.errors.not_allowed_in_current_state' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::NotAllowedInCurrentState'),
+        'com.vmware.vapi.std.errors.resource_busy' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::ResourceBusy'),
+        'com.vmware.vapi.std.errors.resource_inaccessible' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::ResourceInaccessible'),
+        'com.vmware.vapi.std.errors.service_unavailable' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::ServiceUnavailable'),
+        'com.vmware.vapi.std.errors.unauthenticated' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Unauthenticated'),
+        'com.vmware.vapi.std.errors.unauthorized' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Unauthorized')
+      },
+      [],
+      []
+    )
+
+    SERVICE_INFO = VAPI::Bindings::ServiceInfo.new(
+      SERVICE_ID,
+      'list' => LIST_INFO,
+      'get' => GET_INFO,
+      'create' => CREATE_INFO,
+      'update' => UPDATE_INFO,
+      'delete' => DELETE_INFO,
+      'connect' => CONNECT_INFO,
+      'disconnect' => DISCONNECT_INFO
+    )
+
+    # Constructs a new instance.
+    #
+    # @param config [VAPI::Bindings::StubConfig] A hash with the api provider details.
+    def initialize(config)
+      super(config, SERVICE_INFO)
     end
 
+    RESOURCE_TYPE = 'com.vmware.vcenter.vm.hardware.Cdrom'
+    # Returns commonly used information about the virtual CD-ROM devices belonging to the virtual machine.
+    #
+    # @param vm [String]
+    #     Virtual machine identifier.
+    # @return [Array<Com::Vmware::Vcenter::VM::Hardware::Cdrom::Summary>]
+    #     List of commonly used information about virtual CD-ROM devices.
+    # @raise [Com::Vmware::Vapi::Std::Errors::Error]
+    #     if the system reports an error while responding to the request.
+    # @raise [Com::Vmware::Vapi::Std::Errors::NotFound]
+    #     if the virtual machine is not found.
+    # @raise [Com::Vmware::Vapi::Std::Errors::ResourceInaccessible]
+    #     if the virtual machine's configuration state cannot be accessed.
+    # @raise [Com::Vmware::Vapi::Std::Errors::ServiceUnavailable]
+    #     if the system is unable to communicate with a service to complete the request.
+    # @raise [Com::Vmware::Vapi::Std::Errors::Unauthenticated]
+    #     if the user can not be authenticated.
+    # @raise [Com::Vmware::Vapi::Std::Errors::Unauthorized]
+    #     if the user doesn't have the required privileges.
+    def list(vm)
+      invoke_with_info(LIST_INFO,
+                       'vm' => vm)
+    end
 
+    # Returns information about a virtual CD-ROM device.
+    #
+    # @param vm [String]
+    #     Virtual machine identifier.
+    # @param cdrom [String]
+    #     Virtual CD-ROM device identifier.
+    # @return [Com::Vmware::Vcenter::VM::Hardware::Cdrom::Info]
+    #     Information about the specified virtual CD-ROM device.
+    # @raise [Com::Vmware::Vapi::Std::Errors::Error]
+    #     if the system reports an error while responding to the request.
+    # @raise [Com::Vmware::Vapi::Std::Errors::NotFound]
+    #     if the virtual machine or virtual CD-ROM device is not found.
+    # @raise [Com::Vmware::Vapi::Std::Errors::ResourceInaccessible]
+    #     if the virtual machine's configuration state cannot be accessed.
+    # @raise [Com::Vmware::Vapi::Std::Errors::ServiceUnavailable]
+    #     if the system is unable to communicate with a service to complete the request.
+    # @raise [Com::Vmware::Vapi::Std::Errors::Unauthenticated]
+    #     if the user can not be authenticated.
+    # @raise [Com::Vmware::Vapi::Std::Errors::Unauthorized]
+    #     if the user doesn't have the required privileges.
+    def get(vm, cdrom)
+      invoke_with_info(GET_INFO,
+                       'vm' => vm,
+                       'cdrom' => cdrom)
+    end
+
+    # Adds a virtual CD-ROM device to the virtual machine.
+    #
+    # @param vm [String]
+    #     Virtual machine identifier.
+    # @param spec [Com::Vmware::Vcenter::VM::Hardware::Cdrom::CreateSpec]
+    #     Specification for the new virtual CD-ROM device.
+    # @return [String]
+    #     Virtual CD-ROM device identifier.
+    # @raise [Com::Vmware::Vapi::Std::Errors::Error]
+    #     if the system reported that the CD-ROM device was created but was unable to confirm the creation because the identifier of the new device could not be determined.
+    # @raise [Com::Vmware::Vapi::Std::Errors::Error]
+    #     if the system reports an error while responding to the request.
+    # @raise [Com::Vmware::Vapi::Std::Errors::NotFound]
+    #     if the virtual machine is not found.
+    # @raise [Com::Vmware::Vapi::Std::Errors::NotAllowedInCurrentState]
+    #     if the virtual machine is suspended or if the virtual machine is powered on and virtual CD-ROM type is IDE.
+    # @raise [Com::Vmware::Vapi::Std::Errors::UnableToAllocateResource]
+    #     if the specified storage address is unavailable; for example, if the SCSI adapter requested does not exist.
+    # @raise [Com::Vmware::Vapi::Std::Errors::ResourceInUse]
+    #     if the specified storage address is in use.
+    # @raise [Com::Vmware::Vapi::Std::Errors::InvalidArgument]
+    #     if the specified storage address is out of bounds.
+    # @raise [Com::Vmware::Vapi::Std::Errors::ResourceBusy]
+    #     if the virtual machine is busy performing another operation.
+    # @raise [Com::Vmware::Vapi::Std::Errors::ResourceInaccessible]
+    #     if the virtual machine's configuration state cannot be accessed.
+    # @raise [Com::Vmware::Vapi::Std::Errors::ServiceUnavailable]
+    #     if the system is unable to communicate with a service to complete the request.
+    # @raise [Com::Vmware::Vapi::Std::Errors::Unauthenticated]
+    #     if the user can not be authenticated.
+    # @raise [Com::Vmware::Vapi::Std::Errors::Unauthorized]
+    #     if the user doesn't have the required privileges.
+    # @raise [Com::Vmware::Vapi::Std::Errors::Unsupported]
+    #     if the guest operating system of the virtual machine is not supported and  spec  includes  nil   fields  that default to guest-specific values.
+    def create(vm, spec)
+      invoke_with_info(CREATE_INFO,
+                       'vm' => vm,
+                       'spec' => spec)
+    end
+
+    # Updates the configuration of a virtual CD-ROM device.
+    #
+    # @param vm [String]
+    #     Virtual machine identifier.
+    # @param cdrom [String]
+    #     Virtual CD-ROM device identifier.
+    # @param spec [Com::Vmware::Vcenter::VM::Hardware::Cdrom::UpdateSpec]
+    #     Specification for updating the virtual CD-ROM device.
+    # @return [Void]
+    # @raise [Com::Vmware::Vapi::Std::Errors::Error]
+    #     if the system reports an error while responding to the request.
+    # @raise [Com::Vmware::Vapi::Std::Errors::NotFound]
+    #     if the virtual machine or virtual CD-ROM device is not found.
+    # @raise [Com::Vmware::Vapi::Std::Errors::NotAllowedInCurrentState]
+    #     if one or more of the  fields  specified in the  ``spec``   parameter  cannot be modified due to the current power state of the virtual machine or the connection state of the virtual CD-ROM device.
+    # @raise [Com::Vmware::Vapi::Std::Errors::ResourceBusy]
+    #     if the virtual machine is busy performing another operation.
+    # @raise [Com::Vmware::Vapi::Std::Errors::ResourceInaccessible]
+    #     if the virtual machine's configuration state cannot be accessed.
+    # @raise [Com::Vmware::Vapi::Std::Errors::ServiceUnavailable]
+    #     if the system is unable to communicate with a service to complete the request.
+    # @raise [Com::Vmware::Vapi::Std::Errors::Unauthenticated]
+    #     if the user can not be authenticated.
+    # @raise [Com::Vmware::Vapi::Std::Errors::Unauthorized]
+    #     if the user doesn't have the required privileges.
+    def update(vm, cdrom, spec)
+      invoke_with_info(UPDATE_INFO,
+                       'vm' => vm,
+                       'cdrom' => cdrom,
+                       'spec' => spec)
+    end
+
+    # Removes a virtual CD-ROM device from the virtual machine.
+    #
+    # @param vm [String]
+    #     Virtual machine identifier.
+    # @param cdrom [String]
+    #     Virtual CD-ROM device identifier.
+    # @return [Void]
+    # @raise [Com::Vmware::Vapi::Std::Errors::Error]
+    #     if the system reports an error while responding to the request.
+    # @raise [Com::Vmware::Vapi::Std::Errors::NotFound]
+    #     if the virtual machine or virtual CD-ROM device is not found.
+    # @raise [Com::Vmware::Vapi::Std::Errors::NotAllowedInCurrentState]
+    #     if the virtual machine is suspended or if the virtual machine is powered on and virtual CD-ROM type is IDE.
+    # @raise [Com::Vmware::Vapi::Std::Errors::ResourceBusy]
+    #     if the virtual machine is busy performing another operation.
+    # @raise [Com::Vmware::Vapi::Std::Errors::ResourceInaccessible]
+    #     if the virtual machine's configuration state cannot be accessed.
+    # @raise [Com::Vmware::Vapi::Std::Errors::ServiceUnavailable]
+    #     if the system is unable to communicate with a service to complete the request.
+    # @raise [Com::Vmware::Vapi::Std::Errors::Unauthenticated]
+    #     if the user can not be authenticated.
+    # @raise [Com::Vmware::Vapi::Std::Errors::Unauthorized]
+    #     if the user doesn't have the required privileges.
+    def delete(vm, cdrom)
+      invoke_with_info(DELETE_INFO,
+                       'vm' => vm,
+                       'cdrom' => cdrom)
+    end
+
+    # Connects a virtual CD-ROM device of a powered-on virtual machine to its backing. Connecting the virtual device makes the backing accessible from the perspective of the guest operating system.  
+    # 
+    #  For a powered-off virtual machine, the   :func:`Com::Vmware::Vcenter::VM::Hardware::Cdrom.update`    method  may be used to configure the virtual CD-ROM device to start in the connected state when the virtual machine is powered on.
+    #
+    # @param vm [String]
+    #     Virtual machine identifier.
+    # @param cdrom [String]
+    #     Virtual CD-ROM device identifier.
+    # @return [Void]
+    # @raise [Com::Vmware::Vapi::Std::Errors::Error]
+    #     if the system reports an error while responding to the request.
+    # @raise [Com::Vmware::Vapi::Std::Errors::NotFound]
+    #     if the virtual machine or virtual CD-ROM device is not found.
+    # @raise [Com::Vmware::Vapi::Std::Errors::AlreadyInDesiredState]
+    #     if the virtual CD-ROM device is already connected.
+    # @raise [Com::Vmware::Vapi::Std::Errors::NotAllowedInCurrentState]
+    #     if the virtual machine is not powered on.
+    # @raise [Com::Vmware::Vapi::Std::Errors::ResourceBusy]
+    #     if the virtual machine is busy performing another operation.
+    # @raise [Com::Vmware::Vapi::Std::Errors::ResourceInaccessible]
+    #     if the virtual machine's configuration state cannot be accessed.
+    # @raise [Com::Vmware::Vapi::Std::Errors::ServiceUnavailable]
+    #     if the system is unable to communicate with a service to complete the request.
+    # @raise [Com::Vmware::Vapi::Std::Errors::Unauthenticated]
+    #     if the user can not be authenticated.
+    # @raise [Com::Vmware::Vapi::Std::Errors::Unauthorized]
+    #     if the user doesn't have the required privileges.
+    def connect(vm, cdrom)
+      invoke_with_info(CONNECT_INFO,
+                       'vm' => vm,
+                       'cdrom' => cdrom)
+    end
+
+    # Disconnects a virtual CD-ROM device of a powered-on virtual machine from its backing. The virtual device is still present and its backing configuration is unchanged, but from the perspective of the guest operating system, the CD-ROM device is not connected to its backing resource.  
+    # 
+    #  For a powered-off virtual machine, the   :func:`Com::Vmware::Vcenter::VM::Hardware::Cdrom.update`    method  may be used to configure the virtual CD-ROM device to start in the disconnected state when the virtual machine is powered on.
+    #
+    # @param vm [String]
+    #     Virtual machine identifier.
+    # @param cdrom [String]
+    #     Virtual CD-ROM device identifier.
+    # @return [Void]
+    # @raise [Com::Vmware::Vapi::Std::Errors::Error]
+    #     if the system reports an error while responding to the request.
+    # @raise [Com::Vmware::Vapi::Std::Errors::NotFound]
+    #     if the virtual machine or virtual CD-ROM device is not found.
+    # @raise [Com::Vmware::Vapi::Std::Errors::AlreadyInDesiredState]
+    #     if the virtual CD-ROM device is already disconnected.
+    # @raise [Com::Vmware::Vapi::Std::Errors::NotAllowedInCurrentState]
+    #     if the virtual machine is not powered on.
+    # @raise [Com::Vmware::Vapi::Std::Errors::ResourceBusy]
+    #     if the virtual machine is busy performing another operation.
+    # @raise [Com::Vmware::Vapi::Std::Errors::ResourceInaccessible]
+    #     if the virtual machine's configuration state cannot be accessed.
+    # @raise [Com::Vmware::Vapi::Std::Errors::ServiceUnavailable]
+    #     if the system is unable to communicate with a service to complete the request.
+    # @raise [Com::Vmware::Vapi::Std::Errors::Unauthenticated]
+    #     if the user can not be authenticated.
+    # @raise [Com::Vmware::Vapi::Std::Errors::Unauthorized]
+    #     if the user doesn't have the required privileges.
+    def disconnect(vm, cdrom)
+      invoke_with_info(DISCONNECT_INFO,
+                       'vm' => vm,
+                       'cdrom' => cdrom)
+    end
+
+    # The  ``Com::Vmware::Vcenter::VM::Hardware::Cdrom::BackingInfo``   class  contains information about the physical resource backing a virtual CD-ROM device.
+    # @!attribute [rw] type
+    #     @return [Com::Vmware::Vcenter::VM::Hardware::Cdrom::BackingType]
+    #     Backing type for the virtual CD-ROM device.
+    # @!attribute [rw] iso_file
+    #     @return [String]
+    #     Path of the image file backing the virtual CD-ROM device.
+    #     This  field  is optional and it is only relevant when the value of  ``type``  is   :attr:`Com::Vmware::Vcenter::VM::Hardware::Cdrom::BackingType.ISO_FILE`  .
+    # @!attribute [rw] host_device
+    #     @return [String, nil]
+    #     Name of the host device backing the virtual CD-ROM device.  
+    #     This  field  will be  nil  if  ``autoDetect``  is true and the virtual CD-ROM device is not connected or no suitable device is available on the host.
+    # @!attribute [rw] auto_detect
+    #     @return [Boolean]
+    #     Flag indicating whether the virtual CD-ROM device is configured to automatically detect a suitable host device.
+    #     This  field  is optional and it is only relevant when the value of  ``type``  is   :attr:`Com::Vmware::Vcenter::VM::Hardware::Cdrom::BackingType.HOST_DEVICE`  .
+    # @!attribute [rw] device_access_type
+    #     @return [Com::Vmware::Vcenter::VM::Hardware::Cdrom::DeviceAccessType]
+    #     Access type for the device backing.
+    #     This  field  is optional and it is only relevant when the value of  ``type``  is one of   :attr:`Com::Vmware::Vcenter::VM::Hardware::Cdrom::BackingType.HOST_DEVICE`   or   :attr:`Com::Vmware::Vcenter::VM::Hardware::Cdrom::BackingType.CLIENT_DEVICE`  .
+    class BackingInfo < VAPI::Bindings::VapiStruct
+      class << self
+        # Holds (gets or creates) the binding type metadata for this structure type.
+        # @scope class
+        # @return [VAPI::Bindings::StructType] the binding type
+        def binding_type
+          @binding_type ||= VAPI::Bindings::StructType.new(
+            'com.vmware.vcenter.vm.hardware.cdrom.backing_info',
+            {
+              'type' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::VM::Hardware::Cdrom::BackingType'),
+              'iso_file' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::StringType.instance),
+              'host_device' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::StringType.instance),
+              'auto_detect' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::BooleanType.instance),
+              'device_access_type' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::VM::Hardware::Cdrom::DeviceAccessType'))
+            },
+            BackingInfo,
+            false,
+            nil
+          )
+        end
+      end
+
+      attr_accessor :type,
+                    :iso_file,
+                    :host_device,
+                    :auto_detect,
+                    :device_access_type
+
+      # Constructs a new instance.
+      # @param ruby_values [Hash] a map of initial property values (optional)
+      # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
+      def initialize(ruby_values = nil, struct_value = nil)
+        super(self.class.binding_type, ruby_values, struct_value)
+      end
+    end
+
+    # The  ``Com::Vmware::Vcenter::VM::Hardware::Cdrom::BackingSpec``   class  provides a specification of the physical resource backing a virtual CD-ROM device.
+    # @!attribute [rw] type
+    #     @return [Com::Vmware::Vcenter::VM::Hardware::Cdrom::BackingType]
+    #     Backing type for the virtual CD-ROM device.
+    # @!attribute [rw] iso_file
+    #     @return [String]
+    #     Path of the image file that should be used as the virtual CD-ROM device backing.
+    #     This  field  is optional and it is only relevant when the value of  ``type``  is   :attr:`Com::Vmware::Vcenter::VM::Hardware::Cdrom::BackingType.ISO_FILE`  .
+    # @!attribute [rw] host_device
+    #     @return [String, nil]
+    #     Name of the device that should be used as the virtual CD-ROM device backing.
+    #     If  nil , the virtual CD-ROM device will be configured to automatically detect a suitable host device.
+    # @!attribute [rw] device_access_type
+    #     @return [Com::Vmware::Vcenter::VM::Hardware::Cdrom::DeviceAccessType, nil]
+    #     Access type for the device backing.
+    #     If  nil , defaults to   :attr:`Com::Vmware::Vcenter::VM::Hardware::Cdrom::DeviceAccessType.EMULATION`  .
+    class BackingSpec < VAPI::Bindings::VapiStruct
+      class << self
+        # Holds (gets or creates) the binding type metadata for this structure type.
+        # @scope class
+        # @return [VAPI::Bindings::StructType] the binding type
+        def binding_type
+          @binding_type ||= VAPI::Bindings::StructType.new(
+            'com.vmware.vcenter.vm.hardware.cdrom.backing_spec',
+            {
+              'type' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::VM::Hardware::Cdrom::BackingType'),
+              'iso_file' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::StringType.instance),
+              'host_device' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::StringType.instance),
+              'device_access_type' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::VM::Hardware::Cdrom::DeviceAccessType'))
+            },
+            BackingSpec,
+            false,
+            nil
+          )
+        end
+      end
+
+      attr_accessor :type,
+                    :iso_file,
+                    :host_device,
+                    :device_access_type
+
+      # Constructs a new instance.
+      # @param ruby_values [Hash] a map of initial property values (optional)
+      # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
+      def initialize(ruby_values = nil, struct_value = nil)
+        super(self.class.binding_type, ruby_values, struct_value)
+      end
+    end
+
+    # The  ``Com::Vmware::Vcenter::VM::Hardware::Cdrom::Info``   class  contains information about a virtual CD-ROM device.
+    # @!attribute [rw] type
+    #     @return [Com::Vmware::Vcenter::VM::Hardware::Cdrom::HostBusAdapterType]
+    #     Type of host bus adapter to which the device is attached.
+    # @!attribute [rw] label
+    #     @return [String]
+    #     Device label.
+    # @!attribute [rw] ide
+    #     @return [Com::Vmware::Vcenter::VM::Hardware::IdeAddressInfo]
+    #     Address of device attached to a virtual IDE adapter.
+    #     This  field  is optional and it is only relevant when the value of  ``type``  is   :attr:`Com::Vmware::Vcenter::VM::Hardware::Cdrom::HostBusAdapterType.IDE`  .
+    # @!attribute [rw] sata
+    #     @return [Com::Vmware::Vcenter::VM::Hardware::SataAddressInfo]
+    #     Address of device attached to a virtual SATA adapter.
+    #     This  field  is optional and it is only relevant when the value of  ``type``  is   :attr:`Com::Vmware::Vcenter::VM::Hardware::Cdrom::HostBusAdapterType.SATA`  .
+    # @!attribute [rw] backing
+    #     @return [Com::Vmware::Vcenter::VM::Hardware::Cdrom::BackingInfo]
+    #     Physical resource backing for the virtual CD-ROM device.
+    class Info < VAPI::Bindings::VapiStruct
+      class << self
+        # Holds (gets or creates) the binding type metadata for this structure type.
+        # @scope class
+        # @return [VAPI::Bindings::StructType] the binding type
+        def binding_type
+          @binding_type ||= VAPI::Bindings::StructType.new(
+            'com.vmware.vcenter.vm.hardware.cdrom.info',
+            {
+              'type' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::VM::Hardware::Cdrom::HostBusAdapterType'),
+              'label' => VAPI::Bindings::StringType.instance,
+              'ide' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::VM::Hardware::IdeAddressInfo')),
+              'sata' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::VM::Hardware::SataAddressInfo')),
+              'backing' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::VM::Hardware::Cdrom::BackingInfo'),
+              'state' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::VM::Hardware::ConnectionState'),
+              'start_connected' => VAPI::Bindings::BooleanType.instance,
+              'allow_guest_control' => VAPI::Bindings::BooleanType.instance
+            },
+            Info,
+            false,
+            nil
+          )
+        end
+      end
+
+      attr_accessor :type,
+                    :label,
+                    :ide,
+                    :sata,
+                    :backing,
+                    :state,
+                    :start_connected,
+                    :allow_guest_control
+
+      # Constructs a new instance.
+      # @param ruby_values [Hash] a map of initial property values (optional)
+      # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
+      def initialize(ruby_values = nil, struct_value = nil)
+        super(self.class.binding_type, ruby_values, struct_value)
+      end
+    end
+
+    # The  ``Com::Vmware::Vcenter::VM::Hardware::Cdrom::CreateSpec``   class  provides a specification for the configuration of a newly-created virtual CD-ROM device.
+    # @!attribute [rw] type
+    #     @return [Com::Vmware::Vcenter::VM::Hardware::Cdrom::HostBusAdapterType, nil]
+    #     Type of host bus adapter to which the device should be attached.
+    #     If  nil , guest-specific default values will be used
+    # @!attribute [rw] ide
+    #     @return [Com::Vmware::Vcenter::VM::Hardware::IdeAddressSpec, nil]
+    #     Address for attaching the device to a virtual IDE adapter.
+    #     If  nil , the server will choose an available address; if none is available, the request will fail.
+    # @!attribute [rw] sata
+    #     @return [Com::Vmware::Vcenter::VM::Hardware::SataAddressSpec, nil]
+    #     Address for attaching the device to a virtual SATA adapter.
+    #     If  nil , the server will choose an available address; if none is available, the request will fail.
+    # @!attribute [rw] backing
+    #     @return [Com::Vmware::Vcenter::VM::Hardware::Cdrom::BackingSpec, nil]
+    #     Physical resource backing for the virtual CD-ROM device.
+    #     If  nil , defaults to automatic detection of a suitable host device.
+    class CreateSpec < VAPI::Bindings::VapiStruct
+      class << self
+        # Holds (gets or creates) the binding type metadata for this structure type.
+        # @scope class
+        # @return [VAPI::Bindings::StructType] the binding type
+        def binding_type
+          @binding_type ||= VAPI::Bindings::StructType.new(
+            'com.vmware.vcenter.vm.hardware.cdrom.create_spec',
+            {
+              'type' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::VM::Hardware::Cdrom::HostBusAdapterType')),
+              'ide' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::VM::Hardware::IdeAddressSpec')),
+              'sata' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::VM::Hardware::SataAddressSpec')),
+              'backing' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::VM::Hardware::Cdrom::BackingSpec')),
+              'start_connected' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::BooleanType.instance),
+              'allow_guest_control' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::BooleanType.instance)
+            },
+            CreateSpec,
+            false,
+            nil
+          )
+        end
+      end
+
+      attr_accessor :type,
+                    :ide,
+                    :sata,
+                    :backing,
+                    :start_connected,
+                    :allow_guest_control
+
+      # Constructs a new instance.
+      # @param ruby_values [Hash] a map of initial property values (optional)
+      # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
+      def initialize(ruby_values = nil, struct_value = nil)
+        super(self.class.binding_type, ruby_values, struct_value)
+      end
+    end
+
+    # The  ``Com::Vmware::Vcenter::VM::Hardware::Cdrom::UpdateSpec``   class  describes the updates to be made to the configuration of a virtual CD-ROM device.
+    # @!attribute [rw] backing
+    #     @return [Com::Vmware::Vcenter::VM::Hardware::Cdrom::BackingSpec, nil]
+    #     Physical resource backing for the virtual CD-ROM device.  
+    #     
+    #      This  field  may only be modified if the virtual machine is not powered on or the virtual CD-ROM device is not connected.
+    #     If  nil , the value is unchanged.
+    class UpdateSpec < VAPI::Bindings::VapiStruct
+      class << self
+        # Holds (gets or creates) the binding type metadata for this structure type.
+        # @scope class
+        # @return [VAPI::Bindings::StructType] the binding type
+        def binding_type
+          @binding_type ||= VAPI::Bindings::StructType.new(
+            'com.vmware.vcenter.vm.hardware.cdrom.update_spec',
+            {
+              'backing' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::VM::Hardware::Cdrom::BackingSpec')),
+              'start_connected' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::BooleanType.instance),
+              'allow_guest_control' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::BooleanType.instance)
+            },
+            UpdateSpec,
+            false,
+            nil
+          )
+        end
+      end
+
+      attr_accessor :backing,
+                    :start_connected,
+                    :allow_guest_control
+
+      # Constructs a new instance.
+      # @param ruby_values [Hash] a map of initial property values (optional)
+      # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
+      def initialize(ruby_values = nil, struct_value = nil)
+        super(self.class.binding_type, ruby_values, struct_value)
+      end
+    end
+
+    # The  ``Com::Vmware::Vcenter::VM::Hardware::Cdrom::Summary``   class  contains commonly used information about a virtual CD-ROM device.
+    # @!attribute [rw] cdrom
+    #     @return [String]
+    #     Identifier of the virtual CD-ROM device.
+    class Summary < VAPI::Bindings::VapiStruct
+      class << self
+        # Holds (gets or creates) the binding type metadata for this structure type.
+        # @scope class
+        # @return [VAPI::Bindings::StructType] the binding type
+        def binding_type
+          @binding_type ||= VAPI::Bindings::StructType.new(
+            'com.vmware.vcenter.vm.hardware.cdrom.summary',
+            {
+              'cdrom' => VAPI::Bindings::IdType.new('com.vmware.vcenter.vm.hardware.Cdrom')
+            },
+            Summary,
+            false,
+            nil
+          )
+        end
+      end
+
+      attr_accessor :cdrom
+
+      # Constructs a new instance.
+      # @param ruby_values [Hash] a map of initial property values (optional)
+      # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
+      def initialize(ruby_values = nil, struct_value = nil)
+        super(self.class.binding_type, ruby_values, struct_value)
+      end
+    end
+
+    # The  ``Com::Vmware::Vcenter::VM::Hardware::Cdrom::HostBusAdapterType``   enumerated type  defines the valid types of host bus adapters that may be used for attaching a Cdrom to a virtual machine.
+    # @!attribute [rw] ide
+    #     @return [Com::Vmware::Vcenter::VM::Hardware::Cdrom::HostBusAdapterType]
+    #     Cdrom is attached to an IDE adapter.
+    # @!attribute [rw] sata
+    #     @return [Com::Vmware::Vcenter::VM::Hardware::Cdrom::HostBusAdapterType]
+    #     Cdrom is attached to a SATA adapter.
+    class HostBusAdapterType < VAPI::Bindings::VapiEnum
+      class << self
+        # Holds (gets or creates) the binding type metadata for this enumeration type.
+        # @scope class
+        # @return [VAPI::Bindings::EnumType] the binding type
+        def binding_type
+          @binding_type ||= VAPI::Bindings::EnumType.new(
+            'com.vmware.vcenter.vm.hardware.cdrom.host_bus_adapter_type',
+            HostBusAdapterType
+          )
+        end
+
+        # Converts from a string value (perhaps off the wire) to an instance
+        # of this enum type.
+        # @param value [String] the actual value of the enum instance
+        # @return [HostBusAdapterType] the instance found for the value, otherwise
+        #         an unknown instance will be built for the value
+        def from_string(value)
+          const_get(value)
+        rescue NameError
+          HostBusAdapterType.send(:new, 'UNKNOWN', value)
+        end
+      end
+
+      # Constructs a new instance.
+      # @param value [String] the actual value of the enum instance
+      # @param unknown [String] the unknown value when value is 'UKNOWN'
+      def initialize(value, unknown = nil)
+        super(self.class.binding_type, value, unknown)
+      end
+
+      private_class_method :new
+
+      # @!attribute [rw] ide
+      #     @return [Com::Vmware::Vcenter::VM::Hardware::Cdrom::HostBusAdapterType]
+      #     Cdrom is attached to an IDE adapter.
+      IDE = HostBusAdapterType.send(:new, 'IDE')
+
+      # @!attribute [rw] sata
+      #     @return [Com::Vmware::Vcenter::VM::Hardware::Cdrom::HostBusAdapterType]
+      #     Cdrom is attached to a SATA adapter.
+      SATA = HostBusAdapterType.send(:new, 'SATA')
+    end
+    # The  ``Com::Vmware::Vcenter::VM::Hardware::Cdrom::BackingType``   enumerated type  defines the valid backing types for a virtual CD-ROM device.
+    # @!attribute [rw] iso_file
+    #     @return [Com::Vmware::Vcenter::VM::Hardware::Cdrom::BackingType]
+    #     Virtual CD-ROM device is backed by an ISO file.
+    # @!attribute [rw] host_device
+    #     @return [Com::Vmware::Vcenter::VM::Hardware::Cdrom::BackingType]
+    #     Virtual CD-ROM device is backed by a device on the host where the virtual machine is running.
+    # @!attribute [rw] client_device
+    #     @return [Com::Vmware::Vcenter::VM::Hardware::Cdrom::BackingType]
+    #     Virtual CD-ROM device is backed by a device on the client that is connected to the virtual machine console.
+    class BackingType < VAPI::Bindings::VapiEnum
+      class << self
+        # Holds (gets or creates) the binding type metadata for this enumeration type.
+        # @scope class
+        # @return [VAPI::Bindings::EnumType] the binding type
+        def binding_type
+          @binding_type ||= VAPI::Bindings::EnumType.new(
+            'com.vmware.vcenter.vm.hardware.cdrom.backing_type',
+            BackingType
+          )
+        end
+
+        # Converts from a string value (perhaps off the wire) to an instance
+        # of this enum type.
+        # @param value [String] the actual value of the enum instance
+        # @return [BackingType] the instance found for the value, otherwise
+        #         an unknown instance will be built for the value
+        def from_string(value)
+          const_get(value)
+        rescue NameError
+          BackingType.send(:new, 'UNKNOWN', value)
+        end
+      end
+
+      # Constructs a new instance.
+      # @param value [String] the actual value of the enum instance
+      # @param unknown [String] the unknown value when value is 'UKNOWN'
+      def initialize(value, unknown = nil)
+        super(self.class.binding_type, value, unknown)
+      end
+
+      private_class_method :new
+
+      # @!attribute [rw] iso_file
+      #     @return [Com::Vmware::Vcenter::VM::Hardware::Cdrom::BackingType]
+      #     Virtual CD-ROM device is backed by an ISO file.
+      ISO_FILE = BackingType.send(:new, 'ISO_FILE')
+
+      # @!attribute [rw] host_device
+      #     @return [Com::Vmware::Vcenter::VM::Hardware::Cdrom::BackingType]
+      #     Virtual CD-ROM device is backed by a device on the host where the virtual machine is running.
+      HOST_DEVICE = BackingType.send(:new, 'HOST_DEVICE')
+
+      # @!attribute [rw] client_device
+      #     @return [Com::Vmware::Vcenter::VM::Hardware::Cdrom::BackingType]
+      #     Virtual CD-ROM device is backed by a device on the client that is connected to the virtual machine console.
+      CLIENT_DEVICE = BackingType.send(:new, 'CLIENT_DEVICE')
+    end
+    # The  ``Com::Vmware::Vcenter::VM::Hardware::Cdrom::DeviceAccessType``   enumerated type  defines the valid device access types for a physical device packing of a virtual CD-ROM device.
+    # @!attribute [rw] emulation
+    #     @return [Com::Vmware::Vcenter::VM::Hardware::Cdrom::DeviceAccessType]
+    #     ATAPI or SCSI device emulation.
+    # @!attribute [rw] passthru
+    #     @return [Com::Vmware::Vcenter::VM::Hardware::Cdrom::DeviceAccessType]
+    #     Raw passthru device access.
+    # @!attribute [rw] passthru_exclusive
+    #     @return [Com::Vmware::Vcenter::VM::Hardware::Cdrom::DeviceAccessType]
+    #     Raw passthru device access, with exclusive access to the device.
+    class DeviceAccessType < VAPI::Bindings::VapiEnum
+      class << self
+        # Holds (gets or creates) the binding type metadata for this enumeration type.
+        # @scope class
+        # @return [VAPI::Bindings::EnumType] the binding type
+        def binding_type
+          @binding_type ||= VAPI::Bindings::EnumType.new(
+            'com.vmware.vcenter.vm.hardware.cdrom.device_access_type',
+            DeviceAccessType
+          )
+        end
+
+        # Converts from a string value (perhaps off the wire) to an instance
+        # of this enum type.
+        # @param value [String] the actual value of the enum instance
+        # @return [DeviceAccessType] the instance found for the value, otherwise
+        #         an unknown instance will be built for the value
+        def from_string(value)
+          const_get(value)
+        rescue NameError
+          DeviceAccessType.send(:new, 'UNKNOWN', value)
+        end
+      end
+
+      # Constructs a new instance.
+      # @param value [String] the actual value of the enum instance
+      # @param unknown [String] the unknown value when value is 'UKNOWN'
+      def initialize(value, unknown = nil)
+        super(self.class.binding_type, value, unknown)
+      end
+
+      private_class_method :new
+
+      # @!attribute [rw] emulation
+      #     @return [Com::Vmware::Vcenter::VM::Hardware::Cdrom::DeviceAccessType]
+      #     ATAPI or SCSI device emulation.
+      EMULATION = DeviceAccessType.send(:new, 'EMULATION')
+
+      # @!attribute [rw] passthru
+      #     @return [Com::Vmware::Vcenter::VM::Hardware::Cdrom::DeviceAccessType]
+      #     Raw passthru device access.
+      PASSTHRU = DeviceAccessType.send(:new, 'PASSTHRU')
+
+      # @!attribute [rw] passthru_exclusive
+      #     @return [Com::Vmware::Vcenter::VM::Hardware::Cdrom::DeviceAccessType]
+      #     Raw passthru device access, with exclusive access to the device.
+      PASSTHRU_EXCLUSIVE = DeviceAccessType.send(:new, 'PASSTHRU_EXCLUSIVE')
+    end
+  end
+  # The  ``Com::Vmware::Vcenter::VM::Hardware::Cpu``   class  provides  methods  for configuring the CPU settings of a virtual machine.
+  class Cpu < VAPI::Bindings::VapiService
+    # static metamodel definitions
+    SERVICE_ID = VAPI::Core::ServiceIdentifier.new('com.vmware.vcenter.vm.hardware.cpu')
+
+    GET_INFO = VAPI::Bindings::OperationInfo.new(
+      VAPI::Core::OperationIdentifier.new('get', SERVICE_ID),
+      VAPI::Bindings::OperationInputType.new(
+        'vm' => VAPI::Bindings::IdType.new('VirtualMachine')
+      ),
+      VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::VM::Hardware::Cpu::Info'),
+      {
+        'com.vmware.vapi.std.errors.error' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Error'),
+        'com.vmware.vapi.std.errors.not_found' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::NotFound'),
+        'com.vmware.vapi.std.errors.resource_inaccessible' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::ResourceInaccessible'),
+        'com.vmware.vapi.std.errors.service_unavailable' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::ServiceUnavailable'),
+        'com.vmware.vapi.std.errors.unauthenticated' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Unauthenticated'),
+        'com.vmware.vapi.std.errors.unauthorized' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Unauthorized')
+      },
+      [],
+      []
+    )
+
+    UPDATE_INFO = VAPI::Bindings::OperationInfo.new(
+      VAPI::Core::OperationIdentifier.new('update', SERVICE_ID),
+      VAPI::Bindings::OperationInputType.new(
+        'vm' => VAPI::Bindings::IdType.new('VirtualMachine'),
+        'spec' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::VM::Hardware::Cpu::UpdateSpec')
+      ),
+      VAPI::Bindings::VoidType.instance,
+      {
+        'com.vmware.vapi.std.errors.error' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Error'),
+        'com.vmware.vapi.std.errors.not_found' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::NotFound'),
+        'com.vmware.vapi.std.errors.invalid_argument' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::InvalidArgument'),
+        'com.vmware.vapi.std.errors.not_allowed_in_current_state' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::NotAllowedInCurrentState'),
+        'com.vmware.vapi.std.errors.resource_busy' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::ResourceBusy'),
+        'com.vmware.vapi.std.errors.resource_inaccessible' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::ResourceInaccessible'),
+        'com.vmware.vapi.std.errors.service_unavailable' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::ServiceUnavailable'),
+        'com.vmware.vapi.std.errors.unauthenticated' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Unauthenticated'),
+        'com.vmware.vapi.std.errors.unauthorized' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Unauthorized')
+      },
+      [],
+      []
+    )
+
+    SERVICE_INFO = VAPI::Bindings::ServiceInfo.new(
+      SERVICE_ID,
+      'get' => GET_INFO,
+      'update' => UPDATE_INFO
+    )
+
+    # Constructs a new instance.
+    #
+    # @param config [VAPI::Bindings::StubConfig] A hash with the api provider details.
+    def initialize(config)
+      super(config, SERVICE_INFO)
+    end
+
+    # Returns the CPU-related settings of a virtual machine.
+    #
+    # @param vm [String]
+    #     Virtual machine identifier.
+    # @return [Com::Vmware::Vcenter::VM::Hardware::Cpu::Info]
+    #     CPU-related settings of the virtual machine.
+    # @raise [Com::Vmware::Vapi::Std::Errors::Error]
+    #     if the system reports an error while responding to the request.
+    # @raise [Com::Vmware::Vapi::Std::Errors::NotFound]
+    #     if the virtual machine is not found.
+    # @raise [Com::Vmware::Vapi::Std::Errors::ResourceInaccessible]
+    #     if the virtual machine's configuration state cannot be accessed.
+    # @raise [Com::Vmware::Vapi::Std::Errors::ServiceUnavailable]
+    #     if the system is unable to communicate with a service to complete the request.
+    # @raise [Com::Vmware::Vapi::Std::Errors::Unauthenticated]
+    #     if the user can not be authenticated.
+    # @raise [Com::Vmware::Vapi::Std::Errors::Unauthorized]
+    #     if the user doesn't have the required privileges.
+    def get(vm)
+      invoke_with_info(GET_INFO,
+                       'vm' => vm)
+    end
+
+    # Updates the CPU-related settings of a virtual machine.
+    #
+    # @param vm [String]
+    #     Virtual machine identifier.
+    # @param spec [Com::Vmware::Vcenter::VM::Hardware::Cpu::UpdateSpec]
+    #     Specification for updating the CPU-related settings of the virtual machine.
+    # @return [Void]
+    # @raise [Com::Vmware::Vapi::Std::Errors::Error]
+    #     if the system reports an error while responding to the request.
+    # @raise [Com::Vmware::Vapi::Std::Errors::NotFound]
+    #     if the virtual machine is not found.
+    # @raise [Com::Vmware::Vapi::Std::Errors::InvalidArgument]
+    #     if one of the provided settings is not permitted; for example, specifying a negative value for  ``count`` .
+    # @raise [Com::Vmware::Vapi::Std::Errors::NotAllowedInCurrentState]
+    #     if  ``hotAddEnabled``  or  ``hotRemoveEnabled``  is specified and the virtual machine is not powered off.
+    # @raise [Com::Vmware::Vapi::Std::Errors::NotAllowedInCurrentState]
+    #     if  ``count``  is specified and is greater than  ``count`` ,  ``hotAddEnabled``  is false, and the virtual machine is not powered off.
+    # @raise [Com::Vmware::Vapi::Std::Errors::NotAllowedInCurrentState]
+    #     if  ``count``  is specified and is less than  ``count`` ,  ``hotRemoveEnabled``  is false, and the virtual machine is not powered off.
+    # @raise [Com::Vmware::Vapi::Std::Errors::ResourceBusy]
+    #     if the virtual machine is busy performing another operation.
+    # @raise [Com::Vmware::Vapi::Std::Errors::ResourceInaccessible]
+    #     if the virtual machine's configuration state cannot be accessed.
+    # @raise [Com::Vmware::Vapi::Std::Errors::ServiceUnavailable]
+    #     if the system is unable to communicate with a service to complete the request.
+    # @raise [Com::Vmware::Vapi::Std::Errors::Unauthenticated]
+    #     if the user can not be authenticated.
+    # @raise [Com::Vmware::Vapi::Std::Errors::Unauthorized]
+    #     if the user doesn't have the required privileges.
+    def update(vm, spec)
+      invoke_with_info(UPDATE_INFO,
+                       'vm' => vm,
+                       'spec' => spec)
+    end
+
+    # The  ``Com::Vmware::Vcenter::VM::Hardware::Cpu::Info``   class  contains CPU-related information about a virtual machine.
+    # @!attribute [rw] count
+    #     @return [Fixnum]
+    #     Number of CPU cores.
+    # @!attribute [rw] cores_per_socket
+    #     @return [Fixnum]
+    #     Number of CPU cores per socket.
+    # @!attribute [rw] hot_add_enabled
+    #     @return [Boolean]
+    #     Flag indicating whether adding CPUs while the virtual machine is running is enabled.
+    # @!attribute [rw] hot_remove_enabled
+    #     @return [Boolean]
+    #     Flag indicating whether removing CPUs while the virtual machine is running is enabled.
+    class Info < VAPI::Bindings::VapiStruct
+      class << self
+        # Holds (gets or creates) the binding type metadata for this structure type.
+        # @scope class
+        # @return [VAPI::Bindings::StructType] the binding type
+        def binding_type
+          @binding_type ||= VAPI::Bindings::StructType.new(
+            'com.vmware.vcenter.vm.hardware.cpu.info',
+            {
+              'count' => VAPI::Bindings::IntegerType.instance,
+              'cores_per_socket' => VAPI::Bindings::IntegerType.instance,
+              'hot_add_enabled' => VAPI::Bindings::BooleanType.instance,
+              'hot_remove_enabled' => VAPI::Bindings::BooleanType.instance
+            },
+            Info,
+            false,
+            nil
+          )
+        end
+      end
+
+      attr_accessor :count,
+                    :cores_per_socket,
+                    :hot_add_enabled,
+                    :hot_remove_enabled
+
+      # Constructs a new instance.
+      # @param ruby_values [Hash] a map of initial property values (optional)
+      # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
+      def initialize(ruby_values = nil, struct_value = nil)
+        super(self.class.binding_type, ruby_values, struct_value)
+      end
+    end
+
+    # The  ``Com::Vmware::Vcenter::VM::Hardware::Cpu::UpdateSpec``   class  describes the updates to be made to the CPU-related settings of a virtual machine.
+    # @!attribute [rw] count
+    #     @return [Fixnum, nil]
+    #     New number of CPU cores. The number of CPU cores in the virtual machine must be a multiple of the number of cores per socket.  
+    #     
+    #      The supported range of CPU counts is constrained by the configured guest operating system and virtual hardware version of the virtual machine.  
+    #     
+    #      If the virtual machine is running, the number of CPU cores may only be increased if   :attr:`Com::Vmware::Vcenter::VM::Hardware::Cpu::Info.hot_add_enabled`   is true, and may only be decreased if   :attr:`Com::Vmware::Vcenter::VM::Hardware::Cpu::Info.hot_remove_enabled`   is true.
+    #     If  nil , the value is unchanged.
+    # @!attribute [rw] cores_per_socket
+    #     @return [Fixnum, nil]
+    #     New number of CPU cores per socket. The number of CPU cores in the virtual machine must be a multiple of the number of cores per socket.
+    #     If  nil , the value is unchanged.
+    # @!attribute [rw] hot_add_enabled
+    #     @return [Boolean, nil]
+    #     Flag indicating whether adding CPUs while the virtual machine is running is enabled.  
+    #     
+    #      This  field  may only be modified if the virtual machine is powered off.
+    #     If  nil , the value is unchanged.
+    # @!attribute [rw] hot_remove_enabled
+    #     @return [Boolean, nil]
+    #     Flag indicating whether removing CPUs while the virtual machine is running is enabled.  
+    #     
+    #      This  field  may only be modified if the virtual machine is powered off.
+    #     If  nil , the value is unchanged.
+    class UpdateSpec < VAPI::Bindings::VapiStruct
+      class << self
+        # Holds (gets or creates) the binding type metadata for this structure type.
+        # @scope class
+        # @return [VAPI::Bindings::StructType] the binding type
+        def binding_type
+          @binding_type ||= VAPI::Bindings::StructType.new(
+            'com.vmware.vcenter.vm.hardware.cpu.update_spec',
+            {
+              'count' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::IntegerType.instance),
+              'cores_per_socket' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::IntegerType.instance),
+              'hot_add_enabled' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::BooleanType.instance),
+              'hot_remove_enabled' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::BooleanType.instance)
+            },
+            UpdateSpec,
+            false,
+            nil
+          )
+        end
+      end
+
+      attr_accessor :count,
+                    :cores_per_socket,
+                    :hot_add_enabled,
+                    :hot_remove_enabled
+
+      # Constructs a new instance.
+      # @param ruby_values [Hash] a map of initial property values (optional)
+      # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
+      def initialize(ruby_values = nil, struct_value = nil)
+        super(self.class.binding_type, ruby_values, struct_value)
+      end
+    end
+
+  end
+  # The  ``Com::Vmware::Vcenter::VM::Hardware::Disk``   class  provides  methods  for configuring the virtual disks of a virtual machine. A virtual disk has a backing such as a VMDK file. The backing has an independent lifecycle from the virtual machine when it is detached from the virtual machine. The   :func:`Com::Vmware::Vcenter::VM::Hardware::Disk.create`    method  provides the ability to create a new virtual disk. When creating a virtual disk, a new VMDK file may be created or an existing VMDK file may used as a backing. Once a VMDK file is associated with a virtual machine, its lifecycle will be bound to the virtual machine. In other words, it will be deleted when the virtual machine is deleted. The   :func:`Com::Vmware::Vcenter::VM::Hardware::Disk.delete`    method  provides the ability to detach a VMDK file from the virtual machine. The   :func:`Com::Vmware::Vcenter::VM::Hardware::Disk.delete`    method  does not delete the VMDK file that backs the virtual disk. Once detached, the VMDK file will not be destroyed when the virtual machine to which it was associated is deleted.
+  class Disk < VAPI::Bindings::VapiService
+    # static metamodel definitions
+    SERVICE_ID = VAPI::Core::ServiceIdentifier.new('com.vmware.vcenter.vm.hardware.disk')
+
+    LIST_INFO = VAPI::Bindings::OperationInfo.new(
+      VAPI::Core::OperationIdentifier.new('list', SERVICE_ID),
+      VAPI::Bindings::OperationInputType.new(
+        'vm' => VAPI::Bindings::IdType.new('VirtualMachine')
+      ),
+      VAPI::Bindings::ListType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::VM::Hardware::Disk::Summary')),
+      {
+        'com.vmware.vapi.std.errors.error' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Error'),
+        'com.vmware.vapi.std.errors.not_found' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::NotFound'),
+        'com.vmware.vapi.std.errors.resource_inaccessible' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::ResourceInaccessible'),
+        'com.vmware.vapi.std.errors.service_unavailable' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::ServiceUnavailable'),
+        'com.vmware.vapi.std.errors.unauthenticated' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Unauthenticated'),
+        'com.vmware.vapi.std.errors.unauthorized' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Unauthorized')
+      },
+      [],
+      []
+    )
+
+    GET_INFO = VAPI::Bindings::OperationInfo.new(
+      VAPI::Core::OperationIdentifier.new('get', SERVICE_ID),
+      VAPI::Bindings::OperationInputType.new(
+        'vm' => VAPI::Bindings::IdType.new('VirtualMachine'),
+        'disk' => VAPI::Bindings::IdType.new('com.vmware.vcenter.vm.hardware.Disk')
+      ),
+      VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::VM::Hardware::Disk::Info'),
+      {
+        'com.vmware.vapi.std.errors.error' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Error'),
+        'com.vmware.vapi.std.errors.not_found' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::NotFound'),
+        'com.vmware.vapi.std.errors.resource_inaccessible' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::ResourceInaccessible'),
+        'com.vmware.vapi.std.errors.service_unavailable' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::ServiceUnavailable'),
+        'com.vmware.vapi.std.errors.unauthenticated' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Unauthenticated'),
+        'com.vmware.vapi.std.errors.unauthorized' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Unauthorized')
+      },
+      [],
+      []
+    )
+
+    CREATE_INFO = VAPI::Bindings::OperationInfo.new(
+      VAPI::Core::OperationIdentifier.new('create', SERVICE_ID),
+      VAPI::Bindings::OperationInputType.new(
+        'vm' => VAPI::Bindings::IdType.new('VirtualMachine'),
+        'spec' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::VM::Hardware::Disk::CreateSpec')
+      ),
+      VAPI::Bindings::IdType.new('com.vmware.vcenter.vm.hardware.Disk'),
+      {
+        'com.vmware.vapi.std.errors.error' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Error'),
+        'com.vmware.vapi.std.errors.not_found' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::NotFound'),
+        'com.vmware.vapi.std.errors.not_allowed_in_current_state' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::NotAllowedInCurrentState'),
+        'com.vmware.vapi.std.errors.unable_to_allocate_resource' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::UnableToAllocateResource'),
+        'com.vmware.vapi.std.errors.resource_in_use' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::ResourceInUse'),
+        'com.vmware.vapi.std.errors.invalid_argument' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::InvalidArgument'),
+        'com.vmware.vapi.std.errors.resource_busy' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::ResourceBusy'),
+        'com.vmware.vapi.std.errors.resource_inaccessible' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::ResourceInaccessible'),
+        'com.vmware.vapi.std.errors.service_unavailable' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::ServiceUnavailable'),
+        'com.vmware.vapi.std.errors.unauthenticated' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Unauthenticated'),
+        'com.vmware.vapi.std.errors.unauthorized' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Unauthorized'),
+        'com.vmware.vapi.std.errors.unsupported' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Unsupported')
+      },
+      [],
+      []
+    )
+
+    UPDATE_INFO = VAPI::Bindings::OperationInfo.new(
+      VAPI::Core::OperationIdentifier.new('update', SERVICE_ID),
+      VAPI::Bindings::OperationInputType.new(
+        'vm' => VAPI::Bindings::IdType.new('VirtualMachine'),
+        'disk' => VAPI::Bindings::IdType.new('com.vmware.vcenter.vm.hardware.Disk'),
+        'spec' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::VM::Hardware::Disk::UpdateSpec')
+      ),
+      VAPI::Bindings::VoidType.instance,
+      {
+        'com.vmware.vapi.std.errors.error' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Error'),
+        'com.vmware.vapi.std.errors.not_found' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::NotFound'),
+        'com.vmware.vapi.std.errors.not_allowed_in_current_state' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::NotAllowedInCurrentState'),
+        'com.vmware.vapi.std.errors.resource_busy' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::ResourceBusy'),
+        'com.vmware.vapi.std.errors.resource_inaccessible' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::ResourceInaccessible'),
+        'com.vmware.vapi.std.errors.service_unavailable' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::ServiceUnavailable'),
+        'com.vmware.vapi.std.errors.unauthenticated' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Unauthenticated'),
+        'com.vmware.vapi.std.errors.unauthorized' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Unauthorized')
+      },
+      [],
+      []
+    )
+
+    DELETE_INFO = VAPI::Bindings::OperationInfo.new(
+      VAPI::Core::OperationIdentifier.new('delete', SERVICE_ID),
+      VAPI::Bindings::OperationInputType.new(
+        'vm' => VAPI::Bindings::IdType.new('VirtualMachine'),
+        'disk' => VAPI::Bindings::IdType.new('com.vmware.vcenter.vm.hardware.Disk')
+      ),
+      VAPI::Bindings::VoidType.instance,
+      {
+        'com.vmware.vapi.std.errors.error' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Error'),
+        'com.vmware.vapi.std.errors.not_found' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::NotFound'),
+        'com.vmware.vapi.std.errors.not_allowed_in_current_state' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::NotAllowedInCurrentState'),
+        'com.vmware.vapi.std.errors.resource_busy' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::ResourceBusy'),
+        'com.vmware.vapi.std.errors.resource_inaccessible' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::ResourceInaccessible'),
+        'com.vmware.vapi.std.errors.service_unavailable' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::ServiceUnavailable'),
+        'com.vmware.vapi.std.errors.unauthenticated' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Unauthenticated'),
+        'com.vmware.vapi.std.errors.unauthorized' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Unauthorized')
+      },
+      [],
+      []
+    )
+
+    SERVICE_INFO = VAPI::Bindings::ServiceInfo.new(
+      SERVICE_ID,
+      'list' => LIST_INFO,
+      'get' => GET_INFO,
+      'create' => CREATE_INFO,
+      'update' => UPDATE_INFO,
+      'delete' => DELETE_INFO
+    )
+
+    # Constructs a new instance.
+    #
+    # @param config [VAPI::Bindings::StubConfig] A hash with the api provider details.
+    def initialize(config)
+      super(config, SERVICE_INFO)
+    end
+
+    RESOURCE_TYPE = 'com.vmware.vcenter.vm.hardware.Disk'
+    # Returns commonly used information about the virtual disks belonging to the virtual machine.
+    #
+    # @param vm [String]
+    #     Virtual machine identifier.
+    # @return [Array<Com::Vmware::Vcenter::VM::Hardware::Disk::Summary>]
+    #     List of commonly used information about the virtual disks.
+    # @raise [Com::Vmware::Vapi::Std::Errors::Error]
+    #     if the system reports an error while responding to the request.
+    # @raise [Com::Vmware::Vapi::Std::Errors::NotFound]
+    #     if the virtual machine is not found.
+    # @raise [Com::Vmware::Vapi::Std::Errors::ResourceInaccessible]
+    #     if the virtual machine's configuration state cannot be accessed.
+    # @raise [Com::Vmware::Vapi::Std::Errors::ServiceUnavailable]
+    #     if the system is unable to communicate with a service to complete the request.
+    # @raise [Com::Vmware::Vapi::Std::Errors::Unauthenticated]
+    #     if the user can not be authenticated.
+    # @raise [Com::Vmware::Vapi::Std::Errors::Unauthorized]
+    #     if the user doesn't have the required privileges.
+    def list(vm)
+      invoke_with_info(LIST_INFO,
+                       'vm' => vm)
+    end
+
+    # Returns information about a virtual disk.
+    #
+    # @param vm [String]
+    #     Virtual machine identifier.
+    # @param disk [String]
+    #     Virtual disk identifier.
+    # @return [Com::Vmware::Vcenter::VM::Hardware::Disk::Info]
+    #     Information about the specified virtual disk.
+    # @raise [Com::Vmware::Vapi::Std::Errors::Error]
+    #     if the system reports an error while responding to the request.
+    # @raise [Com::Vmware::Vapi::Std::Errors::NotFound]
+    #     if the virtual machine or virtual disk is not found.
+    # @raise [Com::Vmware::Vapi::Std::Errors::ResourceInaccessible]
+    #     if the virtual machine's configuration state cannot be accessed.
+    # @raise [Com::Vmware::Vapi::Std::Errors::ServiceUnavailable]
+    #     if the system is unable to communicate with a service to complete the request.
+    # @raise [Com::Vmware::Vapi::Std::Errors::Unauthenticated]
+    #     if the user can not be authenticated.
+    # @raise [Com::Vmware::Vapi::Std::Errors::Unauthorized]
+    #     if the user doesn't have the required privileges.
+    def get(vm, disk)
+      invoke_with_info(GET_INFO,
+                       'vm' => vm,
+                       'disk' => disk)
+    end
+
+    # Adds a virtual disk to the virtual machine. While adding the virtual disk, a new VMDK file may be created or an existing VMDK file may be used to back the virtual disk.
+    #
+    # @param vm [String]
+    #     Virtual machine identifier.
+    # @param spec [Com::Vmware::Vcenter::VM::Hardware::Disk::CreateSpec]
+    #     Specification for the new virtual disk.
+    # @return [String]
+    #     Virtual disk identifier.
+    # @raise [Com::Vmware::Vapi::Std::Errors::Error]
+    #     if system reported that the disk device was created but was unable to confirm the creation because the identifier of the new device could not be determined.
+    # @raise [Com::Vmware::Vapi::Std::Errors::Error]
+    #     if the system reports an error while responding to the request.
+    # @raise [Com::Vmware::Vapi::Std::Errors::NotFound]
+    #     if the virtual machine is not found.
+    # @raise [Com::Vmware::Vapi::Std::Errors::NotAllowedInCurrentState]
+    #     if the virtual machine is suspended or if the virtual machine is powered on and virtual disk type is IDE.
+    # @raise [Com::Vmware::Vapi::Std::Errors::UnableToAllocateResource]
+    #     if the specified storage address is unavailable; for example, if the SCSI adapter requested does not exist.
+    # @raise [Com::Vmware::Vapi::Std::Errors::ResourceInUse]
+    #     if the specified storage address is in use.
+    # @raise [Com::Vmware::Vapi::Std::Errors::InvalidArgument]
+    #     if the specified storage address is out of bounds.
+    # @raise [Com::Vmware::Vapi::Std::Errors::ResourceBusy]
+    #     if the virtual machine is busy performing another operation.
+    # @raise [Com::Vmware::Vapi::Std::Errors::ResourceInaccessible]
+    #     if the virtual machine's configuration state cannot be accessed.
+    # @raise [Com::Vmware::Vapi::Std::Errors::ServiceUnavailable]
+    #     if the system is unable to communicate with a service to complete the request.
+    # @raise [Com::Vmware::Vapi::Std::Errors::Unauthenticated]
+    #     if the user can not be authenticated.
+    # @raise [Com::Vmware::Vapi::Std::Errors::Unauthorized]
+    #     if the user doesn't have the required privileges.
+    # @raise [Com::Vmware::Vapi::Std::Errors::Unsupported]
+    #     if the guest operating system of the virtual machine is not supported and  spec  includes  nil   fields  that default to guest-specific values.
+    def create(vm, spec)
+      invoke_with_info(CREATE_INFO,
+                       'vm' => vm,
+                       'spec' => spec)
+    end
+
+    # Updates the configuration of a virtual disk. An update  method  can be used to detach the existing VMDK file and attach another VMDK file to the virtual machine.
+    #
+    # @param vm [String]
+    #     Virtual machine identifier.
+    # @param disk [String]
+    #     Virtual disk identifier.
+    # @param spec [Com::Vmware::Vcenter::VM::Hardware::Disk::UpdateSpec]
+    #     Specification for updating the virtual disk.
+    # @return [Void]
+    # @raise [Com::Vmware::Vapi::Std::Errors::Error]
+    #     if the system reports an error while responding to the request.
+    # @raise [Com::Vmware::Vapi::Std::Errors::NotFound]
+    #     if the virtual machine or virtual disk is not found.
+    # @raise [Com::Vmware::Vapi::Std::Errors::NotAllowedInCurrentState]
+    #     if one or more of the  fields  specified in the  ``spec``   parameter  cannot be modified due to the current power state of the virtual machine or the connection state of the virtual disk.
+    # @raise [Com::Vmware::Vapi::Std::Errors::ResourceBusy]
+    #     if the virtual machine is busy performing another operation.
+    # @raise [Com::Vmware::Vapi::Std::Errors::ResourceInaccessible]
+    #     if the virtual machine's configuration state cannot be accessed.
+    # @raise [Com::Vmware::Vapi::Std::Errors::ServiceUnavailable]
+    #     if the system is unable to communicate with a service to complete the request.
+    # @raise [Com::Vmware::Vapi::Std::Errors::Unauthenticated]
+    #     if the user can not be authenticated.
+    # @raise [Com::Vmware::Vapi::Std::Errors::Unauthorized]
+    #     if the user doesn't have the required privileges.
+    def update(vm, disk, spec)
+      invoke_with_info(UPDATE_INFO,
+                       'vm' => vm,
+                       'disk' => disk,
+                       'spec' => spec)
+    end
+
+    # Removes a virtual disk from the virtual machine. This  method  does not destroy the VMDK file that backs the virtual disk. It only detaches the VMDK file from the virtual machine. Once detached, the VMDK file will not be destroyed when the virtual machine to which it was associated is deleted.
+    #
+    # @param vm [String]
+    #     Virtual machine identifier.
+    # @param disk [String]
+    #     Virtual disk identifier.
+    # @return [Void]
+    # @raise [Com::Vmware::Vapi::Std::Errors::Error]
+    #     if the system reports an error while responding to the request.
+    # @raise [Com::Vmware::Vapi::Std::Errors::NotFound]
+    #     if the virtual machine or virtual disk is not found.
+    # @raise [Com::Vmware::Vapi::Std::Errors::NotAllowedInCurrentState]
+    #     if the virtual machine is suspended or if the virtual machine is powered on and virtual disk type is IDE.
+    # @raise [Com::Vmware::Vapi::Std::Errors::ResourceBusy]
+    #     if the virtual machine is busy performing another operation.
+    # @raise [Com::Vmware::Vapi::Std::Errors::ResourceInaccessible]
+    #     if the virtual machine's configuration state cannot be accessed.
+    # @raise [Com::Vmware::Vapi::Std::Errors::ServiceUnavailable]
+    #     if the system is unable to communicate with a service to complete the request.
+    # @raise [Com::Vmware::Vapi::Std::Errors::Unauthenticated]
+    #     if the user can not be authenticated.
+    # @raise [Com::Vmware::Vapi::Std::Errors::Unauthorized]
+    #     if the user doesn't have the required privileges.
+    def delete(vm, disk)
+      invoke_with_info(DELETE_INFO,
+                       'vm' => vm,
+                       'disk' => disk)
+    end
+
+    # The  ``Com::Vmware::Vcenter::VM::Hardware::Disk::BackingInfo``   class  contains information about the physical resource backing a virtual disk.
+    # @!attribute [rw] type
+    #     @return [Com::Vmware::Vcenter::VM::Hardware::Disk::BackingType]
+    #     Backing type for the virtual disk.
+    # @!attribute [rw] vmdk_file
+    #     @return [String]
+    #     Path of the VMDK file backing the virtual disk.
+    #     This  field  is optional and it is only relevant when the value of  ``type``  is   :attr:`Com::Vmware::Vcenter::VM::Hardware::Disk::BackingType.VMDK_FILE`  .
+    class BackingInfo < VAPI::Bindings::VapiStruct
+      class << self
+        # Holds (gets or creates) the binding type metadata for this structure type.
+        # @scope class
+        # @return [VAPI::Bindings::StructType] the binding type
+        def binding_type
+          @binding_type ||= VAPI::Bindings::StructType.new(
+            'com.vmware.vcenter.vm.hardware.disk.backing_info',
+            {
+              'type' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::VM::Hardware::Disk::BackingType'),
+              'vmdk_file' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::StringType.instance)
+            },
+            BackingInfo,
+            false,
+            nil
+          )
+        end
+      end
+
+      attr_accessor :type,
+                    :vmdk_file
+
+      # Constructs a new instance.
+      # @param ruby_values [Hash] a map of initial property values (optional)
+      # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
+      def initialize(ruby_values = nil, struct_value = nil)
+        super(self.class.binding_type, ruby_values, struct_value)
+      end
+    end
+
+    # The  ``Com::Vmware::Vcenter::VM::Hardware::Disk::BackingSpec``   class  provides a specification of the physical resource backing a virtual disk.
+    # @!attribute [rw] type
+    #     @return [Com::Vmware::Vcenter::VM::Hardware::Disk::BackingType]
+    #     Backing type for the virtual disk.
+    # @!attribute [rw] vmdk_file
+    #     @return [String]
+    #     Path of the VMDK file backing the virtual disk.
+    #     This  field  is optional and it is only relevant when the value of  ``type``  is   :attr:`Com::Vmware::Vcenter::VM::Hardware::Disk::BackingType.VMDK_FILE`  .
+    class BackingSpec < VAPI::Bindings::VapiStruct
+      class << self
+        # Holds (gets or creates) the binding type metadata for this structure type.
+        # @scope class
+        # @return [VAPI::Bindings::StructType] the binding type
+        def binding_type
+          @binding_type ||= VAPI::Bindings::StructType.new(
+            'com.vmware.vcenter.vm.hardware.disk.backing_spec',
+            {
+              'type' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::VM::Hardware::Disk::BackingType'),
+              'vmdk_file' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::StringType.instance)
+            },
+            BackingSpec,
+            false,
+            nil
+          )
+        end
+      end
+
+      attr_accessor :type,
+                    :vmdk_file
+
+      # Constructs a new instance.
+      # @param ruby_values [Hash] a map of initial property values (optional)
+      # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
+      def initialize(ruby_values = nil, struct_value = nil)
+        super(self.class.binding_type, ruby_values, struct_value)
+      end
+    end
+
+    # The  ``Com::Vmware::Vcenter::VM::Hardware::Disk::VmdkCreateSpec``   class  provides a specification for creating a new VMDK file to be used as a backing for a virtual disk. The virtual disk will be stored in the same directory as the virtual machine's configuration file.
+    # @!attribute [rw] name
+    #     @return [String, nil]
+    #     Base name of the VMDK file. The name should not include the '.vmdk' file extension.
+    #     If  nil , a name (derived from the name of the virtual machine) will be chosen by the server.
+    # @!attribute [rw] capacity
+    #     @return [Fixnum, nil]
+    #     Capacity of the virtual disk backing in bytes.
+    #     If  nil , defaults to a guest-specific capacity.
+    class VmdkCreateSpec < VAPI::Bindings::VapiStruct
+      class << self
+        # Holds (gets or creates) the binding type metadata for this structure type.
+        # @scope class
+        # @return [VAPI::Bindings::StructType] the binding type
+        def binding_type
+          @binding_type ||= VAPI::Bindings::StructType.new(
+            'com.vmware.vcenter.vm.hardware.disk.vmdk_create_spec',
+            {
+              'name' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::StringType.instance),
+              'capacity' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::IntegerType.instance)
+            },
+            VmdkCreateSpec,
+            false,
+            nil
+          )
+        end
+      end
+
+      attr_accessor :name,
+                    :capacity
+
+      # Constructs a new instance.
+      # @param ruby_values [Hash] a map of initial property values (optional)
+      # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
+      def initialize(ruby_values = nil, struct_value = nil)
+        super(self.class.binding_type, ruby_values, struct_value)
+      end
+    end
+
+    # The  ``Com::Vmware::Vcenter::VM::Hardware::Disk::Info``   class  contains information about a virtual disk.
+    # @!attribute [rw] label
+    #     @return [String]
+    #     Device label.
+    # @!attribute [rw] type
+    #     @return [Com::Vmware::Vcenter::VM::Hardware::Disk::HostBusAdapterType]
+    #     Type of host bus adapter to which the device is attached.
+    # @!attribute [rw] ide
+    #     @return [Com::Vmware::Vcenter::VM::Hardware::IdeAddressInfo]
+    #     Address of device attached to a virtual IDE adapter.
+    #     Workaround for PR1459646
+    # @!attribute [rw] scsi
+    #     @return [Com::Vmware::Vcenter::VM::Hardware::ScsiAddressInfo]
+    #     Address of device attached to a virtual SCSI adapter.
+    #     Workaround for PR1459646
+    # @!attribute [rw] sata
+    #     @return [Com::Vmware::Vcenter::VM::Hardware::SataAddressInfo]
+    #     Address of device attached to a virtual SATA adapter.
+    #     Workaround for PR1459646
+    # @!attribute [rw] backing
+    #     @return [Com::Vmware::Vcenter::VM::Hardware::Disk::BackingInfo]
+    #     Physical resource backing for the virtual disk.
+    # @!attribute [rw] capacity
+    #     @return [Fixnum, nil]
+    #     Capacity of the virtual disk in bytes.
+    #     If  nil , virtual disk is inaccessible or disk capacity is 0.
+    class Info < VAPI::Bindings::VapiStruct
+      class << self
+        # Holds (gets or creates) the binding type metadata for this structure type.
+        # @scope class
+        # @return [VAPI::Bindings::StructType] the binding type
+        def binding_type
+          @binding_type ||= VAPI::Bindings::StructType.new(
+            'com.vmware.vcenter.vm.hardware.disk.info',
+            {
+              'label' => VAPI::Bindings::StringType.instance,
+              'type' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::VM::Hardware::Disk::HostBusAdapterType'),
+              'ide' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::VM::Hardware::IdeAddressInfo')),
+              'scsi' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::VM::Hardware::ScsiAddressInfo')),
+              'sata' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::VM::Hardware::SataAddressInfo')),
+              'backing' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::VM::Hardware::Disk::BackingInfo'),
+              'capacity' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::IntegerType.instance)
+            },
+            Info,
+            false,
+            nil
+          )
+        end
+      end
+
+      attr_accessor :label,
+                    :type,
+                    :ide,
+                    :scsi,
+                    :sata,
+                    :backing,
+                    :capacity
+
+      # Constructs a new instance.
+      # @param ruby_values [Hash] a map of initial property values (optional)
+      # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
+      def initialize(ruby_values = nil, struct_value = nil)
+        super(self.class.binding_type, ruby_values, struct_value)
+      end
+    end
+
+    # The  ``Com::Vmware::Vcenter::VM::Hardware::Disk::CreateSpec``   class  provides a specification for the configuration of a newly-created virtual disk.
+    # @!attribute [rw] type
+    #     @return [Com::Vmware::Vcenter::VM::Hardware::Disk::HostBusAdapterType, nil]
+    #     Type of host bus adapter to which the device should be attached.
+    #     If  nil , guest-specific default values will be used
+    # @!attribute [rw] ide
+    #     @return [Com::Vmware::Vcenter::VM::Hardware::IdeAddressSpec, nil]
+    #     Address for attaching the device to a virtual IDE adapter.
+    #     If  nil , the server will choose an available address; if none is available, the request will fail.
+    # @!attribute [rw] scsi
+    #     @return [Com::Vmware::Vcenter::VM::Hardware::ScsiAddressSpec, nil]
+    #     Address for attaching the device to a virtual SCSI adapter.
+    #     If  nil , the server will choose an available address; if none is available, the request will fail.
+    # @!attribute [rw] sata
+    #     @return [Com::Vmware::Vcenter::VM::Hardware::SataAddressSpec, nil]
+    #     Address for attaching the device to a virtual SATA adapter.
+    #     If  nil , the server will choose an available address; if none is available, the request will fail.
+    # @!attribute [rw] backing
+    #     @return [Com::Vmware::Vcenter::VM::Hardware::Disk::BackingSpec, nil]
+    #     Existing physical resource backing for the virtual disk. Exactly one of  ``backing``  or  ``newVmdk``  must be specified.
+    #     If  nil , the virtual disk will not be connected to an existing backing.
+    # @!attribute [rw] new_vmdk
+    #     @return [Com::Vmware::Vcenter::VM::Hardware::Disk::VmdkCreateSpec, nil]
+    #     Specification for creating a new VMDK backing for the virtual disk. Exactly one of  ``backing``  or  ``newVmdk``  must be specified.
+    #     If  nil , a new VMDK backing will not be created.
+    class CreateSpec < VAPI::Bindings::VapiStruct
+      class << self
+        # Holds (gets or creates) the binding type metadata for this structure type.
+        # @scope class
+        # @return [VAPI::Bindings::StructType] the binding type
+        def binding_type
+          @binding_type ||= VAPI::Bindings::StructType.new(
+            'com.vmware.vcenter.vm.hardware.disk.create_spec',
+            {
+              'type' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::VM::Hardware::Disk::HostBusAdapterType')),
+              'ide' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::VM::Hardware::IdeAddressSpec')),
+              'scsi' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::VM::Hardware::ScsiAddressSpec')),
+              'sata' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::VM::Hardware::SataAddressSpec')),
+              'backing' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::VM::Hardware::Disk::BackingSpec')),
+              'new_vmdk' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::VM::Hardware::Disk::VmdkCreateSpec'))
+            },
+            CreateSpec,
+            false,
+            nil
+          )
+        end
+      end
+
+      attr_accessor :type,
+                    :ide,
+                    :scsi,
+                    :sata,
+                    :backing,
+                    :new_vmdk
+
+      # Constructs a new instance.
+      # @param ruby_values [Hash] a map of initial property values (optional)
+      # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
+      def initialize(ruby_values = nil, struct_value = nil)
+        super(self.class.binding_type, ruby_values, struct_value)
+      end
+    end
+
+    # The  ``Com::Vmware::Vcenter::VM::Hardware::Disk::UpdateSpec``   class  describes the updates to be made to the configuration of a virtual disk.
+    # @!attribute [rw] backing
+    #     @return [Com::Vmware::Vcenter::VM::Hardware::Disk::BackingSpec, nil]
+    #     Physical resource backing for the virtual disk.  
+    #     
+    #      This  field  may only be modified if the virtual machine is not powered on.
+    #     If  nil , the value is unchanged.
+    class UpdateSpec < VAPI::Bindings::VapiStruct
+      class << self
+        # Holds (gets or creates) the binding type metadata for this structure type.
+        # @scope class
+        # @return [VAPI::Bindings::StructType] the binding type
+        def binding_type
+          @binding_type ||= VAPI::Bindings::StructType.new(
+            'com.vmware.vcenter.vm.hardware.disk.update_spec',
+            {
+              'backing' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::VM::Hardware::Disk::BackingSpec'))
+            },
+            UpdateSpec,
+            false,
+            nil
+          )
+        end
+      end
+
+      attr_accessor :backing
+
+      # Constructs a new instance.
+      # @param ruby_values [Hash] a map of initial property values (optional)
+      # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
+      def initialize(ruby_values = nil, struct_value = nil)
+        super(self.class.binding_type, ruby_values, struct_value)
+      end
+    end
+
+    # The  ``Com::Vmware::Vcenter::VM::Hardware::Disk::Summary``   class  contains commonly used information about a virtual disk.
+    # @!attribute [rw] disk
+    #     @return [String]
+    #     Identifier of the virtual Disk.
+    class Summary < VAPI::Bindings::VapiStruct
+      class << self
+        # Holds (gets or creates) the binding type metadata for this structure type.
+        # @scope class
+        # @return [VAPI::Bindings::StructType] the binding type
+        def binding_type
+          @binding_type ||= VAPI::Bindings::StructType.new(
+            'com.vmware.vcenter.vm.hardware.disk.summary',
+            {
+              'disk' => VAPI::Bindings::IdType.new('com.vmware.vcenter.vm.hardware.Disk')
+            },
+            Summary,
+            false,
+            nil
+          )
+        end
+      end
+
+      attr_accessor :disk
+
+      # Constructs a new instance.
+      # @param ruby_values [Hash] a map of initial property values (optional)
+      # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
+      def initialize(ruby_values = nil, struct_value = nil)
+        super(self.class.binding_type, ruby_values, struct_value)
+      end
+    end
+
+    # The  ``Com::Vmware::Vcenter::VM::Hardware::Disk::HostBusAdapterType``   enumerated type  defines the valid types of host bus adapters that may be used for attaching a virtual storage device to a virtual machine.
+    # @!attribute [rw] ide
+    #     @return [Com::Vmware::Vcenter::VM::Hardware::Disk::HostBusAdapterType]
+    #     Disk is attached to an IDE adapter.
+    # @!attribute [rw] scsi
+    #     @return [Com::Vmware::Vcenter::VM::Hardware::Disk::HostBusAdapterType]
+    #     Disk is attached to a SCSI adapter.
+    # @!attribute [rw] sata
+    #     @return [Com::Vmware::Vcenter::VM::Hardware::Disk::HostBusAdapterType]
+    #     Disk is attached to a SATA adapter.
+    class HostBusAdapterType < VAPI::Bindings::VapiEnum
+      class << self
+        # Holds (gets or creates) the binding type metadata for this enumeration type.
+        # @scope class
+        # @return [VAPI::Bindings::EnumType] the binding type
+        def binding_type
+          @binding_type ||= VAPI::Bindings::EnumType.new(
+            'com.vmware.vcenter.vm.hardware.disk.host_bus_adapter_type',
+            HostBusAdapterType
+          )
+        end
+
+        # Converts from a string value (perhaps off the wire) to an instance
+        # of this enum type.
+        # @param value [String] the actual value of the enum instance
+        # @return [HostBusAdapterType] the instance found for the value, otherwise
+        #         an unknown instance will be built for the value
+        def from_string(value)
+          const_get(value)
+        rescue NameError
+          HostBusAdapterType.send(:new, 'UNKNOWN', value)
+        end
+      end
+
+      # Constructs a new instance.
+      # @param value [String] the actual value of the enum instance
+      # @param unknown [String] the unknown value when value is 'UKNOWN'
+      def initialize(value, unknown = nil)
+        super(self.class.binding_type, value, unknown)
+      end
+
+      private_class_method :new
+
+      # @!attribute [rw] ide
+      #     @return [Com::Vmware::Vcenter::VM::Hardware::Disk::HostBusAdapterType]
+      #     Disk is attached to an IDE adapter.
+      IDE = HostBusAdapterType.send(:new, 'IDE')
+
+      # @!attribute [rw] scsi
+      #     @return [Com::Vmware::Vcenter::VM::Hardware::Disk::HostBusAdapterType]
+      #     Disk is attached to a SCSI adapter.
+      SCSI = HostBusAdapterType.send(:new, 'SCSI')
+
+      # @!attribute [rw] sata
+      #     @return [Com::Vmware::Vcenter::VM::Hardware::Disk::HostBusAdapterType]
+      #     Disk is attached to a SATA adapter.
+      SATA = HostBusAdapterType.send(:new, 'SATA')
+    end
+    # The  ``Com::Vmware::Vcenter::VM::Hardware::Disk::BackingType``   enumerated type  defines the valid backing types for a virtual disk.
+    # @!attribute [rw] vmdk_file
+    #     @return [Com::Vmware::Vcenter::VM::Hardware::Disk::BackingType]
+    #     Virtual disk is backed by a VMDK file.
+    class BackingType < VAPI::Bindings::VapiEnum
+      class << self
+        # Holds (gets or creates) the binding type metadata for this enumeration type.
+        # @scope class
+        # @return [VAPI::Bindings::EnumType] the binding type
+        def binding_type
+          @binding_type ||= VAPI::Bindings::EnumType.new(
+            'com.vmware.vcenter.vm.hardware.disk.backing_type',
+            BackingType
+          )
+        end
+
+        # Converts from a string value (perhaps off the wire) to an instance
+        # of this enum type.
+        # @param value [String] the actual value of the enum instance
+        # @return [BackingType] the instance found for the value, otherwise
+        #         an unknown instance will be built for the value
+        def from_string(value)
+          const_get(value)
+        rescue NameError
+          BackingType.send(:new, 'UNKNOWN', value)
+        end
+      end
+
+      # Constructs a new instance.
+      # @param value [String] the actual value of the enum instance
+      # @param unknown [String] the unknown value when value is 'UKNOWN'
+      def initialize(value, unknown = nil)
+        super(self.class.binding_type, value, unknown)
+      end
+
+      private_class_method :new
+
+      # @!attribute [rw] vmdk_file
+      #     @return [Com::Vmware::Vcenter::VM::Hardware::Disk::BackingType]
+      #     Virtual disk is backed by a VMDK file.
+      VMDK_FILE = BackingType.send(:new, 'VMDK_FILE')
+    end
+  end
+  # The  ``Com::Vmware::Vcenter::VM::Hardware::Ethernet``   class  provides  methods  for configuring the virtual Ethernet adapters of a virtual machine.
+  class Ethernet < VAPI::Bindings::VapiService
+    # static metamodel definitions
+    SERVICE_ID = VAPI::Core::ServiceIdentifier.new('com.vmware.vcenter.vm.hardware.ethernet')
+
+    LIST_INFO = VAPI::Bindings::OperationInfo.new(
+      VAPI::Core::OperationIdentifier.new('list', SERVICE_ID),
+      VAPI::Bindings::OperationInputType.new(
+        'vm' => VAPI::Bindings::IdType.new('VirtualMachine')
+      ),
+      VAPI::Bindings::ListType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::VM::Hardware::Ethernet::Summary')),
+      {
+        'com.vmware.vapi.std.errors.error' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Error'),
+        'com.vmware.vapi.std.errors.not_found' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::NotFound'),
+        'com.vmware.vapi.std.errors.resource_inaccessible' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::ResourceInaccessible'),
+        'com.vmware.vapi.std.errors.service_unavailable' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::ServiceUnavailable'),
+        'com.vmware.vapi.std.errors.unauthenticated' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Unauthenticated'),
+        'com.vmware.vapi.std.errors.unauthorized' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Unauthorized')
+      },
+      [],
+      []
+    )
+
+    GET_INFO = VAPI::Bindings::OperationInfo.new(
+      VAPI::Core::OperationIdentifier.new('get', SERVICE_ID),
+      VAPI::Bindings::OperationInputType.new(
+        'vm' => VAPI::Bindings::IdType.new('VirtualMachine'),
+        'nic' => VAPI::Bindings::IdType.new('com.vmware.vcenter.vm.hardware.Ethernet')
+      ),
+      VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::VM::Hardware::Ethernet::Info'),
+      {
+        'com.vmware.vapi.std.errors.error' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Error'),
+        'com.vmware.vapi.std.errors.not_found' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::NotFound'),
+        'com.vmware.vapi.std.errors.resource_inaccessible' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::ResourceInaccessible'),
+        'com.vmware.vapi.std.errors.service_unavailable' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::ServiceUnavailable'),
+        'com.vmware.vapi.std.errors.unauthenticated' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Unauthenticated'),
+        'com.vmware.vapi.std.errors.unauthorized' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Unauthorized')
+      },
+      [],
+      []
+    )
+
+    CREATE_INFO = VAPI::Bindings::OperationInfo.new(
+      VAPI::Core::OperationIdentifier.new('create', SERVICE_ID),
+      VAPI::Bindings::OperationInputType.new(
+        'vm' => VAPI::Bindings::IdType.new('VirtualMachine'),
+        'spec' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::VM::Hardware::Ethernet::CreateSpec')
+      ),
+      VAPI::Bindings::IdType.new('com.vmware.vcenter.vm.hardware.Ethernet'),
+      {
+        'com.vmware.vapi.std.errors.error' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Error'),
+        'com.vmware.vapi.std.errors.not_found' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::NotFound'),
+        'com.vmware.vapi.std.errors.unable_to_allocate_resource' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::UnableToAllocateResource'),
+        'com.vmware.vapi.std.errors.invalid_argument' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::InvalidArgument'),
+        'com.vmware.vapi.std.errors.resource_busy' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::ResourceBusy'),
+        'com.vmware.vapi.std.errors.resource_inaccessible' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::ResourceInaccessible'),
+        'com.vmware.vapi.std.errors.service_unavailable' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::ServiceUnavailable'),
+        'com.vmware.vapi.std.errors.unauthenticated' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Unauthenticated'),
+        'com.vmware.vapi.std.errors.unauthorized' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Unauthorized'),
+        'com.vmware.vapi.std.errors.unsupported' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Unsupported')
+      },
+      [],
+      []
+    )
+
+    UPDATE_INFO = VAPI::Bindings::OperationInfo.new(
+      VAPI::Core::OperationIdentifier.new('update', SERVICE_ID),
+      VAPI::Bindings::OperationInputType.new(
+        'vm' => VAPI::Bindings::IdType.new('VirtualMachine'),
+        'nic' => VAPI::Bindings::IdType.new('com.vmware.vcenter.vm.hardware.Ethernet'),
+        'spec' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::VM::Hardware::Ethernet::UpdateSpec')
+      ),
+      VAPI::Bindings::VoidType.instance,
+      {
+        'com.vmware.vapi.std.errors.error' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Error'),
+        'com.vmware.vapi.std.errors.invalid_argument' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::InvalidArgument'),
+        'com.vmware.vapi.std.errors.not_found' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::NotFound'),
+        'com.vmware.vapi.std.errors.resource_busy' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::ResourceBusy'),
+        'com.vmware.vapi.std.errors.resource_inaccessible' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::ResourceInaccessible'),
+        'com.vmware.vapi.std.errors.service_unavailable' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::ServiceUnavailable'),
+        'com.vmware.vapi.std.errors.unauthenticated' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Unauthenticated'),
+        'com.vmware.vapi.std.errors.unauthorized' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Unauthorized')
+      },
+      [],
+      []
+    )
+
+    DELETE_INFO = VAPI::Bindings::OperationInfo.new(
+      VAPI::Core::OperationIdentifier.new('delete', SERVICE_ID),
+      VAPI::Bindings::OperationInputType.new(
+        'vm' => VAPI::Bindings::IdType.new('VirtualMachine'),
+        'nic' => VAPI::Bindings::IdType.new('com.vmware.vcenter.vm.hardware.Ethernet')
+      ),
+      VAPI::Bindings::VoidType.instance,
+      {
+        'com.vmware.vapi.std.errors.error' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Error'),
+        'com.vmware.vapi.std.errors.not_found' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::NotFound'),
+        'com.vmware.vapi.std.errors.resource_busy' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::ResourceBusy'),
+        'com.vmware.vapi.std.errors.resource_inaccessible' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::ResourceInaccessible'),
+        'com.vmware.vapi.std.errors.service_unavailable' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::ServiceUnavailable'),
+        'com.vmware.vapi.std.errors.unauthenticated' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Unauthenticated'),
+        'com.vmware.vapi.std.errors.unauthorized' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Unauthorized')
+      },
+      [],
+      []
+    )
+
+    CONNECT_INFO = VAPI::Bindings::OperationInfo.new(
+      VAPI::Core::OperationIdentifier.new('connect', SERVICE_ID),
+      VAPI::Bindings::OperationInputType.new(
+        'vm' => VAPI::Bindings::IdType.new('VirtualMachine'),
+        'nic' => VAPI::Bindings::IdType.new('com.vmware.vcenter.vm.hardware.Ethernet')
+      ),
+      VAPI::Bindings::VoidType.instance,
+      {
+        'com.vmware.vapi.std.errors.error' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Error'),
+        'com.vmware.vapi.std.errors.not_found' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::NotFound'),
+        'com.vmware.vapi.std.errors.already_in_desired_state' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::AlreadyInDesiredState'),
+        'com.vmware.vapi.std.errors.not_allowed_in_current_state' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::NotAllowedInCurrentState'),
+        'com.vmware.vapi.std.errors.resource_busy' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::ResourceBusy'),
+        'com.vmware.vapi.std.errors.resource_inaccessible' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::ResourceInaccessible'),
+        'com.vmware.vapi.std.errors.service_unavailable' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::ServiceUnavailable'),
+        'com.vmware.vapi.std.errors.unauthenticated' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Unauthenticated'),
+        'com.vmware.vapi.std.errors.unauthorized' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Unauthorized')
+      },
+      [],
+      []
+    )
+
+    DISCONNECT_INFO = VAPI::Bindings::OperationInfo.new(
+      VAPI::Core::OperationIdentifier.new('disconnect', SERVICE_ID),
+      VAPI::Bindings::OperationInputType.new(
+        'vm' => VAPI::Bindings::IdType.new('VirtualMachine'),
+        'nic' => VAPI::Bindings::IdType.new('com.vmware.vcenter.vm.hardware.Ethernet')
+      ),
+      VAPI::Bindings::VoidType.instance,
+      {
+        'com.vmware.vapi.std.errors.error' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Error'),
+        'com.vmware.vapi.std.errors.not_found' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::NotFound'),
+        'com.vmware.vapi.std.errors.already_in_desired_state' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::AlreadyInDesiredState'),
+        'com.vmware.vapi.std.errors.not_allowed_in_current_state' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::NotAllowedInCurrentState'),
+        'com.vmware.vapi.std.errors.resource_busy' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::ResourceBusy'),
+        'com.vmware.vapi.std.errors.resource_inaccessible' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::ResourceInaccessible'),
+        'com.vmware.vapi.std.errors.service_unavailable' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::ServiceUnavailable'),
+        'com.vmware.vapi.std.errors.unauthenticated' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Unauthenticated'),
+        'com.vmware.vapi.std.errors.unauthorized' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Unauthorized')
+      },
+      [],
+      []
+    )
+
+    SERVICE_INFO = VAPI::Bindings::ServiceInfo.new(
+      SERVICE_ID,
+      'list' => LIST_INFO,
+      'get' => GET_INFO,
+      'create' => CREATE_INFO,
+      'update' => UPDATE_INFO,
+      'delete' => DELETE_INFO,
+      'connect' => CONNECT_INFO,
+      'disconnect' => DISCONNECT_INFO
+    )
+
+    # Constructs a new instance.
+    #
+    # @param config [VAPI::Bindings::StubConfig] A hash with the api provider details.
+    def initialize(config)
+      super(config, SERVICE_INFO)
+    end
+
+    RESOURCE_TYPE = 'com.vmware.vcenter.vm.hardware.Ethernet'
+    # Returns commonly used information about the virtual Ethernet adapters belonging to the virtual machine.
+    #
+    # @param vm [String]
+    #     Virtual machine identifier.
+    # @return [Array<Com::Vmware::Vcenter::VM::Hardware::Ethernet::Summary>]
+    #     List of commonly used information about virtual Ethernet adapters.
+    # @raise [Com::Vmware::Vapi::Std::Errors::Error]
+    #     if the system reports an error while responding to the request.
+    # @raise [Com::Vmware::Vapi::Std::Errors::NotFound]
+    #     if the virtual machine is not found.
+    # @raise [Com::Vmware::Vapi::Std::Errors::ResourceInaccessible]
+    #     if the virtual machine's configuration state cannot be accessed.
+    # @raise [Com::Vmware::Vapi::Std::Errors::ServiceUnavailable]
+    #     if the system is unable to communicate with a service to complete the request.
+    # @raise [Com::Vmware::Vapi::Std::Errors::Unauthenticated]
+    #     if the user can not be authenticated.
+    # @raise [Com::Vmware::Vapi::Std::Errors::Unauthorized]
+    #     if the user doesn't have the required privileges.
+    def list(vm)
+      invoke_with_info(LIST_INFO,
+                       'vm' => vm)
+    end
+
+    # Returns information about a virtual Ethernet adapter.
+    #
+    # @param vm [String]
+    #     Virtual machine identifier.
+    # @param nic [String]
+    #     Virtual Ethernet adapter identifier.
+    # @return [Com::Vmware::Vcenter::VM::Hardware::Ethernet::Info]
+    #     Information about the specified virtual Ethernet adapter.
+    # @raise [Com::Vmware::Vapi::Std::Errors::Error]
+    #     if the system reports an error while responding to the request.
+    # @raise [Com::Vmware::Vapi::Std::Errors::NotFound]
+    #     if the virtual machine or virtual Ethernet adapter is not found.
+    # @raise [Com::Vmware::Vapi::Std::Errors::ResourceInaccessible]
+    #     if the virtual machine's configuration state cannot be accessed.
+    # @raise [Com::Vmware::Vapi::Std::Errors::ServiceUnavailable]
+    #     if the system is unable to communicate with a service to complete the request.
+    # @raise [Com::Vmware::Vapi::Std::Errors::Unauthenticated]
+    #     if the user can not be authenticated.
+    # @raise [Com::Vmware::Vapi::Std::Errors::Unauthorized]
+    #     if the user doesn't have the required privileges.
+    def get(vm, nic)
+      invoke_with_info(GET_INFO,
+                       'vm' => vm,
+                       'nic' => nic)
+    end
+
+    # Adds a virtual Ethernet adapter to the virtual machine.
+    #
+    # @param vm [String]
+    #     Virtual machine identifier.
+    # @param spec [Com::Vmware::Vcenter::VM::Hardware::Ethernet::CreateSpec]
+    #     Specification for the new virtual Ethernet adapter.
+    # @return [String]
+    #     Virtual Ethernet adapter identifier.
+    # @raise [Com::Vmware::Vapi::Std::Errors::Error]
+    #     if the system reported that the Ethernet adapter was created but was unable to confirm the creation because the identifier of the new adapter could not be determined.
+    # @raise [Com::Vmware::Vapi::Std::Errors::Error]
+    #     if the system reports an error while responding to the request.
+    # @raise [Com::Vmware::Vapi::Std::Errors::NotFound]
+    #     if the virtual machine or network backing is not found.
+    # @raise [Com::Vmware::Vapi::Std::Errors::UnableToAllocateResource]
+    #     if the virtual machine already has the maximum number of supported Ethernet adapters.
+    # @raise [Com::Vmware::Vapi::Std::Errors::InvalidArgument]
+    #     if the specified PCI address is out of bounds, HOST_DEVICE is specified as the type, or a backing cannot be found in the case that backing is left  nil .
+    # @raise [Com::Vmware::Vapi::Std::Errors::ResourceBusy]
+    #     if the virtual machine is busy performing another operation.
+    # @raise [Com::Vmware::Vapi::Std::Errors::ResourceInaccessible]
+    #     if the virtual machine's configuration state cannot be accessed.
+    # @raise [Com::Vmware::Vapi::Std::Errors::ServiceUnavailable]
+    #     if the system is unable to communicate with a service to complete the request.
+    # @raise [Com::Vmware::Vapi::Std::Errors::Unauthenticated]
+    #     if the user can not be authenticated.
+    # @raise [Com::Vmware::Vapi::Std::Errors::Unauthorized]
+    #     if the user doesn't have the required privileges.
+    # @raise [Com::Vmware::Vapi::Std::Errors::Unsupported]
+    #     if the guest operating system of the virtual machine is not supported and  spec  includes  nil   fields  that default to guest-specific values.
+    def create(vm, spec)
+      invoke_with_info(CREATE_INFO,
+                       'vm' => vm,
+                       'spec' => spec)
+    end
+
+    # Updates the configuration of a virtual Ethernet adapter.
+    #
+    # @param vm [String]
+    #     Virtual machine identifier.
+    # @param nic [String]
+    #     Virtual Ethernet adapter identifier.
+    # @param spec [Com::Vmware::Vcenter::VM::Hardware::Ethernet::UpdateSpec]
+    #     Specification for updating the virtual Ethernet adapter.
+    # @return [Void]
+    # @raise [Com::Vmware::Vapi::Std::Errors::Error]
+    #     if the system reports an error while responding to the request.
+    # @raise [Com::Vmware::Vapi::Std::Errors::InvalidArgument]
+    #     if HOST_DEVICE is specified as the type.
+    # @raise [Com::Vmware::Vapi::Std::Errors::NotFound]
+    #     if the virtual machine, virtual Ethernet adapter, or backing network is not found.
+    # @raise [Com::Vmware::Vapi::Std::Errors::ResourceBusy]
+    #     if the virtual machine is busy performing another operation.
+    # @raise [Com::Vmware::Vapi::Std::Errors::ResourceInaccessible]
+    #     if the virtual machine's configuration state cannot be accessed.
+    # @raise [Com::Vmware::Vapi::Std::Errors::ServiceUnavailable]
+    #     if the system is unable to communicate with a service to complete the request.
+    # @raise [Com::Vmware::Vapi::Std::Errors::Unauthenticated]
+    #     if the user can not be authenticated.
+    # @raise [Com::Vmware::Vapi::Std::Errors::Unauthorized]
+    #     if the user doesn't have the required privileges.
+    def update(vm, nic, spec)
+      invoke_with_info(UPDATE_INFO,
+                       'vm' => vm,
+                       'nic' => nic,
+                       'spec' => spec)
+    end
+
+    # Removes a virtual Ethernet adapter from the virtual machine.
+    #
+    # @param vm [String]
+    #     Virtual machine identifier.
+    # @param nic [String]
+    #     Virtual Ethernet adapter identifier.
+    # @return [Void]
+    # @raise [Com::Vmware::Vapi::Std::Errors::Error]
+    #     if the system reports an error while responding to the request.
+    # @raise [Com::Vmware::Vapi::Std::Errors::NotFound]
+    #     if the virtual machine or virtual Ethernet adapter is not found.
+    # @raise [Com::Vmware::Vapi::Std::Errors::ResourceBusy]
+    #     if the virtual machine is busy performing another operation.
+    # @raise [Com::Vmware::Vapi::Std::Errors::ResourceInaccessible]
+    #     if the virtual machine's configuration state cannot be accessed.
+    # @raise [Com::Vmware::Vapi::Std::Errors::ServiceUnavailable]
+    #     if the system is unable to communicate with a service to complete the request.
+    # @raise [Com::Vmware::Vapi::Std::Errors::Unauthenticated]
+    #     if the user can not be authenticated.
+    # @raise [Com::Vmware::Vapi::Std::Errors::Unauthorized]
+    #     if the user doesn't have the required privileges.
+    def delete(vm, nic)
+      invoke_with_info(DELETE_INFO,
+                       'vm' => vm,
+                       'nic' => nic)
+    end
+
+    # Connects a virtual Ethernet adapter of a powered-on virtual machine to its backing. Connecting the virtual device makes the backing accessible from the perspective of the guest operating system.  
+    # 
+    #  For a powered-off virtual machine, the   :func:`Com::Vmware::Vcenter::VM::Hardware::Ethernet.update`    method  may be used to configure the virtual Ethernet adapter to start in the connected state when the virtual machine is powered on.
+    #
+    # @param vm [String]
+    #     Virtual machine identifier.
+    # @param nic [String]
+    #     Virtual Ethernet adapter identifier.
+    # @return [Void]
+    # @raise [Com::Vmware::Vapi::Std::Errors::Error]
+    #     if the system reports an error while responding to the request.
+    # @raise [Com::Vmware::Vapi::Std::Errors::NotFound]
+    #     if the virtual machine or virtual Ethernet adapter is not found.
+    # @raise [Com::Vmware::Vapi::Std::Errors::AlreadyInDesiredState]
+    #     if the virtual Ethernet adapter is already connected.
+    # @raise [Com::Vmware::Vapi::Std::Errors::NotAllowedInCurrentState]
+    #     if the virtual machine is not powered on.
+    # @raise [Com::Vmware::Vapi::Std::Errors::ResourceBusy]
+    #     if the virtual machine is busy performing another operation.
+    # @raise [Com::Vmware::Vapi::Std::Errors::ResourceInaccessible]
+    #     if the virtual machine's configuration state cannot be accessed.
+    # @raise [Com::Vmware::Vapi::Std::Errors::ServiceUnavailable]
+    #     if the system is unable to communicate with a service to complete the request.
+    # @raise [Com::Vmware::Vapi::Std::Errors::Unauthenticated]
+    #     if the user can not be authenticated.
+    # @raise [Com::Vmware::Vapi::Std::Errors::Unauthorized]
+    #     if the user doesn't have the required privileges.
+    def connect(vm, nic)
+      invoke_with_info(CONNECT_INFO,
+                       'vm' => vm,
+                       'nic' => nic)
+    end
+
+    # Disconnects a virtual Ethernet adapter of a powered-on virtual machine from its backing. The virtual device is still present and its backing configuration is unchanged, but from the perspective of the guest operating system, the Ethernet adapter is not connected to its backing resource.  
+    # 
+    #  For a powered-off virtual machine, the   :func:`Com::Vmware::Vcenter::VM::Hardware::Ethernet.update`    method  may be used to configure the virtual Ethernet adapter to start in the disconnected state when the virtual machine is powered on.
+    #
+    # @param vm [String]
+    #     Virtual machine identifier.
+    # @param nic [String]
+    #     Virtual Ethernet adapter identifier.
+    # @return [Void]
+    # @raise [Com::Vmware::Vapi::Std::Errors::Error]
+    #     if the system reports an error while responding to the request.
+    # @raise [Com::Vmware::Vapi::Std::Errors::NotFound]
+    #     if the virtual machine or virtual Ethernet adapter is not found.
+    # @raise [Com::Vmware::Vapi::Std::Errors::AlreadyInDesiredState]
+    #     if the virtual Ethernet adapter is already disconnected.
+    # @raise [Com::Vmware::Vapi::Std::Errors::NotAllowedInCurrentState]
+    #     if the virtual machine is not powered on.
+    # @raise [Com::Vmware::Vapi::Std::Errors::ResourceBusy]
+    #     if the virtual machine is busy performing another operation.
+    # @raise [Com::Vmware::Vapi::Std::Errors::ResourceInaccessible]
+    #     if the virtual machine's configuration state cannot be accessed.
+    # @raise [Com::Vmware::Vapi::Std::Errors::ServiceUnavailable]
+    #     if the system is unable to communicate with a service to complete the request.
+    # @raise [Com::Vmware::Vapi::Std::Errors::Unauthenticated]
+    #     if the user can not be authenticated.
+    # @raise [Com::Vmware::Vapi::Std::Errors::Unauthorized]
+    #     if the user doesn't have the required privileges.
+    def disconnect(vm, nic)
+      invoke_with_info(DISCONNECT_INFO,
+                       'vm' => vm,
+                       'nic' => nic)
+    end
+
+    # The  ``Com::Vmware::Vcenter::VM::Hardware::Ethernet::BackingInfo``   class  contains information about the physical resource backing a virtual Ethernet adapter.
+    # @!attribute [rw] type
+    #     @return [Com::Vmware::Vcenter::VM::Hardware::Ethernet::BackingType]
+    #     Backing type for the virtual Ethernet adapter.
+    # @!attribute [rw] network
+    #     @return [String, nil]
+    #     Identifier of the network backing the virtual Ethernet adapter.
+    #     If  nil , the identifier of the network backing could not be determined.
+    # @!attribute [rw] network_name
+    #     @return [String]
+    #     Name of the standard portgroup backing the virtual Ethernet adapter.
+    #     This  field  is optional and it is only relevant when the value of  ``type``  is   :attr:`Com::Vmware::Vcenter::VM::Hardware::Ethernet::BackingType.STANDARD_PORTGROUP`  .
+    # @!attribute [rw] host_device
+    #     @return [String]
+    #     Name of the device backing the virtual Ethernet adapter.
+    #     This  field  is optional and it is only relevant when the value of  ``type``  is   :attr:`Com::Vmware::Vcenter::VM::Hardware::Ethernet::BackingType.HOST_DEVICE`  .
+    # @!attribute [rw] distributed_switch_uuid
+    #     @return [String]
+    #     UUID of the distributed virtual switch that backs the virtual Ethernet adapter.
+    #     This  field  is optional and it is only relevant when the value of  ``type``  is   :attr:`Com::Vmware::Vcenter::VM::Hardware::Ethernet::BackingType.DISTRIBUTED_PORTGROUP`  .
+    # @!attribute [rw] distributed_port
+    #     @return [String, nil]
+    #     Key of the distributed virtual port that backs the virtual Ethernet adapter.
+    #     This  field  will be  nil  if the virtual Ethernet device is not bound to a distributed virtual port; this can happen if the virtual machine is powered off or the virtual Ethernet device is not connected.
+    # @!attribute [rw] connection_cookie
+    #     @return [Fixnum, nil]
+    #     Server-generated cookie that identifies the connection to the port. This ookie may be used to verify that the virtual machine is the rightful owner of the port.
+    #     This  field  will be  nil  if the virtual Ethernet device is not bound to a distributed virtual port; this can happen if the virtual machine is powered off or the virtual Ethernet device is not connected.
+    # @!attribute [rw] opaque_network_type
+    #     @return [String]
+    #     Type of the opaque network that backs the virtual Ethernet adapter.
+    #     This  field  is optional and it is only relevant when the value of  ``type``  is   :attr:`Com::Vmware::Vcenter::VM::Hardware::Ethernet::BackingType.OPAQUE_NETWORK`  .
+    # @!attribute [rw] opaque_network_id
+    #     @return [String]
+    #     Identifier of the opaque network that backs the virtual Ethernet adapter.
+    #     This  field  is optional and it is only relevant when the value of  ``type``  is   :attr:`Com::Vmware::Vcenter::VM::Hardware::Ethernet::BackingType.OPAQUE_NETWORK`  .
+    class BackingInfo < VAPI::Bindings::VapiStruct
+      class << self
+        # Holds (gets or creates) the binding type metadata for this structure type.
+        # @scope class
+        # @return [VAPI::Bindings::StructType] the binding type
+        def binding_type
+          @binding_type ||= VAPI::Bindings::StructType.new(
+            'com.vmware.vcenter.vm.hardware.ethernet.backing_info',
+            {
+              'type' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::VM::Hardware::Ethernet::BackingType'),
+              'network' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::IdType.new),
+              'network_name' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::StringType.instance),
+              'host_device' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::StringType.instance),
+              'distributed_switch_uuid' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::StringType.instance),
+              'distributed_port' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::StringType.instance),
+              'connection_cookie' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::IntegerType.instance),
+              'opaque_network_type' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::StringType.instance),
+              'opaque_network_id' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::StringType.instance)
+            },
+            BackingInfo,
+            false,
+            nil
+          )
+        end
+      end
+
+      attr_accessor :type,
+                    :network,
+                    :network_name,
+                    :host_device,
+                    :distributed_switch_uuid,
+                    :distributed_port,
+                    :connection_cookie,
+                    :opaque_network_type,
+                    :opaque_network_id
+
+      # Constructs a new instance.
+      # @param ruby_values [Hash] a map of initial property values (optional)
+      # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
+      def initialize(ruby_values = nil, struct_value = nil)
+        super(self.class.binding_type, ruby_values, struct_value)
+      end
+    end
+
+    # The  ``Com::Vmware::Vcenter::VM::Hardware::Ethernet::BackingSpec``   class  provides a specification of the physical resource that backs a virtual Ethernet adapter.
+    # @!attribute [rw] type
+    #     @return [Com::Vmware::Vcenter::VM::Hardware::Ethernet::BackingType]
+    #     Backing type for the virtual Ethernet adapter.
+    # @!attribute [rw] network
+    #     @return [String]
+    #     Identifier of the network that backs the virtual Ethernet adapter.
+    #     This  field  is optional and it is only relevant when the value of  ``type``  is one of   :attr:`Com::Vmware::Vcenter::VM::Hardware::Ethernet::BackingType.STANDARD_PORTGROUP`  ,   :attr:`Com::Vmware::Vcenter::VM::Hardware::Ethernet::BackingType.DISTRIBUTED_PORTGROUP`  , or   :attr:`Com::Vmware::Vcenter::VM::Hardware::Ethernet::BackingType.OPAQUE_NETWORK`  .
+    # @!attribute [rw] distributed_port
+    #     @return [String, nil]
+    #     Key of the distributed virtual port that backs the virtual Ethernet adapter. Depending on the type of the Portgroup, the port may be specified using this field. If the portgroup type is early-binding (also known as static), a port is assigned when the Ethernet adapter is configured to use the port. The port may be either automatically or specifically assigned based on the value of this  field . If the portgroup type is ephemeral, the port is created and assigned to a virtual machine when it is powered on and the Ethernet adapter is connected. This  field  cannot be specified as no free ports exist before use.
+    #     May be used to specify a port when the network specified on the  ``network``   field  is a static or early binding distributed portgroup. If  nil , the port will be automatically assigned to the Ethernet adapter based on the policy embodied by the portgroup type.
+    class BackingSpec < VAPI::Bindings::VapiStruct
+      class << self
+        # Holds (gets or creates) the binding type metadata for this structure type.
+        # @scope class
+        # @return [VAPI::Bindings::StructType] the binding type
+        def binding_type
+          @binding_type ||= VAPI::Bindings::StructType.new(
+            'com.vmware.vcenter.vm.hardware.ethernet.backing_spec',
+            {
+              'type' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::VM::Hardware::Ethernet::BackingType'),
+              'network' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::IdType.new),
+              'distributed_port' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::StringType.instance)
+            },
+            BackingSpec,
+            false,
+            nil
+          )
+        end
+      end
+
+      attr_accessor :type,
+                    :network,
+                    :distributed_port
+
+      # Constructs a new instance.
+      # @param ruby_values [Hash] a map of initial property values (optional)
+      # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
+      def initialize(ruby_values = nil, struct_value = nil)
+        super(self.class.binding_type, ruby_values, struct_value)
+      end
+    end
+
+    # The  ``Com::Vmware::Vcenter::VM::Hardware::Ethernet::Info``   class  contains information about a virtual Ethernet adapter.
+    # @!attribute [rw] label
+    #     @return [String]
+    #     Device label.
+    # @!attribute [rw] type
+    #     @return [Com::Vmware::Vcenter::VM::Hardware::Ethernet::EmulationType]
+    #     Ethernet adapter emulation type.
+    # @!attribute [rw] upt_compatibility_enabled
+    #     @return [Boolean]
+    #     Flag indicating whether Universal Pass-Through (UPT) compatibility is enabled on this virtual Ethernet adapter.
+    #     This  field  is optional and it is only relevant when the value of  ``type``  is   :attr:`Com::Vmware::Vcenter::VM::Hardware::Ethernet::EmulationType.VMXNET3`  .
+    # @!attribute [rw] mac_type
+    #     @return [Com::Vmware::Vcenter::VM::Hardware::Ethernet::MacAddressType]
+    #     MAC address type.
+    # @!attribute [rw] mac_address
+    #     @return [String, nil]
+    #     MAC address.
+    #     May be  nil  if   :attr:`Com::Vmware::Vcenter::VM::Hardware::Ethernet::Info.mac_type`   is   :attr:`Com::Vmware::Vcenter::VM::Hardware::Ethernet::MacAddressType.MANUAL`   and has not been specified, or if   :attr:`Com::Vmware::Vcenter::VM::Hardware::Ethernet::Info.mac_type`   is   :attr:`Com::Vmware::Vcenter::VM::Hardware::Ethernet::MacAddressType.GENERATED`   and the virtual machine has never been powered on since the Ethernet adapter was created.
+    # @!attribute [rw] pci_slot_number
+    #     @return [Fixnum, nil]
+    #     Address of the virtual Ethernet adapter on the PCI bus. If the PCI address is invalid, the server will change it when the VM is started or as the device is hot added.
+    #     May be  nil  if the virtual machine has never been powered on since the adapter was created.
+    # @!attribute [rw] wake_on_lan_enabled
+    #     @return [Boolean]
+    #     Flag indicating whether wake-on-LAN is enabled on this virtual Ethernet adapter.
+    # @!attribute [rw] backing
+    #     @return [Com::Vmware::Vcenter::VM::Hardware::Ethernet::BackingInfo]
+    #     Physical resource backing for the virtual Ethernet adapter.
+    class Info < VAPI::Bindings::VapiStruct
+      class << self
+        # Holds (gets or creates) the binding type metadata for this structure type.
+        # @scope class
+        # @return [VAPI::Bindings::StructType] the binding type
+        def binding_type
+          @binding_type ||= VAPI::Bindings::StructType.new(
+            'com.vmware.vcenter.vm.hardware.ethernet.info',
+            {
+              'label' => VAPI::Bindings::StringType.instance,
+              'type' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::VM::Hardware::Ethernet::EmulationType'),
+              'upt_compatibility_enabled' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::BooleanType.instance),
+              'mac_type' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::VM::Hardware::Ethernet::MacAddressType'),
+              'mac_address' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::StringType.instance),
+              'pci_slot_number' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::IntegerType.instance),
+              'wake_on_lan_enabled' => VAPI::Bindings::BooleanType.instance,
+              'backing' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::VM::Hardware::Ethernet::BackingInfo'),
+              'state' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::VM::Hardware::ConnectionState'),
+              'start_connected' => VAPI::Bindings::BooleanType.instance,
+              'allow_guest_control' => VAPI::Bindings::BooleanType.instance
+            },
+            Info,
+            false,
+            nil
+          )
+        end
+      end
+
+      attr_accessor :label,
+                    :type,
+                    :upt_compatibility_enabled,
+                    :mac_type,
+                    :mac_address,
+                    :pci_slot_number,
+                    :wake_on_lan_enabled,
+                    :backing,
+                    :state,
+                    :start_connected,
+                    :allow_guest_control
+
+      # Constructs a new instance.
+      # @param ruby_values [Hash] a map of initial property values (optional)
+      # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
+      def initialize(ruby_values = nil, struct_value = nil)
+        super(self.class.binding_type, ruby_values, struct_value)
+      end
+    end
+
+    # The  ``Com::Vmware::Vcenter::VM::Hardware::Ethernet::CreateSpec``   class  provides a specification for the configuration of a newly-created virtual Ethernet adapter.
+    # @!attribute [rw] type
+    #     @return [Com::Vmware::Vcenter::VM::Hardware::Ethernet::EmulationType, nil]
+    #     Ethernet adapter emulation type.
+    #     If  nil , defaults to a guest-specific type.
+    # @!attribute [rw] upt_compatibility_enabled
+    #     @return [Boolean, nil]
+    #     Flag indicating whether Universal Pass-Through (UPT) compatibility is enabled on this virtual Ethernet adapter.
+    #     If  nil , defaults to false.
+    # @!attribute [rw] mac_type
+    #     @return [Com::Vmware::Vcenter::VM::Hardware::Ethernet::MacAddressType, nil]
+    #     MAC address type.
+    #     If  nil , defaults to   :attr:`Com::Vmware::Vcenter::VM::Hardware::Ethernet::MacAddressType.GENERATED`  .
+    # @!attribute [rw] mac_address
+    #     @return [String]
+    #     MAC address.
+    #     Workaround for PR1459647
+    # @!attribute [rw] pci_slot_number
+    #     @return [Fixnum, nil]
+    #     Address of the virtual Ethernet adapter on the PCI bus. If the PCI address is invalid, the server will change when it the VM is started or as the device is hot added.
+    #     If  nil , the server will choose an available address when the virtual machine is powered on.
+    # @!attribute [rw] wake_on_lan_enabled
+    #     @return [Boolean, nil]
+    #     Flag indicating whether wake-on-LAN is enabled on this virtual Ethernet adapter.
+    #     Defaults to false if  nil .
+    # @!attribute [rw] backing
+    #     @return [Com::Vmware::Vcenter::VM::Hardware::Ethernet::BackingSpec, nil]
+    #     Physical resource backing for the virtual Ethernet adapter.
+    #     If  nil , the system may try to find an appropriate backing. If one is not found, the request will fail.
+    class CreateSpec < VAPI::Bindings::VapiStruct
+      class << self
+        # Holds (gets or creates) the binding type metadata for this structure type.
+        # @scope class
+        # @return [VAPI::Bindings::StructType] the binding type
+        def binding_type
+          @binding_type ||= VAPI::Bindings::StructType.new(
+            'com.vmware.vcenter.vm.hardware.ethernet.create_spec',
+            {
+              'type' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::VM::Hardware::Ethernet::EmulationType')),
+              'upt_compatibility_enabled' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::BooleanType.instance),
+              'mac_type' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::VM::Hardware::Ethernet::MacAddressType')),
+              'mac_address' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::StringType.instance),
+              'pci_slot_number' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::IntegerType.instance),
+              'wake_on_lan_enabled' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::BooleanType.instance),
+              'backing' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::VM::Hardware::Ethernet::BackingSpec')),
+              'start_connected' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::BooleanType.instance),
+              'allow_guest_control' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::BooleanType.instance)
+            },
+            CreateSpec,
+            false,
+            nil
+          )
+        end
+      end
+
+      attr_accessor :type,
+                    :upt_compatibility_enabled,
+                    :mac_type,
+                    :mac_address,
+                    :pci_slot_number,
+                    :wake_on_lan_enabled,
+                    :backing,
+                    :start_connected,
+                    :allow_guest_control
+
+      # Constructs a new instance.
+      # @param ruby_values [Hash] a map of initial property values (optional)
+      # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
+      def initialize(ruby_values = nil, struct_value = nil)
+        super(self.class.binding_type, ruby_values, struct_value)
+      end
+    end
+
+    # The  ``Com::Vmware::Vcenter::VM::Hardware::Ethernet::UpdateSpec``   class  describes the updates to be made to the configuration of a virtual Ethernet adapter.
+    # @!attribute [rw] upt_compatibility_enabled
+    #     @return [Boolean, nil]
+    #     Flag indicating whether Universal Pass-Through (UPT) compatibility should be enabled on this virtual Ethernet adapter.  
+    #     
+    #      This  field  may be modified at any time, and changes will be applied the next time the virtual machine is powered on.
+    #     If  nil , the value is unchanged. Must be  nil  if the emulation type of the virtual Ethernet adapter is not   :attr:`Com::Vmware::Vcenter::VM::Hardware::Ethernet::EmulationType.VMXNET3`  .
+    # @!attribute [rw] mac_type
+    #     @return [Com::Vmware::Vcenter::VM::Hardware::Ethernet::MacAddressType, nil]
+    #     MAC address type.  
+    #     
+    #      This  field  may be modified at any time, and changes will be applied the next time the virtual machine is powered on.
+    #     If  nil , the value is unchanged.
+    # @!attribute [rw] mac_address
+    #     @return [String, nil]
+    #     MAC address.  
+    #     
+    #      This  field  may be modified at any time, and changes will be applied the next time the virtual machine is powered on.
+    #     If  nil , the value is unchanged. Must be specified if   :attr:`Com::Vmware::Vcenter::VM::Hardware::Ethernet::UpdateSpec.mac_type`   is   :attr:`Com::Vmware::Vcenter::VM::Hardware::Ethernet::MacAddressType.MANUAL`  . Must be  nil  if the MAC address type is not   :attr:`Com::Vmware::Vcenter::VM::Hardware::Ethernet::MacAddressType.MANUAL`  .
+    # @!attribute [rw] wake_on_lan_enabled
+    #     @return [Boolean, nil]
+    #     Flag indicating whether wake-on-LAN shoud be enabled on this virtual Ethernet adapter.  
+    #     
+    #      This  field  may be modified at any time, and changes will be applied the next time the virtual machine is powered on.
+    #     If  nil , the value is unchanged.
+    # @!attribute [rw] backing
+    #     @return [Com::Vmware::Vcenter::VM::Hardware::Ethernet::BackingSpec, nil]
+    #     Physical resource backing for the virtual Ethernet adapter.  
+    #     
+    #      This  field  may be modified at any time, and changes will be applied the next time the virtual machine is powered on.
+    #     If  nil , the value is unchanged.
+    class UpdateSpec < VAPI::Bindings::VapiStruct
+      class << self
+        # Holds (gets or creates) the binding type metadata for this structure type.
+        # @scope class
+        # @return [VAPI::Bindings::StructType] the binding type
+        def binding_type
+          @binding_type ||= VAPI::Bindings::StructType.new(
+            'com.vmware.vcenter.vm.hardware.ethernet.update_spec',
+            {
+              'upt_compatibility_enabled' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::BooleanType.instance),
+              'mac_type' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::VM::Hardware::Ethernet::MacAddressType')),
+              'mac_address' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::StringType.instance),
+              'wake_on_lan_enabled' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::BooleanType.instance),
+              'backing' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::VM::Hardware::Ethernet::BackingSpec')),
+              'start_connected' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::BooleanType.instance),
+              'allow_guest_control' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::BooleanType.instance)
+            },
+            UpdateSpec,
+            false,
+            nil
+          )
+        end
+      end
+
+      attr_accessor :upt_compatibility_enabled,
+                    :mac_type,
+                    :mac_address,
+                    :wake_on_lan_enabled,
+                    :backing,
+                    :start_connected,
+                    :allow_guest_control
+
+      # Constructs a new instance.
+      # @param ruby_values [Hash] a map of initial property values (optional)
+      # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
+      def initialize(ruby_values = nil, struct_value = nil)
+        super(self.class.binding_type, ruby_values, struct_value)
+      end
+    end
+
+    # The  ``Com::Vmware::Vcenter::VM::Hardware::Ethernet::Summary``   class  contains commonly used information about a virtual Ethernet adapter.
+    # @!attribute [rw] nic
+    #     @return [String]
+    #     Identifier of the virtual Ethernet adapter.
+    class Summary < VAPI::Bindings::VapiStruct
+      class << self
+        # Holds (gets or creates) the binding type metadata for this structure type.
+        # @scope class
+        # @return [VAPI::Bindings::StructType] the binding type
+        def binding_type
+          @binding_type ||= VAPI::Bindings::StructType.new(
+            'com.vmware.vcenter.vm.hardware.ethernet.summary',
+            {
+              'nic' => VAPI::Bindings::IdType.new('com.vmware.vcenter.vm.hardware.Ethernet')
+            },
+            Summary,
+            false,
+            nil
+          )
+        end
+      end
+
+      attr_accessor :nic
+
+      # Constructs a new instance.
+      # @param ruby_values [Hash] a map of initial property values (optional)
+      # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
+      def initialize(ruby_values = nil, struct_value = nil)
+        super(self.class.binding_type, ruby_values, struct_value)
+      end
+    end
+
+    # The  ``Com::Vmware::Vcenter::VM::Hardware::Ethernet::EmulationType``   enumerated type  defines the valid emulation types for a virtual Ethernet adapter.
+    # @!attribute [rw] e1000
+    #     @return [Com::Vmware::Vcenter::VM::Hardware::Ethernet::EmulationType]
+    #     E1000 ethernet adapter.
+    # @!attribute [rw] e1000e
+    #     @return [Com::Vmware::Vcenter::VM::Hardware::Ethernet::EmulationType]
+    #     E1000e ethernet adapter.
+    # @!attribute [rw] pcne_t32
+    #     @return [Com::Vmware::Vcenter::VM::Hardware::Ethernet::EmulationType]
+    #     AMD Lance PCNet32 Ethernet adapter.
+    # @!attribute [rw] vmxnet
+    #     @return [Com::Vmware::Vcenter::VM::Hardware::Ethernet::EmulationType]
+    #     VMware Vmxnet virtual Ethernet adapter.
+    # @!attribute [rw] vmxne_t2
+    #     @return [Com::Vmware::Vcenter::VM::Hardware::Ethernet::EmulationType]
+    #     VMware Vmxnet2 virtual Ethernet adapter.
+    # @!attribute [rw] vmxne_t3
+    #     @return [Com::Vmware::Vcenter::VM::Hardware::Ethernet::EmulationType]
+    #     VMware Vmxnet3 virtual Ethernet adapter.
+    class EmulationType < VAPI::Bindings::VapiEnum
+      class << self
+        # Holds (gets or creates) the binding type metadata for this enumeration type.
+        # @scope class
+        # @return [VAPI::Bindings::EnumType] the binding type
+        def binding_type
+          @binding_type ||= VAPI::Bindings::EnumType.new(
+            'com.vmware.vcenter.vm.hardware.ethernet.emulation_type',
+            EmulationType
+          )
+        end
+
+        # Converts from a string value (perhaps off the wire) to an instance
+        # of this enum type.
+        # @param value [String] the actual value of the enum instance
+        # @return [EmulationType] the instance found for the value, otherwise
+        #         an unknown instance will be built for the value
+        def from_string(value)
+          const_get(value)
+        rescue NameError
+          EmulationType.send(:new, 'UNKNOWN', value)
+        end
+      end
+
+      # Constructs a new instance.
+      # @param value [String] the actual value of the enum instance
+      # @param unknown [String] the unknown value when value is 'UKNOWN'
+      def initialize(value, unknown = nil)
+        super(self.class.binding_type, value, unknown)
+      end
+
+      private_class_method :new
+
+      # @!attribute [rw] e1000
+      #     @return [Com::Vmware::Vcenter::VM::Hardware::Ethernet::EmulationType]
+      #     E1000 ethernet adapter.
+      E1000 = EmulationType.send(:new, 'E1000')
+
+      # @!attribute [rw] e1000e
+      #     @return [Com::Vmware::Vcenter::VM::Hardware::Ethernet::EmulationType]
+      #     E1000e ethernet adapter.
+      E1000E = EmulationType.send(:new, 'E1000E')
+
+      # @!attribute [rw] pcne_t32
+      #     @return [Com::Vmware::Vcenter::VM::Hardware::Ethernet::EmulationType]
+      #     AMD Lance PCNet32 Ethernet adapter.
+      PCNE_T32 = EmulationType.send(:new, 'PCNE_T32')
+
+      # @!attribute [rw] vmxnet
+      #     @return [Com::Vmware::Vcenter::VM::Hardware::Ethernet::EmulationType]
+      #     VMware Vmxnet virtual Ethernet adapter.
+      VMXNET = EmulationType.send(:new, 'VMXNET')
+
+      # @!attribute [rw] vmxne_t2
+      #     @return [Com::Vmware::Vcenter::VM::Hardware::Ethernet::EmulationType]
+      #     VMware Vmxnet2 virtual Ethernet adapter.
+      VMXNE_T2 = EmulationType.send(:new, 'VMXNE_T2')
+
+      # @!attribute [rw] vmxne_t3
+      #     @return [Com::Vmware::Vcenter::VM::Hardware::Ethernet::EmulationType]
+      #     VMware Vmxnet3 virtual Ethernet adapter.
+      VMXNE_T3 = EmulationType.send(:new, 'VMXNE_T3')
+    end
+    # The  ``Com::Vmware::Vcenter::VM::Hardware::Ethernet::MacAddressType``   enumerated type  defines the valid MAC address origins for a virtual Ethernet adapter.
+    # @!attribute [rw] manual
+    #     @return [Com::Vmware::Vcenter::VM::Hardware::Ethernet::MacAddressType]
+    #     MAC address is assigned statically.
+    # @!attribute [rw] generated
+    #     @return [Com::Vmware::Vcenter::VM::Hardware::Ethernet::MacAddressType]
+    #     MAC address is generated automatically.
+    # @!attribute [rw] assigned
+    #     @return [Com::Vmware::Vcenter::VM::Hardware::Ethernet::MacAddressType]
+    #     MAC address is assigned by vCenter Server.
+    class MacAddressType < VAPI::Bindings::VapiEnum
+      class << self
+        # Holds (gets or creates) the binding type metadata for this enumeration type.
+        # @scope class
+        # @return [VAPI::Bindings::EnumType] the binding type
+        def binding_type
+          @binding_type ||= VAPI::Bindings::EnumType.new(
+            'com.vmware.vcenter.vm.hardware.ethernet.mac_address_type',
+            MacAddressType
+          )
+        end
+
+        # Converts from a string value (perhaps off the wire) to an instance
+        # of this enum type.
+        # @param value [String] the actual value of the enum instance
+        # @return [MacAddressType] the instance found for the value, otherwise
+        #         an unknown instance will be built for the value
+        def from_string(value)
+          const_get(value)
+        rescue NameError
+          MacAddressType.send(:new, 'UNKNOWN', value)
+        end
+      end
+
+      # Constructs a new instance.
+      # @param value [String] the actual value of the enum instance
+      # @param unknown [String] the unknown value when value is 'UKNOWN'
+      def initialize(value, unknown = nil)
+        super(self.class.binding_type, value, unknown)
+      end
+
+      private_class_method :new
+
+      # @!attribute [rw] manual
+      #     @return [Com::Vmware::Vcenter::VM::Hardware::Ethernet::MacAddressType]
+      #     MAC address is assigned statically.
+      MANUAL = MacAddressType.send(:new, 'MANUAL')
+
+      # @!attribute [rw] generated
+      #     @return [Com::Vmware::Vcenter::VM::Hardware::Ethernet::MacAddressType]
+      #     MAC address is generated automatically.
+      GENERATED = MacAddressType.send(:new, 'GENERATED')
+
+      # @!attribute [rw] assigned
+      #     @return [Com::Vmware::Vcenter::VM::Hardware::Ethernet::MacAddressType]
+      #     MAC address is assigned by vCenter Server.
+      ASSIGNED = MacAddressType.send(:new, 'ASSIGNED')
+    end
+    # The  ``Com::Vmware::Vcenter::VM::Hardware::Ethernet::BackingType``   enumerated type  defines the valid backing types for a virtual Ethernet adapter.
+    # @!attribute [rw] standard_portgroup
+    #     @return [Com::Vmware::Vcenter::VM::Hardware::Ethernet::BackingType]
+    #     vSphere standard portgroup network backing.
+    # @!attribute [rw] host_device
+    #     @return [Com::Vmware::Vcenter::VM::Hardware::Ethernet::BackingType]
+    #     Legacy host device network backing. Imported VMs may have virtual Ethernet adapters with this type of backing, but this type of backing cannot be used to create or to update a virtual Ethernet adapter.
+    # @!attribute [rw] distributed_portgroup
+    #     @return [Com::Vmware::Vcenter::VM::Hardware::Ethernet::BackingType]
+    #     Distributed virtual switch backing.
+    # @!attribute [rw] opaque_network
+    #     @return [Com::Vmware::Vcenter::VM::Hardware::Ethernet::BackingType]
+    #     Opaque network backing.
+    class BackingType < VAPI::Bindings::VapiEnum
+      class << self
+        # Holds (gets or creates) the binding type metadata for this enumeration type.
+        # @scope class
+        # @return [VAPI::Bindings::EnumType] the binding type
+        def binding_type
+          @binding_type ||= VAPI::Bindings::EnumType.new(
+            'com.vmware.vcenter.vm.hardware.ethernet.backing_type',
+            BackingType
+          )
+        end
+
+        # Converts from a string value (perhaps off the wire) to an instance
+        # of this enum type.
+        # @param value [String] the actual value of the enum instance
+        # @return [BackingType] the instance found for the value, otherwise
+        #         an unknown instance will be built for the value
+        def from_string(value)
+          const_get(value)
+        rescue NameError
+          BackingType.send(:new, 'UNKNOWN', value)
+        end
+      end
+
+      # Constructs a new instance.
+      # @param value [String] the actual value of the enum instance
+      # @param unknown [String] the unknown value when value is 'UKNOWN'
+      def initialize(value, unknown = nil)
+        super(self.class.binding_type, value, unknown)
+      end
+
+      private_class_method :new
+
+      # @!attribute [rw] standard_portgroup
+      #     @return [Com::Vmware::Vcenter::VM::Hardware::Ethernet::BackingType]
+      #     vSphere standard portgroup network backing.
+      STANDARD_PORTGROUP = BackingType.send(:new, 'STANDARD_PORTGROUP')
+
+      # @!attribute [rw] host_device
+      #     @return [Com::Vmware::Vcenter::VM::Hardware::Ethernet::BackingType]
+      #     Legacy host device network backing. Imported VMs may have virtual Ethernet adapters with this type of backing, but this type of backing cannot be used to create or to update a virtual Ethernet adapter.
+      HOST_DEVICE = BackingType.send(:new, 'HOST_DEVICE')
+
+      # @!attribute [rw] distributed_portgroup
+      #     @return [Com::Vmware::Vcenter::VM::Hardware::Ethernet::BackingType]
+      #     Distributed virtual switch backing.
+      DISTRIBUTED_PORTGROUP = BackingType.send(:new, 'DISTRIBUTED_PORTGROUP')
+
+      # @!attribute [rw] opaque_network
+      #     @return [Com::Vmware::Vcenter::VM::Hardware::Ethernet::BackingType]
+      #     Opaque network backing.
+      OPAQUE_NETWORK = BackingType.send(:new, 'OPAQUE_NETWORK')
+    end
+  end
+  # The  ``Com::Vmware::Vcenter::VM::Hardware::Floppy``   class  provides  methods  for configuring the virtual floppy drives of a virtual machine.
+  class Floppy < VAPI::Bindings::VapiService
+    # static metamodel definitions
+    SERVICE_ID = VAPI::Core::ServiceIdentifier.new('com.vmware.vcenter.vm.hardware.floppy')
+
+    LIST_INFO = VAPI::Bindings::OperationInfo.new(
+      VAPI::Core::OperationIdentifier.new('list', SERVICE_ID),
+      VAPI::Bindings::OperationInputType.new(
+        'vm' => VAPI::Bindings::IdType.new('VirtualMachine')
+      ),
+      VAPI::Bindings::ListType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::VM::Hardware::Floppy::Summary')),
+      {
+        'com.vmware.vapi.std.errors.error' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Error'),
+        'com.vmware.vapi.std.errors.not_found' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::NotFound'),
+        'com.vmware.vapi.std.errors.resource_inaccessible' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::ResourceInaccessible'),
+        'com.vmware.vapi.std.errors.service_unavailable' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::ServiceUnavailable'),
+        'com.vmware.vapi.std.errors.unauthenticated' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Unauthenticated'),
+        'com.vmware.vapi.std.errors.unauthorized' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Unauthorized')
+      },
+      [],
+      []
+    )
+
+    GET_INFO = VAPI::Bindings::OperationInfo.new(
+      VAPI::Core::OperationIdentifier.new('get', SERVICE_ID),
+      VAPI::Bindings::OperationInputType.new(
+        'vm' => VAPI::Bindings::IdType.new('VirtualMachine'),
+        'floppy' => VAPI::Bindings::IdType.new('com.vmware.vcenter.vm.hardware.Floppy')
+      ),
+      VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::VM::Hardware::Floppy::Info'),
+      {
+        'com.vmware.vapi.std.errors.error' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Error'),
+        'com.vmware.vapi.std.errors.not_found' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::NotFound'),
+        'com.vmware.vapi.std.errors.resource_inaccessible' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::ResourceInaccessible'),
+        'com.vmware.vapi.std.errors.service_unavailable' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::ServiceUnavailable'),
+        'com.vmware.vapi.std.errors.unauthenticated' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Unauthenticated'),
+        'com.vmware.vapi.std.errors.unauthorized' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Unauthorized')
+      },
+      [],
+      []
+    )
+
+    CREATE_INFO = VAPI::Bindings::OperationInfo.new(
+      VAPI::Core::OperationIdentifier.new('create', SERVICE_ID),
+      VAPI::Bindings::OperationInputType.new(
+        'vm' => VAPI::Bindings::IdType.new('VirtualMachine'),
+        'spec' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::VM::Hardware::Floppy::CreateSpec')
+      ),
+      VAPI::Bindings::IdType.new('com.vmware.vcenter.vm.hardware.Floppy'),
+      {
+        'com.vmware.vapi.std.errors.error' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Error'),
+        'com.vmware.vapi.std.errors.not_found' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::NotFound'),
+        'com.vmware.vapi.std.errors.not_allowed_in_current_state' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::NotAllowedInCurrentState'),
+        'com.vmware.vapi.std.errors.unable_to_allocate_resource' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::UnableToAllocateResource'),
+        'com.vmware.vapi.std.errors.resource_busy' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::ResourceBusy'),
+        'com.vmware.vapi.std.errors.resource_inaccessible' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::ResourceInaccessible'),
+        'com.vmware.vapi.std.errors.service_unavailable' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::ServiceUnavailable'),
+        'com.vmware.vapi.std.errors.unauthenticated' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Unauthenticated'),
+        'com.vmware.vapi.std.errors.unauthorized' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Unauthorized')
+      },
+      [],
+      []
+    )
+
+    UPDATE_INFO = VAPI::Bindings::OperationInfo.new(
+      VAPI::Core::OperationIdentifier.new('update', SERVICE_ID),
+      VAPI::Bindings::OperationInputType.new(
+        'vm' => VAPI::Bindings::IdType.new('VirtualMachine'),
+        'floppy' => VAPI::Bindings::IdType.new('com.vmware.vcenter.vm.hardware.Floppy'),
+        'spec' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::VM::Hardware::Floppy::UpdateSpec')
+      ),
+      VAPI::Bindings::VoidType.instance,
+      {
+        'com.vmware.vapi.std.errors.error' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Error'),
+        'com.vmware.vapi.std.errors.not_found' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::NotFound'),
+        'com.vmware.vapi.std.errors.not_allowed_in_current_state' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::NotAllowedInCurrentState'),
+        'com.vmware.vapi.std.errors.resource_busy' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::ResourceBusy'),
+        'com.vmware.vapi.std.errors.resource_inaccessible' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::ResourceInaccessible'),
+        'com.vmware.vapi.std.errors.service_unavailable' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::ServiceUnavailable'),
+        'com.vmware.vapi.std.errors.unauthenticated' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Unauthenticated'),
+        'com.vmware.vapi.std.errors.unauthorized' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Unauthorized')
+      },
+      [],
+      []
+    )
+
+    DELETE_INFO = VAPI::Bindings::OperationInfo.new(
+      VAPI::Core::OperationIdentifier.new('delete', SERVICE_ID),
+      VAPI::Bindings::OperationInputType.new(
+        'vm' => VAPI::Bindings::IdType.new('VirtualMachine'),
+        'floppy' => VAPI::Bindings::IdType.new('com.vmware.vcenter.vm.hardware.Floppy')
+      ),
+      VAPI::Bindings::VoidType.instance,
+      {
+        'com.vmware.vapi.std.errors.error' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Error'),
+        'com.vmware.vapi.std.errors.not_found' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::NotFound'),
+        'com.vmware.vapi.std.errors.not_allowed_in_current_state' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::NotAllowedInCurrentState'),
+        'com.vmware.vapi.std.errors.resource_busy' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::ResourceBusy'),
+        'com.vmware.vapi.std.errors.resource_inaccessible' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::ResourceInaccessible'),
+        'com.vmware.vapi.std.errors.service_unavailable' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::ServiceUnavailable'),
+        'com.vmware.vapi.std.errors.unauthenticated' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Unauthenticated'),
+        'com.vmware.vapi.std.errors.unauthorized' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Unauthorized')
+      },
+      [],
+      []
+    )
+
+    CONNECT_INFO = VAPI::Bindings::OperationInfo.new(
+      VAPI::Core::OperationIdentifier.new('connect', SERVICE_ID),
+      VAPI::Bindings::OperationInputType.new(
+        'vm' => VAPI::Bindings::IdType.new('VirtualMachine'),
+        'floppy' => VAPI::Bindings::IdType.new('com.vmware.vcenter.vm.hardware.Floppy')
+      ),
+      VAPI::Bindings::VoidType.instance,
+      {
+        'com.vmware.vapi.std.errors.error' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Error'),
+        'com.vmware.vapi.std.errors.not_found' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::NotFound'),
+        'com.vmware.vapi.std.errors.already_in_desired_state' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::AlreadyInDesiredState'),
+        'com.vmware.vapi.std.errors.not_allowed_in_current_state' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::NotAllowedInCurrentState'),
+        'com.vmware.vapi.std.errors.resource_busy' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::ResourceBusy'),
+        'com.vmware.vapi.std.errors.resource_inaccessible' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::ResourceInaccessible'),
+        'com.vmware.vapi.std.errors.service_unavailable' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::ServiceUnavailable'),
+        'com.vmware.vapi.std.errors.unauthenticated' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Unauthenticated'),
+        'com.vmware.vapi.std.errors.unauthorized' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Unauthorized')
+      },
+      [],
+      []
+    )
+
+    DISCONNECT_INFO = VAPI::Bindings::OperationInfo.new(
+      VAPI::Core::OperationIdentifier.new('disconnect', SERVICE_ID),
+      VAPI::Bindings::OperationInputType.new(
+        'vm' => VAPI::Bindings::IdType.new('VirtualMachine'),
+        'floppy' => VAPI::Bindings::IdType.new('com.vmware.vcenter.vm.hardware.Floppy')
+      ),
+      VAPI::Bindings::VoidType.instance,
+      {
+        'com.vmware.vapi.std.errors.error' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Error'),
+        'com.vmware.vapi.std.errors.not_found' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::NotFound'),
+        'com.vmware.vapi.std.errors.already_in_desired_state' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::AlreadyInDesiredState'),
+        'com.vmware.vapi.std.errors.not_allowed_in_current_state' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::NotAllowedInCurrentState'),
+        'com.vmware.vapi.std.errors.resource_busy' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::ResourceBusy'),
+        'com.vmware.vapi.std.errors.resource_inaccessible' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::ResourceInaccessible'),
+        'com.vmware.vapi.std.errors.service_unavailable' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::ServiceUnavailable'),
+        'com.vmware.vapi.std.errors.unauthenticated' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Unauthenticated'),
+        'com.vmware.vapi.std.errors.unauthorized' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Unauthorized')
+      },
+      [],
+      []
+    )
+
+    SERVICE_INFO = VAPI::Bindings::ServiceInfo.new(
+      SERVICE_ID,
+      'list' => LIST_INFO,
+      'get' => GET_INFO,
+      'create' => CREATE_INFO,
+      'update' => UPDATE_INFO,
+      'delete' => DELETE_INFO,
+      'connect' => CONNECT_INFO,
+      'disconnect' => DISCONNECT_INFO
+    )
+
+    # Constructs a new instance.
+    #
+    # @param config [VAPI::Bindings::StubConfig] A hash with the api provider details.
+    def initialize(config)
+      super(config, SERVICE_INFO)
+    end
+
+    RESOURCE_TYPE = 'com.vmware.vcenter.vm.hardware.Floppy'
+    # Returns commonly used information about the virtual floppy drives belonging to the virtual machine.
+    #
+    # @param vm [String]
+    #     Virtual machine identifier.
+    # @return [Array<Com::Vmware::Vcenter::VM::Hardware::Floppy::Summary>]
+    #     List of commonly used information about virtual floppy drives.
+    # @raise [Com::Vmware::Vapi::Std::Errors::Error]
+    #     if the system reports an error while responding to the request.
+    # @raise [Com::Vmware::Vapi::Std::Errors::NotFound]
+    #     if the virtual machine is not found.
+    # @raise [Com::Vmware::Vapi::Std::Errors::ResourceInaccessible]
+    #     if the virtual machine's configuration state cannot be accessed.
+    # @raise [Com::Vmware::Vapi::Std::Errors::ServiceUnavailable]
+    #     if the system is unable to communicate with a service to complete the request.
+    # @raise [Com::Vmware::Vapi::Std::Errors::Unauthenticated]
+    #     if the user can not be authenticated.
+    # @raise [Com::Vmware::Vapi::Std::Errors::Unauthorized]
+    #     if the user doesn't have the required privileges.
+    def list(vm)
+      invoke_with_info(LIST_INFO,
+                       'vm' => vm)
+    end
+
+    # Returns information about a virtual floppy drive.
+    #
+    # @param vm [String]
+    #     Virtual machine identifier.
+    # @param floppy [String]
+    #     Virtual floppy drive identifier.
+    # @return [Com::Vmware::Vcenter::VM::Hardware::Floppy::Info]
+    #     Information about the specified virtual floppy drive.
+    # @raise [Com::Vmware::Vapi::Std::Errors::Error]
+    #     if the system reports an error while responding to the request.
+    # @raise [Com::Vmware::Vapi::Std::Errors::NotFound]
+    #     if the virtual machine or virtual floppy drive is not found.
+    # @raise [Com::Vmware::Vapi::Std::Errors::ResourceInaccessible]
+    #     if the virtual machine's configuration state cannot be accessed.
+    # @raise [Com::Vmware::Vapi::Std::Errors::ServiceUnavailable]
+    #     if the system is unable to communicate with a service to complete the request.
+    # @raise [Com::Vmware::Vapi::Std::Errors::Unauthenticated]
+    #     if the user can not be authenticated.
+    # @raise [Com::Vmware::Vapi::Std::Errors::Unauthorized]
+    #     if the user doesn't have the required privileges.
+    def get(vm, floppy)
+      invoke_with_info(GET_INFO,
+                       'vm' => vm,
+                       'floppy' => floppy)
+    end
+
+    # Adds a virtual floppy drive to the virtual machine.
+    #
+    # @param vm [String]
+    #     Virtual machine identifier.
+    # @param spec [Com::Vmware::Vcenter::VM::Hardware::Floppy::CreateSpec]
+    #     Specification for the new virtual floppy drive.
+    # @return [String]
+    #     Virtual floppy drive identifier.
+    # @raise [Com::Vmware::Vapi::Std::Errors::Error]
+    #     if the system reported that the floppy device was created but was unable to confirm the creation because the identifier of the new device could not be determined.
+    # @raise [Com::Vmware::Vapi::Std::Errors::Error]
+    #     if the system reports an error while responding to the request.
+    # @raise [Com::Vmware::Vapi::Std::Errors::NotFound]
+    #     if the virtual machine is not found.
+    # @raise [Com::Vmware::Vapi::Std::Errors::NotAllowedInCurrentState]
+    #     if the virtual machine is not powered off.
+    # @raise [Com::Vmware::Vapi::Std::Errors::UnableToAllocateResource]
+    #     if the virtual machine already has the maximum number of supported floppy drives.
+    # @raise [Com::Vmware::Vapi::Std::Errors::ResourceBusy]
+    #     if the virtual machine is busy performing another operation.
+    # @raise [Com::Vmware::Vapi::Std::Errors::ResourceInaccessible]
+    #     if the virtual machine's configuration state cannot be accessed.
+    # @raise [Com::Vmware::Vapi::Std::Errors::ServiceUnavailable]
+    #     if the system is unable to communicate with a service to complete the request.
+    # @raise [Com::Vmware::Vapi::Std::Errors::Unauthenticated]
+    #     if the user can not be authenticated.
+    # @raise [Com::Vmware::Vapi::Std::Errors::Unauthorized]
+    #     if the user doesn't have the required privileges.
+    def create(vm, spec)
+      invoke_with_info(CREATE_INFO,
+                       'vm' => vm,
+                       'spec' => spec)
+    end
+
+    # Updates the configuration of a virtual floppy drive.
+    #
+    # @param vm [String]
+    #     Virtual machine identifier.
+    # @param floppy [String]
+    #     Virtual floppy drive identifier.
+    # @param spec [Com::Vmware::Vcenter::VM::Hardware::Floppy::UpdateSpec]
+    #     Specification for updating the virtual floppy drive.
+    # @return [Void]
+    # @raise [Com::Vmware::Vapi::Std::Errors::Error]
+    #     if the system reports an error while responding to the request.
+    # @raise [Com::Vmware::Vapi::Std::Errors::NotFound]
+    #     if the virtual machine or virtual floppy drive is not found.
+    # @raise [Com::Vmware::Vapi::Std::Errors::NotAllowedInCurrentState]
+    #     if one or more of the  fields  specified in the  ``spec``   parameter  cannot be modified due to the current power state of the virtual machine or the connection state of the virtual floppy drive.
+    # @raise [Com::Vmware::Vapi::Std::Errors::ResourceBusy]
+    #     if the virtual machine is busy performing another operation.
+    # @raise [Com::Vmware::Vapi::Std::Errors::ResourceInaccessible]
+    #     if the virtual machine's configuration state cannot be accessed.
+    # @raise [Com::Vmware::Vapi::Std::Errors::ServiceUnavailable]
+    #     if the system is unable to communicate with a service to complete the request.
+    # @raise [Com::Vmware::Vapi::Std::Errors::Unauthenticated]
+    #     if the user can not be authenticated.
+    # @raise [Com::Vmware::Vapi::Std::Errors::Unauthorized]
+    #     if the user doesn't have the required privileges.
+    def update(vm, floppy, spec)
+      invoke_with_info(UPDATE_INFO,
+                       'vm' => vm,
+                       'floppy' => floppy,
+                       'spec' => spec)
+    end
+
+    # Removes a virtual floppy drive from the virtual machine.
+    #
+    # @param vm [String]
+    #     Virtual machine identifier.
+    # @param floppy [String]
+    #     Virtual floppy drive identifier.
+    # @return [Void]
+    # @raise [Com::Vmware::Vapi::Std::Errors::Error]
+    #     if the system reports an error while responding to the request.
+    # @raise [Com::Vmware::Vapi::Std::Errors::NotFound]
+    #     if the virtual machine or virtual floppy drive is not found.
+    # @raise [Com::Vmware::Vapi::Std::Errors::NotAllowedInCurrentState]
+    #     if the virtual machine is not powered off.
+    # @raise [Com::Vmware::Vapi::Std::Errors::ResourceBusy]
+    #     if the virtual machine is busy performing another operation.
+    # @raise [Com::Vmware::Vapi::Std::Errors::ResourceInaccessible]
+    #     if the virtual machine's configuration state cannot be accessed.
+    # @raise [Com::Vmware::Vapi::Std::Errors::ServiceUnavailable]
+    #     if the system is unable to communicate with a service to complete the request.
+    # @raise [Com::Vmware::Vapi::Std::Errors::Unauthenticated]
+    #     if the user can not be authenticated.
+    # @raise [Com::Vmware::Vapi::Std::Errors::Unauthorized]
+    #     if the user doesn't have the required privileges.
+    def delete(vm, floppy)
+      invoke_with_info(DELETE_INFO,
+                       'vm' => vm,
+                       'floppy' => floppy)
+    end
+
+    # Connects a virtual floppy drive of a powered-on virtual machine to its backing. Connecting the virtual device makes the backing accessible from the perspective of the guest operating system.  
+    # 
+    #  For a powered-off virtual machine, the   :func:`Com::Vmware::Vcenter::VM::Hardware::Floppy.update`    method  may be used to configure the virtual floppy drive to start in the connected state when the virtual machine is powered on.
+    #
+    # @param vm [String]
+    #     Virtual machine identifier.
+    # @param floppy [String]
+    #     Virtual floppy drive identifier.
+    # @return [Void]
+    # @raise [Com::Vmware::Vapi::Std::Errors::Error]
+    #     if the system reports an error while responding to the request.
+    # @raise [Com::Vmware::Vapi::Std::Errors::NotFound]
+    #     if the virtual machine or virtual floppy drive is not found.
+    # @raise [Com::Vmware::Vapi::Std::Errors::AlreadyInDesiredState]
+    #     if the virtual floppy drive is already connected.
+    # @raise [Com::Vmware::Vapi::Std::Errors::NotAllowedInCurrentState]
+    #     if the virtual machine is not powered on.
+    # @raise [Com::Vmware::Vapi::Std::Errors::ResourceBusy]
+    #     if the virtual machine is busy performing another operation.
+    # @raise [Com::Vmware::Vapi::Std::Errors::ResourceInaccessible]
+    #     if the virtual machine's configuration state cannot be accessed.
+    # @raise [Com::Vmware::Vapi::Std::Errors::ServiceUnavailable]
+    #     if the system is unable to communicate with a service to complete the request.
+    # @raise [Com::Vmware::Vapi::Std::Errors::Unauthenticated]
+    #     if the user can not be authenticated.
+    # @raise [Com::Vmware::Vapi::Std::Errors::Unauthorized]
+    #     if the user doesn't have the required privileges.
+    def connect(vm, floppy)
+      invoke_with_info(CONNECT_INFO,
+                       'vm' => vm,
+                       'floppy' => floppy)
+    end
+
+    # Disconnects a virtual floppy drive of a powered-on virtual machine from its backing. The virtual device is still present and its backing configuration is unchanged, but from the perspective of the guest operating system, the floppy drive is not connected to its backing resource.  
+    # 
+    #  For a powered-off virtual machine, the   :func:`Com::Vmware::Vcenter::VM::Hardware::Floppy.update`    method  may be used to configure the virtual floppy floppy to start in the disconnected state when the virtual machine is powered on.
+    #
+    # @param vm [String]
+    #     Virtual machine identifier.
+    # @param floppy [String]
+    #     Virtual floppy drive identifier.
+    # @return [Void]
+    # @raise [Com::Vmware::Vapi::Std::Errors::Error]
+    #     if the system reports an error while responding to the request.
+    # @raise [Com::Vmware::Vapi::Std::Errors::NotFound]
+    #     if the virtual machine or virtual floppy drive is not found.
+    # @raise [Com::Vmware::Vapi::Std::Errors::AlreadyInDesiredState]
+    #     if the virtual floppy drive is already disconnected.
+    # @raise [Com::Vmware::Vapi::Std::Errors::NotAllowedInCurrentState]
+    #     if the virtual machine is not powered on.
+    # @raise [Com::Vmware::Vapi::Std::Errors::ResourceBusy]
+    #     if the virtual machine is busy performing another operation.
+    # @raise [Com::Vmware::Vapi::Std::Errors::ResourceInaccessible]
+    #     if the virtual machine's configuration state cannot be accessed.
+    # @raise [Com::Vmware::Vapi::Std::Errors::ServiceUnavailable]
+    #     if the system is unable to communicate with a service to complete the request.
+    # @raise [Com::Vmware::Vapi::Std::Errors::Unauthenticated]
+    #     if the user can not be authenticated.
+    # @raise [Com::Vmware::Vapi::Std::Errors::Unauthorized]
+    #     if the user doesn't have the required privileges.
+    def disconnect(vm, floppy)
+      invoke_with_info(DISCONNECT_INFO,
+                       'vm' => vm,
+                       'floppy' => floppy)
+    end
+
+    # The  ``Com::Vmware::Vcenter::VM::Hardware::Floppy::BackingInfo``   class  contains information about the physical resource backing a virtual floppy drive.
+    # @!attribute [rw] type
+    #     @return [Com::Vmware::Vcenter::VM::Hardware::Floppy::BackingType]
+    #     Backing type for the virtual floppy drive.
+    # @!attribute [rw] image_file
+    #     @return [String]
+    #     Path of the image file backing the virtual floppy drive.
+    #     This  field  is optional and it is only relevant when the value of  ``type``  is   :attr:`Com::Vmware::Vcenter::VM::Hardware::Floppy::BackingType.IMAGE_FILE`  .
+    # @!attribute [rw] host_device
+    #     @return [String, nil]
+    #     Name of the host device backing the virtual floppy drive.  
+    #     This  field  will be  nil  if  ``autoDetect``  is true and the virtual floppy drive is not connected or no suitable device is available on the host.
+    # @!attribute [rw] auto_detect
+    #     @return [Boolean]
+    #     Flag indicating whether the virtual floppy drive is configured to automatically detect a suitable host device.
+    #     This  field  is optional and it is only relevant when the value of  ``type``  is   :attr:`Com::Vmware::Vcenter::VM::Hardware::Floppy::BackingType.HOST_DEVICE`  .
+    class BackingInfo < VAPI::Bindings::VapiStruct
+      class << self
+        # Holds (gets or creates) the binding type metadata for this structure type.
+        # @scope class
+        # @return [VAPI::Bindings::StructType] the binding type
+        def binding_type
+          @binding_type ||= VAPI::Bindings::StructType.new(
+            'com.vmware.vcenter.vm.hardware.floppy.backing_info',
+            {
+              'type' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::VM::Hardware::Floppy::BackingType'),
+              'image_file' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::StringType.instance),
+              'host_device' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::StringType.instance),
+              'auto_detect' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::BooleanType.instance)
+            },
+            BackingInfo,
+            false,
+            nil
+          )
+        end
+      end
+
+      attr_accessor :type,
+                    :image_file,
+                    :host_device,
+                    :auto_detect
+
+      # Constructs a new instance.
+      # @param ruby_values [Hash] a map of initial property values (optional)
+      # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
+      def initialize(ruby_values = nil, struct_value = nil)
+        super(self.class.binding_type, ruby_values, struct_value)
+      end
+    end
+
+    # The  ``Com::Vmware::Vcenter::VM::Hardware::Floppy::BackingSpec``   class  provides a specification of the physical resource backing a virtual floppy drive.
+    # @!attribute [rw] type
+    #     @return [Com::Vmware::Vcenter::VM::Hardware::Floppy::BackingType]
+    #     Backing type for the virtual floppy drive.
+    # @!attribute [rw] image_file
+    #     @return [String]
+    #     Path of the image file that should be used as the virtual floppy drive backing.
+    #     This  field  is optional and it is only relevant when the value of  ``type``  is   :attr:`Com::Vmware::Vcenter::VM::Hardware::Floppy::BackingType.IMAGE_FILE`  .
+    # @!attribute [rw] host_device
+    #     @return [String, nil]
+    #     Name of the device that should be used as the virtual floppy drive backing.
+    #     If  nil , the virtual floppy drive will be configured to automatically detect a suitable host device.
+    class BackingSpec < VAPI::Bindings::VapiStruct
+      class << self
+        # Holds (gets or creates) the binding type metadata for this structure type.
+        # @scope class
+        # @return [VAPI::Bindings::StructType] the binding type
+        def binding_type
+          @binding_type ||= VAPI::Bindings::StructType.new(
+            'com.vmware.vcenter.vm.hardware.floppy.backing_spec',
+            {
+              'type' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::VM::Hardware::Floppy::BackingType'),
+              'image_file' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::StringType.instance),
+              'host_device' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::StringType.instance)
+            },
+            BackingSpec,
+            false,
+            nil
+          )
+        end
+      end
+
+      attr_accessor :type,
+                    :image_file,
+                    :host_device
+
+      # Constructs a new instance.
+      # @param ruby_values [Hash] a map of initial property values (optional)
+      # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
+      def initialize(ruby_values = nil, struct_value = nil)
+        super(self.class.binding_type, ruby_values, struct_value)
+      end
+    end
+
+    # The  ``Com::Vmware::Vcenter::VM::Hardware::Floppy::Info``   class  contains information about a virtual floppy drive.
+    # @!attribute [rw] label
+    #     @return [String]
+    #     Device label.
+    # @!attribute [rw] backing
+    #     @return [Com::Vmware::Vcenter::VM::Hardware::Floppy::BackingInfo]
+    #     Physical resource backing for the virtual floppy drive.
+    class Info < VAPI::Bindings::VapiStruct
+      class << self
+        # Holds (gets or creates) the binding type metadata for this structure type.
+        # @scope class
+        # @return [VAPI::Bindings::StructType] the binding type
+        def binding_type
+          @binding_type ||= VAPI::Bindings::StructType.new(
+            'com.vmware.vcenter.vm.hardware.floppy.info',
+            {
+              'label' => VAPI::Bindings::StringType.instance,
+              'backing' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::VM::Hardware::Floppy::BackingInfo'),
+              'state' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::VM::Hardware::ConnectionState'),
+              'start_connected' => VAPI::Bindings::BooleanType.instance,
+              'allow_guest_control' => VAPI::Bindings::BooleanType.instance
+            },
+            Info,
+            false,
+            nil
+          )
+        end
+      end
+
+      attr_accessor :label,
+                    :backing,
+                    :state,
+                    :start_connected,
+                    :allow_guest_control
+
+      # Constructs a new instance.
+      # @param ruby_values [Hash] a map of initial property values (optional)
+      # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
+      def initialize(ruby_values = nil, struct_value = nil)
+        super(self.class.binding_type, ruby_values, struct_value)
+      end
+    end
+
+    # The  ``Com::Vmware::Vcenter::VM::Hardware::Floppy::CreateSpec``   class  provides a specification for the configuration of a newly-created virtual floppy drive.
+    # @!attribute [rw] backing
+    #     @return [Com::Vmware::Vcenter::VM::Hardware::Floppy::BackingSpec, nil]
+    #     Physical resource backing for the virtual floppy drive.
+    #     If  nil , defaults to automatic detection of a suitable host device.
+    class CreateSpec < VAPI::Bindings::VapiStruct
+      class << self
+        # Holds (gets or creates) the binding type metadata for this structure type.
+        # @scope class
+        # @return [VAPI::Bindings::StructType] the binding type
+        def binding_type
+          @binding_type ||= VAPI::Bindings::StructType.new(
+            'com.vmware.vcenter.vm.hardware.floppy.create_spec',
+            {
+              'backing' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::VM::Hardware::Floppy::BackingSpec')),
+              'start_connected' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::BooleanType.instance),
+              'allow_guest_control' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::BooleanType.instance)
+            },
+            CreateSpec,
+            false,
+            nil
+          )
+        end
+      end
+
+      attr_accessor :backing,
+                    :start_connected,
+                    :allow_guest_control
+
+      # Constructs a new instance.
+      # @param ruby_values [Hash] a map of initial property values (optional)
+      # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
+      def initialize(ruby_values = nil, struct_value = nil)
+        super(self.class.binding_type, ruby_values, struct_value)
+      end
+    end
+
+    # The  ``Com::Vmware::Vcenter::VM::Hardware::Floppy::UpdateSpec``   class  describes the updates to be made to the configuration of a virtual floppy drive.
+    # @!attribute [rw] backing
+    #     @return [Com::Vmware::Vcenter::VM::Hardware::Floppy::BackingSpec, nil]
+    #     Physical resource backing for the virtual floppy drive.  
+    #     
+    #      This  field  may only be modified if the virtual machine is not powered on or the virtual floppy drive is not connected.
+    #     If  nil , the value is unchanged.
+    class UpdateSpec < VAPI::Bindings::VapiStruct
+      class << self
+        # Holds (gets or creates) the binding type metadata for this structure type.
+        # @scope class
+        # @return [VAPI::Bindings::StructType] the binding type
+        def binding_type
+          @binding_type ||= VAPI::Bindings::StructType.new(
+            'com.vmware.vcenter.vm.hardware.floppy.update_spec',
+            {
+              'backing' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::VM::Hardware::Floppy::BackingSpec')),
+              'start_connected' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::BooleanType.instance),
+              'allow_guest_control' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::BooleanType.instance)
+            },
+            UpdateSpec,
+            false,
+            nil
+          )
+        end
+      end
+
+      attr_accessor :backing,
+                    :start_connected,
+                    :allow_guest_control
+
+      # Constructs a new instance.
+      # @param ruby_values [Hash] a map of initial property values (optional)
+      # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
+      def initialize(ruby_values = nil, struct_value = nil)
+        super(self.class.binding_type, ruby_values, struct_value)
+      end
+    end
+
+    # The  ``Com::Vmware::Vcenter::VM::Hardware::Floppy::Summary``   class  contains commonly used information about a virtual floppy drive.
+    # @!attribute [rw] floppy
+    #     @return [String]
+    #     Identifier of the virtual floppy drive.
+    class Summary < VAPI::Bindings::VapiStruct
+      class << self
+        # Holds (gets or creates) the binding type metadata for this structure type.
+        # @scope class
+        # @return [VAPI::Bindings::StructType] the binding type
+        def binding_type
+          @binding_type ||= VAPI::Bindings::StructType.new(
+            'com.vmware.vcenter.vm.hardware.floppy.summary',
+            {
+              'floppy' => VAPI::Bindings::IdType.new('com.vmware.vcenter.vm.hardware.Floppy')
+            },
+            Summary,
+            false,
+            nil
+          )
+        end
+      end
+
+      attr_accessor :floppy
+
+      # Constructs a new instance.
+      # @param ruby_values [Hash] a map of initial property values (optional)
+      # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
+      def initialize(ruby_values = nil, struct_value = nil)
+        super(self.class.binding_type, ruby_values, struct_value)
+      end
+    end
+
+    # The  ``Com::Vmware::Vcenter::VM::Hardware::Floppy::BackingType``   enumerated type  defines the valid backing types for a virtual floppy drive.
+    # @!attribute [rw] image_file
+    #     @return [Com::Vmware::Vcenter::VM::Hardware::Floppy::BackingType]
+    #     Virtual floppy drive is backed by an image file.
+    # @!attribute [rw] host_device
+    #     @return [Com::Vmware::Vcenter::VM::Hardware::Floppy::BackingType]
+    #     Virtual floppy drive is backed by a device on the host where the virtual machine is running.
+    # @!attribute [rw] client_device
+    #     @return [Com::Vmware::Vcenter::VM::Hardware::Floppy::BackingType]
+    #     Virtual floppy drive is backed by a device on the client that is connected to the virtual machine console.
+    class BackingType < VAPI::Bindings::VapiEnum
+      class << self
+        # Holds (gets or creates) the binding type metadata for this enumeration type.
+        # @scope class
+        # @return [VAPI::Bindings::EnumType] the binding type
+        def binding_type
+          @binding_type ||= VAPI::Bindings::EnumType.new(
+            'com.vmware.vcenter.vm.hardware.floppy.backing_type',
+            BackingType
+          )
+        end
+
+        # Converts from a string value (perhaps off the wire) to an instance
+        # of this enum type.
+        # @param value [String] the actual value of the enum instance
+        # @return [BackingType] the instance found for the value, otherwise
+        #         an unknown instance will be built for the value
+        def from_string(value)
+          const_get(value)
+        rescue NameError
+          BackingType.send(:new, 'UNKNOWN', value)
+        end
+      end
+
+      # Constructs a new instance.
+      # @param value [String] the actual value of the enum instance
+      # @param unknown [String] the unknown value when value is 'UKNOWN'
+      def initialize(value, unknown = nil)
+        super(self.class.binding_type, value, unknown)
+      end
+
+      private_class_method :new
+
+      # @!attribute [rw] image_file
+      #     @return [Com::Vmware::Vcenter::VM::Hardware::Floppy::BackingType]
+      #     Virtual floppy drive is backed by an image file.
+      IMAGE_FILE = BackingType.send(:new, 'IMAGE_FILE')
+
+      # @!attribute [rw] host_device
+      #     @return [Com::Vmware::Vcenter::VM::Hardware::Floppy::BackingType]
+      #     Virtual floppy drive is backed by a device on the host where the virtual machine is running.
+      HOST_DEVICE = BackingType.send(:new, 'HOST_DEVICE')
+
+      # @!attribute [rw] client_device
+      #     @return [Com::Vmware::Vcenter::VM::Hardware::Floppy::BackingType]
+      #     Virtual floppy drive is backed by a device on the client that is connected to the virtual machine console.
+      CLIENT_DEVICE = BackingType.send(:new, 'CLIENT_DEVICE')
+    end
+  end
+  # The  ``Com::Vmware::Vcenter::VM::Hardware::Memory``   class  provides  methods  for configuring the memory settings of a virtual machine.
+  class Memory < VAPI::Bindings::VapiService
+    # static metamodel definitions
+    SERVICE_ID = VAPI::Core::ServiceIdentifier.new('com.vmware.vcenter.vm.hardware.memory')
+
+    GET_INFO = VAPI::Bindings::OperationInfo.new(
+      VAPI::Core::OperationIdentifier.new('get', SERVICE_ID),
+      VAPI::Bindings::OperationInputType.new(
+        'vm' => VAPI::Bindings::IdType.new('VirtualMachine')
+      ),
+      VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::VM::Hardware::Memory::Info'),
+      {
+        'com.vmware.vapi.std.errors.error' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Error'),
+        'com.vmware.vapi.std.errors.not_found' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::NotFound'),
+        'com.vmware.vapi.std.errors.resource_inaccessible' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::ResourceInaccessible'),
+        'com.vmware.vapi.std.errors.service_unavailable' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::ServiceUnavailable'),
+        'com.vmware.vapi.std.errors.unauthenticated' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Unauthenticated'),
+        'com.vmware.vapi.std.errors.unauthorized' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Unauthorized')
+      },
+      [],
+      []
+    )
+
+    UPDATE_INFO = VAPI::Bindings::OperationInfo.new(
+      VAPI::Core::OperationIdentifier.new('update', SERVICE_ID),
+      VAPI::Bindings::OperationInputType.new(
+        'vm' => VAPI::Bindings::IdType.new('VirtualMachine'),
+        'spec' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::VM::Hardware::Memory::UpdateSpec')
+      ),
+      VAPI::Bindings::VoidType.instance,
+      {
+        'com.vmware.vapi.std.errors.error' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Error'),
+        'com.vmware.vapi.std.errors.not_found' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::NotFound'),
+        'com.vmware.vapi.std.errors.invalid_argument' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::InvalidArgument'),
+        'com.vmware.vapi.std.errors.not_allowed_in_current_state' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::NotAllowedInCurrentState'),
+        'com.vmware.vapi.std.errors.resource_busy' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::ResourceBusy'),
+        'com.vmware.vapi.std.errors.resource_inaccessible' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::ResourceInaccessible'),
+        'com.vmware.vapi.std.errors.service_unavailable' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::ServiceUnavailable'),
+        'com.vmware.vapi.std.errors.unauthenticated' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Unauthenticated'),
+        'com.vmware.vapi.std.errors.unauthorized' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Unauthorized')
+      },
+      [],
+      []
+    )
+
+    SERVICE_INFO = VAPI::Bindings::ServiceInfo.new(
+      SERVICE_ID,
+      'get' => GET_INFO,
+      'update' => UPDATE_INFO
+    )
+
+    # Constructs a new instance.
+    #
+    # @param config [VAPI::Bindings::StubConfig] A hash with the api provider details.
+    def initialize(config)
+      super(config, SERVICE_INFO)
+    end
+
+    # Returns the memory-related settings of a virtual machine.
+    #
+    # @param vm [String]
+    #     Virtual machine identifier.
+    # @return [Com::Vmware::Vcenter::VM::Hardware::Memory::Info]
+    #     Memory-related settings of the virtual machine.
+    # @raise [Com::Vmware::Vapi::Std::Errors::Error]
+    #     if the system reports an error while responding to the request.
+    # @raise [Com::Vmware::Vapi::Std::Errors::NotFound]
+    #     if the virtual machine is not found.
+    # @raise [Com::Vmware::Vapi::Std::Errors::ResourceInaccessible]
+    #     if the virtual machine's configuration state cannot be accessed.
+    # @raise [Com::Vmware::Vapi::Std::Errors::ServiceUnavailable]
+    #     if the system is unable to communicate with a service to complete the request.
+    # @raise [Com::Vmware::Vapi::Std::Errors::Unauthenticated]
+    #     if the user can not be authenticated.
+    # @raise [Com::Vmware::Vapi::Std::Errors::Unauthorized]
+    #     if the user doesn't have the required privileges.
+    def get(vm)
+      invoke_with_info(GET_INFO,
+                       'vm' => vm)
+    end
+
+    # Updates the memory-related settings of a virtual machine.
+    #
+    # @param vm [String]
+    #     Virtual machine identifier.
+    # @param spec [Com::Vmware::Vcenter::VM::Hardware::Memory::UpdateSpec]
+    #     Specification for updating the memory-related settings of the virtual machine.
+    # @return [Void]
+    # @raise [Com::Vmware::Vapi::Std::Errors::Error]
+    #     if the system reports an error while responding to the request.
+    # @raise [Com::Vmware::Vapi::Std::Errors::NotFound]
+    #     if the virtual machine is not found.
+    # @raise [Com::Vmware::Vapi::Std::Errors::InvalidArgument]
+    #     if one of the provided settings is not permitted; for example, specifying a negative value for  ``sizeMiB`` .
+    # @raise [Com::Vmware::Vapi::Std::Errors::NotAllowedInCurrentState]
+    #     if  ``hotAddEnabled``  is specified and the virtual machine is not powered off.
+    # @raise [Com::Vmware::Vapi::Std::Errors::NotAllowedInCurrentState]
+    #     if  ``sizeMiB``  is specified,  ``hotAddEnabled``  is false, and the virtual machine is not powered off.
+    # @raise [Com::Vmware::Vapi::Std::Errors::ResourceBusy]
+    #     if the virtual machine is busy performing another operation.
+    # @raise [Com::Vmware::Vapi::Std::Errors::ResourceInaccessible]
+    #     if the virtual machine's configuration state cannot be accessed.
+    # @raise [Com::Vmware::Vapi::Std::Errors::ServiceUnavailable]
+    #     if the system is unable to communicate with a service to complete the request.
+    # @raise [Com::Vmware::Vapi::Std::Errors::Unauthenticated]
+    #     if the user can not be authenticated.
+    # @raise [Com::Vmware::Vapi::Std::Errors::Unauthorized]
+    #     if the user doesn't have the required privileges.
+    def update(vm, spec)
+      invoke_with_info(UPDATE_INFO,
+                       'vm' => vm,
+                       'spec' => spec)
+    end
+
+    # The  ``Com::Vmware::Vcenter::VM::Hardware::Memory::Info``   class  contains memory-related information about a virtual machine.
+    # @!attribute [rw] size_mib
+    #     @return [Fixnum]
+    #     Memory size in mebibytes.
+    # @!attribute [rw] hot_add_enabled
+    #     @return [Boolean]
+    #     Flag indicating whether adding memory while the virtual machine is running is enabled.  
+    #     
+    #      Some guest operating systems may consume more resources or perform less efficiently when they run on hardware that supports adding memory while the machine is running.
+    # @!attribute [rw] hot_add_increment_size_mib
+    #     @return [Fixnum, nil]
+    #     The granularity, in mebibytes, at which memory can be added to a running virtual machine.  
+    #     
+    #      When adding memory to a running virtual machine, the amount of memory added must be at least   :attr:`Com::Vmware::Vcenter::VM::Hardware::Memory::Info.hot_add_increment_size_mib`   and the total memory size of the virtual machine must be a multiple of {\@link>hotAddIncrementSize}.
+    #     Only set when   :attr:`Com::Vmware::Vcenter::VM::Hardware::Memory::Info.hot_add_enabled`   is true and the virtual machine is running.
+    # @!attribute [rw] hot_add_limit_mib
+    #     @return [Fixnum, nil]
+    #     The maximum amount of memory, in mebibytes, that can be added to a running virtual machine.
+    #     Only set when   :attr:`Com::Vmware::Vcenter::VM::Hardware::Memory::Info.hot_add_enabled`   is true and the virtual machine is running.
+    class Info < VAPI::Bindings::VapiStruct
+      class << self
+        # Holds (gets or creates) the binding type metadata for this structure type.
+        # @scope class
+        # @return [VAPI::Bindings::StructType] the binding type
+        def binding_type
+          @binding_type ||= VAPI::Bindings::StructType.new(
+            'com.vmware.vcenter.vm.hardware.memory.info',
+            {
+              'size_MiB' => VAPI::Bindings::IntegerType.instance,
+              'hot_add_enabled' => VAPI::Bindings::BooleanType.instance,
+              'hot_add_increment_size_MiB' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::IntegerType.instance),
+              'hot_add_limit_MiB' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::IntegerType.instance)
+            },
+            Info,
+            false,
+            nil
+          )
+        end
+      end
+
+      attr_accessor :size_mib,
+                    :hot_add_enabled,
+                    :hot_add_increment_size_mib,
+                    :hot_add_limit_mib
+
+      # Constructs a new instance.
+      # @param ruby_values [Hash] a map of initial property values (optional)
+      # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
+      def initialize(ruby_values = nil, struct_value = nil)
+        super(self.class.binding_type, ruby_values, struct_value)
+      end
+    end
+
+    # The  ``Com::Vmware::Vcenter::VM::Hardware::Memory::UpdateSpec``   class  describes the updates to be made to the memory-related settings of a virtual machine.
+    # @!attribute [rw] size_mib
+    #     @return [Fixnum, nil]
+    #     New memory size in mebibytes.  
+    #     
+    #      The supported range of memory sizes is constrained by the configured guest operating system and virtual hardware version of the virtual machine.  
+    #     
+    #      If the virtual machine is running, this value may only be changed if   :attr:`Com::Vmware::Vcenter::VM::Hardware::Memory::Info.hot_add_enabled`   is true, and the new memory size must satisfy the constraints specified by   :attr:`Com::Vmware::Vcenter::VM::Hardware::Memory::Info.hot_add_increment_size_mib`   and   :attr:`Com::Vmware::Vcenter::VM::Hardware::Memory::Info.hot_add_limit_mib`  .
+    #     If  nil , the value is unchanged.
+    # @!attribute [rw] hot_add_enabled
+    #     @return [Boolean, nil]
+    #     Flag indicating whether adding memory while the virtual machine is running should be enabled.  
+    #     
+    #      Some guest operating systems may consume more resources or perform less efficiently when they run on hardware that supports adding memory while the machine is running.  
+    #     
+    #      This  field  may only be modified if the virtual machine is not powered on.
+    #     If  nil , the value is unchanged.
+    class UpdateSpec < VAPI::Bindings::VapiStruct
+      class << self
+        # Holds (gets or creates) the binding type metadata for this structure type.
+        # @scope class
+        # @return [VAPI::Bindings::StructType] the binding type
+        def binding_type
+          @binding_type ||= VAPI::Bindings::StructType.new(
+            'com.vmware.vcenter.vm.hardware.memory.update_spec',
+            {
+              'size_MiB' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::IntegerType.instance),
+              'hot_add_enabled' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::BooleanType.instance)
+            },
+            UpdateSpec,
+            false,
+            nil
+          )
+        end
+      end
+
+      attr_accessor :size_mib,
+                    :hot_add_enabled
+
+      # Constructs a new instance.
+      # @param ruby_values [Hash] a map of initial property values (optional)
+      # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
+      def initialize(ruby_values = nil, struct_value = nil)
+        super(self.class.binding_type, ruby_values, struct_value)
+      end
+    end
+
+  end
+  # The  ``Com::Vmware::Vcenter::VM::Hardware::Parallel``   class  provides  methods  for configuring the virtual parallel ports of a virtual machine.
+  class Parallel < VAPI::Bindings::VapiService
+    # static metamodel definitions
+    SERVICE_ID = VAPI::Core::ServiceIdentifier.new('com.vmware.vcenter.vm.hardware.parallel')
+
+    LIST_INFO = VAPI::Bindings::OperationInfo.new(
+      VAPI::Core::OperationIdentifier.new('list', SERVICE_ID),
+      VAPI::Bindings::OperationInputType.new(
+        'vm' => VAPI::Bindings::IdType.new('VirtualMachine')
+      ),
+      VAPI::Bindings::ListType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::VM::Hardware::Parallel::Summary')),
+      {
+        'com.vmware.vapi.std.errors.error' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Error'),
+        'com.vmware.vapi.std.errors.not_found' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::NotFound'),
+        'com.vmware.vapi.std.errors.resource_inaccessible' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::ResourceInaccessible'),
+        'com.vmware.vapi.std.errors.service_unavailable' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::ServiceUnavailable'),
+        'com.vmware.vapi.std.errors.unauthenticated' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Unauthenticated'),
+        'com.vmware.vapi.std.errors.unauthorized' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Unauthorized')
+      },
+      [],
+      []
+    )
+
+    GET_INFO = VAPI::Bindings::OperationInfo.new(
+      VAPI::Core::OperationIdentifier.new('get', SERVICE_ID),
+      VAPI::Bindings::OperationInputType.new(
+        'vm' => VAPI::Bindings::IdType.new('VirtualMachine'),
+        'port' => VAPI::Bindings::IdType.new('com.vmware.vcenter.vm.hardware.ParallelPort')
+      ),
+      VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::VM::Hardware::Parallel::Info'),
+      {
+        'com.vmware.vapi.std.errors.error' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Error'),
+        'com.vmware.vapi.std.errors.not_found' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::NotFound'),
+        'com.vmware.vapi.std.errors.resource_inaccessible' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::ResourceInaccessible'),
+        'com.vmware.vapi.std.errors.service_unavailable' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::ServiceUnavailable'),
+        'com.vmware.vapi.std.errors.unauthenticated' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Unauthenticated'),
+        'com.vmware.vapi.std.errors.unauthorized' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Unauthorized')
+      },
+      [],
+      []
+    )
+
+    CREATE_INFO = VAPI::Bindings::OperationInfo.new(
+      VAPI::Core::OperationIdentifier.new('create', SERVICE_ID),
+      VAPI::Bindings::OperationInputType.new(
+        'vm' => VAPI::Bindings::IdType.new('VirtualMachine'),
+        'spec' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::VM::Hardware::Parallel::CreateSpec')
+      ),
+      VAPI::Bindings::IdType.new('com.vmware.vcenter.vm.hardware.ParallelPort'),
+      {
+        'com.vmware.vapi.std.errors.error' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Error'),
+        'com.vmware.vapi.std.errors.not_found' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::NotFound'),
+        'com.vmware.vapi.std.errors.not_allowed_in_current_state' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::NotAllowedInCurrentState'),
+        'com.vmware.vapi.std.errors.unable_to_allocate_resource' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::UnableToAllocateResource'),
+        'com.vmware.vapi.std.errors.resource_busy' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::ResourceBusy'),
+        'com.vmware.vapi.std.errors.resource_inaccessible' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::ResourceInaccessible'),
+        'com.vmware.vapi.std.errors.service_unavailable' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::ServiceUnavailable'),
+        'com.vmware.vapi.std.errors.unauthenticated' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Unauthenticated'),
+        'com.vmware.vapi.std.errors.unauthorized' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Unauthorized')
+      },
+      [],
+      []
+    )
+
+    UPDATE_INFO = VAPI::Bindings::OperationInfo.new(
+      VAPI::Core::OperationIdentifier.new('update', SERVICE_ID),
+      VAPI::Bindings::OperationInputType.new(
+        'vm' => VAPI::Bindings::IdType.new('VirtualMachine'),
+        'port' => VAPI::Bindings::IdType.new('com.vmware.vcenter.vm.hardware.ParallelPort'),
+        'spec' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::VM::Hardware::Parallel::UpdateSpec')
+      ),
+      VAPI::Bindings::VoidType.instance,
+      {
+        'com.vmware.vapi.std.errors.error' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Error'),
+        'com.vmware.vapi.std.errors.not_found' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::NotFound'),
+        'com.vmware.vapi.std.errors.not_allowed_in_current_state' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::NotAllowedInCurrentState'),
+        'com.vmware.vapi.std.errors.resource_busy' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::ResourceBusy'),
+        'com.vmware.vapi.std.errors.resource_inaccessible' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::ResourceInaccessible'),
+        'com.vmware.vapi.std.errors.service_unavailable' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::ServiceUnavailable'),
+        'com.vmware.vapi.std.errors.unauthenticated' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Unauthenticated'),
+        'com.vmware.vapi.std.errors.unauthorized' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Unauthorized')
+      },
+      [],
+      []
+    )
+
+    DELETE_INFO = VAPI::Bindings::OperationInfo.new(
+      VAPI::Core::OperationIdentifier.new('delete', SERVICE_ID),
+      VAPI::Bindings::OperationInputType.new(
+        'vm' => VAPI::Bindings::IdType.new('VirtualMachine'),
+        'port' => VAPI::Bindings::IdType.new('com.vmware.vcenter.vm.hardware.ParallelPort')
+      ),
+      VAPI::Bindings::VoidType.instance,
+      {
+        'com.vmware.vapi.std.errors.error' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Error'),
+        'com.vmware.vapi.std.errors.not_found' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::NotFound'),
+        'com.vmware.vapi.std.errors.not_allowed_in_current_state' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::NotAllowedInCurrentState'),
+        'com.vmware.vapi.std.errors.resource_busy' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::ResourceBusy'),
+        'com.vmware.vapi.std.errors.resource_inaccessible' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::ResourceInaccessible'),
+        'com.vmware.vapi.std.errors.service_unavailable' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::ServiceUnavailable'),
+        'com.vmware.vapi.std.errors.unauthenticated' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Unauthenticated'),
+        'com.vmware.vapi.std.errors.unauthorized' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Unauthorized')
+      },
+      [],
+      []
+    )
+
+    CONNECT_INFO = VAPI::Bindings::OperationInfo.new(
+      VAPI::Core::OperationIdentifier.new('connect', SERVICE_ID),
+      VAPI::Bindings::OperationInputType.new(
+        'vm' => VAPI::Bindings::IdType.new('VirtualMachine'),
+        'port' => VAPI::Bindings::IdType.new('com.vmware.vcenter.vm.hardware.ParallelPort')
+      ),
+      VAPI::Bindings::VoidType.instance,
+      {
+        'com.vmware.vapi.std.errors.error' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Error'),
+        'com.vmware.vapi.std.errors.not_found' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::NotFound'),
+        'com.vmware.vapi.std.errors.already_in_desired_state' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::AlreadyInDesiredState'),
+        'com.vmware.vapi.std.errors.not_allowed_in_current_state' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::NotAllowedInCurrentState'),
+        'com.vmware.vapi.std.errors.resource_busy' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::ResourceBusy'),
+        'com.vmware.vapi.std.errors.resource_inaccessible' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::ResourceInaccessible'),
+        'com.vmware.vapi.std.errors.service_unavailable' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::ServiceUnavailable'),
+        'com.vmware.vapi.std.errors.unauthenticated' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Unauthenticated'),
+        'com.vmware.vapi.std.errors.unauthorized' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Unauthorized')
+      },
+      [],
+      []
+    )
+
+    DISCONNECT_INFO = VAPI::Bindings::OperationInfo.new(
+      VAPI::Core::OperationIdentifier.new('disconnect', SERVICE_ID),
+      VAPI::Bindings::OperationInputType.new(
+        'vm' => VAPI::Bindings::IdType.new('VirtualMachine'),
+        'port' => VAPI::Bindings::IdType.new('com.vmware.vcenter.vm.hardware.ParallelPort')
+      ),
+      VAPI::Bindings::VoidType.instance,
+      {
+        'com.vmware.vapi.std.errors.error' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Error'),
+        'com.vmware.vapi.std.errors.not_found' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::NotFound'),
+        'com.vmware.vapi.std.errors.already_in_desired_state' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::AlreadyInDesiredState'),
+        'com.vmware.vapi.std.errors.not_allowed_in_current_state' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::NotAllowedInCurrentState'),
+        'com.vmware.vapi.std.errors.resource_busy' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::ResourceBusy'),
+        'com.vmware.vapi.std.errors.resource_inaccessible' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::ResourceInaccessible'),
+        'com.vmware.vapi.std.errors.service_unavailable' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::ServiceUnavailable'),
+        'com.vmware.vapi.std.errors.unauthenticated' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Unauthenticated'),
+        'com.vmware.vapi.std.errors.unauthorized' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Unauthorized')
+      },
+      [],
+      []
+    )
+
+    SERVICE_INFO = VAPI::Bindings::ServiceInfo.new(
+      SERVICE_ID,
+      'list' => LIST_INFO,
+      'get' => GET_INFO,
+      'create' => CREATE_INFO,
+      'update' => UPDATE_INFO,
+      'delete' => DELETE_INFO,
+      'connect' => CONNECT_INFO,
+      'disconnect' => DISCONNECT_INFO
+    )
+
+    # Constructs a new instance.
+    #
+    # @param config [VAPI::Bindings::StubConfig] A hash with the api provider details.
+    def initialize(config)
+      super(config, SERVICE_INFO)
+    end
+
+    RESOURCE_TYPE = 'com.vmware.vcenter.vm.hardware.ParallelPort'
+    # Returns commonly used information about the virtual parallel ports belonging to the virtual machine.
+    #
+    # @param vm [String]
+    #     Virtual machine identifier.
+    # @return [Array<Com::Vmware::Vcenter::VM::Hardware::Parallel::Summary>]
+    #     List of commonly used information about virtual parallel ports.
+    # @raise [Com::Vmware::Vapi::Std::Errors::Error]
+    #     if the system reports an error while responding to the request.
+    # @raise [Com::Vmware::Vapi::Std::Errors::NotFound]
+    #     if the virtual machine is not found.
+    # @raise [Com::Vmware::Vapi::Std::Errors::ResourceInaccessible]
+    #     if the virtual machine's configuration state cannot be accessed.
+    # @raise [Com::Vmware::Vapi::Std::Errors::ServiceUnavailable]
+    #     if the system is unable to communicate with a service to complete the request.
+    # @raise [Com::Vmware::Vapi::Std::Errors::Unauthenticated]
+    #     if the user can not be authenticated.
+    # @raise [Com::Vmware::Vapi::Std::Errors::Unauthorized]
+    #     if the user doesn't have the required privileges.
+    def list(vm)
+      invoke_with_info(LIST_INFO,
+                       'vm' => vm)
+    end
+
+    # Returns information about a virtual parallel port.
+    #
+    # @param vm [String]
+    #     Virtual machine identifier.
+    # @param port [String]
+    #     Virtual parallel port identifier.
+    # @return [Com::Vmware::Vcenter::VM::Hardware::Parallel::Info]
+    #     Information about the specified virtual parallel port.
+    # @raise [Com::Vmware::Vapi::Std::Errors::Error]
+    #     if the system reports an error while responding to the request.
+    # @raise [Com::Vmware::Vapi::Std::Errors::NotFound]
+    #     if the virtual machine or virtual parallel port is not found.
+    # @raise [Com::Vmware::Vapi::Std::Errors::ResourceInaccessible]
+    #     if the virtual machine's configuration state cannot be accessed.
+    # @raise [Com::Vmware::Vapi::Std::Errors::ServiceUnavailable]
+    #     if the system is unable to communicate with a service to complete the request.
+    # @raise [Com::Vmware::Vapi::Std::Errors::Unauthenticated]
+    #     if the user can not be authenticated.
+    # @raise [Com::Vmware::Vapi::Std::Errors::Unauthorized]
+    #     if the user doesn't have the required privileges.
+    def get(vm, port)
+      invoke_with_info(GET_INFO,
+                       'vm' => vm,
+                       'port' => port)
+    end
+
+    # Adds a virtual parallel port to the virtual machine.
+    #
+    # @param vm [String]
+    #     Virtual machine identifier.
+    # @param spec [Com::Vmware::Vcenter::VM::Hardware::Parallel::CreateSpec]
+    #     Specification for the new virtual parallel port.
+    # @return [String]
+    #     Virtual parallel port identifier.
+    # @raise [Com::Vmware::Vapi::Std::Errors::Error]
+    #     if the system reported that the parallel port device was created but was unable to confirm the creation because the identifier of the new device could not be determined.
+    # @raise [Com::Vmware::Vapi::Std::Errors::Error]
+    #     if the system reports an error while responding to the request.
+    # @raise [Com::Vmware::Vapi::Std::Errors::NotFound]
+    #     if the virtual machine is not found.
+    # @raise [Com::Vmware::Vapi::Std::Errors::NotAllowedInCurrentState]
+    #     if the virtual machine is not powered off.
+    # @raise [Com::Vmware::Vapi::Std::Errors::UnableToAllocateResource]
+    #     if the virtual machine already has the maximum number of supported parallel ports.
+    # @raise [Com::Vmware::Vapi::Std::Errors::ResourceBusy]
+    #     if the virtual machine is busy performing another operation.
+    # @raise [Com::Vmware::Vapi::Std::Errors::ResourceInaccessible]
+    #     if the virtual machine's configuration state cannot be accessed.
+    # @raise [Com::Vmware::Vapi::Std::Errors::ServiceUnavailable]
+    #     if the system is unable to communicate with a service to complete the request.
+    # @raise [Com::Vmware::Vapi::Std::Errors::Unauthenticated]
+    #     if the user can not be authenticated.
+    # @raise [Com::Vmware::Vapi::Std::Errors::Unauthorized]
+    #     if the user doesn't have the required privileges.
+    def create(vm, spec)
+      invoke_with_info(CREATE_INFO,
+                       'vm' => vm,
+                       'spec' => spec)
+    end
+
+    # Updates the configuration of a virtual parallel port.
+    #
+    # @param vm [String]
+    #     Virtual machine identifier.
+    # @param port [String]
+    #     Virtual parallel port identifier.
+    # @param spec [Com::Vmware::Vcenter::VM::Hardware::Parallel::UpdateSpec]
+    #     Specification for updating the virtual parallel port.
+    # @return [Void]
+    # @raise [Com::Vmware::Vapi::Std::Errors::Error]
+    #     if the system reports an error while responding to the request.
+    # @raise [Com::Vmware::Vapi::Std::Errors::NotFound]
+    #     if the virtual machine or virtual parallel port is not found.
+    # @raise [Com::Vmware::Vapi::Std::Errors::NotAllowedInCurrentState]
+    #     if one or more of the  fields  specified in the  ``spec``   parameter  cannot be modified due to the current power state of the virtual machine or the connection state of the virtual parallel port.
+    # @raise [Com::Vmware::Vapi::Std::Errors::ResourceBusy]
+    #     if the virtual machine is busy performing another operation.
+    # @raise [Com::Vmware::Vapi::Std::Errors::ResourceInaccessible]
+    #     if the virtual machine's configuration state cannot be accessed.
+    # @raise [Com::Vmware::Vapi::Std::Errors::ServiceUnavailable]
+    #     if the system is unable to communicate with a service to complete the request.
+    # @raise [Com::Vmware::Vapi::Std::Errors::Unauthenticated]
+    #     if the user can not be authenticated.
+    # @raise [Com::Vmware::Vapi::Std::Errors::Unauthorized]
+    #     if the user doesn't have the required privileges.
+    def update(vm, port, spec)
+      invoke_with_info(UPDATE_INFO,
+                       'vm' => vm,
+                       'port' => port,
+                       'spec' => spec)
+    end
+
+    # Removes a virtual parallel port from the virtual machine.
+    #
+    # @param vm [String]
+    #     Virtual machine identifier.
+    # @param port [String]
+    #     Virtual parallel port identifier.
+    # @return [Void]
+    # @raise [Com::Vmware::Vapi::Std::Errors::Error]
+    #     if the system reports an error while responding to the request.
+    # @raise [Com::Vmware::Vapi::Std::Errors::NotFound]
+    #     if the virtual machine or virtual parallel port is not found.
+    # @raise [Com::Vmware::Vapi::Std::Errors::NotAllowedInCurrentState]
+    #     if the virtual machine is not powered off.
+    # @raise [Com::Vmware::Vapi::Std::Errors::ResourceBusy]
+    #     if the virtual machine is busy performing another operation.
+    # @raise [Com::Vmware::Vapi::Std::Errors::ResourceInaccessible]
+    #     if the virtual machine's configuration state cannot be accessed.
+    # @raise [Com::Vmware::Vapi::Std::Errors::ServiceUnavailable]
+    #     if the system is unable to communicate with a service to complete the request.
+    # @raise [Com::Vmware::Vapi::Std::Errors::Unauthenticated]
+    #     if the user can not be authenticated.
+    # @raise [Com::Vmware::Vapi::Std::Errors::Unauthorized]
+    #     if the user doesn't have the required privileges.
+    def delete(vm, port)
+      invoke_with_info(DELETE_INFO,
+                       'vm' => vm,
+                       'port' => port)
+    end
+
+    # Connects a virtual parallel port of a powered-on virtual machine to its backing. Connecting the virtual device makes the backing accessible from the perspective of the guest operating system.  
+    # 
+    #  For a powered-off virtual machine, the   :func:`Com::Vmware::Vcenter::VM::Hardware::Parallel.update`    method  may be used to configure the virtual parallel port to start in the connected state when the virtual machine is powered on.
+    #
+    # @param vm [String]
+    #     Virtual machine identifier.
+    # @param port [String]
+    #     Virtual parallel port identifier.
+    # @return [Void]
+    # @raise [Com::Vmware::Vapi::Std::Errors::Error]
+    #     if the system reports an error while responding to the request.
+    # @raise [Com::Vmware::Vapi::Std::Errors::NotFound]
+    #     if the virtual machine or virtual parallel port is not found.
+    # @raise [Com::Vmware::Vapi::Std::Errors::AlreadyInDesiredState]
+    #     if the virtual parallel port is already connected.
+    # @raise [Com::Vmware::Vapi::Std::Errors::NotAllowedInCurrentState]
+    #     if the virtual machine is not powered on.
+    # @raise [Com::Vmware::Vapi::Std::Errors::ResourceBusy]
+    #     if the virtual machine is busy performing another operation.
+    # @raise [Com::Vmware::Vapi::Std::Errors::ResourceInaccessible]
+    #     if the virtual machine's configuration state cannot be accessed.
+    # @raise [Com::Vmware::Vapi::Std::Errors::ServiceUnavailable]
+    #     if the system is unable to communicate with a service to complete the request.
+    # @raise [Com::Vmware::Vapi::Std::Errors::Unauthenticated]
+    #     if the user can not be authenticated.
+    # @raise [Com::Vmware::Vapi::Std::Errors::Unauthorized]
+    #     if the user doesn't have the required privileges.
+    def connect(vm, port)
+      invoke_with_info(CONNECT_INFO,
+                       'vm' => vm,
+                       'port' => port)
+    end
+
+    # Disconnects a virtual parallel port of a powered-on virtual machine from its backing. The virtual device is still present and its backing configuration is unchanged, but from the perspective of the guest operating system, the parallel port is not connected to its backing.  
+    # 
+    #  For a powered-off virtual machine, the   :func:`Com::Vmware::Vcenter::VM::Hardware::Parallel.update`    method  may be used to configure the virtual parallel port to start in the disconnected state when the virtual machine is powered on.
+    #
+    # @param vm [String]
+    #     Virtual machine identifier.
+    # @param port [String]
+    #     Virtual parallel port identifier.
+    # @return [Void]
+    # @raise [Com::Vmware::Vapi::Std::Errors::Error]
+    #     if the system reports an error while responding to the request.
+    # @raise [Com::Vmware::Vapi::Std::Errors::NotFound]
+    #     if the virtual machine or virtual parallel port is not found.
+    # @raise [Com::Vmware::Vapi::Std::Errors::AlreadyInDesiredState]
+    #     if the virtual parallel port is already disconnected.
+    # @raise [Com::Vmware::Vapi::Std::Errors::NotAllowedInCurrentState]
+    #     if the virtual machine is not powered on.
+    # @raise [Com::Vmware::Vapi::Std::Errors::ResourceBusy]
+    #     if the virtual machine is busy performing another operation.
+    # @raise [Com::Vmware::Vapi::Std::Errors::ResourceInaccessible]
+    #     if the virtual machine's configuration state cannot be accessed.
+    # @raise [Com::Vmware::Vapi::Std::Errors::ServiceUnavailable]
+    #     if the system is unable to communicate with a service to complete the request.
+    # @raise [Com::Vmware::Vapi::Std::Errors::Unauthenticated]
+    #     if the user can not be authenticated.
+    # @raise [Com::Vmware::Vapi::Std::Errors::Unauthorized]
+    #     if the user doesn't have the required privileges.
+    def disconnect(vm, port)
+      invoke_with_info(DISCONNECT_INFO,
+                       'vm' => vm,
+                       'port' => port)
+    end
+
+    # The  ``Com::Vmware::Vcenter::VM::Hardware::Parallel::BackingInfo``   class  contains information about the physical resource backing a virtual parallel port.
+    # @!attribute [rw] type
+    #     @return [Com::Vmware::Vcenter::VM::Hardware::Parallel::BackingType]
+    #     Backing type for the virtual parallel port.
+    # @!attribute [rw] file
+    #     @return [String]
+    #     Path of the file backing the virtual parallel port.
+    #     This  field  is optional and it is only relevant when the value of  ``type``  is   :attr:`Com::Vmware::Vcenter::VM::Hardware::Parallel::BackingType.FILE`  .
+    # @!attribute [rw] host_device
+    #     @return [String, nil]
+    #     Name of the device backing the virtual parallel port.  
+    #     This  field  will be  nil  if  ``autoDetect``  is true and the virtual parallel port is not connected or no suitable device is available on the host.
+    # @!attribute [rw] auto_detect
+    #     @return [Boolean]
+    #     Flag indicating whether the virtual parallel port is configured to automatically detect a suitable host device.
+    #     This  field  is optional and it is only relevant when the value of  ``type``  is   :attr:`Com::Vmware::Vcenter::VM::Hardware::Parallel::BackingType.HOST_DEVICE`  .
+    class BackingInfo < VAPI::Bindings::VapiStruct
+      class << self
+        # Holds (gets or creates) the binding type metadata for this structure type.
+        # @scope class
+        # @return [VAPI::Bindings::StructType] the binding type
+        def binding_type
+          @binding_type ||= VAPI::Bindings::StructType.new(
+            'com.vmware.vcenter.vm.hardware.parallel.backing_info',
+            {
+              'type' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::VM::Hardware::Parallel::BackingType'),
+              'file' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::StringType.instance),
+              'host_device' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::StringType.instance),
+              'auto_detect' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::BooleanType.instance)
+            },
+            BackingInfo,
+            false,
+            nil
+          )
+        end
+      end
+
+      attr_accessor :type,
+                    :file,
+                    :host_device,
+                    :auto_detect
+
+      # Constructs a new instance.
+      # @param ruby_values [Hash] a map of initial property values (optional)
+      # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
+      def initialize(ruby_values = nil, struct_value = nil)
+        super(self.class.binding_type, ruby_values, struct_value)
+      end
+    end
+
+    # The  ``Com::Vmware::Vcenter::VM::Hardware::Parallel::BackingSpec``   class  provides a specification of the physical resource backing a virtual parallel port.
+    # @!attribute [rw] type
+    #     @return [Com::Vmware::Vcenter::VM::Hardware::Parallel::BackingType]
+    #     Backing type for the virtual parallel port.
+    # @!attribute [rw] file
+    #     @return [String]
+    #     Path of the file that should be used as the virtual parallel port backing.
+    #     This  field  is optional and it is only relevant when the value of  ``type``  is   :attr:`Com::Vmware::Vcenter::VM::Hardware::Parallel::BackingType.FILE`  .
+    # @!attribute [rw] host_device
+    #     @return [String, nil]
+    #     Name of the device that should be used as the virtual parallel port backing.
+    #     If  nil , the virtual parallel port will be configured to automatically detect a suitable host device.
+    class BackingSpec < VAPI::Bindings::VapiStruct
+      class << self
+        # Holds (gets or creates) the binding type metadata for this structure type.
+        # @scope class
+        # @return [VAPI::Bindings::StructType] the binding type
+        def binding_type
+          @binding_type ||= VAPI::Bindings::StructType.new(
+            'com.vmware.vcenter.vm.hardware.parallel.backing_spec',
+            {
+              'type' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::VM::Hardware::Parallel::BackingType'),
+              'file' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::StringType.instance),
+              'host_device' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::StringType.instance)
+            },
+            BackingSpec,
+            false,
+            nil
+          )
+        end
+      end
+
+      attr_accessor :type,
+                    :file,
+                    :host_device
+
+      # Constructs a new instance.
+      # @param ruby_values [Hash] a map of initial property values (optional)
+      # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
+      def initialize(ruby_values = nil, struct_value = nil)
+        super(self.class.binding_type, ruby_values, struct_value)
+      end
+    end
+
+    # The  ``Com::Vmware::Vcenter::VM::Hardware::Parallel::Info``   class  contains information about a virtual parallel port.
+    # @!attribute [rw] label
+    #     @return [String]
+    #     Device label.
+    # @!attribute [rw] backing
+    #     @return [Com::Vmware::Vcenter::VM::Hardware::Parallel::BackingInfo]
+    #     Physical resource backing for the virtual parallel port.
+    class Info < VAPI::Bindings::VapiStruct
+      class << self
+        # Holds (gets or creates) the binding type metadata for this structure type.
+        # @scope class
+        # @return [VAPI::Bindings::StructType] the binding type
+        def binding_type
+          @binding_type ||= VAPI::Bindings::StructType.new(
+            'com.vmware.vcenter.vm.hardware.parallel.info',
+            {
+              'label' => VAPI::Bindings::StringType.instance,
+              'backing' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::VM::Hardware::Parallel::BackingInfo'),
+              'state' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::VM::Hardware::ConnectionState'),
+              'start_connected' => VAPI::Bindings::BooleanType.instance,
+              'allow_guest_control' => VAPI::Bindings::BooleanType.instance
+            },
+            Info,
+            false,
+            nil
+          )
+        end
+      end
+
+      attr_accessor :label,
+                    :backing,
+                    :state,
+                    :start_connected,
+                    :allow_guest_control
+
+      # Constructs a new instance.
+      # @param ruby_values [Hash] a map of initial property values (optional)
+      # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
+      def initialize(ruby_values = nil, struct_value = nil)
+        super(self.class.binding_type, ruby_values, struct_value)
+      end
+    end
+
+    # The  ``Com::Vmware::Vcenter::VM::Hardware::Parallel::CreateSpec``   class  provides a specification for the configuration of a newly-created virtual parallel port.
+    # @!attribute [rw] backing
+    #     @return [Com::Vmware::Vcenter::VM::Hardware::Parallel::BackingSpec, nil]
+    #     Physical resource backing for the virtual parallel port.
+    #     If  nil , defaults to automatic detection of a suitable host device.
+    class CreateSpec < VAPI::Bindings::VapiStruct
+      class << self
+        # Holds (gets or creates) the binding type metadata for this structure type.
+        # @scope class
+        # @return [VAPI::Bindings::StructType] the binding type
+        def binding_type
+          @binding_type ||= VAPI::Bindings::StructType.new(
+            'com.vmware.vcenter.vm.hardware.parallel.create_spec',
+            {
+              'backing' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::VM::Hardware::Parallel::BackingSpec')),
+              'start_connected' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::BooleanType.instance),
+              'allow_guest_control' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::BooleanType.instance)
+            },
+            CreateSpec,
+            false,
+            nil
+          )
+        end
+      end
+
+      attr_accessor :backing,
+                    :start_connected,
+                    :allow_guest_control
+
+      # Constructs a new instance.
+      # @param ruby_values [Hash] a map of initial property values (optional)
+      # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
+      def initialize(ruby_values = nil, struct_value = nil)
+        super(self.class.binding_type, ruby_values, struct_value)
+      end
+    end
+
+    # The  ``Com::Vmware::Vcenter::VM::Hardware::Parallel::UpdateSpec``   class  describes the updates to be made to the configuration of a virtual parallel port.
+    # @!attribute [rw] backing
+    #     @return [Com::Vmware::Vcenter::VM::Hardware::Parallel::BackingSpec, nil]
+    #     Physical resource backing for the virtual parallel port.  
+    #     
+    #      This  field  may only be modified if the virtual machine is not powered on or the virtual parallel port is not connected.
+    #     If  nil , the value is unchanged.
+    class UpdateSpec < VAPI::Bindings::VapiStruct
+      class << self
+        # Holds (gets or creates) the binding type metadata for this structure type.
+        # @scope class
+        # @return [VAPI::Bindings::StructType] the binding type
+        def binding_type
+          @binding_type ||= VAPI::Bindings::StructType.new(
+            'com.vmware.vcenter.vm.hardware.parallel.update_spec',
+            {
+              'backing' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::VM::Hardware::Parallel::BackingSpec')),
+              'start_connected' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::BooleanType.instance),
+              'allow_guest_control' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::BooleanType.instance)
+            },
+            UpdateSpec,
+            false,
+            nil
+          )
+        end
+      end
+
+      attr_accessor :backing,
+                    :start_connected,
+                    :allow_guest_control
+
+      # Constructs a new instance.
+      # @param ruby_values [Hash] a map of initial property values (optional)
+      # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
+      def initialize(ruby_values = nil, struct_value = nil)
+        super(self.class.binding_type, ruby_values, struct_value)
+      end
+    end
+
+    # The  ``Com::Vmware::Vcenter::VM::Hardware::Parallel::Summary``   class  contains commonly used information about a virtual parallel port.
+    # @!attribute [rw] port
+    #     @return [String]
+    #     Identifier of the virtual parallel port.
+    class Summary < VAPI::Bindings::VapiStruct
+      class << self
+        # Holds (gets or creates) the binding type metadata for this structure type.
+        # @scope class
+        # @return [VAPI::Bindings::StructType] the binding type
+        def binding_type
+          @binding_type ||= VAPI::Bindings::StructType.new(
+            'com.vmware.vcenter.vm.hardware.parallel.summary',
+            {
+              'port' => VAPI::Bindings::IdType.new('com.vmware.vcenter.vm.hardware.ParallelPort')
+            },
+            Summary,
+            false,
+            nil
+          )
+        end
+      end
+
+      attr_accessor :port
+
+      # Constructs a new instance.
+      # @param ruby_values [Hash] a map of initial property values (optional)
+      # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
+      def initialize(ruby_values = nil, struct_value = nil)
+        super(self.class.binding_type, ruby_values, struct_value)
+      end
+    end
+
+    # The  ``Com::Vmware::Vcenter::VM::Hardware::Parallel::BackingType``   enumerated type  defines the valid backing types for a virtual parallel port.
+    # @!attribute [rw] file
+    #     @return [Com::Vmware::Vcenter::VM::Hardware::Parallel::BackingType]
+    #     Virtual parallel port is backed by a file.
+    # @!attribute [rw] host_device
+    #     @return [Com::Vmware::Vcenter::VM::Hardware::Parallel::BackingType]
+    #     Virtual parallel port is backed by a device on the host where the virtual machine is running.
+    class BackingType < VAPI::Bindings::VapiEnum
+      class << self
+        # Holds (gets or creates) the binding type metadata for this enumeration type.
+        # @scope class
+        # @return [VAPI::Bindings::EnumType] the binding type
+        def binding_type
+          @binding_type ||= VAPI::Bindings::EnumType.new(
+            'com.vmware.vcenter.vm.hardware.parallel.backing_type',
+            BackingType
+          )
+        end
+
+        # Converts from a string value (perhaps off the wire) to an instance
+        # of this enum type.
+        # @param value [String] the actual value of the enum instance
+        # @return [BackingType] the instance found for the value, otherwise
+        #         an unknown instance will be built for the value
+        def from_string(value)
+          const_get(value)
+        rescue NameError
+          BackingType.send(:new, 'UNKNOWN', value)
+        end
+      end
+
+      # Constructs a new instance.
+      # @param value [String] the actual value of the enum instance
+      # @param unknown [String] the unknown value when value is 'UKNOWN'
+      def initialize(value, unknown = nil)
+        super(self.class.binding_type, value, unknown)
+      end
+
+      private_class_method :new
+
+      # @!attribute [rw] file
+      #     @return [Com::Vmware::Vcenter::VM::Hardware::Parallel::BackingType]
+      #     Virtual parallel port is backed by a file.
+      FILE = BackingType.send(:new, 'FILE')
+
+      # @!attribute [rw] host_device
+      #     @return [Com::Vmware::Vcenter::VM::Hardware::Parallel::BackingType]
+      #     Virtual parallel port is backed by a device on the host where the virtual machine is running.
+      HOST_DEVICE = BackingType.send(:new, 'HOST_DEVICE')
+    end
+  end
+  # The  ``Com::Vmware::Vcenter::VM::Hardware::Serial``   class  provides  methods  for configuring the virtual serial ports of a virtual machine.
+  class Serial < VAPI::Bindings::VapiService
+    # static metamodel definitions
+    SERVICE_ID = VAPI::Core::ServiceIdentifier.new('com.vmware.vcenter.vm.hardware.serial')
+
+    LIST_INFO = VAPI::Bindings::OperationInfo.new(
+      VAPI::Core::OperationIdentifier.new('list', SERVICE_ID),
+      VAPI::Bindings::OperationInputType.new(
+        'vm' => VAPI::Bindings::IdType.new('VirtualMachine')
+      ),
+      VAPI::Bindings::ListType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::VM::Hardware::Serial::Summary')),
+      {
+        'com.vmware.vapi.std.errors.error' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Error'),
+        'com.vmware.vapi.std.errors.not_found' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::NotFound'),
+        'com.vmware.vapi.std.errors.resource_inaccessible' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::ResourceInaccessible'),
+        'com.vmware.vapi.std.errors.service_unavailable' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::ServiceUnavailable'),
+        'com.vmware.vapi.std.errors.unauthenticated' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Unauthenticated'),
+        'com.vmware.vapi.std.errors.unauthorized' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Unauthorized')
+      },
+      [],
+      []
+    )
+
+    GET_INFO = VAPI::Bindings::OperationInfo.new(
+      VAPI::Core::OperationIdentifier.new('get', SERVICE_ID),
+      VAPI::Bindings::OperationInputType.new(
+        'vm' => VAPI::Bindings::IdType.new('VirtualMachine'),
+        'port' => VAPI::Bindings::IdType.new('com.vmware.vcenter.vm.hardware.SerialPort')
+      ),
+      VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::VM::Hardware::Serial::Info'),
+      {
+        'com.vmware.vapi.std.errors.error' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Error'),
+        'com.vmware.vapi.std.errors.not_found' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::NotFound'),
+        'com.vmware.vapi.std.errors.resource_inaccessible' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::ResourceInaccessible'),
+        'com.vmware.vapi.std.errors.service_unavailable' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::ServiceUnavailable'),
+        'com.vmware.vapi.std.errors.unauthenticated' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Unauthenticated'),
+        'com.vmware.vapi.std.errors.unauthorized' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Unauthorized')
+      },
+      [],
+      []
+    )
+
+    CREATE_INFO = VAPI::Bindings::OperationInfo.new(
+      VAPI::Core::OperationIdentifier.new('create', SERVICE_ID),
+      VAPI::Bindings::OperationInputType.new(
+        'vm' => VAPI::Bindings::IdType.new('VirtualMachine'),
+        'spec' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::VM::Hardware::Serial::CreateSpec')
+      ),
+      VAPI::Bindings::IdType.new('com.vmware.vcenter.vm.hardware.SerialPort'),
+      {
+        'com.vmware.vapi.std.errors.error' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Error'),
+        'com.vmware.vapi.std.errors.not_found' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::NotFound'),
+        'com.vmware.vapi.std.errors.not_allowed_in_current_state' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::NotAllowedInCurrentState'),
+        'com.vmware.vapi.std.errors.unable_to_allocate_resource' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::UnableToAllocateResource'),
+        'com.vmware.vapi.std.errors.resource_busy' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::ResourceBusy'),
+        'com.vmware.vapi.std.errors.resource_inaccessible' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::ResourceInaccessible'),
+        'com.vmware.vapi.std.errors.service_unavailable' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::ServiceUnavailable'),
+        'com.vmware.vapi.std.errors.unauthenticated' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Unauthenticated'),
+        'com.vmware.vapi.std.errors.unauthorized' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Unauthorized')
+      },
+      [],
+      []
+    )
+
+    UPDATE_INFO = VAPI::Bindings::OperationInfo.new(
+      VAPI::Core::OperationIdentifier.new('update', SERVICE_ID),
+      VAPI::Bindings::OperationInputType.new(
+        'vm' => VAPI::Bindings::IdType.new('VirtualMachine'),
+        'port' => VAPI::Bindings::IdType.new('com.vmware.vcenter.vm.hardware.SerialPort'),
+        'spec' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::VM::Hardware::Serial::UpdateSpec')
+      ),
+      VAPI::Bindings::VoidType.instance,
+      {
+        'com.vmware.vapi.std.errors.error' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Error'),
+        'com.vmware.vapi.std.errors.not_found' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::NotFound'),
+        'com.vmware.vapi.std.errors.not_allowed_in_current_state' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::NotAllowedInCurrentState'),
+        'com.vmware.vapi.std.errors.resource_busy' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::ResourceBusy'),
+        'com.vmware.vapi.std.errors.resource_inaccessible' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::ResourceInaccessible'),
+        'com.vmware.vapi.std.errors.service_unavailable' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::ServiceUnavailable'),
+        'com.vmware.vapi.std.errors.unauthenticated' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Unauthenticated'),
+        'com.vmware.vapi.std.errors.unauthorized' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Unauthorized')
+      },
+      [],
+      []
+    )
+
+    DELETE_INFO = VAPI::Bindings::OperationInfo.new(
+      VAPI::Core::OperationIdentifier.new('delete', SERVICE_ID),
+      VAPI::Bindings::OperationInputType.new(
+        'vm' => VAPI::Bindings::IdType.new('VirtualMachine'),
+        'port' => VAPI::Bindings::IdType.new('com.vmware.vcenter.vm.hardware.SerialPort')
+      ),
+      VAPI::Bindings::VoidType.instance,
+      {
+        'com.vmware.vapi.std.errors.error' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Error'),
+        'com.vmware.vapi.std.errors.not_found' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::NotFound'),
+        'com.vmware.vapi.std.errors.not_allowed_in_current_state' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::NotAllowedInCurrentState'),
+        'com.vmware.vapi.std.errors.resource_busy' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::ResourceBusy'),
+        'com.vmware.vapi.std.errors.resource_inaccessible' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::ResourceInaccessible'),
+        'com.vmware.vapi.std.errors.service_unavailable' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::ServiceUnavailable'),
+        'com.vmware.vapi.std.errors.unauthenticated' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Unauthenticated'),
+        'com.vmware.vapi.std.errors.unauthorized' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Unauthorized')
+      },
+      [],
+      []
+    )
+
+    CONNECT_INFO = VAPI::Bindings::OperationInfo.new(
+      VAPI::Core::OperationIdentifier.new('connect', SERVICE_ID),
+      VAPI::Bindings::OperationInputType.new(
+        'vm' => VAPI::Bindings::IdType.new('VirtualMachine'),
+        'port' => VAPI::Bindings::IdType.new('com.vmware.vcenter.vm.hardware.SerialPort')
+      ),
+      VAPI::Bindings::VoidType.instance,
+      {
+        'com.vmware.vapi.std.errors.error' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Error'),
+        'com.vmware.vapi.std.errors.not_found' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::NotFound'),
+        'com.vmware.vapi.std.errors.already_in_desired_state' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::AlreadyInDesiredState'),
+        'com.vmware.vapi.std.errors.not_allowed_in_current_state' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::NotAllowedInCurrentState'),
+        'com.vmware.vapi.std.errors.resource_busy' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::ResourceBusy'),
+        'com.vmware.vapi.std.errors.resource_inaccessible' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::ResourceInaccessible'),
+        'com.vmware.vapi.std.errors.service_unavailable' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::ServiceUnavailable'),
+        'com.vmware.vapi.std.errors.unauthenticated' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Unauthenticated'),
+        'com.vmware.vapi.std.errors.unauthorized' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Unauthorized')
+      },
+      [],
+      []
+    )
+
+    DISCONNECT_INFO = VAPI::Bindings::OperationInfo.new(
+      VAPI::Core::OperationIdentifier.new('disconnect', SERVICE_ID),
+      VAPI::Bindings::OperationInputType.new(
+        'vm' => VAPI::Bindings::IdType.new('VirtualMachine'),
+        'port' => VAPI::Bindings::IdType.new('com.vmware.vcenter.vm.hardware.SerialPort')
+      ),
+      VAPI::Bindings::VoidType.instance,
+      {
+        'com.vmware.vapi.std.errors.error' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Error'),
+        'com.vmware.vapi.std.errors.not_found' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::NotFound'),
+        'com.vmware.vapi.std.errors.already_in_desired_state' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::AlreadyInDesiredState'),
+        'com.vmware.vapi.std.errors.not_allowed_in_current_state' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::NotAllowedInCurrentState'),
+        'com.vmware.vapi.std.errors.resource_busy' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::ResourceBusy'),
+        'com.vmware.vapi.std.errors.resource_inaccessible' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::ResourceInaccessible'),
+        'com.vmware.vapi.std.errors.service_unavailable' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::ServiceUnavailable'),
+        'com.vmware.vapi.std.errors.unauthenticated' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Unauthenticated'),
+        'com.vmware.vapi.std.errors.unauthorized' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Unauthorized')
+      },
+      [],
+      []
+    )
+
+    SERVICE_INFO = VAPI::Bindings::ServiceInfo.new(
+      SERVICE_ID,
+      'list' => LIST_INFO,
+      'get' => GET_INFO,
+      'create' => CREATE_INFO,
+      'update' => UPDATE_INFO,
+      'delete' => DELETE_INFO,
+      'connect' => CONNECT_INFO,
+      'disconnect' => DISCONNECT_INFO
+    )
+
+    # Constructs a new instance.
+    #
+    # @param config [VAPI::Bindings::StubConfig] A hash with the api provider details.
+    def initialize(config)
+      super(config, SERVICE_INFO)
+    end
+
+    RESOURCE_TYPE = 'com.vmware.vcenter.vm.hardware.SerialPort'
+    # Returns commonly used information about the virtual serial ports belonging to the virtual machine.
+    #
+    # @param vm [String]
+    #     Virtual machine identifier.
+    # @return [Array<Com::Vmware::Vcenter::VM::Hardware::Serial::Summary>]
+    #     List of commonly used information about virtual serial ports.
+    # @raise [Com::Vmware::Vapi::Std::Errors::Error]
+    #     if the system reports an error while responding to the request.
+    # @raise [Com::Vmware::Vapi::Std::Errors::NotFound]
+    #     if the virtual machine is not found.
+    # @raise [Com::Vmware::Vapi::Std::Errors::ResourceInaccessible]
+    #     if the virtual machine's configuration state cannot be accessed.
+    # @raise [Com::Vmware::Vapi::Std::Errors::ServiceUnavailable]
+    #     if the system is unable to communicate with a service to complete the request.
+    # @raise [Com::Vmware::Vapi::Std::Errors::Unauthenticated]
+    #     if the user can not be authenticated.
+    # @raise [Com::Vmware::Vapi::Std::Errors::Unauthorized]
+    #     if the user doesn't have the required privileges.
+    def list(vm)
+      invoke_with_info(LIST_INFO,
+                       'vm' => vm)
+    end
+
+    # Returns information about a virtual serial port.
+    #
+    # @param vm [String]
+    #     Virtual machine identifier.
+    # @param port [String]
+    #     Virtual serial port identifier.
+    # @return [Com::Vmware::Vcenter::VM::Hardware::Serial::Info]
+    #     Information about the specified virtual serial port.
+    # @raise [Com::Vmware::Vapi::Std::Errors::Error]
+    #     if the system reports an error while responding to the request.
+    # @raise [Com::Vmware::Vapi::Std::Errors::NotFound]
+    #     if the virtual machine or virtual serial port is not found.
+    # @raise [Com::Vmware::Vapi::Std::Errors::ResourceInaccessible]
+    #     if the virtual machine's configuration state cannot be accessed.
+    # @raise [Com::Vmware::Vapi::Std::Errors::ServiceUnavailable]
+    #     if the system is unable to communicate with a service to complete the request.
+    # @raise [Com::Vmware::Vapi::Std::Errors::Unauthenticated]
+    #     if the user can not be authenticated.
+    # @raise [Com::Vmware::Vapi::Std::Errors::Unauthorized]
+    #     if the user doesn't have the required privileges.
+    def get(vm, port)
+      invoke_with_info(GET_INFO,
+                       'vm' => vm,
+                       'port' => port)
+    end
+
+    # Adds a virtual serial port to the virtual machine.
+    #
+    # @param vm [String]
+    #     Virtual machine identifier.
+    # @param spec [Com::Vmware::Vcenter::VM::Hardware::Serial::CreateSpec]
+    #     Specification for the new virtual serial port.
+    # @return [String]
+    #     Virtual serial port identifier.
+    # @raise [Com::Vmware::Vapi::Std::Errors::Error]
+    #     if the system reported that the serial port device was created but was unable to confirm the creation because the identifier of the new device could not be determined.
+    # @raise [Com::Vmware::Vapi::Std::Errors::Error]
+    #     if the system reports an error while responding to the request.
+    # @raise [Com::Vmware::Vapi::Std::Errors::NotFound]
+    #     if the virtual machine is not found.
+    # @raise [Com::Vmware::Vapi::Std::Errors::NotAllowedInCurrentState]
+    #     if the virtual machine is not powered off.
+    # @raise [Com::Vmware::Vapi::Std::Errors::UnableToAllocateResource]
+    #     if the virtual machine already has the maximum number of supported serial ports.
+    # @raise [Com::Vmware::Vapi::Std::Errors::ResourceBusy]
+    #     if the virtual machine is busy performing another operation.
+    # @raise [Com::Vmware::Vapi::Std::Errors::ResourceInaccessible]
+    #     if the virtual machine's configuration state cannot be accessed.
+    # @raise [Com::Vmware::Vapi::Std::Errors::ServiceUnavailable]
+    #     if the system is unable to communicate with a service to complete the request.
+    # @raise [Com::Vmware::Vapi::Std::Errors::Unauthenticated]
+    #     if the user can not be authenticated.
+    # @raise [Com::Vmware::Vapi::Std::Errors::Unauthorized]
+    #     if the user doesn't have the required privileges.
+    def create(vm, spec)
+      invoke_with_info(CREATE_INFO,
+                       'vm' => vm,
+                       'spec' => spec)
+    end
+
+    # Updates the configuration of a virtual serial port.
+    #
+    # @param vm [String]
+    #     Virtual machine identifier.
+    # @param port [String]
+    #     Virtual serial port identifier.
+    # @param spec [Com::Vmware::Vcenter::VM::Hardware::Serial::UpdateSpec]
+    #     Specification for updating the virtual serial port.
+    # @return [Void]
+    # @raise [Com::Vmware::Vapi::Std::Errors::Error]
+    #     if the system reports an error while responding to the request.
+    # @raise [Com::Vmware::Vapi::Std::Errors::NotFound]
+    #     if the virtual machine or virtual serial port is not found.
+    # @raise [Com::Vmware::Vapi::Std::Errors::NotAllowedInCurrentState]
+    #     if one or more of the  fields  specified in the  ``spec``   parameter  cannot be modified due to the current power state of the virtual machine or the connection state of the virtual serial port.
+    # @raise [Com::Vmware::Vapi::Std::Errors::ResourceBusy]
+    #     if the virtual machine is busy performing another operation.
+    # @raise [Com::Vmware::Vapi::Std::Errors::ResourceInaccessible]
+    #     if the virtual machine's configuration state cannot be accessed.
+    # @raise [Com::Vmware::Vapi::Std::Errors::ServiceUnavailable]
+    #     if the system is unable to communicate with a service to complete the request.
+    # @raise [Com::Vmware::Vapi::Std::Errors::Unauthenticated]
+    #     if the user can not be authenticated.
+    # @raise [Com::Vmware::Vapi::Std::Errors::Unauthorized]
+    #     if the user doesn't have the required privileges.
+    def update(vm, port, spec)
+      invoke_with_info(UPDATE_INFO,
+                       'vm' => vm,
+                       'port' => port,
+                       'spec' => spec)
+    end
+
+    # Removes a virtual serial port from the virtual machine.
+    #
+    # @param vm [String]
+    #     Virtual machine identifier.
+    # @param port [String]
+    #     Virtual serial port identifier.
+    # @return [Void]
+    # @raise [Com::Vmware::Vapi::Std::Errors::Error]
+    #     if the system reports an error while responding to the request.
+    # @raise [Com::Vmware::Vapi::Std::Errors::NotFound]
+    #     if the virtual machine or virtual serial port is not found.
+    # @raise [Com::Vmware::Vapi::Std::Errors::NotAllowedInCurrentState]
+    #     if the virtual machine is not powered off.
+    # @raise [Com::Vmware::Vapi::Std::Errors::ResourceBusy]
+    #     if the virtual machine is busy performing another operation.
+    # @raise [Com::Vmware::Vapi::Std::Errors::ResourceInaccessible]
+    #     if the virtual machine's configuration state cannot be accessed.
+    # @raise [Com::Vmware::Vapi::Std::Errors::ServiceUnavailable]
+    #     if the system is unable to communicate with a service to complete the request.
+    # @raise [Com::Vmware::Vapi::Std::Errors::Unauthenticated]
+    #     if the user can not be authenticated.
+    # @raise [Com::Vmware::Vapi::Std::Errors::Unauthorized]
+    #     if the user doesn't have the required privileges.
+    def delete(vm, port)
+      invoke_with_info(DELETE_INFO,
+                       'vm' => vm,
+                       'port' => port)
+    end
+
+    # Connects a virtual serial port of a powered-on virtual machine to its backing. Connecting the virtual device makes the backing accessible from the perspective of the guest operating system.  
+    # 
+    #  For a powered-off virtual machine, the   :func:`Com::Vmware::Vcenter::VM::Hardware::Serial.update`    method  may be used to configure the virtual serial port to start in the connected state when the virtual machine is powered on.
+    #
+    # @param vm [String]
+    #     Virtual machine identifier.
+    # @param port [String]
+    #     Virtual serial port identifier.
+    # @return [Void]
+    # @raise [Com::Vmware::Vapi::Std::Errors::Error]
+    #     if the system reports an error while responding to the request.
+    # @raise [Com::Vmware::Vapi::Std::Errors::NotFound]
+    #     if the virtual machine or virtual serial port is not found.
+    # @raise [Com::Vmware::Vapi::Std::Errors::AlreadyInDesiredState]
+    #     if the virtual serial port is already connected.
+    # @raise [Com::Vmware::Vapi::Std::Errors::NotAllowedInCurrentState]
+    #     if the virtual machine is not powered on.
+    # @raise [Com::Vmware::Vapi::Std::Errors::ResourceBusy]
+    #     if the virtual machine is busy performing another operation.
+    # @raise [Com::Vmware::Vapi::Std::Errors::ResourceInaccessible]
+    #     if the virtual machine's configuration state cannot be accessed.
+    # @raise [Com::Vmware::Vapi::Std::Errors::ServiceUnavailable]
+    #     if the system is unable to communicate with a service to complete the request.
+    # @raise [Com::Vmware::Vapi::Std::Errors::Unauthenticated]
+    #     if the user can not be authenticated.
+    # @raise [Com::Vmware::Vapi::Std::Errors::Unauthorized]
+    #     if the user doesn't have the required privileges.
+    def connect(vm, port)
+      invoke_with_info(CONNECT_INFO,
+                       'vm' => vm,
+                       'port' => port)
+    end
+
+    # Disconnects a virtual serial port of a powered-on virtual machine from its backing. The virtual device is still present and its backing configuration is unchanged, but from the perspective of the guest operating system, the serial port is not connected to its backing.  
+    # 
+    #  For a powered-off virtual machine, the   :func:`Com::Vmware::Vcenter::VM::Hardware::Serial.update`    method  may be used to configure the virtual serial port to start in the disconnected state when the virtual machine is powered on.
+    #
+    # @param vm [String]
+    #     Virtual machine identifier.
+    # @param port [String]
+    #     Virtual serial port identifier.
+    # @return [Void]
+    # @raise [Com::Vmware::Vapi::Std::Errors::Error]
+    #     if the system reports an error while responding to the request.
+    # @raise [Com::Vmware::Vapi::Std::Errors::NotFound]
+    #     if the virtual machine or virtual serial port is not found.
+    # @raise [Com::Vmware::Vapi::Std::Errors::AlreadyInDesiredState]
+    #     if the virtual serial port is already disconnected.
+    # @raise [Com::Vmware::Vapi::Std::Errors::NotAllowedInCurrentState]
+    #     if the virtual machine is not powered on.
+    # @raise [Com::Vmware::Vapi::Std::Errors::ResourceBusy]
+    #     if the virtual machine is busy performing another operation.
+    # @raise [Com::Vmware::Vapi::Std::Errors::ResourceInaccessible]
+    #     if the virtual machine's configuration state cannot be accessed.
+    # @raise [Com::Vmware::Vapi::Std::Errors::ServiceUnavailable]
+    #     if the system is unable to communicate with a service to complete the request.
+    # @raise [Com::Vmware::Vapi::Std::Errors::Unauthenticated]
+    #     if the user can not be authenticated.
+    # @raise [Com::Vmware::Vapi::Std::Errors::Unauthorized]
+    #     if the user doesn't have the required privileges.
+    def disconnect(vm, port)
+      invoke_with_info(DISCONNECT_INFO,
+                       'vm' => vm,
+                       'port' => port)
+    end
+
+    # The  ``Com::Vmware::Vcenter::VM::Hardware::Serial::BackingInfo``   class  contains information about the physical resource backing a virtual serial port.
+    # @!attribute [rw] type
+    #     @return [Com::Vmware::Vcenter::VM::Hardware::Serial::BackingType]
+    #     Backing type for the virtual serial port.
+    # @!attribute [rw] file
+    #     @return [String]
+    #     Path of the file backing the virtual serial port.
+    #     This  field  is optional and it is only relevant when the value of  ``type``  is   :attr:`Com::Vmware::Vcenter::VM::Hardware::Serial::BackingType.FILE`  .
+    # @!attribute [rw] host_device
+    #     @return [String, nil]
+    #     Name of the device backing the virtual serial port.  
+    #     This  field  will be  nil  if  ``autoDetect``  is true and the virtual serial port is not connected or no suitable device is available on the host.
+    # @!attribute [rw] auto_detect
+    #     @return [Boolean]
+    #     Flag indicating whether the virtual serial port is configured to automatically detect a suitable host device.
+    #     This  field  is optional and it is only relevant when the value of  ``type``  is   :attr:`Com::Vmware::Vcenter::VM::Hardware::Serial::BackingType.HOST_DEVICE`  .
+    # @!attribute [rw] pipe
+    #     @return [String]
+    #     Name of the pipe backing the virtual serial port.
+    #     This  field  is optional and it is only relevant when the value of  ``type``  is one of   :attr:`Com::Vmware::Vcenter::VM::Hardware::Serial::BackingType.PIPE_SERVER`   or   :attr:`Com::Vmware::Vcenter::VM::Hardware::Serial::BackingType.PIPE_CLIENT`  .
+    # @!attribute [rw] no_rx_loss
+    #     @return [Boolean]
+    #     Flag that enables optimized data transfer over the pipe. When the value is true, the host buffers data to prevent data overrun. This allows the virtual machine to read all of the data transferred over the pipe with no data loss.
+    #     This  field  is optional and it is only relevant when the value of  ``type``  is one of   :attr:`Com::Vmware::Vcenter::VM::Hardware::Serial::BackingType.PIPE_SERVER`   or   :attr:`Com::Vmware::Vcenter::VM::Hardware::Serial::BackingType.PIPE_CLIENT`  .
+    # @!attribute [rw] network_location
+    #     @return [URI]
+    #     URI specifying the location of the network service backing the virtual serial port.  
+    #     
+    #       * If   :attr:`Com::Vmware::Vcenter::VM::Hardware::Serial::BackingInfo.type`   is   :attr:`Com::Vmware::Vcenter::VM::Hardware::Serial::BackingType.NETWORK_SERVER`  , this  field  is the location used by clients to connect to this server. The hostname part of the URI should either be empty or should specify the address of the host on which the virtual machine is running.
+    #        * If   :attr:`Com::Vmware::Vcenter::VM::Hardware::Serial::BackingInfo.type`   is   :attr:`Com::Vmware::Vcenter::VM::Hardware::Serial::BackingType.NETWORK_CLIENT`  , this  field  is the location used by the virtual machine to connect to the remote server.
+    #       
+    #     This  field  is optional and it is only relevant when the value of  ``type``  is one of   :attr:`Com::Vmware::Vcenter::VM::Hardware::Serial::BackingType.NETWORK_SERVER`   or   :attr:`Com::Vmware::Vcenter::VM::Hardware::Serial::BackingType.NETWORK_CLIENT`  .
+    # @!attribute [rw] proxy
+    #     @return [URI, nil]
+    #     Proxy service that provides network access to the network backing. If set, the virtual machine initiates a connection with the proxy service and forwards the traffic to the proxy.
+    #     If  nil , no proxy service is configured.
+    class BackingInfo < VAPI::Bindings::VapiStruct
+      class << self
+        # Holds (gets or creates) the binding type metadata for this structure type.
+        # @scope class
+        # @return [VAPI::Bindings::StructType] the binding type
+        def binding_type
+          @binding_type ||= VAPI::Bindings::StructType.new(
+            'com.vmware.vcenter.vm.hardware.serial.backing_info',
+            {
+              'type' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::VM::Hardware::Serial::BackingType'),
+              'file' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::StringType.instance),
+              'host_device' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::StringType.instance),
+              'auto_detect' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::BooleanType.instance),
+              'pipe' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::StringType.instance),
+              'no_rx_loss' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::BooleanType.instance),
+              'network_location' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::URIType.instance),
+              'proxy' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::URIType.instance)
+            },
+            BackingInfo,
+            false,
+            nil
+          )
+        end
+      end
+
+      attr_accessor :type,
+                    :file,
+                    :host_device,
+                    :auto_detect,
+                    :pipe,
+                    :no_rx_loss,
+                    :network_location,
+                    :proxy
+
+      # Constructs a new instance.
+      # @param ruby_values [Hash] a map of initial property values (optional)
+      # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
+      def initialize(ruby_values = nil, struct_value = nil)
+        super(self.class.binding_type, ruby_values, struct_value)
+      end
+    end
+
+    # The  ``Com::Vmware::Vcenter::VM::Hardware::Serial::BackingSpec``   class  provides a specification of the physical resource backing a virtual serial port.
+    # @!attribute [rw] type
+    #     @return [Com::Vmware::Vcenter::VM::Hardware::Serial::BackingType]
+    #     Backing type for the virtual serial port.
+    # @!attribute [rw] file
+    #     @return [String]
+    #     Path of the file backing the virtual serial port.
+    #     This  field  is optional and it is only relevant when the value of  ``type``  is   :attr:`Com::Vmware::Vcenter::VM::Hardware::Serial::BackingType.FILE`  .
+    # @!attribute [rw] host_device
+    #     @return [String, nil]
+    #     Name of the device backing the virtual serial port.  
+    #     If  nil , the virtual serial port will be configured to automatically detect a suitable host device.
+    # @!attribute [rw] pipe
+    #     @return [String]
+    #     Name of the pipe backing the virtual serial port.
+    #     This  field  is optional and it is only relevant when the value of  ``type``  is one of   :attr:`Com::Vmware::Vcenter::VM::Hardware::Serial::BackingType.PIPE_SERVER`   or   :attr:`Com::Vmware::Vcenter::VM::Hardware::Serial::BackingType.PIPE_CLIENT`  .
+    # @!attribute [rw] no_rx_loss
+    #     @return [Boolean, nil]
+    #     Flag that enables optimized data transfer over the pipe. When the value is true, the host buffers data to prevent data overrun. This allows the virtual machine to read all of the data transferred over the pipe with no data loss.
+    #     If  nil , defaults to  false .
+    # @!attribute [rw] network_location
+    #     @return [URI]
+    #     URI specifying the location of the network service backing the virtual serial port.  
+    #     
+    #       * If   :attr:`Com::Vmware::Vcenter::VM::Hardware::Serial::BackingSpec.type`   is   :attr:`Com::Vmware::Vcenter::VM::Hardware::Serial::BackingType.NETWORK_SERVER`  , this  field  is the location used by clients to connect to this server. The hostname part of the URI should either be empty or should specify the address of the host on which the virtual machine is running.
+    #        * If   :attr:`Com::Vmware::Vcenter::VM::Hardware::Serial::BackingSpec.type`   is   :attr:`Com::Vmware::Vcenter::VM::Hardware::Serial::BackingType.NETWORK_CLIENT`  , this  field  is the location used by the virtual machine to connect to the remote server.
+    #       
+    #     This  field  is optional and it is only relevant when the value of  ``type``  is one of   :attr:`Com::Vmware::Vcenter::VM::Hardware::Serial::BackingType.NETWORK_SERVER`   or   :attr:`Com::Vmware::Vcenter::VM::Hardware::Serial::BackingType.NETWORK_CLIENT`  .
+    # @!attribute [rw] proxy
+    #     @return [URI, nil]
+    #     Proxy service that provides network access to the network backing. If set, the virtual machine initiates a connection with the proxy service and forwards the traffic to the proxy.
+    #     If  nil , no proxy service should be used.
+    class BackingSpec < VAPI::Bindings::VapiStruct
+      class << self
+        # Holds (gets or creates) the binding type metadata for this structure type.
+        # @scope class
+        # @return [VAPI::Bindings::StructType] the binding type
+        def binding_type
+          @binding_type ||= VAPI::Bindings::StructType.new(
+            'com.vmware.vcenter.vm.hardware.serial.backing_spec',
+            {
+              'type' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::VM::Hardware::Serial::BackingType'),
+              'file' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::StringType.instance),
+              'host_device' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::StringType.instance),
+              'pipe' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::StringType.instance),
+              'no_rx_loss' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::BooleanType.instance),
+              'network_location' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::URIType.instance),
+              'proxy' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::URIType.instance)
+            },
+            BackingSpec,
+            false,
+            nil
+          )
+        end
+      end
+
+      attr_accessor :type,
+                    :file,
+                    :host_device,
+                    :pipe,
+                    :no_rx_loss,
+                    :network_location,
+                    :proxy
+
+      # Constructs a new instance.
+      # @param ruby_values [Hash] a map of initial property values (optional)
+      # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
+      def initialize(ruby_values = nil, struct_value = nil)
+        super(self.class.binding_type, ruby_values, struct_value)
+      end
+    end
+
+    # The  ``Com::Vmware::Vcenter::VM::Hardware::Serial::Info``   class  contains information about a virtual serial port.
+    # @!attribute [rw] label
+    #     @return [String]
+    #     Device label.
+    # @!attribute [rw] yield_on_poll
+    #     @return [Boolean]
+    #     CPU yield behavior. If set to true, the virtual machine will periodically relinquish the processor if its sole task is polling the virtual serial port. The amount of time it takes to regain the processor will depend on the degree of other virtual machine activity on the host.
+    # @!attribute [rw] backing
+    #     @return [Com::Vmware::Vcenter::VM::Hardware::Serial::BackingInfo]
+    #     Physical resource backing for the virtual serial port.
+    class Info < VAPI::Bindings::VapiStruct
+      class << self
+        # Holds (gets or creates) the binding type metadata for this structure type.
+        # @scope class
+        # @return [VAPI::Bindings::StructType] the binding type
+        def binding_type
+          @binding_type ||= VAPI::Bindings::StructType.new(
+            'com.vmware.vcenter.vm.hardware.serial.info',
+            {
+              'label' => VAPI::Bindings::StringType.instance,
+              'yield_on_poll' => VAPI::Bindings::BooleanType.instance,
+              'backing' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::VM::Hardware::Serial::BackingInfo'),
+              'state' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::VM::Hardware::ConnectionState'),
+              'start_connected' => VAPI::Bindings::BooleanType.instance,
+              'allow_guest_control' => VAPI::Bindings::BooleanType.instance
+            },
+            Info,
+            false,
+            nil
+          )
+        end
+      end
+
+      attr_accessor :label,
+                    :yield_on_poll,
+                    :backing,
+                    :state,
+                    :start_connected,
+                    :allow_guest_control
+
+      # Constructs a new instance.
+      # @param ruby_values [Hash] a map of initial property values (optional)
+      # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
+      def initialize(ruby_values = nil, struct_value = nil)
+        super(self.class.binding_type, ruby_values, struct_value)
+      end
+    end
+
+    # The  ``Com::Vmware::Vcenter::VM::Hardware::Serial::CreateSpec``   class  provides a specification for the configuration of a newly-created virtual serial port.
+    # @!attribute [rw] yield_on_poll
+    #     @return [Boolean, nil]
+    #     CPU yield behavior. If set to true, the virtual machine will periodically relinquish the processor if its sole task is polling the virtual serial port. The amount of time it takes to regain the processor will depend on the degree of other virtual machine activity on the host.
+    #     If  nil , defaults to false.
+    # @!attribute [rw] backing
+    #     @return [Com::Vmware::Vcenter::VM::Hardware::Serial::BackingSpec, nil]
+    #     Physical resource backing for the virtual serial port.
+    #     If  nil , defaults to automatic detection of a suitable host device.
+    class CreateSpec < VAPI::Bindings::VapiStruct
+      class << self
+        # Holds (gets or creates) the binding type metadata for this structure type.
+        # @scope class
+        # @return [VAPI::Bindings::StructType] the binding type
+        def binding_type
+          @binding_type ||= VAPI::Bindings::StructType.new(
+            'com.vmware.vcenter.vm.hardware.serial.create_spec',
+            {
+              'yield_on_poll' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::BooleanType.instance),
+              'backing' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::VM::Hardware::Serial::BackingSpec')),
+              'start_connected' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::BooleanType.instance),
+              'allow_guest_control' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::BooleanType.instance)
+            },
+            CreateSpec,
+            false,
+            nil
+          )
+        end
+      end
+
+      attr_accessor :yield_on_poll,
+                    :backing,
+                    :start_connected,
+                    :allow_guest_control
+
+      # Constructs a new instance.
+      # @param ruby_values [Hash] a map of initial property values (optional)
+      # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
+      def initialize(ruby_values = nil, struct_value = nil)
+        super(self.class.binding_type, ruby_values, struct_value)
+      end
+    end
+
+    # The  ``Com::Vmware::Vcenter::VM::Hardware::Serial::UpdateSpec``   class  describes the updates to be made to the configuration of a virtual serial port.
+    # @!attribute [rw] yield_on_poll
+    #     @return [Boolean, nil]
+    #     CPU yield behavior. If set to true, the virtual machine will periodically relinquish the processor if its sole task is polling the virtual serial port. The amount of time it takes to regain the processor will depend on the degree of other virtual machine activity on the host.  
+    #     
+    #      This  field  may be modified at any time, and changes applied to a connected virtual serial port take effect immediately.
+    #     If  nil , the value is unchanged.
+    # @!attribute [rw] backing
+    #     @return [Com::Vmware::Vcenter::VM::Hardware::Serial::BackingSpec, nil]
+    #     Physical resource backing for the virtual serial port.  
+    #     
+    #      This  field  may only be modified if the virtual machine is not powered on or the virtual serial port is not connected.
+    #     If  nil , the value is unchanged.
+    class UpdateSpec < VAPI::Bindings::VapiStruct
+      class << self
+        # Holds (gets or creates) the binding type metadata for this structure type.
+        # @scope class
+        # @return [VAPI::Bindings::StructType] the binding type
+        def binding_type
+          @binding_type ||= VAPI::Bindings::StructType.new(
+            'com.vmware.vcenter.vm.hardware.serial.update_spec',
+            {
+              'yield_on_poll' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::BooleanType.instance),
+              'backing' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::VM::Hardware::Serial::BackingSpec')),
+              'start_connected' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::BooleanType.instance),
+              'allow_guest_control' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::BooleanType.instance)
+            },
+            UpdateSpec,
+            false,
+            nil
+          )
+        end
+      end
+
+      attr_accessor :yield_on_poll,
+                    :backing,
+                    :start_connected,
+                    :allow_guest_control
+
+      # Constructs a new instance.
+      # @param ruby_values [Hash] a map of initial property values (optional)
+      # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
+      def initialize(ruby_values = nil, struct_value = nil)
+        super(self.class.binding_type, ruby_values, struct_value)
+      end
+    end
+
+    # The  ``Com::Vmware::Vcenter::VM::Hardware::Serial::Summary``   class  contains commonly used information about a virtual serial port.
+    # @!attribute [rw] port
+    #     @return [String]
+    #     Identifier of the virtual serial port.
+    class Summary < VAPI::Bindings::VapiStruct
+      class << self
+        # Holds (gets or creates) the binding type metadata for this structure type.
+        # @scope class
+        # @return [VAPI::Bindings::StructType] the binding type
+        def binding_type
+          @binding_type ||= VAPI::Bindings::StructType.new(
+            'com.vmware.vcenter.vm.hardware.serial.summary',
+            {
+              'port' => VAPI::Bindings::IdType.new('com.vmware.vcenter.vm.hardware.SerialPort')
+            },
+            Summary,
+            false,
+            nil
+          )
+        end
+      end
+
+      attr_accessor :port
+
+      # Constructs a new instance.
+      # @param ruby_values [Hash] a map of initial property values (optional)
+      # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
+      def initialize(ruby_values = nil, struct_value = nil)
+        super(self.class.binding_type, ruby_values, struct_value)
+      end
+    end
+
+    # The  ``Com::Vmware::Vcenter::VM::Hardware::Serial::BackingType``   enumerated type  defines the valid backing types for a virtual serial port.
+    # @!attribute [rw] file
+    #     @return [Com::Vmware::Vcenter::VM::Hardware::Serial::BackingType]
+    #     Virtual serial port is backed by a file.
+    # @!attribute [rw] host_device
+    #     @return [Com::Vmware::Vcenter::VM::Hardware::Serial::BackingType]
+    #     Virtual serial port is backed by a device on the host where the virtual machine is running.
+    # @!attribute [rw] pipe_server
+    #     @return [Com::Vmware::Vcenter::VM::Hardware::Serial::BackingType]
+    #     Virtual serial port is backed by a named pipe server. The virtual machine will accept a connection from a host application or another virtual machine on the same host. This is useful for capturing debugging information sent through the virtual serial port.
+    # @!attribute [rw] pipe_client
+    #     @return [Com::Vmware::Vcenter::VM::Hardware::Serial::BackingType]
+    #     Virtual serial port is backed by a named pipe client. The virtual machine will connect to the named pipe provided by a host application or another virtual machine on the same host. This is useful for capturing debugging information sent through the virtual serial port.
+    # @!attribute [rw] network_server
+    #     @return [Com::Vmware::Vcenter::VM::Hardware::Serial::BackingType]
+    #     Virtual serial port is backed by a network server. This backing may be used to create a network-accessible serial port on the virtual machine, accepting a connection from a remote system.
+    # @!attribute [rw] network_client
+    #     @return [Com::Vmware::Vcenter::VM::Hardware::Serial::BackingType]
+    #     Virtual serial port is backed by a network client. This backing may be used to create a network-accessible serial port on the virtual machine, initiating a connection to a remote system.
+    class BackingType < VAPI::Bindings::VapiEnum
+      class << self
+        # Holds (gets or creates) the binding type metadata for this enumeration type.
+        # @scope class
+        # @return [VAPI::Bindings::EnumType] the binding type
+        def binding_type
+          @binding_type ||= VAPI::Bindings::EnumType.new(
+            'com.vmware.vcenter.vm.hardware.serial.backing_type',
+            BackingType
+          )
+        end
+
+        # Converts from a string value (perhaps off the wire) to an instance
+        # of this enum type.
+        # @param value [String] the actual value of the enum instance
+        # @return [BackingType] the instance found for the value, otherwise
+        #         an unknown instance will be built for the value
+        def from_string(value)
+          const_get(value)
+        rescue NameError
+          BackingType.send(:new, 'UNKNOWN', value)
+        end
+      end
+
+      # Constructs a new instance.
+      # @param value [String] the actual value of the enum instance
+      # @param unknown [String] the unknown value when value is 'UKNOWN'
+      def initialize(value, unknown = nil)
+        super(self.class.binding_type, value, unknown)
+      end
+
+      private_class_method :new
+
+      # @!attribute [rw] file
+      #     @return [Com::Vmware::Vcenter::VM::Hardware::Serial::BackingType]
+      #     Virtual serial port is backed by a file.
+      FILE = BackingType.send(:new, 'FILE')
+
+      # @!attribute [rw] host_device
+      #     @return [Com::Vmware::Vcenter::VM::Hardware::Serial::BackingType]
+      #     Virtual serial port is backed by a device on the host where the virtual machine is running.
+      HOST_DEVICE = BackingType.send(:new, 'HOST_DEVICE')
+
+      # @!attribute [rw] pipe_server
+      #     @return [Com::Vmware::Vcenter::VM::Hardware::Serial::BackingType]
+      #     Virtual serial port is backed by a named pipe server. The virtual machine will accept a connection from a host application or another virtual machine on the same host. This is useful for capturing debugging information sent through the virtual serial port.
+      PIPE_SERVER = BackingType.send(:new, 'PIPE_SERVER')
+
+      # @!attribute [rw] pipe_client
+      #     @return [Com::Vmware::Vcenter::VM::Hardware::Serial::BackingType]
+      #     Virtual serial port is backed by a named pipe client. The virtual machine will connect to the named pipe provided by a host application or another virtual machine on the same host. This is useful for capturing debugging information sent through the virtual serial port.
+      PIPE_CLIENT = BackingType.send(:new, 'PIPE_CLIENT')
+
+      # @!attribute [rw] network_server
+      #     @return [Com::Vmware::Vcenter::VM::Hardware::Serial::BackingType]
+      #     Virtual serial port is backed by a network server. This backing may be used to create a network-accessible serial port on the virtual machine, accepting a connection from a remote system.
+      NETWORK_SERVER = BackingType.send(:new, 'NETWORK_SERVER')
+
+      # @!attribute [rw] network_client
+      #     @return [Com::Vmware::Vcenter::VM::Hardware::Serial::BackingType]
+      #     Virtual serial port is backed by a network client. This backing may be used to create a network-accessible serial port on the virtual machine, initiating a connection to a remote system.
+      NETWORK_CLIENT = BackingType.send(:new, 'NETWORK_CLIENT')
+    end
+  end
+  # The  ``Com::Vmware::Vcenter::VM::Hardware::IdeAddressInfo``   class  contains information about the address of a virtual device that is attached to a virtual IDE adapter of a virtual machine.
+  # @!attribute [rw] primary
+  #     @return [Boolean]
+  #     Flag specifying whether the device is attached to the primary or secondary IDE adapter of the virtual machine.
+  # @!attribute [rw] master
+  #     @return [Boolean]
+  #     Flag specifying whether the device is the master or slave device on the IDE adapter.
+  class IdeAddressInfo < VAPI::Bindings::VapiStruct
+    class << self
+      # Holds (gets or creates) the binding type metadata for this structure type.
+      # @scope class
+      # @return [VAPI::Bindings::StructType] the binding type
+      def binding_type
+        @binding_type ||= VAPI::Bindings::StructType.new(
+          'com.vmware.vcenter.vm.hardware.ide_address_info',
+          {
+            'primary' => VAPI::Bindings::BooleanType.instance,
+            'master' => VAPI::Bindings::BooleanType.instance
+          },
+          IdeAddressInfo,
+          false,
+          nil
+        )
+      end
+    end
+
+    attr_accessor :primary,
+                  :master
+
+    # Constructs a new instance.
+    # @param ruby_values [Hash] a map of initial property values (optional)
+    # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
+    def initialize(ruby_values = nil, struct_value = nil)
+      super(self.class.binding_type, ruby_values, struct_value)
+    end
+  end
+  # The  ``Com::Vmware::Vcenter::VM::Hardware::ScsiAddressInfo``   class  contains information about the address of a virtual device that is attached to a virtual SCSI adapter of a virtual machine.
+  # @!attribute [rw] bus
+  #     @return [Fixnum]
+  #     Bus number of the adapter to which the device is attached.
+  # @!attribute [rw] unit
+  #     @return [Fixnum]
+  #     Unit number of the device.
+  class ScsiAddressInfo < VAPI::Bindings::VapiStruct
+    class << self
+      # Holds (gets or creates) the binding type metadata for this structure type.
+      # @scope class
+      # @return [VAPI::Bindings::StructType] the binding type
+      def binding_type
+        @binding_type ||= VAPI::Bindings::StructType.new(
+          'com.vmware.vcenter.vm.hardware.scsi_address_info',
+          {
+            'bus' => VAPI::Bindings::IntegerType.instance,
+            'unit' => VAPI::Bindings::IntegerType.instance
+          },
+          ScsiAddressInfo,
+          false,
+          nil
+        )
+      end
+    end
+
+    attr_accessor :bus,
+                  :unit
+
+    # Constructs a new instance.
+    # @param ruby_values [Hash] a map of initial property values (optional)
+    # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
+    def initialize(ruby_values = nil, struct_value = nil)
+      super(self.class.binding_type, ruby_values, struct_value)
+    end
+  end
+  # The  ``Com::Vmware::Vcenter::VM::Hardware::SataAddressInfo``   class  contains information about the address of a virtual device that is attached to a virtual SATA adapter of a virtual machine.
+  # @!attribute [rw] bus
+  #     @return [Fixnum]
+  #     Bus number of the adapter to which the device is attached.
+  # @!attribute [rw] unit
+  #     @return [Fixnum]
+  #     Unit number of the device.
+  class SataAddressInfo < VAPI::Bindings::VapiStruct
+    class << self
+      # Holds (gets or creates) the binding type metadata for this structure type.
+      # @scope class
+      # @return [VAPI::Bindings::StructType] the binding type
+      def binding_type
+        @binding_type ||= VAPI::Bindings::StructType.new(
+          'com.vmware.vcenter.vm.hardware.sata_address_info',
+          {
+            'bus' => VAPI::Bindings::IntegerType.instance,
+            'unit' => VAPI::Bindings::IntegerType.instance
+          },
+          SataAddressInfo,
+          false,
+          nil
+        )
+      end
+    end
+
+    attr_accessor :bus,
+                  :unit
+
+    # Constructs a new instance.
+    # @param ruby_values [Hash] a map of initial property values (optional)
+    # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
+    def initialize(ruby_values = nil, struct_value = nil)
+      super(self.class.binding_type, ruby_values, struct_value)
+    end
+  end
+  # The  ``Com::Vmware::Vcenter::VM::Hardware::IdeAddressSpec``   class  contains information for specifying the address of a virtual device that is attached to a virtual IDE adapter of a virtual machine.
+  # @!attribute [rw] primary
+  #     @return [Boolean, nil]
+  #     Flag specifying whether the device should be attached to the primary or secondary IDE adapter of the virtual machine.
+  #     If  nil , the server will choose a adapter with an available connection. If no IDE connections are available, the request will be rejected.
+  # @!attribute [rw] master
+  #     @return [Boolean, nil]
+  #     Flag specifying whether the device should be the master or slave device on the IDE adapter.
+  #     If  nil , the server will choose an available connection type. If no IDE connections are available, the request will be rejected.
+  class IdeAddressSpec < VAPI::Bindings::VapiStruct
+    class << self
+      # Holds (gets or creates) the binding type metadata for this structure type.
+      # @scope class
+      # @return [VAPI::Bindings::StructType] the binding type
+      def binding_type
+        @binding_type ||= VAPI::Bindings::StructType.new(
+          'com.vmware.vcenter.vm.hardware.ide_address_spec',
+          {
+            'primary' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::BooleanType.instance),
+            'master' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::BooleanType.instance)
+          },
+          IdeAddressSpec,
+          false,
+          nil
+        )
+      end
+    end
+
+    attr_accessor :primary,
+                  :master
+
+    # Constructs a new instance.
+    # @param ruby_values [Hash] a map of initial property values (optional)
+    # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
+    def initialize(ruby_values = nil, struct_value = nil)
+      super(self.class.binding_type, ruby_values, struct_value)
+    end
+  end
+  # The  ``Com::Vmware::Vcenter::VM::Hardware::ScsiAddressSpec``   class  contains information for specifying the address of a virtual device that is attached to a virtual SCSI adapter of a virtual machine.
+  # @!attribute [rw] bus
+  #     @return [Fixnum]
+  #     Bus number of the adapter to which the device should be attached.
+  # @!attribute [rw] unit
+  #     @return [Fixnum, nil]
+  #     Unit number of the device.
+  #     If  nil , the server will choose an available unit number on the specified adapter. If there are no available connections on the adapter, the request will be rejected.
+  class ScsiAddressSpec < VAPI::Bindings::VapiStruct
+    class << self
+      # Holds (gets or creates) the binding type metadata for this structure type.
+      # @scope class
+      # @return [VAPI::Bindings::StructType] the binding type
+      def binding_type
+        @binding_type ||= VAPI::Bindings::StructType.new(
+          'com.vmware.vcenter.vm.hardware.scsi_address_spec',
+          {
+            'bus' => VAPI::Bindings::IntegerType.instance,
+            'unit' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::IntegerType.instance)
+          },
+          ScsiAddressSpec,
+          false,
+          nil
+        )
+      end
+    end
+
+    attr_accessor :bus,
+                  :unit
+
+    # Constructs a new instance.
+    # @param ruby_values [Hash] a map of initial property values (optional)
+    # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
+    def initialize(ruby_values = nil, struct_value = nil)
+      super(self.class.binding_type, ruby_values, struct_value)
+    end
+  end
+  # The  ``Com::Vmware::Vcenter::VM::Hardware::SataAddressSpec``   class  contains information for specifying the address of a virtual device that is attached to a virtual SATA adapter of a virtual machine.
+  # @!attribute [rw] bus
+  #     @return [Fixnum]
+  #     Bus number of the adapter to which the device should be attached.
+  # @!attribute [rw] unit
+  #     @return [Fixnum, nil]
+  #     Unit number of the device.
+  #     If  nil , the server will choose an available unit number on the specified adapter. If there are no available connections on the adapter, the request will be rejected.
+  class SataAddressSpec < VAPI::Bindings::VapiStruct
+    class << self
+      # Holds (gets or creates) the binding type metadata for this structure type.
+      # @scope class
+      # @return [VAPI::Bindings::StructType] the binding type
+      def binding_type
+        @binding_type ||= VAPI::Bindings::StructType.new(
+          'com.vmware.vcenter.vm.hardware.sata_address_spec',
+          {
+            'bus' => VAPI::Bindings::IntegerType.instance,
+            'unit' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::IntegerType.instance)
+          },
+          SataAddressSpec,
+          false,
+          nil
+        )
+      end
+    end
+
+    attr_accessor :bus,
+                  :unit
+
+    # Constructs a new instance.
+    # @param ruby_values [Hash] a map of initial property values (optional)
+    # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
+    def initialize(ruby_values = nil, struct_value = nil)
+      super(self.class.binding_type, ruby_values, struct_value)
+    end
+  end
+  # The  ``Com::Vmware::Vcenter::VM::Hardware::ConnectionInfo``   class  provides information about the state and configuration of a removable virtual device.
+  # @!attribute [rw] state
+  #     @return [Com::Vmware::Vcenter::VM::Hardware::ConnectionState]
+  #     Connection status of the virtual device.
+  # @!attribute [rw] start_connected
+  #     @return [Boolean]
+  #     Flag indicating whether the virtual device should be connected whenever the virtual machine is powered on.
+  # @!attribute [rw] allow_guest_control
+  #     @return [Boolean]
+  #     Flag indicating whether the guest can connect and disconnect the device.
+  class ConnectionInfo < VAPI::Bindings::VapiStruct
+    class << self
+      # Holds (gets or creates) the binding type metadata for this structure type.
+      # @scope class
+      # @return [VAPI::Bindings::StructType] the binding type
+      def binding_type
+        @binding_type ||= VAPI::Bindings::StructType.new(
+          'com.vmware.vcenter.vm.hardware.connection_info',
+          {
+            'state' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::VM::Hardware::ConnectionState'),
+            'start_connected' => VAPI::Bindings::BooleanType.instance,
+            'allow_guest_control' => VAPI::Bindings::BooleanType.instance
+          },
+          ConnectionInfo,
+          false,
+          nil
+        )
+      end
+    end
+
+    attr_accessor :state,
+                  :start_connected,
+                  :allow_guest_control
+
+    # Constructs a new instance.
+    # @param ruby_values [Hash] a map of initial property values (optional)
+    # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
+    def initialize(ruby_values = nil, struct_value = nil)
+      super(self.class.binding_type, ruby_values, struct_value)
+    end
+  end
+  # The  ``Com::Vmware::Vcenter::VM::Hardware::ConnectionCreateSpec``   class  provides a specification for the configuration of a newly-created removable device.
+  # @!attribute [rw] start_connected
+  #     @return [Boolean, nil]
+  #     Flag indicating whether the virtual device should be connected whenever the virtual machine is powered on.
+  #     Defaults to false if  nil .
+  # @!attribute [rw] allow_guest_control
+  #     @return [Boolean, nil]
+  #     Flag indicating whether the guest can connect and disconnect the device.
+  #     Defaults to false if  nil .
+  class ConnectionCreateSpec < VAPI::Bindings::VapiStruct
+    class << self
+      # Holds (gets or creates) the binding type metadata for this structure type.
+      # @scope class
+      # @return [VAPI::Bindings::StructType] the binding type
+      def binding_type
+        @binding_type ||= VAPI::Bindings::StructType.new(
+          'com.vmware.vcenter.vm.hardware.connection_create_spec',
+          {
+            'start_connected' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::BooleanType.instance),
+            'allow_guest_control' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::BooleanType.instance)
+          },
+          ConnectionCreateSpec,
+          false,
+          nil
+        )
+      end
+    end
+
+    attr_accessor :start_connected,
+                  :allow_guest_control
+
+    # Constructs a new instance.
+    # @param ruby_values [Hash] a map of initial property values (optional)
+    # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
+    def initialize(ruby_values = nil, struct_value = nil)
+      super(self.class.binding_type, ruby_values, struct_value)
+    end
+  end
+  # The  ``Com::Vmware::Vcenter::VM::Hardware::ConnectionUpdateSpec``   class  describes the updates to be made to the configuration of a removable virtual device.
+  # @!attribute [rw] start_connected
+  #     @return [Boolean, nil]
+  #     Flag indicating whether the virtual device should be connected whenever the virtual machine is powered on.
+  #     If  nil , the value is unchanged.
+  # @!attribute [rw] allow_guest_control
+  #     @return [Boolean, nil]
+  #     Flag indicating whether the guest can connect and disconnect the device.
+  #     If  nil , the value is unchanged.
+  class ConnectionUpdateSpec < VAPI::Bindings::VapiStruct
+    class << self
+      # Holds (gets or creates) the binding type metadata for this structure type.
+      # @scope class
+      # @return [VAPI::Bindings::StructType] the binding type
+      def binding_type
+        @binding_type ||= VAPI::Bindings::StructType.new(
+          'com.vmware.vcenter.vm.hardware.connection_update_spec',
+          {
+            'start_connected' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::BooleanType.instance),
+            'allow_guest_control' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::BooleanType.instance)
+          },
+          ConnectionUpdateSpec,
+          false,
+          nil
+        )
+      end
+    end
+
+    attr_accessor :start_connected,
+                  :allow_guest_control
+
+    # Constructs a new instance.
+    # @param ruby_values [Hash] a map of initial property values (optional)
+    # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
+    def initialize(ruby_values = nil, struct_value = nil)
+      super(self.class.binding_type, ruby_values, struct_value)
+    end
+  end
+  # The  ``Com::Vmware::Vcenter::VM::Hardware::ConnectionState``   enumerated type  defines the valid states for a removable device that is configured to be connected.
+  # @!attribute [rw] connected
+  #     @return [Com::Vmware::Vcenter::VM::Hardware::ConnectionState]
+  #     The device is connected and working correctly.
+  # @!attribute [rw] recoverable_error
+  #     @return [Com::Vmware::Vcenter::VM::Hardware::ConnectionState]
+  #     Device connection failed due to a recoverable error; for example, the virtual device backing is currently in use by another virtual machine.
+  # @!attribute [rw] unrecoverable_error
+  #     @return [Com::Vmware::Vcenter::VM::Hardware::ConnectionState]
+  #     Device connection failed due to an unrecoverable error; for example, the virtual device backing does not exist.
+  # @!attribute [rw] not_connected
+  #     @return [Com::Vmware::Vcenter::VM::Hardware::ConnectionState]
+  #     The device is not connected.
+  # @!attribute [rw] unknown
+  #     @return [Com::Vmware::Vcenter::VM::Hardware::ConnectionState]
+  #     The device status is unknown.
+  class ConnectionState < VAPI::Bindings::VapiEnum
+    class << self
+      # Holds (gets or creates) the binding type metadata for this enumeration type.
+      # @scope class
+      # @return [VAPI::Bindings::EnumType] the binding type
+      def binding_type
+        @binding_type ||= VAPI::Bindings::EnumType.new(
+          'com.vmware.vcenter.vm.hardware.connection_state',
+          ConnectionState
+        )
+      end
+
+      # Converts from a string value (perhaps off the wire) to an instance
+      # of this enum type.
+      # @param value [String] the actual value of the enum instance
+      # @return [ConnectionState] the instance found for the value, otherwise
+      #         an unknown instance will be built for the value
+      def from_string(value)
+        const_get(value)
+      rescue NameError
+        ConnectionState.send(:new, 'UNKNOWN', value)
+      end
+    end
+
+    # Constructs a new instance.
+    # @param value [String] the actual value of the enum instance
+    # @param unknown [String] the unknown value when value is 'UKNOWN'
+    def initialize(value, unknown = nil)
+      super(self.class.binding_type, value, unknown)
+    end
+
+    private_class_method :new
+
+    # @!attribute [rw] connected
+    #     @return [Com::Vmware::Vcenter::VM::Hardware::ConnectionState]
+    #     The device is connected and working correctly.
+    CONNECTED = ConnectionState.send(:new, 'CONNECTED')
+
+    # @!attribute [rw] recoverable_error
+    #     @return [Com::Vmware::Vcenter::VM::Hardware::ConnectionState]
+    #     Device connection failed due to a recoverable error; for example, the virtual device backing is currently in use by another virtual machine.
+    RECOVERABLE_ERROR = ConnectionState.send(:new, 'RECOVERABLE_ERROR')
+
+    # @!attribute [rw] unrecoverable_error
+    #     @return [Com::Vmware::Vcenter::VM::Hardware::ConnectionState]
+    #     Device connection failed due to an unrecoverable error; for example, the virtual device backing does not exist.
+    UNRECOVERABLE_ERROR = ConnectionState.send(:new, 'UNRECOVERABLE_ERROR')
+
+    # @!attribute [rw] not_connected
+    #     @return [Com::Vmware::Vcenter::VM::Hardware::ConnectionState]
+    #     The device is not connected.
+    NOT_CONNECTED = ConnectionState.send(:new, 'NOT_CONNECTED')
+
+    # @!attribute [rw] unknown
+    #     @return [Com::Vmware::Vcenter::VM::Hardware::ConnectionState]
+    #     The device status is unknown.
+    UNKNOWN = ConnectionState.send(:new, 'UNKNOWN')
+  end
 end

--- a/client/sdk/com/vmware/vcenter/vm/hardware/adapter.rb
+++ b/client/sdk/com/vmware/vcenter/vm/hardware/adapter.rb
@@ -1,5 +1,6 @@
 #---------------------------------------------------------------------------
-# Copyright 2016 VMware, Inc.  All rights reserved.
+# Copyright 2017 VMware, Inc.  All rights reserved.
+#
 # AUTO GENERATED FILE -- DO NOT MODIFY!
 #
 # vAPI type descriptors for package com.vmware.vcenter.vm.hardware.adapter.
@@ -8,1043 +9,983 @@ require 'vapi'
 
 # declare the module hierarchy before we use the shorthand syntax below
 module Com
-    module Vmware
-        module Vcenter
-            module Vm
-                module Hardware
-                    module Adapter
-                    end
-                end
-            end
+  module Vmware
+    module Vcenter
+      module Vm
+        module Hardware
+          module Adapter
+          end
         end
+      end
     end
+  end
 end
 
 # The  ``com.vmware.vcenter.vm.hardware.adapter``   package  provides  classs  for managing the configuration and state of the virtual adapters belonging to a virtual machine. This includes  methods  for reading and manipulating the conifguration of USB adapters and host bus adapters.  
 # 
 #  Note that  classs  for adapters with no configurable properties or runtime state, such as IDE and PCI adapters, are omitted.
 module Com::Vmware::Vcenter::Vm::Hardware::Adapter
+  # The  ``Com::Vmware::Vcenter::VM::Hardware::Adapter::Sata``   class  provides  methods  for configuring the virtual SATA adapters of a virtual machine.
+  class Sata < VAPI::Bindings::VapiService
+    # static metamodel definitions
+    SERVICE_ID = VAPI::Core::ServiceIdentifier.new('com.vmware.vcenter.vm.hardware.adapter.sata')
 
-    # The  ``Com::Vmware::Vcenter::Vm::Hardware::Adapter::Sata``   class  provides  methods  for configuring the virtual SATA adapters of a virtual machine.
-    class Sata < VAPI::Bindings::VapiService
+    LIST_INFO = VAPI::Bindings::OperationInfo.new(
+      VAPI::Core::OperationIdentifier.new('list', SERVICE_ID),
+      VAPI::Bindings::OperationInputType.new(
+        'vm' => VAPI::Bindings::IdType.new('VirtualMachine')
+      ),
+      VAPI::Bindings::ListType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::VM::Hardware::Adapter::Sata::Summary')),
+      {
+        'com.vmware.vapi.std.errors.error' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Error'),
+        'com.vmware.vapi.std.errors.not_found' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::NotFound'),
+        'com.vmware.vapi.std.errors.resource_inaccessible' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::ResourceInaccessible'),
+        'com.vmware.vapi.std.errors.service_unavailable' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::ServiceUnavailable'),
+        'com.vmware.vapi.std.errors.unauthenticated' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Unauthenticated'),
+        'com.vmware.vapi.std.errors.unauthorized' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Unauthorized')
+      },
+      [],
+      []
+    )
 
-        protected
+    GET_INFO = VAPI::Bindings::OperationInfo.new(
+      VAPI::Core::OperationIdentifier.new('get', SERVICE_ID),
+      VAPI::Bindings::OperationInputType.new(
+        'vm' => VAPI::Bindings::IdType.new('VirtualMachine'),
+        'adapter' => VAPI::Bindings::IdType.new('com.vmware.vcenter.vm.hardware.SataAdapter')
+      ),
+      VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::VM::Hardware::Adapter::Sata::Info'),
+      {
+        'com.vmware.vapi.std.errors.error' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Error'),
+        'com.vmware.vapi.std.errors.not_found' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::NotFound'),
+        'com.vmware.vapi.std.errors.resource_inaccessible' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::ResourceInaccessible'),
+        'com.vmware.vapi.std.errors.service_unavailable' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::ServiceUnavailable'),
+        'com.vmware.vapi.std.errors.unauthenticated' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Unauthenticated'),
+        'com.vmware.vapi.std.errors.unauthorized' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Unauthorized')
+      },
+      [],
+      []
+    )
 
-        # static metamodel definitions
-        @@service_id = VAPI::Core::ServiceIdentifier.new('com.vmware.vcenter.vm.hardware.adapter.sata')
+    CREATE_INFO = VAPI::Bindings::OperationInfo.new(
+      VAPI::Core::OperationIdentifier.new('create', SERVICE_ID),
+      VAPI::Bindings::OperationInputType.new(
+        'vm' => VAPI::Bindings::IdType.new('VirtualMachine'),
+        'spec' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::VM::Hardware::Adapter::Sata::CreateSpec')
+      ),
+      VAPI::Bindings::IdType.new('com.vmware.vcenter.vm.hardware.SataAdapter'),
+      {
+        'com.vmware.vapi.std.errors.error' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Error'),
+        'com.vmware.vapi.std.errors.not_allowed_in_current_state' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::NotAllowedInCurrentState'),
+        'com.vmware.vapi.std.errors.not_found' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::NotFound'),
+        'com.vmware.vapi.std.errors.unable_to_allocate_resource' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::UnableToAllocateResource'),
+        'com.vmware.vapi.std.errors.resource_in_use' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::ResourceInUse'),
+        'com.vmware.vapi.std.errors.invalid_argument' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::InvalidArgument'),
+        'com.vmware.vapi.std.errors.resource_busy' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::ResourceBusy'),
+        'com.vmware.vapi.std.errors.resource_inaccessible' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::ResourceInaccessible'),
+        'com.vmware.vapi.std.errors.service_unavailable' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::ServiceUnavailable'),
+        'com.vmware.vapi.std.errors.unauthenticated' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Unauthenticated'),
+        'com.vmware.vapi.std.errors.unauthorized' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Unauthorized'),
+        'com.vmware.vapi.std.errors.unsupported' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Unsupported')
+      },
+      [],
+      []
+    )
 
-        @@list_info = VAPI::Bindings::OperationInfo.new(
-            VAPI::Core::OperationIdentifier.new('list', @@service_id),
-            VAPI::Bindings::OperationInputType.new({
-                'vm' => VAPI::Bindings::IdType.new(resource_types='VirtualMachine'),
-            }),
-            VAPI::Bindings::ListType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::Vm::Hardware::Adapter::Sata::Summary')),
-            {
-                'com.vmware.vapi.std.errors.error' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Error'),
-                'com.vmware.vapi.std.errors.not_found' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::NotFound'),
-                'com.vmware.vapi.std.errors.resource_inaccessible' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::ResourceInaccessible'),
-                'com.vmware.vapi.std.errors.service_unavailable' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::ServiceUnavailable'),
-                'com.vmware.vapi.std.errors.unauthenticated' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Unauthenticated'),
-                'com.vmware.vapi.std.errors.unauthorized' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Unauthorized'),
+    DELETE_INFO = VAPI::Bindings::OperationInfo.new(
+      VAPI::Core::OperationIdentifier.new('delete', SERVICE_ID),
+      VAPI::Bindings::OperationInputType.new(
+        'vm' => VAPI::Bindings::IdType.new('VirtualMachine'),
+        'adapter' => VAPI::Bindings::IdType.new('com.vmware.vcenter.vm.hardware.SataAdapter')
+      ),
+      VAPI::Bindings::VoidType.instance,
+      {
+        'com.vmware.vapi.std.errors.error' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Error'),
+        'com.vmware.vapi.std.errors.not_allowed_in_current_state' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::NotAllowedInCurrentState'),
+        'com.vmware.vapi.std.errors.not_found' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::NotFound'),
+        'com.vmware.vapi.std.errors.resource_busy' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::ResourceBusy'),
+        'com.vmware.vapi.std.errors.resource_inaccessible' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::ResourceInaccessible'),
+        'com.vmware.vapi.std.errors.service_unavailable' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::ServiceUnavailable'),
+        'com.vmware.vapi.std.errors.unauthenticated' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Unauthenticated'),
+        'com.vmware.vapi.std.errors.unauthorized' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Unauthorized')
+      },
+      [],
+      []
+    )
 
-            },
-            [],
-            [])
-        @@get_info = VAPI::Bindings::OperationInfo.new(
-            VAPI::Core::OperationIdentifier.new('get', @@service_id),
-            VAPI::Bindings::OperationInputType.new({
-                'vm' => VAPI::Bindings::IdType.new(resource_types='VirtualMachine'),
-                'adapter' => VAPI::Bindings::IdType.new(resource_types='com.vmware.vcenter.vm.hardware.SataAdapter'),
-            }),
-            VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::Vm::Hardware::Adapter::Sata::Info'),
-            {
-                'com.vmware.vapi.std.errors.error' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Error'),
-                'com.vmware.vapi.std.errors.not_found' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::NotFound'),
-                'com.vmware.vapi.std.errors.resource_inaccessible' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::ResourceInaccessible'),
-                'com.vmware.vapi.std.errors.service_unavailable' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::ServiceUnavailable'),
-                'com.vmware.vapi.std.errors.unauthenticated' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Unauthenticated'),
-                'com.vmware.vapi.std.errors.unauthorized' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Unauthorized'),
+    SERVICE_INFO = VAPI::Bindings::ServiceInfo.new(
+      SERVICE_ID,
+      'list' => LIST_INFO,
+      'get' => GET_INFO,
+      'create' => CREATE_INFO,
+      'delete' => DELETE_INFO
+    )
 
-            },
-            [],
-            [])
-        @@create_info = VAPI::Bindings::OperationInfo.new(
-            VAPI::Core::OperationIdentifier.new('create', @@service_id),
-            VAPI::Bindings::OperationInputType.new({
-                'vm' => VAPI::Bindings::IdType.new(resource_types='VirtualMachine'),
-                'spec' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::Vm::Hardware::Adapter::Sata::CreateSpec'),
-            }),
-            VAPI::Bindings::IdType.new(resource_types='com.vmware.vcenter.vm.hardware.SataAdapter'),
-            {
-                'com.vmware.vapi.std.errors.error' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Error'),
-                'com.vmware.vapi.std.errors.not_allowed_in_current_state' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::NotAllowedInCurrentState'),
-                'com.vmware.vapi.std.errors.not_found' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::NotFound'),
-                'com.vmware.vapi.std.errors.unable_to_allocate_resource' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::UnableToAllocateResource'),
-                'com.vmware.vapi.std.errors.resource_in_use' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::ResourceInUse'),
-                'com.vmware.vapi.std.errors.invalid_argument' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::InvalidArgument'),
-                'com.vmware.vapi.std.errors.resource_busy' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::ResourceBusy'),
-                'com.vmware.vapi.std.errors.resource_inaccessible' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::ResourceInaccessible'),
-                'com.vmware.vapi.std.errors.service_unavailable' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::ServiceUnavailable'),
-                'com.vmware.vapi.std.errors.unauthenticated' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Unauthenticated'),
-                'com.vmware.vapi.std.errors.unauthorized' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Unauthorized'),
-                'com.vmware.vapi.std.errors.unsupported' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Unsupported'),
-
-            },
-            [],
-            [])
-        @@delete_info = VAPI::Bindings::OperationInfo.new(
-            VAPI::Core::OperationIdentifier.new('delete', @@service_id),
-            VAPI::Bindings::OperationInputType.new({
-                'vm' => VAPI::Bindings::IdType.new(resource_types='VirtualMachine'),
-                'adapter' => VAPI::Bindings::IdType.new(resource_types='com.vmware.vcenter.vm.hardware.SataAdapter'),
-            }),
-            VAPI::Bindings::VoidType.instance,
-            {
-                'com.vmware.vapi.std.errors.error' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Error'),
-                'com.vmware.vapi.std.errors.not_allowed_in_current_state' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::NotAllowedInCurrentState'),
-                'com.vmware.vapi.std.errors.not_found' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::NotFound'),
-                'com.vmware.vapi.std.errors.resource_busy' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::ResourceBusy'),
-                'com.vmware.vapi.std.errors.resource_inaccessible' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::ResourceInaccessible'),
-                'com.vmware.vapi.std.errors.service_unavailable' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::ServiceUnavailable'),
-                'com.vmware.vapi.std.errors.unauthenticated' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Unauthenticated'),
-                'com.vmware.vapi.std.errors.unauthorized' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Unauthorized'),
-
-            },
-            [],
-            [])
-
-        @@service_info = VAPI::Bindings::ServiceInfo.new(@@service_id, {
-            'list' => @@list_info,
-            'get' => @@get_info,
-            'create' => @@create_info,
-            'delete' => @@delete_info,
-        })
-
-        public
-
-        # Constructs a new instance.
-        #
-        # @param config [VAPI::Bindings::StubConfig] A hash with the api provider details.
-        def initialize(config)
-            super(config, @@service_info)
-        end
-
-        RESOURCE_TYPE = 'com.vmware.vcenter.vm.hardware.SataAdapter'
-
-
-        # Returns commonly used information about the virtual SATA adapters belonging to the virtual machine.
-        #
-        # @param vm [String]
-        #     Virtual machine identifier.
-        # @return [Array<Com::Vmware::Vcenter::Vm::Hardware::Adapter::Sata::Summary>]
-        #     List of commonly used information about virtual SATA adapters.
-        # @raise [Com::Vmware::Vapi::Std::Errors::Error]
-        #     if the system reports an error while responding to the request.
-        # @raise [Com::Vmware::Vapi::Std::Errors::NotFound]
-        #     if the virtual machine is not found.
-        # @raise [Com::Vmware::Vapi::Std::Errors::ResourceInaccessible]
-        #     if the virtual machine's configuration state cannot be accessed.
-        # @raise [Com::Vmware::Vapi::Std::Errors::ServiceUnavailable]
-        #     if the system is unable to communicate with a service to complete the request.
-        # @raise [Com::Vmware::Vapi::Std::Errors::Unauthenticated]
-        #     if the user can not be authenticated.
-        # @raise [Com::Vmware::Vapi::Std::Errors::Unauthorized]
-        #     if the user doesn't have the required privileges.
-        def list(vm)
-            invoke_with_info(@@list_info, {
-                'vm' => vm,
-            })
-        end
-
-
-        # Returns information about a virtual SATA adapter.
-        #
-        # @param vm [String]
-        #     Virtual machine identifier.
-        # @param adapter [String]
-        #     Virtual SATA adapter identifier.
-        # @return [Com::Vmware::Vcenter::Vm::Hardware::Adapter::Sata::Info]
-        #     Information about the specified virtual SATA adapter.
-        # @raise [Com::Vmware::Vapi::Std::Errors::Error]
-        #     if the system reports an error while responding to the request.
-        # @raise [Com::Vmware::Vapi::Std::Errors::NotFound]
-        #     if the virtual machine or virtual SATA adapter is not found.
-        # @raise [Com::Vmware::Vapi::Std::Errors::ResourceInaccessible]
-        #     if the virtual machine's configuration state cannot be accessed.
-        # @raise [Com::Vmware::Vapi::Std::Errors::ServiceUnavailable]
-        #     if the system is unable to communicate with a service to complete the request.
-        # @raise [Com::Vmware::Vapi::Std::Errors::Unauthenticated]
-        #     if the user can not be authenticated.
-        # @raise [Com::Vmware::Vapi::Std::Errors::Unauthorized]
-        #     if the user doesn't have the required privileges.
-        def get(vm, adapter)
-            invoke_with_info(@@get_info, {
-                'vm' => vm,
-                'adapter' => adapter,
-            })
-        end
-
-
-        # Adds a virtual SATA adapter to the virtual machine.
-        #
-        # @param vm [String]
-        #     Virtual machine identifier.
-        # @param spec [Com::Vmware::Vcenter::Vm::Hardware::Adapter::Sata::CreateSpec]
-        #     Specification for the new virtual SATA adapter.
-        # @return [String]
-        #     Virtual SATA adapter identifier.
-        # @raise [Com::Vmware::Vapi::Std::Errors::Error]
-        #     if the system reports an error while responding to the request.
-        # @raise [Com::Vmware::Vapi::Std::Errors::Error]
-        #     if the system reported that the SATA adapter was created but was unable to confirm the creation because the identifier of the new adapter could not be determined.
-        # @raise [Com::Vmware::Vapi::Std::Errors::NotAllowedInCurrentState]
-        #     if the virtual machine is suspended
-        # @raise [Com::Vmware::Vapi::Std::Errors::NotFound]
-        #     if the virtual machine is not found.
-        # @raise [Com::Vmware::Vapi::Std::Errors::UnableToAllocateResource]
-        #     if there are no more available SATA buses on the virtual machine.
-        # @raise [Com::Vmware::Vapi::Std::Errors::ResourceInUse]
-        #     if the specified SATA bus or PCI address is in use.
-        # @raise [Com::Vmware::Vapi::Std::Errors::InvalidArgument]
-        #     if the specified SATA bus or PCI address is out of bounds.
-        # @raise [Com::Vmware::Vapi::Std::Errors::ResourceBusy]
-        #     if the virtual machine is busy performing another operation.
-        # @raise [Com::Vmware::Vapi::Std::Errors::ResourceInaccessible]
-        #     if the virtual machine's configuration state cannot be accessed.
-        # @raise [Com::Vmware::Vapi::Std::Errors::ServiceUnavailable]
-        #     if the system is unable to communicate with a service to complete the request.
-        # @raise [Com::Vmware::Vapi::Std::Errors::Unauthenticated]
-        #     if the user can not be authenticated.
-        # @raise [Com::Vmware::Vapi::Std::Errors::Unauthorized]
-        #     if the user doesn't have the required privileges.
-        # @raise [Com::Vmware::Vapi::Std::Errors::Unsupported]
-        #     if the guest operating system of the virtual machine is not supported and  spec  includes  nil   fields  that default to guest-specific values.
-        def create(vm, spec)
-            invoke_with_info(@@create_info, {
-                'vm' => vm,
-                'spec' => spec,
-            })
-        end
-
-
-        # Removes a virtual SATA adapter from the virtual machine.
-        #
-        # @param vm [String]
-        #     Virtual machine identifier.
-        # @param adapter [String]
-        #     Virtual SATA adapter identifier.
-        # @return [Void]
-        # @raise [Com::Vmware::Vapi::Std::Errors::Error]
-        #     if the system reports an error while responding to the request.
-        # @raise [Com::Vmware::Vapi::Std::Errors::NotAllowedInCurrentState]
-        #     if the virtual machine is suspended
-        # @raise [Com::Vmware::Vapi::Std::Errors::NotFound]
-        #     if the virtual machine or virtual SATA adapter is not found.
-        # @raise [Com::Vmware::Vapi::Std::Errors::ResourceBusy]
-        #     if the virtual machine is busy performing another operation.
-        # @raise [Com::Vmware::Vapi::Std::Errors::ResourceInaccessible]
-        #     if the virtual machine's configuration state cannot be accessed.
-        # @raise [Com::Vmware::Vapi::Std::Errors::ServiceUnavailable]
-        #     if the system is unable to communicate with a service to complete the request.
-        # @raise [Com::Vmware::Vapi::Std::Errors::Unauthenticated]
-        #     if the user can not be authenticated.
-        # @raise [Com::Vmware::Vapi::Std::Errors::Unauthorized]
-        #     if the user doesn't have the required privileges.
-        def delete(vm, adapter)
-            invoke_with_info(@@delete_info, {
-                'vm' => vm,
-                'adapter' => adapter,
-            })
-        end
-
-
-
-        # The  ``Com::Vmware::Vcenter::Vm::Hardware::Adapter::Sata::Info``   class  contains information about a virtual SATA adapter.
-        # @!attribute [rw] label
-        #     @return [String]
-        #     Device label.
-        # @!attribute [rw] type
-        #     @return [Com::Vmware::Vcenter::Vm::Hardware::Adapter::Sata::Type]
-        #     Adapter type.
-        # @!attribute [rw] bus
-        #     @return [Fixnum]
-        #     SATA bus number.
-        # @!attribute [rw] pci_slot_number
-        #     @return [Fixnum, nil]
-        #     Address of the SATA adapter on the PCI bus.
-        #     May be  nil  if the virtual machine has never been powered on since the adapter was created.
-        class Info < VAPI::Bindings::VapiStruct
-
-            class << self
-                # Holds (gets or creates) the binding type metadata for this structure type.
-                # @scope class
-                # @return [VAPI::Bindings::StructType] the binding type
-                def binding_type
-                    @binding_type ||= VAPI::Bindings::StructType.new(
-                        'com.vmware.vcenter.vm.hardware.adapter.sata.info',
-                        {
-                            'label' => VAPI::Bindings::StringType.instance,
-                            'type' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::Vm::Hardware::Adapter::Sata::Type'),
-                            'bus' => VAPI::Bindings::IntegerType.instance,
-                            'pci_slot_number' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::IntegerType.instance),
-                        },
-                        Info,
-                        false,
-                        nil)
-                end
-            end
-
-            attr_accessor :label,
-                          :type,
-                          :bus,
-                          :pci_slot_number
-
-            # Constructs a new instance.
-            # @param ruby_values [Hash] a map of initial property values (optional)
-            # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
-            def initialize(ruby_values=nil, struct_value=nil)
-                super(self.class.binding_type, ruby_values, struct_value)
-            end
-        end
-
-
-        # The  ``Com::Vmware::Vcenter::Vm::Hardware::Adapter::Sata::CreateSpec``   class  provides a specification for the configuration of a newly-created virtual SATA adapter.
-        # @!attribute [rw] type
-        #     @return [Com::Vmware::Vcenter::Vm::Hardware::Adapter::Sata::Type, nil]
-        #     Adapter type.
-        #     If  nil , a guest-specific default value will be used.
-        # @!attribute [rw] bus
-        #     @return [Fixnum, nil]
-        #     SATA bus number.
-        #     If  nil , the server will choose an available bus number; if none is available, the request will fail.
-        # @!attribute [rw] pci_slot_number
-        #     @return [Fixnum, nil]
-        #     Address of the SATA adapter on the PCI bus.
-        #     If  nil , the server will choose an available address when the virtual machine is powered on.
-        class CreateSpec < VAPI::Bindings::VapiStruct
-
-            class << self
-                # Holds (gets or creates) the binding type metadata for this structure type.
-                # @scope class
-                # @return [VAPI::Bindings::StructType] the binding type
-                def binding_type
-                    @binding_type ||= VAPI::Bindings::StructType.new(
-                        'com.vmware.vcenter.vm.hardware.adapter.sata.create_spec',
-                        {
-                            'type' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::Vm::Hardware::Adapter::Sata::Type')),
-                            'bus' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::IntegerType.instance),
-                            'pci_slot_number' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::IntegerType.instance),
-                        },
-                        CreateSpec,
-                        false,
-                        nil)
-                end
-            end
-
-            attr_accessor :type,
-                          :bus,
-                          :pci_slot_number
-
-            # Constructs a new instance.
-            # @param ruby_values [Hash] a map of initial property values (optional)
-            # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
-            def initialize(ruby_values=nil, struct_value=nil)
-                super(self.class.binding_type, ruby_values, struct_value)
-            end
-        end
-
-
-        # The  ``Com::Vmware::Vcenter::Vm::Hardware::Adapter::Sata::Summary``   class  contains commonly used information about a Virtual SATA adapter.
-        # @!attribute [rw] adapter
-        #     @return [String]
-        #     Identifier of the virtual SATA adapter.
-        class Summary < VAPI::Bindings::VapiStruct
-
-            class << self
-                # Holds (gets or creates) the binding type metadata for this structure type.
-                # @scope class
-                # @return [VAPI::Bindings::StructType] the binding type
-                def binding_type
-                    @binding_type ||= VAPI::Bindings::StructType.new(
-                        'com.vmware.vcenter.vm.hardware.adapter.sata.summary',
-                        {
-                            'adapter' => VAPI::Bindings::IdType.new(resource_types='com.vmware.vcenter.vm.hardware.SataAdapter'),
-                        },
-                        Summary,
-                        false,
-                        nil)
-                end
-            end
-
-            attr_accessor :adapter
-
-            # Constructs a new instance.
-            # @param ruby_values [Hash] a map of initial property values (optional)
-            # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
-            def initialize(ruby_values=nil, struct_value=nil)
-                super(self.class.binding_type, ruby_values, struct_value)
-            end
-        end
-
-
-
-        # The  ``Com::Vmware::Vcenter::Vm::Hardware::Adapter::Sata::Type``   enumerated type  defines the valid emulation types for a virtual SATA adapter.
-        # @!attribute [rw] ahci
-        #     @return [Com::Vmware::Vcenter::Vm::Hardware::Adapter::Sata::Type]
-        #     AHCI host bus adapter.
-        class Type < VAPI::Bindings::VapiEnum
-
-            class << self
-                # Holds (gets or creates) the binding type metadata for this enumeration type.
-                # @scope class
-                # @return [VAPI::Bindings::EnumType] the binding type
-                def binding_type
-                    @binding_type ||= VAPI::Bindings::EnumType.new(
-                        'com.vmware.vcenter.vm.hardware.adapter.sata.type',
-                        Type)
-                end
-
-                # Converts from a string value (perhaps off the wire) to an instance
-                # of this enum type.
-                # @param value [String] the actual value of the enum instance
-                # @return [Type] the instance found for the value, otherwise
-                #         an unknown instance will be built for the value
-                def from_string(value)
-                    begin
-                        const_get(value)
-                    rescue NameError
-                        Type.new('UNKNOWN', value)
-                    end
-                end
-            end
-
-            private
-
-            # Constructs a new instance.
-            # @param value [String] the actual value of the enum instance
-            # @param unknown [String] the unknown value when value is 'UKNOWN'
-            def initialize(value, unknown=nil)
-                super(self.class.binding_type, value, unknown)
-            end
-
-            public
-
-            # @!attribute [rw] ahci
-            #     @return [Com::Vmware::Vcenter::Vm::Hardware::Adapter::Sata::Type]
-            #     AHCI host bus adapter.
-            AHCI = Type.new('AHCI')
-
-        end
-
-
+    # Constructs a new instance.
+    #
+    # @param config [VAPI::Bindings::StubConfig] A hash with the api provider details.
+    def initialize(config)
+      super(config, SERVICE_INFO)
     end
 
-
-    # The  ``Com::Vmware::Vcenter::Vm::Hardware::Adapter::Scsi``   class  provides  methods  for configuring the virtual SCSI adapters of a virtual machine.
-    class Scsi < VAPI::Bindings::VapiService
-
-        protected
-
-        # static metamodel definitions
-        @@service_id = VAPI::Core::ServiceIdentifier.new('com.vmware.vcenter.vm.hardware.adapter.scsi')
-
-        @@list_info = VAPI::Bindings::OperationInfo.new(
-            VAPI::Core::OperationIdentifier.new('list', @@service_id),
-            VAPI::Bindings::OperationInputType.new({
-                'vm' => VAPI::Bindings::IdType.new(resource_types='VirtualMachine'),
-            }),
-            VAPI::Bindings::ListType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::Vm::Hardware::Adapter::Scsi::Summary')),
-            {
-                'com.vmware.vapi.std.errors.error' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Error'),
-                'com.vmware.vapi.std.errors.not_found' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::NotFound'),
-                'com.vmware.vapi.std.errors.resource_inaccessible' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::ResourceInaccessible'),
-                'com.vmware.vapi.std.errors.service_unavailable' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::ServiceUnavailable'),
-                'com.vmware.vapi.std.errors.unauthenticated' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Unauthenticated'),
-                'com.vmware.vapi.std.errors.unauthorized' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Unauthorized'),
-
-            },
-            [],
-            [])
-        @@get_info = VAPI::Bindings::OperationInfo.new(
-            VAPI::Core::OperationIdentifier.new('get', @@service_id),
-            VAPI::Bindings::OperationInputType.new({
-                'vm' => VAPI::Bindings::IdType.new(resource_types='VirtualMachine'),
-                'adapter' => VAPI::Bindings::IdType.new(resource_types='com.vmware.vcenter.vm.hardware.ScsiAdapter'),
-            }),
-            VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::Vm::Hardware::Adapter::Scsi::Info'),
-            {
-                'com.vmware.vapi.std.errors.error' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Error'),
-                'com.vmware.vapi.std.errors.not_found' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::NotFound'),
-                'com.vmware.vapi.std.errors.resource_inaccessible' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::ResourceInaccessible'),
-                'com.vmware.vapi.std.errors.service_unavailable' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::ServiceUnavailable'),
-                'com.vmware.vapi.std.errors.unauthenticated' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Unauthenticated'),
-                'com.vmware.vapi.std.errors.unauthorized' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Unauthorized'),
-
-            },
-            [],
-            [])
-        @@create_info = VAPI::Bindings::OperationInfo.new(
-            VAPI::Core::OperationIdentifier.new('create', @@service_id),
-            VAPI::Bindings::OperationInputType.new({
-                'vm' => VAPI::Bindings::IdType.new(resource_types='VirtualMachine'),
-                'spec' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::Vm::Hardware::Adapter::Scsi::CreateSpec'),
-            }),
-            VAPI::Bindings::IdType.new(resource_types='com.vmware.vcenter.vm.hardware.ScsiAdapter'),
-            {
-                'com.vmware.vapi.std.errors.error' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Error'),
-                'com.vmware.vapi.std.errors.not_allowed_in_current_state' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::NotAllowedInCurrentState'),
-                'com.vmware.vapi.std.errors.not_found' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::NotFound'),
-                'com.vmware.vapi.std.errors.unable_to_allocate_resource' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::UnableToAllocateResource'),
-                'com.vmware.vapi.std.errors.resource_in_use' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::ResourceInUse'),
-                'com.vmware.vapi.std.errors.invalid_argument' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::InvalidArgument'),
-                'com.vmware.vapi.std.errors.resource_busy' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::ResourceBusy'),
-                'com.vmware.vapi.std.errors.resource_inaccessible' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::ResourceInaccessible'),
-                'com.vmware.vapi.std.errors.service_unavailable' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::ServiceUnavailable'),
-                'com.vmware.vapi.std.errors.unauthenticated' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Unauthenticated'),
-                'com.vmware.vapi.std.errors.unauthorized' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Unauthorized'),
-                'com.vmware.vapi.std.errors.unsupported' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Unsupported'),
-
-            },
-            [],
-            [])
-        @@update_info = VAPI::Bindings::OperationInfo.new(
-            VAPI::Core::OperationIdentifier.new('update', @@service_id),
-            VAPI::Bindings::OperationInputType.new({
-                'vm' => VAPI::Bindings::IdType.new(resource_types='VirtualMachine'),
-                'adapter' => VAPI::Bindings::IdType.new(resource_types='com.vmware.vcenter.vm.hardware.ScsiAdapter'),
-                'spec' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::Vm::Hardware::Adapter::Scsi::UpdateSpec'),
-            }),
-            VAPI::Bindings::VoidType.instance,
-            {
-                'com.vmware.vapi.std.errors.error' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Error'),
-                'com.vmware.vapi.std.errors.not_found' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::NotFound'),
-                'com.vmware.vapi.std.errors.not_allowed_in_current_state' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::NotAllowedInCurrentState'),
-                'com.vmware.vapi.std.errors.resource_busy' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::ResourceBusy'),
-                'com.vmware.vapi.std.errors.resource_inaccessible' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::ResourceInaccessible'),
-                'com.vmware.vapi.std.errors.service_unavailable' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::ServiceUnavailable'),
-                'com.vmware.vapi.std.errors.unauthenticated' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Unauthenticated'),
-                'com.vmware.vapi.std.errors.unauthorized' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Unauthorized'),
-
-            },
-            [],
-            [])
-        @@delete_info = VAPI::Bindings::OperationInfo.new(
-            VAPI::Core::OperationIdentifier.new('delete', @@service_id),
-            VAPI::Bindings::OperationInputType.new({
-                'vm' => VAPI::Bindings::IdType.new(resource_types='VirtualMachine'),
-                'adapter' => VAPI::Bindings::IdType.new(resource_types='com.vmware.vcenter.vm.hardware.ScsiAdapter'),
-            }),
-            VAPI::Bindings::VoidType.instance,
-            {
-                'com.vmware.vapi.std.errors.error' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Error'),
-                'com.vmware.vapi.std.errors.not_allowed_in_current_state' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::NotAllowedInCurrentState'),
-                'com.vmware.vapi.std.errors.not_found' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::NotFound'),
-                'com.vmware.vapi.std.errors.resource_busy' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::ResourceBusy'),
-                'com.vmware.vapi.std.errors.resource_inaccessible' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::ResourceInaccessible'),
-                'com.vmware.vapi.std.errors.service_unavailable' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::ServiceUnavailable'),
-                'com.vmware.vapi.std.errors.unauthenticated' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Unauthenticated'),
-                'com.vmware.vapi.std.errors.unauthorized' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Unauthorized'),
-
-            },
-            [],
-            [])
-
-        @@service_info = VAPI::Bindings::ServiceInfo.new(@@service_id, {
-            'list' => @@list_info,
-            'get' => @@get_info,
-            'create' => @@create_info,
-            'update' => @@update_info,
-            'delete' => @@delete_info,
-        })
-
-        public
-
-        # Constructs a new instance.
-        #
-        # @param config [VAPI::Bindings::StubConfig] A hash with the api provider details.
-        def initialize(config)
-            super(config, @@service_info)
-        end
-
-        RESOURCE_TYPE = 'com.vmware.vcenter.vm.hardware.ScsiAdapter'
-
-
-        # Returns commonly used information about the virtual SCSI adapters belonging to the virtual machine.
-        #
-        # @param vm [String]
-        #     Virtual machine identifier.
-        # @return [Array<Com::Vmware::Vcenter::Vm::Hardware::Adapter::Scsi::Summary>]
-        #     List of commonly used information about virtual SCSI adapters.
-        # @raise [Com::Vmware::Vapi::Std::Errors::Error]
-        #     if the system reports an error while responding to the request.
-        # @raise [Com::Vmware::Vapi::Std::Errors::NotFound]
-        #     if the virtual machine is not found.
-        # @raise [Com::Vmware::Vapi::Std::Errors::ResourceInaccessible]
-        #     if the virtual machine's configuration state cannot be accessed.
-        # @raise [Com::Vmware::Vapi::Std::Errors::ServiceUnavailable]
-        #     if the system is unable to communicate with a service to complete the request.
-        # @raise [Com::Vmware::Vapi::Std::Errors::Unauthenticated]
-        #     if the user can not be authenticated.
-        # @raise [Com::Vmware::Vapi::Std::Errors::Unauthorized]
-        #     if the user doesn't have the required privileges.
-        def list(vm)
-            invoke_with_info(@@list_info, {
-                'vm' => vm,
-            })
-        end
-
-
-        # Returns information about a virtual SCSI adapter.
-        #
-        # @param vm [String]
-        #     Virtual machine identifier.
-        # @param adapter [String]
-        #     Virtual SCSI adapter identifier.
-        # @return [Com::Vmware::Vcenter::Vm::Hardware::Adapter::Scsi::Info]
-        #     Information about the specified virtual SCSI adapter.
-        # @raise [Com::Vmware::Vapi::Std::Errors::Error]
-        #     if the system reports an error while responding to the request.
-        # @raise [Com::Vmware::Vapi::Std::Errors::NotFound]
-        #     if the virtual machine or virtual SCSI adapter is not found.
-        # @raise [Com::Vmware::Vapi::Std::Errors::ResourceInaccessible]
-        #     if the virtual machine's configuration state cannot be accessed.
-        # @raise [Com::Vmware::Vapi::Std::Errors::ServiceUnavailable]
-        #     if the system is unable to communicate with a service to complete the request.
-        # @raise [Com::Vmware::Vapi::Std::Errors::Unauthenticated]
-        #     if the user can not be authenticated.
-        # @raise [Com::Vmware::Vapi::Std::Errors::Unauthorized]
-        #     if the user doesn't have the required privileges.
-        def get(vm, adapter)
-            invoke_with_info(@@get_info, {
-                'vm' => vm,
-                'adapter' => adapter,
-            })
-        end
-
-
-        # Adds a virtual SCSI adapter to the virtual machine.
-        #
-        # @param vm [String]
-        #     Virtual machine identifier.
-        # @param spec [Com::Vmware::Vcenter::Vm::Hardware::Adapter::Scsi::CreateSpec]
-        #     Specification for the new virtual SCSI adapter.
-        # @return [String]
-        #     Virtual SCSI adapter identifier.
-        # @raise [Com::Vmware::Vapi::Std::Errors::Error]
-        #     if the system reported that the SCSI adapter was created but was unable to confirm the creation because the identifier of the new adapter could not be determined.
-        # @raise [Com::Vmware::Vapi::Std::Errors::Error]
-        #     if the system reports an error while responding to the request.
-        # @raise [Com::Vmware::Vapi::Std::Errors::NotAllowedInCurrentState]
-        #     if the virtual machine is suspended
-        # @raise [Com::Vmware::Vapi::Std::Errors::NotFound]
-        #     if the virtual machine is not found.
-        # @raise [Com::Vmware::Vapi::Std::Errors::UnableToAllocateResource]
-        #     if there are no more available SCSI buses on the virtual machine.
-        # @raise [Com::Vmware::Vapi::Std::Errors::ResourceInUse]
-        #     if the specified SCSI bus is in use.
-        # @raise [Com::Vmware::Vapi::Std::Errors::InvalidArgument]
-        #     if the specified SATA bus or PCI address is out of bounds.
-        # @raise [Com::Vmware::Vapi::Std::Errors::ResourceBusy]
-        #     if the virtual machine is busy performing another operation.
-        # @raise [Com::Vmware::Vapi::Std::Errors::ResourceInaccessible]
-        #     if the virtual machine's configuration state cannot be accessed.
-        # @raise [Com::Vmware::Vapi::Std::Errors::ServiceUnavailable]
-        #     if the system is unable to communicate with a service to complete the request.
-        # @raise [Com::Vmware::Vapi::Std::Errors::Unauthenticated]
-        #     if the user can not be authenticated.
-        # @raise [Com::Vmware::Vapi::Std::Errors::Unauthorized]
-        #     if the user doesn't have the required privileges.
-        # @raise [Com::Vmware::Vapi::Std::Errors::Unsupported]
-        #     if the guest operating system of the virtual machine is not supported and  spec  includes  nil   fields  that default to guest-specific values.
-        def create(vm, spec)
-            invoke_with_info(@@create_info, {
-                'vm' => vm,
-                'spec' => spec,
-            })
-        end
-
-
-        # Updates the configuration of a virtual SCSI adapter.
-        #
-        # @param vm [String]
-        #     Virtual machine identifier.
-        # @param adapter [String]
-        #     Virtual SCSI adapter identifier.
-        # @param spec [Com::Vmware::Vcenter::Vm::Hardware::Adapter::Scsi::UpdateSpec]
-        #     Specification for updating the virtual SCSI adapter.
-        # @return [Void]
-        # @raise [Com::Vmware::Vapi::Std::Errors::Error]
-        #     if the system reports an error while responding to the request.
-        # @raise [Com::Vmware::Vapi::Std::Errors::NotFound]
-        #     if the virtual machine or virtual SCSI adapter is not found.
-        # @raise [Com::Vmware::Vapi::Std::Errors::NotAllowedInCurrentState]
-        #     if one or more of the  fields  specified in the  ``spec``   parameter  cannot be modified due to the current power state of the virtual machine or the connection state of the virtual SCSI adapter.
-        # @raise [Com::Vmware::Vapi::Std::Errors::ResourceBusy]
-        #     if the virtual machine is busy performing another operation.
-        # @raise [Com::Vmware::Vapi::Std::Errors::ResourceInaccessible]
-        #     if the virtual machine's configuration state cannot be accessed.
-        # @raise [Com::Vmware::Vapi::Std::Errors::ServiceUnavailable]
-        #     if the system is unable to communicate with a service to complete the request.
-        # @raise [Com::Vmware::Vapi::Std::Errors::Unauthenticated]
-        #     if the user can not be authenticated.
-        # @raise [Com::Vmware::Vapi::Std::Errors::Unauthorized]
-        #     if the user doesn't have the required privileges.
-        def update(vm, adapter, spec)
-            invoke_with_info(@@update_info, {
-                'vm' => vm,
-                'adapter' => adapter,
-                'spec' => spec,
-            })
-        end
-
-
-        # Removes a virtual SCSI adapter from the virtual machine.
-        #
-        # @param vm [String]
-        #     Virtual machine identifier.
-        # @param adapter [String]
-        #     Virtual SCSI adapter identifier.
-        # @return [Void]
-        # @raise [Com::Vmware::Vapi::Std::Errors::Error]
-        #     if the system reports an error while responding to the request.
-        # @raise [Com::Vmware::Vapi::Std::Errors::NotAllowedInCurrentState]
-        #     if the virtual machine is suspended
-        # @raise [Com::Vmware::Vapi::Std::Errors::NotFound]
-        #     if the virtual machine or virtual SCSI adapter is not found.
-        # @raise [Com::Vmware::Vapi::Std::Errors::ResourceBusy]
-        #     if the virtual machine is busy performing another operation.
-        # @raise [Com::Vmware::Vapi::Std::Errors::ResourceInaccessible]
-        #     if the virtual machine's configuration state cannot be accessed.
-        # @raise [Com::Vmware::Vapi::Std::Errors::ServiceUnavailable]
-        #     if the system is unable to communicate with a service to complete the request.
-        # @raise [Com::Vmware::Vapi::Std::Errors::Unauthenticated]
-        #     if the user can not be authenticated.
-        # @raise [Com::Vmware::Vapi::Std::Errors::Unauthorized]
-        #     if the user doesn't have the required privileges.
-        def delete(vm, adapter)
-            invoke_with_info(@@delete_info, {
-                'vm' => vm,
-                'adapter' => adapter,
-            })
-        end
-
-
-
-        # The  ``Com::Vmware::Vcenter::Vm::Hardware::Adapter::Scsi::Info``   class  contains information about a virtual SCSI adapter.
-        # @!attribute [rw] label
-        #     @return [String]
-        #     Device label.
-        # @!attribute [rw] type
-        #     @return [Com::Vmware::Vcenter::Vm::Hardware::Adapter::Scsi::Type]
-        #     Adapter type.
-        # @!attribute [rw] scsi
-        #     @return [Com::Vmware::Vcenter::Vm::Hardware::ScsiAddressInfo]
-        #     Address of the SCSI adapter on the SCSI bus.
-        # @!attribute [rw] pci_slot_number
-        #     @return [Fixnum, nil]
-        #     Address of the SCSI adapter on the PCI bus. If the PCI address is invalid, the server will change it when the VM is started or as the device is hot added.
-        #     May be  nil  if the virtual machine has never been powered on since the adapter was created.
-        # @!attribute [rw] sharing
-        #     @return [Com::Vmware::Vcenter::Vm::Hardware::Adapter::Scsi::Sharing]
-        #     Bus sharing mode.
-        class Info < VAPI::Bindings::VapiStruct
-
-            class << self
-                # Holds (gets or creates) the binding type metadata for this structure type.
-                # @scope class
-                # @return [VAPI::Bindings::StructType] the binding type
-                def binding_type
-                    @binding_type ||= VAPI::Bindings::StructType.new(
-                        'com.vmware.vcenter.vm.hardware.adapter.scsi.info',
-                        {
-                            'label' => VAPI::Bindings::StringType.instance,
-                            'type' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::Vm::Hardware::Adapter::Scsi::Type'),
-                            'scsi' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::Vm::Hardware::ScsiAddressInfo'),
-                            'pci_slot_number' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::IntegerType.instance),
-                            'sharing' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::Vm::Hardware::Adapter::Scsi::Sharing'),
-                        },
-                        Info,
-                        false,
-                        nil)
-                end
-            end
-
-            attr_accessor :label,
-                          :type,
-                          :scsi,
-                          :pci_slot_number,
-                          :sharing
-
-            # Constructs a new instance.
-            # @param ruby_values [Hash] a map of initial property values (optional)
-            # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
-            def initialize(ruby_values=nil, struct_value=nil)
-                super(self.class.binding_type, ruby_values, struct_value)
-            end
-        end
-
-
-        # The  ``Com::Vmware::Vcenter::Vm::Hardware::Adapter::Scsi::CreateSpec``   class  provides a specification for the configuration of a newly-created virtual SCSI adapter.
-        # @!attribute [rw] type
-        #     @return [Com::Vmware::Vcenter::Vm::Hardware::Adapter::Scsi::Type, nil]
-        #     Adapter type.
-        #     If  nil , a guest-specific default value will be used.
-        # @!attribute [rw] bus
-        #     @return [Fixnum, nil]
-        #     SCSI bus number.
-        #     If  nil , the server will choose an available bus number; if none is available, the request will fail.
-        # @!attribute [rw] pci_slot_number
-        #     @return [Fixnum, nil]
-        #     Address of the SCSI adapter on the PCI bus. If the PCI address is invalid, the server will change it when the VM is started or as the device is hot added.
-        #     If  nil , the server will choose an available address when the virtual machine is powered on.
-        # @!attribute [rw] sharing
-        #     @return [Com::Vmware::Vcenter::Vm::Hardware::Adapter::Scsi::Sharing, nil]
-        #     Bus sharing mode.
-        #     If  nil , the adapter will default to   :attr:`Com::Vmware::Vcenter::Vm::Hardware::Adapter::Scsi::Sharing.NONE`  .
-        class CreateSpec < VAPI::Bindings::VapiStruct
-
-            class << self
-                # Holds (gets or creates) the binding type metadata for this structure type.
-                # @scope class
-                # @return [VAPI::Bindings::StructType] the binding type
-                def binding_type
-                    @binding_type ||= VAPI::Bindings::StructType.new(
-                        'com.vmware.vcenter.vm.hardware.adapter.scsi.create_spec',
-                        {
-                            'type' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::Vm::Hardware::Adapter::Scsi::Type')),
-                            'bus' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::IntegerType.instance),
-                            'pci_slot_number' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::IntegerType.instance),
-                            'sharing' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::Vm::Hardware::Adapter::Scsi::Sharing')),
-                        },
-                        CreateSpec,
-                        false,
-                        nil)
-                end
-            end
-
-            attr_accessor :type,
-                          :bus,
-                          :pci_slot_number,
-                          :sharing
-
-            # Constructs a new instance.
-            # @param ruby_values [Hash] a map of initial property values (optional)
-            # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
-            def initialize(ruby_values=nil, struct_value=nil)
-                super(self.class.binding_type, ruby_values, struct_value)
-            end
-        end
-
-
-        # The  ``Com::Vmware::Vcenter::Vm::Hardware::Adapter::Scsi::UpdateSpec``   class  describes the updates to be made to the configuration of a virtual SCSI adapter.
-        # @!attribute [rw] sharing
-        #     @return [Com::Vmware::Vcenter::Vm::Hardware::Adapter::Scsi::Sharing, nil]
-        #     Bus sharing mode.  
-        #     
-        #      This  field  may only be modified if the virtual machine is not powered on.
-        #     If  nil , the value is unchanged.
-        class UpdateSpec < VAPI::Bindings::VapiStruct
-
-            class << self
-                # Holds (gets or creates) the binding type metadata for this structure type.
-                # @scope class
-                # @return [VAPI::Bindings::StructType] the binding type
-                def binding_type
-                    @binding_type ||= VAPI::Bindings::StructType.new(
-                        'com.vmware.vcenter.vm.hardware.adapter.scsi.update_spec',
-                        {
-                            'sharing' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::Vm::Hardware::Adapter::Scsi::Sharing')),
-                        },
-                        UpdateSpec,
-                        false,
-                        nil)
-                end
-            end
-
-            attr_accessor :sharing
-
-            # Constructs a new instance.
-            # @param ruby_values [Hash] a map of initial property values (optional)
-            # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
-            def initialize(ruby_values=nil, struct_value=nil)
-                super(self.class.binding_type, ruby_values, struct_value)
-            end
-        end
-
-
-        # The  ``Com::Vmware::Vcenter::Vm::Hardware::Adapter::Scsi::Summary``   class  contains commonly used information about a Virtual SCSI adapter.
-        # @!attribute [rw] adapter
-        #     @return [String]
-        #     Identifier of the virtual SCSI adapter.
-        class Summary < VAPI::Bindings::VapiStruct
-
-            class << self
-                # Holds (gets or creates) the binding type metadata for this structure type.
-                # @scope class
-                # @return [VAPI::Bindings::StructType] the binding type
-                def binding_type
-                    @binding_type ||= VAPI::Bindings::StructType.new(
-                        'com.vmware.vcenter.vm.hardware.adapter.scsi.summary',
-                        {
-                            'adapter' => VAPI::Bindings::IdType.new(resource_types='com.vmware.vcenter.vm.hardware.ScsiAdapter'),
-                        },
-                        Summary,
-                        false,
-                        nil)
-                end
-            end
-
-            attr_accessor :adapter
-
-            # Constructs a new instance.
-            # @param ruby_values [Hash] a map of initial property values (optional)
-            # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
-            def initialize(ruby_values=nil, struct_value=nil)
-                super(self.class.binding_type, ruby_values, struct_value)
-            end
-        end
-
-
-
-        # The  ``Com::Vmware::Vcenter::Vm::Hardware::Adapter::Scsi::Type``   enumerated type  defines the valid emulation types for a virtual SCSI adapter.
-        # @!attribute [rw] buslogic
-        #     @return [Com::Vmware::Vcenter::Vm::Hardware::Adapter::Scsi::Type]
-        #     BusLogic host bus adapter.
-        # @!attribute [rw] lsilogic
-        #     @return [Com::Vmware::Vcenter::Vm::Hardware::Adapter::Scsi::Type]
-        #     LSI Logic host bus adapter.
-        # @!attribute [rw] lsilogicsas
-        #     @return [Com::Vmware::Vcenter::Vm::Hardware::Adapter::Scsi::Type]
-        #     LSI Logic SAS 1068 host bus adapter.
-        # @!attribute [rw] pvscsi
-        #     @return [Com::Vmware::Vcenter::Vm::Hardware::Adapter::Scsi::Type]
-        #     Paravirtualized host bus adapter.
-        class Type < VAPI::Bindings::VapiEnum
-
-            class << self
-                # Holds (gets or creates) the binding type metadata for this enumeration type.
-                # @scope class
-                # @return [VAPI::Bindings::EnumType] the binding type
-                def binding_type
-                    @binding_type ||= VAPI::Bindings::EnumType.new(
-                        'com.vmware.vcenter.vm.hardware.adapter.scsi.type',
-                        Type)
-                end
-
-                # Converts from a string value (perhaps off the wire) to an instance
-                # of this enum type.
-                # @param value [String] the actual value of the enum instance
-                # @return [Type] the instance found for the value, otherwise
-                #         an unknown instance will be built for the value
-                def from_string(value)
-                    begin
-                        const_get(value)
-                    rescue NameError
-                        Type.new('UNKNOWN', value)
-                    end
-                end
-            end
-
-            private
-
-            # Constructs a new instance.
-            # @param value [String] the actual value of the enum instance
-            # @param unknown [String] the unknown value when value is 'UKNOWN'
-            def initialize(value, unknown=nil)
-                super(self.class.binding_type, value, unknown)
-            end
-
-            public
-
-            # @!attribute [rw] buslogic
-            #     @return [Com::Vmware::Vcenter::Vm::Hardware::Adapter::Scsi::Type]
-            #     BusLogic host bus adapter.
-            BUSLOGIC = Type.new('BUSLOGIC')
-
-            # @!attribute [rw] lsilogic
-            #     @return [Com::Vmware::Vcenter::Vm::Hardware::Adapter::Scsi::Type]
-            #     LSI Logic host bus adapter.
-            LSILOGIC = Type.new('LSILOGIC')
-
-            # @!attribute [rw] lsilogicsas
-            #     @return [Com::Vmware::Vcenter::Vm::Hardware::Adapter::Scsi::Type]
-            #     LSI Logic SAS 1068 host bus adapter.
-            LSILOGICSAS = Type.new('LSILOGICSAS')
-
-            # @!attribute [rw] pvscsi
-            #     @return [Com::Vmware::Vcenter::Vm::Hardware::Adapter::Scsi::Type]
-            #     Paravirtualized host bus adapter.
-            PVSCSI = Type.new('PVSCSI')
-
-        end
-
-
-        # The  ``Com::Vmware::Vcenter::Vm::Hardware::Adapter::Scsi::Sharing``   enumerated type  defines the valid bus sharing modes for a virtual SCSI adapter.
-        # @!attribute [rw] none
-        #     @return [Com::Vmware::Vcenter::Vm::Hardware::Adapter::Scsi::Sharing]
-        #     The virtual SCSI bus is not shared.
-        # @!attribute [rw] virtual
-        #     @return [Com::Vmware::Vcenter::Vm::Hardware::Adapter::Scsi::Sharing]
-        #     The virtual SCSI bus is shared between two or more virtual machines. In this case, no physical machine is involved.
-        # @!attribute [rw] physical
-        #     @return [Com::Vmware::Vcenter::Vm::Hardware::Adapter::Scsi::Sharing]
-        #     The virtual SCSI bus is shared between two or more virtual machines residing on different physical hosts.
-        class Sharing < VAPI::Bindings::VapiEnum
-
-            class << self
-                # Holds (gets or creates) the binding type metadata for this enumeration type.
-                # @scope class
-                # @return [VAPI::Bindings::EnumType] the binding type
-                def binding_type
-                    @binding_type ||= VAPI::Bindings::EnumType.new(
-                        'com.vmware.vcenter.vm.hardware.adapter.scsi.sharing',
-                        Sharing)
-                end
-
-                # Converts from a string value (perhaps off the wire) to an instance
-                # of this enum type.
-                # @param value [String] the actual value of the enum instance
-                # @return [Sharing] the instance found for the value, otherwise
-                #         an unknown instance will be built for the value
-                def from_string(value)
-                    begin
-                        const_get(value)
-                    rescue NameError
-                        Sharing.new('UNKNOWN', value)
-                    end
-                end
-            end
-
-            private
-
-            # Constructs a new instance.
-            # @param value [String] the actual value of the enum instance
-            # @param unknown [String] the unknown value when value is 'UKNOWN'
-            def initialize(value, unknown=nil)
-                super(self.class.binding_type, value, unknown)
-            end
-
-            public
-
-            # @!attribute [rw] none
-            #     @return [Com::Vmware::Vcenter::Vm::Hardware::Adapter::Scsi::Sharing]
-            #     The virtual SCSI bus is not shared.
-            NONE = Sharing.new('NONE')
-
-            # @!attribute [rw] virtual
-            #     @return [Com::Vmware::Vcenter::Vm::Hardware::Adapter::Scsi::Sharing]
-            #     The virtual SCSI bus is shared between two or more virtual machines. In this case, no physical machine is involved.
-            VIRTUAL = Sharing.new('VIRTUAL')
-
-            # @!attribute [rw] physical
-            #     @return [Com::Vmware::Vcenter::Vm::Hardware::Adapter::Scsi::Sharing]
-            #     The virtual SCSI bus is shared between two or more virtual machines residing on different physical hosts.
-            PHYSICAL = Sharing.new('PHYSICAL')
-
-        end
-
-
+    RESOURCE_TYPE = 'com.vmware.vcenter.vm.hardware.SataAdapter'
+    # Returns commonly used information about the virtual SATA adapters belonging to the virtual machine.
+    #
+    # @param vm [String]
+    #     Virtual machine identifier.
+    # @return [Array<Com::Vmware::Vcenter::VM::Hardware::Adapter::Sata::Summary>]
+    #     List of commonly used information about virtual SATA adapters.
+    # @raise [Com::Vmware::Vapi::Std::Errors::Error]
+    #     if the system reports an error while responding to the request.
+    # @raise [Com::Vmware::Vapi::Std::Errors::NotFound]
+    #     if the virtual machine is not found.
+    # @raise [Com::Vmware::Vapi::Std::Errors::ResourceInaccessible]
+    #     if the virtual machine's configuration state cannot be accessed.
+    # @raise [Com::Vmware::Vapi::Std::Errors::ServiceUnavailable]
+    #     if the system is unable to communicate with a service to complete the request.
+    # @raise [Com::Vmware::Vapi::Std::Errors::Unauthenticated]
+    #     if the user can not be authenticated.
+    # @raise [Com::Vmware::Vapi::Std::Errors::Unauthorized]
+    #     if the user doesn't have the required privileges.
+    def list(vm)
+      invoke_with_info(LIST_INFO,
+                       'vm' => vm)
     end
 
+    # Returns information about a virtual SATA adapter.
+    #
+    # @param vm [String]
+    #     Virtual machine identifier.
+    # @param adapter [String]
+    #     Virtual SATA adapter identifier.
+    # @return [Com::Vmware::Vcenter::VM::Hardware::Adapter::Sata::Info]
+    #     Information about the specified virtual SATA adapter.
+    # @raise [Com::Vmware::Vapi::Std::Errors::Error]
+    #     if the system reports an error while responding to the request.
+    # @raise [Com::Vmware::Vapi::Std::Errors::NotFound]
+    #     if the virtual machine or virtual SATA adapter is not found.
+    # @raise [Com::Vmware::Vapi::Std::Errors::ResourceInaccessible]
+    #     if the virtual machine's configuration state cannot be accessed.
+    # @raise [Com::Vmware::Vapi::Std::Errors::ServiceUnavailable]
+    #     if the system is unable to communicate with a service to complete the request.
+    # @raise [Com::Vmware::Vapi::Std::Errors::Unauthenticated]
+    #     if the user can not be authenticated.
+    # @raise [Com::Vmware::Vapi::Std::Errors::Unauthorized]
+    #     if the user doesn't have the required privileges.
+    def get(vm, adapter)
+      invoke_with_info(GET_INFO,
+                       'vm' => vm,
+                       'adapter' => adapter)
+    end
 
+    # Adds a virtual SATA adapter to the virtual machine.
+    #
+    # @param vm [String]
+    #     Virtual machine identifier.
+    # @param spec [Com::Vmware::Vcenter::VM::Hardware::Adapter::Sata::CreateSpec]
+    #     Specification for the new virtual SATA adapter.
+    # @return [String]
+    #     Virtual SATA adapter identifier.
+    # @raise [Com::Vmware::Vapi::Std::Errors::Error]
+    #     if the system reports an error while responding to the request.
+    # @raise [Com::Vmware::Vapi::Std::Errors::Error]
+    #     if the system reported that the SATA adapter was created but was unable to confirm the creation because the identifier of the new adapter could not be determined.
+    # @raise [Com::Vmware::Vapi::Std::Errors::NotAllowedInCurrentState]
+    #     if the virtual machine is suspended
+    # @raise [Com::Vmware::Vapi::Std::Errors::NotFound]
+    #     if the virtual machine is not found.
+    # @raise [Com::Vmware::Vapi::Std::Errors::UnableToAllocateResource]
+    #     if there are no more available SATA buses on the virtual machine.
+    # @raise [Com::Vmware::Vapi::Std::Errors::ResourceInUse]
+    #     if the specified SATA bus or PCI address is in use.
+    # @raise [Com::Vmware::Vapi::Std::Errors::InvalidArgument]
+    #     if the specified SATA bus or PCI address is out of bounds.
+    # @raise [Com::Vmware::Vapi::Std::Errors::ResourceBusy]
+    #     if the virtual machine is busy performing another operation.
+    # @raise [Com::Vmware::Vapi::Std::Errors::ResourceInaccessible]
+    #     if the virtual machine's configuration state cannot be accessed.
+    # @raise [Com::Vmware::Vapi::Std::Errors::ServiceUnavailable]
+    #     if the system is unable to communicate with a service to complete the request.
+    # @raise [Com::Vmware::Vapi::Std::Errors::Unauthenticated]
+    #     if the user can not be authenticated.
+    # @raise [Com::Vmware::Vapi::Std::Errors::Unauthorized]
+    #     if the user doesn't have the required privileges.
+    # @raise [Com::Vmware::Vapi::Std::Errors::Unsupported]
+    #     if the guest operating system of the virtual machine is not supported and  spec  includes  nil   fields  that default to guest-specific values.
+    def create(vm, spec)
+      invoke_with_info(CREATE_INFO,
+                       'vm' => vm,
+                       'spec' => spec)
+    end
+
+    # Removes a virtual SATA adapter from the virtual machine.
+    #
+    # @param vm [String]
+    #     Virtual machine identifier.
+    # @param adapter [String]
+    #     Virtual SATA adapter identifier.
+    # @return [Void]
+    # @raise [Com::Vmware::Vapi::Std::Errors::Error]
+    #     if the system reports an error while responding to the request.
+    # @raise [Com::Vmware::Vapi::Std::Errors::NotAllowedInCurrentState]
+    #     if the virtual machine is suspended
+    # @raise [Com::Vmware::Vapi::Std::Errors::NotFound]
+    #     if the virtual machine or virtual SATA adapter is not found.
+    # @raise [Com::Vmware::Vapi::Std::Errors::ResourceBusy]
+    #     if the virtual machine is busy performing another operation.
+    # @raise [Com::Vmware::Vapi::Std::Errors::ResourceInaccessible]
+    #     if the virtual machine's configuration state cannot be accessed.
+    # @raise [Com::Vmware::Vapi::Std::Errors::ServiceUnavailable]
+    #     if the system is unable to communicate with a service to complete the request.
+    # @raise [Com::Vmware::Vapi::Std::Errors::Unauthenticated]
+    #     if the user can not be authenticated.
+    # @raise [Com::Vmware::Vapi::Std::Errors::Unauthorized]
+    #     if the user doesn't have the required privileges.
+    def delete(vm, adapter)
+      invoke_with_info(DELETE_INFO,
+                       'vm' => vm,
+                       'adapter' => adapter)
+    end
+
+    # The  ``Com::Vmware::Vcenter::VM::Hardware::Adapter::Sata::Info``   class  contains information about a virtual SATA adapter.
+    # @!attribute [rw] label
+    #     @return [String]
+    #     Device label.
+    # @!attribute [rw] type
+    #     @return [Com::Vmware::Vcenter::VM::Hardware::Adapter::Sata::Type]
+    #     Adapter type.
+    # @!attribute [rw] bus
+    #     @return [Fixnum]
+    #     SATA bus number.
+    # @!attribute [rw] pci_slot_number
+    #     @return [Fixnum, nil]
+    #     Address of the SATA adapter on the PCI bus.
+    #     May be  nil  if the virtual machine has never been powered on since the adapter was created.
+    class Info < VAPI::Bindings::VapiStruct
+      class << self
+        # Holds (gets or creates) the binding type metadata for this structure type.
+        # @scope class
+        # @return [VAPI::Bindings::StructType] the binding type
+        def binding_type
+          @binding_type ||= VAPI::Bindings::StructType.new(
+            'com.vmware.vcenter.vm.hardware.adapter.sata.info',
+            {
+              'label' => VAPI::Bindings::StringType.instance,
+              'type' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::VM::Hardware::Adapter::Sata::Type'),
+              'bus' => VAPI::Bindings::IntegerType.instance,
+              'pci_slot_number' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::IntegerType.instance)
+            },
+            Info,
+            false,
+            nil
+          )
+        end
+      end
+
+      attr_accessor :label,
+                    :type,
+                    :bus,
+                    :pci_slot_number
+
+      # Constructs a new instance.
+      # @param ruby_values [Hash] a map of initial property values (optional)
+      # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
+      def initialize(ruby_values = nil, struct_value = nil)
+        super(self.class.binding_type, ruby_values, struct_value)
+      end
+    end
+
+    # The  ``Com::Vmware::Vcenter::VM::Hardware::Adapter::Sata::CreateSpec``   class  provides a specification for the configuration of a newly-created virtual SATA adapter.
+    # @!attribute [rw] type
+    #     @return [Com::Vmware::Vcenter::VM::Hardware::Adapter::Sata::Type, nil]
+    #     Adapter type.
+    #     If  nil , a guest-specific default value will be used.
+    # @!attribute [rw] bus
+    #     @return [Fixnum, nil]
+    #     SATA bus number.
+    #     If  nil , the server will choose an available bus number; if none is available, the request will fail.
+    # @!attribute [rw] pci_slot_number
+    #     @return [Fixnum, nil]
+    #     Address of the SATA adapter on the PCI bus.
+    #     If  nil , the server will choose an available address when the virtual machine is powered on.
+    class CreateSpec < VAPI::Bindings::VapiStruct
+      class << self
+        # Holds (gets or creates) the binding type metadata for this structure type.
+        # @scope class
+        # @return [VAPI::Bindings::StructType] the binding type
+        def binding_type
+          @binding_type ||= VAPI::Bindings::StructType.new(
+            'com.vmware.vcenter.vm.hardware.adapter.sata.create_spec',
+            {
+              'type' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::VM::Hardware::Adapter::Sata::Type')),
+              'bus' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::IntegerType.instance),
+              'pci_slot_number' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::IntegerType.instance)
+            },
+            CreateSpec,
+            false,
+            nil
+          )
+        end
+      end
+
+      attr_accessor :type,
+                    :bus,
+                    :pci_slot_number
+
+      # Constructs a new instance.
+      # @param ruby_values [Hash] a map of initial property values (optional)
+      # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
+      def initialize(ruby_values = nil, struct_value = nil)
+        super(self.class.binding_type, ruby_values, struct_value)
+      end
+    end
+
+    # The  ``Com::Vmware::Vcenter::VM::Hardware::Adapter::Sata::Summary``   class  contains commonly used information about a Virtual SATA adapter.
+    # @!attribute [rw] adapter
+    #     @return [String]
+    #     Identifier of the virtual SATA adapter.
+    class Summary < VAPI::Bindings::VapiStruct
+      class << self
+        # Holds (gets or creates) the binding type metadata for this structure type.
+        # @scope class
+        # @return [VAPI::Bindings::StructType] the binding type
+        def binding_type
+          @binding_type ||= VAPI::Bindings::StructType.new(
+            'com.vmware.vcenter.vm.hardware.adapter.sata.summary',
+            {
+              'adapter' => VAPI::Bindings::IdType.new('com.vmware.vcenter.vm.hardware.SataAdapter')
+            },
+            Summary,
+            false,
+            nil
+          )
+        end
+      end
+
+      attr_accessor :adapter
+
+      # Constructs a new instance.
+      # @param ruby_values [Hash] a map of initial property values (optional)
+      # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
+      def initialize(ruby_values = nil, struct_value = nil)
+        super(self.class.binding_type, ruby_values, struct_value)
+      end
+    end
+
+    # The  ``Com::Vmware::Vcenter::VM::Hardware::Adapter::Sata::Type``   enumerated type  defines the valid emulation types for a virtual SATA adapter.
+    # @!attribute [rw] ahci
+    #     @return [Com::Vmware::Vcenter::VM::Hardware::Adapter::Sata::Type]
+    #     AHCI host bus adapter.
+    class Type < VAPI::Bindings::VapiEnum
+      class << self
+        # Holds (gets or creates) the binding type metadata for this enumeration type.
+        # @scope class
+        # @return [VAPI::Bindings::EnumType] the binding type
+        def binding_type
+          @binding_type ||= VAPI::Bindings::EnumType.new(
+            'com.vmware.vcenter.vm.hardware.adapter.sata.type',
+            Type
+          )
+        end
+
+        # Converts from a string value (perhaps off the wire) to an instance
+        # of this enum type.
+        # @param value [String] the actual value of the enum instance
+        # @return [Type] the instance found for the value, otherwise
+        #         an unknown instance will be built for the value
+        def from_string(value)
+          const_get(value)
+        rescue NameError
+          Type.send(:new, 'UNKNOWN', value)
+        end
+      end
+
+      # Constructs a new instance.
+      # @param value [String] the actual value of the enum instance
+      # @param unknown [String] the unknown value when value is 'UKNOWN'
+      def initialize(value, unknown = nil)
+        super(self.class.binding_type, value, unknown)
+      end
+
+      private_class_method :new
+
+      # @!attribute [rw] ahci
+      #     @return [Com::Vmware::Vcenter::VM::Hardware::Adapter::Sata::Type]
+      #     AHCI host bus adapter.
+      AHCI = Type.send(:new, 'AHCI')
+    end
+  end
+  # The  ``Com::Vmware::Vcenter::VM::Hardware::Adapter::Scsi``   class  provides  methods  for configuring the virtual SCSI adapters of a virtual machine.
+  class Scsi < VAPI::Bindings::VapiService
+    # static metamodel definitions
+    SERVICE_ID = VAPI::Core::ServiceIdentifier.new('com.vmware.vcenter.vm.hardware.adapter.scsi')
+
+    LIST_INFO = VAPI::Bindings::OperationInfo.new(
+      VAPI::Core::OperationIdentifier.new('list', SERVICE_ID),
+      VAPI::Bindings::OperationInputType.new(
+        'vm' => VAPI::Bindings::IdType.new('VirtualMachine')
+      ),
+      VAPI::Bindings::ListType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::VM::Hardware::Adapter::Scsi::Summary')),
+      {
+        'com.vmware.vapi.std.errors.error' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Error'),
+        'com.vmware.vapi.std.errors.not_found' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::NotFound'),
+        'com.vmware.vapi.std.errors.resource_inaccessible' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::ResourceInaccessible'),
+        'com.vmware.vapi.std.errors.service_unavailable' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::ServiceUnavailable'),
+        'com.vmware.vapi.std.errors.unauthenticated' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Unauthenticated'),
+        'com.vmware.vapi.std.errors.unauthorized' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Unauthorized')
+      },
+      [],
+      []
+    )
+
+    GET_INFO = VAPI::Bindings::OperationInfo.new(
+      VAPI::Core::OperationIdentifier.new('get', SERVICE_ID),
+      VAPI::Bindings::OperationInputType.new(
+        'vm' => VAPI::Bindings::IdType.new('VirtualMachine'),
+        'adapter' => VAPI::Bindings::IdType.new('com.vmware.vcenter.vm.hardware.ScsiAdapter')
+      ),
+      VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::VM::Hardware::Adapter::Scsi::Info'),
+      {
+        'com.vmware.vapi.std.errors.error' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Error'),
+        'com.vmware.vapi.std.errors.not_found' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::NotFound'),
+        'com.vmware.vapi.std.errors.resource_inaccessible' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::ResourceInaccessible'),
+        'com.vmware.vapi.std.errors.service_unavailable' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::ServiceUnavailable'),
+        'com.vmware.vapi.std.errors.unauthenticated' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Unauthenticated'),
+        'com.vmware.vapi.std.errors.unauthorized' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Unauthorized')
+      },
+      [],
+      []
+    )
+
+    CREATE_INFO = VAPI::Bindings::OperationInfo.new(
+      VAPI::Core::OperationIdentifier.new('create', SERVICE_ID),
+      VAPI::Bindings::OperationInputType.new(
+        'vm' => VAPI::Bindings::IdType.new('VirtualMachine'),
+        'spec' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::VM::Hardware::Adapter::Scsi::CreateSpec')
+      ),
+      VAPI::Bindings::IdType.new('com.vmware.vcenter.vm.hardware.ScsiAdapter'),
+      {
+        'com.vmware.vapi.std.errors.error' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Error'),
+        'com.vmware.vapi.std.errors.not_allowed_in_current_state' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::NotAllowedInCurrentState'),
+        'com.vmware.vapi.std.errors.not_found' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::NotFound'),
+        'com.vmware.vapi.std.errors.unable_to_allocate_resource' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::UnableToAllocateResource'),
+        'com.vmware.vapi.std.errors.resource_in_use' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::ResourceInUse'),
+        'com.vmware.vapi.std.errors.invalid_argument' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::InvalidArgument'),
+        'com.vmware.vapi.std.errors.resource_busy' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::ResourceBusy'),
+        'com.vmware.vapi.std.errors.resource_inaccessible' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::ResourceInaccessible'),
+        'com.vmware.vapi.std.errors.service_unavailable' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::ServiceUnavailable'),
+        'com.vmware.vapi.std.errors.unauthenticated' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Unauthenticated'),
+        'com.vmware.vapi.std.errors.unauthorized' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Unauthorized'),
+        'com.vmware.vapi.std.errors.unsupported' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Unsupported')
+      },
+      [],
+      []
+    )
+
+    UPDATE_INFO = VAPI::Bindings::OperationInfo.new(
+      VAPI::Core::OperationIdentifier.new('update', SERVICE_ID),
+      VAPI::Bindings::OperationInputType.new(
+        'vm' => VAPI::Bindings::IdType.new('VirtualMachine'),
+        'adapter' => VAPI::Bindings::IdType.new('com.vmware.vcenter.vm.hardware.ScsiAdapter'),
+        'spec' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::VM::Hardware::Adapter::Scsi::UpdateSpec')
+      ),
+      VAPI::Bindings::VoidType.instance,
+      {
+        'com.vmware.vapi.std.errors.error' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Error'),
+        'com.vmware.vapi.std.errors.not_found' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::NotFound'),
+        'com.vmware.vapi.std.errors.not_allowed_in_current_state' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::NotAllowedInCurrentState'),
+        'com.vmware.vapi.std.errors.resource_busy' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::ResourceBusy'),
+        'com.vmware.vapi.std.errors.resource_inaccessible' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::ResourceInaccessible'),
+        'com.vmware.vapi.std.errors.service_unavailable' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::ServiceUnavailable'),
+        'com.vmware.vapi.std.errors.unauthenticated' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Unauthenticated'),
+        'com.vmware.vapi.std.errors.unauthorized' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Unauthorized')
+      },
+      [],
+      []
+    )
+
+    DELETE_INFO = VAPI::Bindings::OperationInfo.new(
+      VAPI::Core::OperationIdentifier.new('delete', SERVICE_ID),
+      VAPI::Bindings::OperationInputType.new(
+        'vm' => VAPI::Bindings::IdType.new('VirtualMachine'),
+        'adapter' => VAPI::Bindings::IdType.new('com.vmware.vcenter.vm.hardware.ScsiAdapter')
+      ),
+      VAPI::Bindings::VoidType.instance,
+      {
+        'com.vmware.vapi.std.errors.error' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Error'),
+        'com.vmware.vapi.std.errors.not_allowed_in_current_state' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::NotAllowedInCurrentState'),
+        'com.vmware.vapi.std.errors.not_found' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::NotFound'),
+        'com.vmware.vapi.std.errors.resource_busy' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::ResourceBusy'),
+        'com.vmware.vapi.std.errors.resource_inaccessible' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::ResourceInaccessible'),
+        'com.vmware.vapi.std.errors.service_unavailable' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::ServiceUnavailable'),
+        'com.vmware.vapi.std.errors.unauthenticated' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Unauthenticated'),
+        'com.vmware.vapi.std.errors.unauthorized' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Unauthorized')
+      },
+      [],
+      []
+    )
+
+    SERVICE_INFO = VAPI::Bindings::ServiceInfo.new(
+      SERVICE_ID,
+      'list' => LIST_INFO,
+      'get' => GET_INFO,
+      'create' => CREATE_INFO,
+      'update' => UPDATE_INFO,
+      'delete' => DELETE_INFO
+    )
+
+    # Constructs a new instance.
+    #
+    # @param config [VAPI::Bindings::StubConfig] A hash with the api provider details.
+    def initialize(config)
+      super(config, SERVICE_INFO)
+    end
+
+    RESOURCE_TYPE = 'com.vmware.vcenter.vm.hardware.ScsiAdapter'
+    # Returns commonly used information about the virtual SCSI adapters belonging to the virtual machine.
+    #
+    # @param vm [String]
+    #     Virtual machine identifier.
+    # @return [Array<Com::Vmware::Vcenter::VM::Hardware::Adapter::Scsi::Summary>]
+    #     List of commonly used information about virtual SCSI adapters.
+    # @raise [Com::Vmware::Vapi::Std::Errors::Error]
+    #     if the system reports an error while responding to the request.
+    # @raise [Com::Vmware::Vapi::Std::Errors::NotFound]
+    #     if the virtual machine is not found.
+    # @raise [Com::Vmware::Vapi::Std::Errors::ResourceInaccessible]
+    #     if the virtual machine's configuration state cannot be accessed.
+    # @raise [Com::Vmware::Vapi::Std::Errors::ServiceUnavailable]
+    #     if the system is unable to communicate with a service to complete the request.
+    # @raise [Com::Vmware::Vapi::Std::Errors::Unauthenticated]
+    #     if the user can not be authenticated.
+    # @raise [Com::Vmware::Vapi::Std::Errors::Unauthorized]
+    #     if the user doesn't have the required privileges.
+    def list(vm)
+      invoke_with_info(LIST_INFO,
+                       'vm' => vm)
+    end
+
+    # Returns information about a virtual SCSI adapter.
+    #
+    # @param vm [String]
+    #     Virtual machine identifier.
+    # @param adapter [String]
+    #     Virtual SCSI adapter identifier.
+    # @return [Com::Vmware::Vcenter::VM::Hardware::Adapter::Scsi::Info]
+    #     Information about the specified virtual SCSI adapter.
+    # @raise [Com::Vmware::Vapi::Std::Errors::Error]
+    #     if the system reports an error while responding to the request.
+    # @raise [Com::Vmware::Vapi::Std::Errors::NotFound]
+    #     if the virtual machine or virtual SCSI adapter is not found.
+    # @raise [Com::Vmware::Vapi::Std::Errors::ResourceInaccessible]
+    #     if the virtual machine's configuration state cannot be accessed.
+    # @raise [Com::Vmware::Vapi::Std::Errors::ServiceUnavailable]
+    #     if the system is unable to communicate with a service to complete the request.
+    # @raise [Com::Vmware::Vapi::Std::Errors::Unauthenticated]
+    #     if the user can not be authenticated.
+    # @raise [Com::Vmware::Vapi::Std::Errors::Unauthorized]
+    #     if the user doesn't have the required privileges.
+    def get(vm, adapter)
+      invoke_with_info(GET_INFO,
+                       'vm' => vm,
+                       'adapter' => adapter)
+    end
+
+    # Adds a virtual SCSI adapter to the virtual machine.
+    #
+    # @param vm [String]
+    #     Virtual machine identifier.
+    # @param spec [Com::Vmware::Vcenter::VM::Hardware::Adapter::Scsi::CreateSpec]
+    #     Specification for the new virtual SCSI adapter.
+    # @return [String]
+    #     Virtual SCSI adapter identifier.
+    # @raise [Com::Vmware::Vapi::Std::Errors::Error]
+    #     if the system reported that the SCSI adapter was created but was unable to confirm the creation because the identifier of the new adapter could not be determined.
+    # @raise [Com::Vmware::Vapi::Std::Errors::Error]
+    #     if the system reports an error while responding to the request.
+    # @raise [Com::Vmware::Vapi::Std::Errors::NotAllowedInCurrentState]
+    #     if the virtual machine is suspended
+    # @raise [Com::Vmware::Vapi::Std::Errors::NotFound]
+    #     if the virtual machine is not found.
+    # @raise [Com::Vmware::Vapi::Std::Errors::UnableToAllocateResource]
+    #     if there are no more available SCSI buses on the virtual machine.
+    # @raise [Com::Vmware::Vapi::Std::Errors::ResourceInUse]
+    #     if the specified SCSI bus is in use.
+    # @raise [Com::Vmware::Vapi::Std::Errors::InvalidArgument]
+    #     if the specified SATA bus or PCI address is out of bounds.
+    # @raise [Com::Vmware::Vapi::Std::Errors::ResourceBusy]
+    #     if the virtual machine is busy performing another operation.
+    # @raise [Com::Vmware::Vapi::Std::Errors::ResourceInaccessible]
+    #     if the virtual machine's configuration state cannot be accessed.
+    # @raise [Com::Vmware::Vapi::Std::Errors::ServiceUnavailable]
+    #     if the system is unable to communicate with a service to complete the request.
+    # @raise [Com::Vmware::Vapi::Std::Errors::Unauthenticated]
+    #     if the user can not be authenticated.
+    # @raise [Com::Vmware::Vapi::Std::Errors::Unauthorized]
+    #     if the user doesn't have the required privileges.
+    # @raise [Com::Vmware::Vapi::Std::Errors::Unsupported]
+    #     if the guest operating system of the virtual machine is not supported and  spec  includes  nil   fields  that default to guest-specific values.
+    def create(vm, spec)
+      invoke_with_info(CREATE_INFO,
+                       'vm' => vm,
+                       'spec' => spec)
+    end
+
+    # Updates the configuration of a virtual SCSI adapter.
+    #
+    # @param vm [String]
+    #     Virtual machine identifier.
+    # @param adapter [String]
+    #     Virtual SCSI adapter identifier.
+    # @param spec [Com::Vmware::Vcenter::VM::Hardware::Adapter::Scsi::UpdateSpec]
+    #     Specification for updating the virtual SCSI adapter.
+    # @return [Void]
+    # @raise [Com::Vmware::Vapi::Std::Errors::Error]
+    #     if the system reports an error while responding to the request.
+    # @raise [Com::Vmware::Vapi::Std::Errors::NotFound]
+    #     if the virtual machine or virtual SCSI adapter is not found.
+    # @raise [Com::Vmware::Vapi::Std::Errors::NotAllowedInCurrentState]
+    #     if one or more of the  fields  specified in the  ``spec``   parameter  cannot be modified due to the current power state of the virtual machine or the connection state of the virtual SCSI adapter.
+    # @raise [Com::Vmware::Vapi::Std::Errors::ResourceBusy]
+    #     if the virtual machine is busy performing another operation.
+    # @raise [Com::Vmware::Vapi::Std::Errors::ResourceInaccessible]
+    #     if the virtual machine's configuration state cannot be accessed.
+    # @raise [Com::Vmware::Vapi::Std::Errors::ServiceUnavailable]
+    #     if the system is unable to communicate with a service to complete the request.
+    # @raise [Com::Vmware::Vapi::Std::Errors::Unauthenticated]
+    #     if the user can not be authenticated.
+    # @raise [Com::Vmware::Vapi::Std::Errors::Unauthorized]
+    #     if the user doesn't have the required privileges.
+    def update(vm, adapter, spec)
+      invoke_with_info(UPDATE_INFO,
+                       'vm' => vm,
+                       'adapter' => adapter,
+                       'spec' => spec)
+    end
+
+    # Removes a virtual SCSI adapter from the virtual machine.
+    #
+    # @param vm [String]
+    #     Virtual machine identifier.
+    # @param adapter [String]
+    #     Virtual SCSI adapter identifier.
+    # @return [Void]
+    # @raise [Com::Vmware::Vapi::Std::Errors::Error]
+    #     if the system reports an error while responding to the request.
+    # @raise [Com::Vmware::Vapi::Std::Errors::NotAllowedInCurrentState]
+    #     if the virtual machine is suspended
+    # @raise [Com::Vmware::Vapi::Std::Errors::NotFound]
+    #     if the virtual machine or virtual SCSI adapter is not found.
+    # @raise [Com::Vmware::Vapi::Std::Errors::ResourceBusy]
+    #     if the virtual machine is busy performing another operation.
+    # @raise [Com::Vmware::Vapi::Std::Errors::ResourceInaccessible]
+    #     if the virtual machine's configuration state cannot be accessed.
+    # @raise [Com::Vmware::Vapi::Std::Errors::ServiceUnavailable]
+    #     if the system is unable to communicate with a service to complete the request.
+    # @raise [Com::Vmware::Vapi::Std::Errors::Unauthenticated]
+    #     if the user can not be authenticated.
+    # @raise [Com::Vmware::Vapi::Std::Errors::Unauthorized]
+    #     if the user doesn't have the required privileges.
+    def delete(vm, adapter)
+      invoke_with_info(DELETE_INFO,
+                       'vm' => vm,
+                       'adapter' => adapter)
+    end
+
+    # The  ``Com::Vmware::Vcenter::VM::Hardware::Adapter::Scsi::Info``   class  contains information about a virtual SCSI adapter.
+    # @!attribute [rw] label
+    #     @return [String]
+    #     Device label.
+    # @!attribute [rw] type
+    #     @return [Com::Vmware::Vcenter::VM::Hardware::Adapter::Scsi::Type]
+    #     Adapter type.
+    # @!attribute [rw] scsi
+    #     @return [Com::Vmware::Vcenter::VM::Hardware::ScsiAddressInfo]
+    #     Address of the SCSI adapter on the SCSI bus.
+    # @!attribute [rw] pci_slot_number
+    #     @return [Fixnum, nil]
+    #     Address of the SCSI adapter on the PCI bus. If the PCI address is invalid, the server will change it when the VM is started or as the device is hot added.
+    #     May be  nil  if the virtual machine has never been powered on since the adapter was created.
+    # @!attribute [rw] sharing
+    #     @return [Com::Vmware::Vcenter::VM::Hardware::Adapter::Scsi::Sharing]
+    #     Bus sharing mode.
+    class Info < VAPI::Bindings::VapiStruct
+      class << self
+        # Holds (gets or creates) the binding type metadata for this structure type.
+        # @scope class
+        # @return [VAPI::Bindings::StructType] the binding type
+        def binding_type
+          @binding_type ||= VAPI::Bindings::StructType.new(
+            'com.vmware.vcenter.vm.hardware.adapter.scsi.info',
+            {
+              'label' => VAPI::Bindings::StringType.instance,
+              'type' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::VM::Hardware::Adapter::Scsi::Type'),
+              'scsi' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::VM::Hardware::ScsiAddressInfo'),
+              'pci_slot_number' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::IntegerType.instance),
+              'sharing' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::VM::Hardware::Adapter::Scsi::Sharing')
+            },
+            Info,
+            false,
+            nil
+          )
+        end
+      end
+
+      attr_accessor :label,
+                    :type,
+                    :scsi,
+                    :pci_slot_number,
+                    :sharing
+
+      # Constructs a new instance.
+      # @param ruby_values [Hash] a map of initial property values (optional)
+      # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
+      def initialize(ruby_values = nil, struct_value = nil)
+        super(self.class.binding_type, ruby_values, struct_value)
+      end
+    end
+
+    # The  ``Com::Vmware::Vcenter::VM::Hardware::Adapter::Scsi::CreateSpec``   class  provides a specification for the configuration of a newly-created virtual SCSI adapter.
+    # @!attribute [rw] type
+    #     @return [Com::Vmware::Vcenter::VM::Hardware::Adapter::Scsi::Type, nil]
+    #     Adapter type.
+    #     If  nil , a guest-specific default value will be used.
+    # @!attribute [rw] bus
+    #     @return [Fixnum, nil]
+    #     SCSI bus number.
+    #     If  nil , the server will choose an available bus number; if none is available, the request will fail.
+    # @!attribute [rw] pci_slot_number
+    #     @return [Fixnum, nil]
+    #     Address of the SCSI adapter on the PCI bus. If the PCI address is invalid, the server will change it when the VM is started or as the device is hot added.
+    #     If  nil , the server will choose an available address when the virtual machine is powered on.
+    # @!attribute [rw] sharing
+    #     @return [Com::Vmware::Vcenter::VM::Hardware::Adapter::Scsi::Sharing, nil]
+    #     Bus sharing mode.
+    #     If  nil , the adapter will default to   :attr:`Com::Vmware::Vcenter::VM::Hardware::Adapter::Scsi::Sharing.NONE`  .
+    class CreateSpec < VAPI::Bindings::VapiStruct
+      class << self
+        # Holds (gets or creates) the binding type metadata for this structure type.
+        # @scope class
+        # @return [VAPI::Bindings::StructType] the binding type
+        def binding_type
+          @binding_type ||= VAPI::Bindings::StructType.new(
+            'com.vmware.vcenter.vm.hardware.adapter.scsi.create_spec',
+            {
+              'type' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::VM::Hardware::Adapter::Scsi::Type')),
+              'bus' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::IntegerType.instance),
+              'pci_slot_number' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::IntegerType.instance),
+              'sharing' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::VM::Hardware::Adapter::Scsi::Sharing'))
+            },
+            CreateSpec,
+            false,
+            nil
+          )
+        end
+      end
+
+      attr_accessor :type,
+                    :bus,
+                    :pci_slot_number,
+                    :sharing
+
+      # Constructs a new instance.
+      # @param ruby_values [Hash] a map of initial property values (optional)
+      # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
+      def initialize(ruby_values = nil, struct_value = nil)
+        super(self.class.binding_type, ruby_values, struct_value)
+      end
+    end
+
+    # The  ``Com::Vmware::Vcenter::VM::Hardware::Adapter::Scsi::UpdateSpec``   class  describes the updates to be made to the configuration of a virtual SCSI adapter.
+    # @!attribute [rw] sharing
+    #     @return [Com::Vmware::Vcenter::VM::Hardware::Adapter::Scsi::Sharing, nil]
+    #     Bus sharing mode.  
+    #     
+    #      This  field  may only be modified if the virtual machine is not powered on.
+    #     If  nil , the value is unchanged.
+    class UpdateSpec < VAPI::Bindings::VapiStruct
+      class << self
+        # Holds (gets or creates) the binding type metadata for this structure type.
+        # @scope class
+        # @return [VAPI::Bindings::StructType] the binding type
+        def binding_type
+          @binding_type ||= VAPI::Bindings::StructType.new(
+            'com.vmware.vcenter.vm.hardware.adapter.scsi.update_spec',
+            {
+              'sharing' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::VM::Hardware::Adapter::Scsi::Sharing'))
+            },
+            UpdateSpec,
+            false,
+            nil
+          )
+        end
+      end
+
+      attr_accessor :sharing
+
+      # Constructs a new instance.
+      # @param ruby_values [Hash] a map of initial property values (optional)
+      # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
+      def initialize(ruby_values = nil, struct_value = nil)
+        super(self.class.binding_type, ruby_values, struct_value)
+      end
+    end
+
+    # The  ``Com::Vmware::Vcenter::VM::Hardware::Adapter::Scsi::Summary``   class  contains commonly used information about a Virtual SCSI adapter.
+    # @!attribute [rw] adapter
+    #     @return [String]
+    #     Identifier of the virtual SCSI adapter.
+    class Summary < VAPI::Bindings::VapiStruct
+      class << self
+        # Holds (gets or creates) the binding type metadata for this structure type.
+        # @scope class
+        # @return [VAPI::Bindings::StructType] the binding type
+        def binding_type
+          @binding_type ||= VAPI::Bindings::StructType.new(
+            'com.vmware.vcenter.vm.hardware.adapter.scsi.summary',
+            {
+              'adapter' => VAPI::Bindings::IdType.new('com.vmware.vcenter.vm.hardware.ScsiAdapter')
+            },
+            Summary,
+            false,
+            nil
+          )
+        end
+      end
+
+      attr_accessor :adapter
+
+      # Constructs a new instance.
+      # @param ruby_values [Hash] a map of initial property values (optional)
+      # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
+      def initialize(ruby_values = nil, struct_value = nil)
+        super(self.class.binding_type, ruby_values, struct_value)
+      end
+    end
+
+    # The  ``Com::Vmware::Vcenter::VM::Hardware::Adapter::Scsi::Type``   enumerated type  defines the valid emulation types for a virtual SCSI adapter.
+    # @!attribute [rw] buslogic
+    #     @return [Com::Vmware::Vcenter::VM::Hardware::Adapter::Scsi::Type]
+    #     BusLogic host bus adapter.
+    # @!attribute [rw] lsilogic
+    #     @return [Com::Vmware::Vcenter::VM::Hardware::Adapter::Scsi::Type]
+    #     LSI Logic host bus adapter.
+    # @!attribute [rw] lsilogicsas
+    #     @return [Com::Vmware::Vcenter::VM::Hardware::Adapter::Scsi::Type]
+    #     LSI Logic SAS 1068 host bus adapter.
+    # @!attribute [rw] pvscsi
+    #     @return [Com::Vmware::Vcenter::VM::Hardware::Adapter::Scsi::Type]
+    #     Paravirtualized host bus adapter.
+    class Type < VAPI::Bindings::VapiEnum
+      class << self
+        # Holds (gets or creates) the binding type metadata for this enumeration type.
+        # @scope class
+        # @return [VAPI::Bindings::EnumType] the binding type
+        def binding_type
+          @binding_type ||= VAPI::Bindings::EnumType.new(
+            'com.vmware.vcenter.vm.hardware.adapter.scsi.type',
+            Type
+          )
+        end
+
+        # Converts from a string value (perhaps off the wire) to an instance
+        # of this enum type.
+        # @param value [String] the actual value of the enum instance
+        # @return [Type] the instance found for the value, otherwise
+        #         an unknown instance will be built for the value
+        def from_string(value)
+          const_get(value)
+        rescue NameError
+          Type.send(:new, 'UNKNOWN', value)
+        end
+      end
+
+      # Constructs a new instance.
+      # @param value [String] the actual value of the enum instance
+      # @param unknown [String] the unknown value when value is 'UKNOWN'
+      def initialize(value, unknown = nil)
+        super(self.class.binding_type, value, unknown)
+      end
+
+      private_class_method :new
+
+      # @!attribute [rw] buslogic
+      #     @return [Com::Vmware::Vcenter::VM::Hardware::Adapter::Scsi::Type]
+      #     BusLogic host bus adapter.
+      BUSLOGIC = Type.send(:new, 'BUSLOGIC')
+
+      # @!attribute [rw] lsilogic
+      #     @return [Com::Vmware::Vcenter::VM::Hardware::Adapter::Scsi::Type]
+      #     LSI Logic host bus adapter.
+      LSILOGIC = Type.send(:new, 'LSILOGIC')
+
+      # @!attribute [rw] lsilogicsas
+      #     @return [Com::Vmware::Vcenter::VM::Hardware::Adapter::Scsi::Type]
+      #     LSI Logic SAS 1068 host bus adapter.
+      LSILOGICSAS = Type.send(:new, 'LSILOGICSAS')
+
+      # @!attribute [rw] pvscsi
+      #     @return [Com::Vmware::Vcenter::VM::Hardware::Adapter::Scsi::Type]
+      #     Paravirtualized host bus adapter.
+      PVSCSI = Type.send(:new, 'PVSCSI')
+    end
+    # The  ``Com::Vmware::Vcenter::VM::Hardware::Adapter::Scsi::Sharing``   enumerated type  defines the valid bus sharing modes for a virtual SCSI adapter.
+    # @!attribute [rw] none
+    #     @return [Com::Vmware::Vcenter::VM::Hardware::Adapter::Scsi::Sharing]
+    #     The virtual SCSI bus is not shared.
+    # @!attribute [rw] virtual
+    #     @return [Com::Vmware::Vcenter::VM::Hardware::Adapter::Scsi::Sharing]
+    #     The virtual SCSI bus is shared between two or more virtual machines. In this case, no physical machine is involved.
+    # @!attribute [rw] physical
+    #     @return [Com::Vmware::Vcenter::VM::Hardware::Adapter::Scsi::Sharing]
+    #     The virtual SCSI bus is shared between two or more virtual machines residing on different physical hosts.
+    class Sharing < VAPI::Bindings::VapiEnum
+      class << self
+        # Holds (gets or creates) the binding type metadata for this enumeration type.
+        # @scope class
+        # @return [VAPI::Bindings::EnumType] the binding type
+        def binding_type
+          @binding_type ||= VAPI::Bindings::EnumType.new(
+            'com.vmware.vcenter.vm.hardware.adapter.scsi.sharing',
+            Sharing
+          )
+        end
+
+        # Converts from a string value (perhaps off the wire) to an instance
+        # of this enum type.
+        # @param value [String] the actual value of the enum instance
+        # @return [Sharing] the instance found for the value, otherwise
+        #         an unknown instance will be built for the value
+        def from_string(value)
+          const_get(value)
+        rescue NameError
+          Sharing.send(:new, 'UNKNOWN', value)
+        end
+      end
+
+      # Constructs a new instance.
+      # @param value [String] the actual value of the enum instance
+      # @param unknown [String] the unknown value when value is 'UKNOWN'
+      def initialize(value, unknown = nil)
+        super(self.class.binding_type, value, unknown)
+      end
+
+      private_class_method :new
+
+      # @!attribute [rw] none
+      #     @return [Com::Vmware::Vcenter::VM::Hardware::Adapter::Scsi::Sharing]
+      #     The virtual SCSI bus is not shared.
+      NONE = Sharing.send(:new, 'NONE')
+
+      # @!attribute [rw] virtual
+      #     @return [Com::Vmware::Vcenter::VM::Hardware::Adapter::Scsi::Sharing]
+      #     The virtual SCSI bus is shared between two or more virtual machines. In this case, no physical machine is involved.
+      VIRTUAL = Sharing.send(:new, 'VIRTUAL')
+
+      # @!attribute [rw] physical
+      #     @return [Com::Vmware::Vcenter::VM::Hardware::Adapter::Scsi::Sharing]
+      #     The virtual SCSI bus is shared between two or more virtual machines residing on different physical hosts.
+      PHYSICAL = Sharing.send(:new, 'PHYSICAL')
+    end
+  end
 end

--- a/client/sdk/com/vmware/vcenter/vm/hardware/boot.rb
+++ b/client/sdk/com/vmware/vcenter/vm/hardware/boot.rb
@@ -1,5 +1,6 @@
 #---------------------------------------------------------------------------
-# Copyright 2016 VMware, Inc.  All rights reserved.
+# Copyright 2017 VMware, Inc.  All rights reserved.
+#
 # AUTO GENERATED FILE -- DO NOT MODIFY!
 #
 # vAPI type descriptors for package com.vmware.vcenter.vm.hardware.boot.
@@ -8,300 +9,278 @@ require 'vapi'
 
 # declare the module hierarchy before we use the shorthand syntax below
 module Com
-    module Vmware
-        module Vcenter
-            module Vm
-                module Hardware
-                    module Boot
-                    end
-                end
-            end
+  module Vmware
+    module Vcenter
+      module Vm
+        module Hardware
+          module Boot
+          end
         end
+      end
     end
+  end
 end
 
 # The  ``com.vmware.vcenter.vm.hardware.boot``   package  provides  classs  for managing the virtual devices used to boot a virtual machine.
 module Com::Vmware::Vcenter::Vm::Hardware::Boot
+  # The  ``Com::Vmware::Vcenter::VM::Hardware::Boot::Device``   class  provides  methods  for configuring the device order used when booting a virtual machine.  
+  # 
+  #  The boot order may be specified using a mixture of device classes and device instances, chosen from among the following:  
+  # 
+  #   *  :attr:`Com::Vmware::Vcenter::VM::Hardware::Boot::Device::Type.CDROM`  : Boot from a virtual CD-ROM drive; the device instance(s) will be chosen by the BIOS subsystem.
+  #    *  :attr:`Com::Vmware::Vcenter::VM::Hardware::Boot::Device::Type.FLOPPY`  : Boot from a virtual floppy drive; the device instance(s) will be chosen by the BIOS subsystem.
+  #    *  :attr:`Com::Vmware::Vcenter::VM::Hardware::Boot::Device::Type.DISK`  : Boot from a virtual disk device; the device instance is specified explicitly in   :attr:`Com::Vmware::Vcenter::VM::Hardware::Boot::Device::Entry.disks`   list, and multiple instances may be specified in the list.
+  #    *  :attr:`Com::Vmware::Vcenter::VM::Hardware::Boot::Device::Type.ETHERNET`  : Boot from a virtual Ethernet adapter; the device instance is specified explicitly as   :attr:`Com::Vmware::Vcenter::VM::Hardware::Boot::Device::Entry.nic`  , and multiple adapters may be specified in the boot order list.
+  #   
+  class Device < VAPI::Bindings::VapiService
+    # static metamodel definitions
+    SERVICE_ID = VAPI::Core::ServiceIdentifier.new('com.vmware.vcenter.vm.hardware.boot.device')
 
-    # The  ``Com::Vmware::Vcenter::Vm::Hardware::Boot::Device``   class  provides  methods  for configuring the device order used when booting a virtual machine.  
-    # 
-    #  The boot order may be specified using a mixture of device classes and device instances, chosen from among the following:  
-    # 
-    #   *  :attr:`Com::Vmware::Vcenter::Vm::Hardware::Boot::Device::Type.CDROM`  : Boot from a virtual CD-ROM drive; the device instance(s) will be chosen by the BIOS subsystem.
-    #    *  :attr:`Com::Vmware::Vcenter::Vm::Hardware::Boot::Device::Type.FLOPPY`  : Boot from a virtual floppy drive; the device instance(s) will be chosen by the BIOS subsystem.
-    #    *  :attr:`Com::Vmware::Vcenter::Vm::Hardware::Boot::Device::Type.DISK`  : Boot from a virtual disk device; the device instance is specified explicitly in   :attr:`Com::Vmware::Vcenter::Vm::Hardware::Boot::Device::Entry.disks`   list, and multiple instances may be specified in the list.
-    #    *  :attr:`Com::Vmware::Vcenter::Vm::Hardware::Boot::Device::Type.ETHERNET`  : Boot from a virtual Ethernet adapter; the device instance is specified explicitly as   :attr:`Com::Vmware::Vcenter::Vm::Hardware::Boot::Device::Entry.nic`  , and multiple adapters may be specified in the boot order list.
-    #   
-    class Device < VAPI::Bindings::VapiService
+    GET_INFO = VAPI::Bindings::OperationInfo.new(
+      VAPI::Core::OperationIdentifier.new('get', SERVICE_ID),
+      VAPI::Bindings::OperationInputType.new(
+        'vm' => VAPI::Bindings::IdType.new('VirtualMachine')
+      ),
+      VAPI::Bindings::ListType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::VM::Hardware::Boot::Device::Entry')),
+      {
+        'com.vmware.vapi.std.errors.error' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Error'),
+        'com.vmware.vapi.std.errors.not_found' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::NotFound'),
+        'com.vmware.vapi.std.errors.resource_inaccessible' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::ResourceInaccessible'),
+        'com.vmware.vapi.std.errors.service_unavailable' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::ServiceUnavailable'),
+        'com.vmware.vapi.std.errors.unauthenticated' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Unauthenticated'),
+        'com.vmware.vapi.std.errors.unauthorized' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Unauthorized')
+      },
+      [],
+      []
+    )
 
-        protected
+    SET_INFO = VAPI::Bindings::OperationInfo.new(
+      VAPI::Core::OperationIdentifier.new('set', SERVICE_ID),
+      VAPI::Bindings::OperationInputType.new(
+        'vm' => VAPI::Bindings::IdType.new('VirtualMachine'),
+        'devices' => VAPI::Bindings::ListType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::VM::Hardware::Boot::Device::Entry'))
+      ),
+      VAPI::Bindings::VoidType.instance,
+      {
+        'com.vmware.vapi.std.errors.error' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Error'),
+        'com.vmware.vapi.std.errors.not_found' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::NotFound'),
+        'com.vmware.vapi.std.errors.invalid_argument' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::InvalidArgument'),
+        'com.vmware.vapi.std.errors.resource_busy' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::ResourceBusy'),
+        'com.vmware.vapi.std.errors.resource_inaccessible' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::ResourceInaccessible'),
+        'com.vmware.vapi.std.errors.service_unavailable' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::ServiceUnavailable'),
+        'com.vmware.vapi.std.errors.unauthenticated' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Unauthenticated'),
+        'com.vmware.vapi.std.errors.unauthorized' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Unauthorized')
+      },
+      [],
+      []
+    )
 
-        # static metamodel definitions
-        @@service_id = VAPI::Core::ServiceIdentifier.new('com.vmware.vcenter.vm.hardware.boot.device')
+    SERVICE_INFO = VAPI::Bindings::ServiceInfo.new(
+      SERVICE_ID,
+      'get' => GET_INFO,
+      'set' => SET_INFO
+    )
 
-        @@get_info = VAPI::Bindings::OperationInfo.new(
-            VAPI::Core::OperationIdentifier.new('get', @@service_id),
-            VAPI::Bindings::OperationInputType.new({
-                'vm' => VAPI::Bindings::IdType.new(resource_types='VirtualMachine'),
-            }),
-            VAPI::Bindings::ListType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::Vm::Hardware::Boot::Device::Entry')),
-            {
-                'com.vmware.vapi.std.errors.error' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Error'),
-                'com.vmware.vapi.std.errors.not_found' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::NotFound'),
-                'com.vmware.vapi.std.errors.resource_inaccessible' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::ResourceInaccessible'),
-                'com.vmware.vapi.std.errors.service_unavailable' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::ServiceUnavailable'),
-                'com.vmware.vapi.std.errors.unauthenticated' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Unauthenticated'),
-                'com.vmware.vapi.std.errors.unauthorized' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Unauthorized'),
-
-            },
-            [],
-            [])
-        @@set_info = VAPI::Bindings::OperationInfo.new(
-            VAPI::Core::OperationIdentifier.new('set', @@service_id),
-            VAPI::Bindings::OperationInputType.new({
-                'vm' => VAPI::Bindings::IdType.new(resource_types='VirtualMachine'),
-                'devices' => VAPI::Bindings::ListType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::Vm::Hardware::Boot::Device::Entry')),
-            }),
-            VAPI::Bindings::VoidType.instance,
-            {
-                'com.vmware.vapi.std.errors.error' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Error'),
-                'com.vmware.vapi.std.errors.not_found' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::NotFound'),
-                'com.vmware.vapi.std.errors.invalid_argument' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::InvalidArgument'),
-                'com.vmware.vapi.std.errors.resource_busy' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::ResourceBusy'),
-                'com.vmware.vapi.std.errors.resource_inaccessible' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::ResourceInaccessible'),
-                'com.vmware.vapi.std.errors.service_unavailable' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::ServiceUnavailable'),
-                'com.vmware.vapi.std.errors.unauthenticated' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Unauthenticated'),
-                'com.vmware.vapi.std.errors.unauthorized' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Unauthorized'),
-
-            },
-            [],
-            [])
-
-        @@service_info = VAPI::Bindings::ServiceInfo.new(@@service_id, {
-            'get' => @@get_info,
-            'set' => @@set_info,
-        })
-
-        public
-
-        # Constructs a new instance.
-        #
-        # @param config [VAPI::Bindings::StubConfig] A hash with the api provider details.
-        def initialize(config)
-            super(config, @@service_info)
-        end
-
-
-        # Returns an ordered list of boot devices for the virtual machine. If the  list  is empty, the virtual machine uses a default boot sequence.
-        #
-        # @param vm [String]
-        #     Virtual machine identifier.
-        # @return [Array<Com::Vmware::Vcenter::Vm::Hardware::Boot::Device::Entry>]
-        #     Ordered list of configured boot devices.
-        # @raise [Com::Vmware::Vapi::Std::Errors::Error]
-        #     if the system reports an error while responding to the request.
-        # @raise [Com::Vmware::Vapi::Std::Errors::NotFound]
-        #     if the virtual machine is not found.
-        # @raise [Com::Vmware::Vapi::Std::Errors::ResourceInaccessible]
-        #     if the virtual machine's configuration state cannot be accessed.
-        # @raise [Com::Vmware::Vapi::Std::Errors::ServiceUnavailable]
-        #     if the system is unable to communicate with a service to complete the request.
-        # @raise [Com::Vmware::Vapi::Std::Errors::Unauthenticated]
-        #     if the user can not be authenticated.
-        # @raise [Com::Vmware::Vapi::Std::Errors::Unauthorized]
-        #     if the user doesn't have the required privileges.
-        def get(vm)
-            invoke_with_info(@@get_info, {
-                'vm' => vm,
-            })
-        end
-
-
-        # Sets the virtual devices that will be used to boot the virtual machine. The virtual machine will check the devices in order, attempting to boot from each, until the virtual machine boots successfully. If the  list  is empty, the virtual machine will use a default boot sequence. There should be no more than one instance of   :class:`Com::Vmware::Vcenter::Vm::Hardware::Boot::Device::Entry`   for a given device type except   :attr:`Com::Vmware::Vcenter::Vm::Hardware::Boot::Device::Type.ETHERNET`   in the  list .
-        #
-        # @param vm [String]
-        #     Virtual machine identifier.
-        # @param devices [Array<Com::Vmware::Vcenter::Vm::Hardware::Boot::Device::Entry>]
-        #     Ordered list of boot devices.
-        # @return [Void]
-        # @raise [Com::Vmware::Vapi::Std::Errors::Error]
-        #     if the system reports an error while responding to the request.
-        # @raise [Com::Vmware::Vapi::Std::Errors::NotFound]
-        #     if the virtual machine is not found, or if any of the specified virtual devices is not found.
-        # @raise [Com::Vmware::Vapi::Std::Errors::InvalidArgument]
-        #     if a any of the  ``CDROM``, ``DISK``, ``ETHERNET``, ``FLOPPY``  values appears in more than one  ``Com::Vmware::Vcenter::Vm::Hardware::Boot::Device::Entry``  with the exception of   :attr:`Com::Vmware::Vcenter::Vm::Hardware::Boot::Device::Type.ETHERNET`  , which may appear multiple times if the virtual machine has been configured with multiple Ethernet adapters.
-        # @raise [Com::Vmware::Vapi::Std::Errors::ResourceBusy]
-        #     if the virtual machine is busy performing another operation.
-        # @raise [Com::Vmware::Vapi::Std::Errors::ResourceInaccessible]
-        #     if the virtual machine's configuration state cannot be accessed.
-        # @raise [Com::Vmware::Vapi::Std::Errors::ServiceUnavailable]
-        #     if the system is unable to communicate with a service to complete the request.
-        # @raise [Com::Vmware::Vapi::Std::Errors::Unauthenticated]
-        #     if the user can not be authenticated.
-        # @raise [Com::Vmware::Vapi::Std::Errors::Unauthorized]
-        #     if the user doesn't have the required privileges.
-        def set(vm, devices)
-            invoke_with_info(@@set_info, {
-                'vm' => vm,
-                'devices' => devices,
-            })
-        end
-
-
-
-        # The  class   ``Com::Vmware::Vcenter::Vm::Hardware::Boot::Device::EntryCreateSpec``  specifies a list of bootable virtual device classes. When a VM is being created and a  list  of  ``Com::Vmware::Vcenter::Vm::Hardware::Boot::Device::EntryCreateSpec``  is specified, the boot order of the specific device instances are not specified in this  class . The boot order of the specific device instance will be the order in which the Ethernet and Disk devices appear in the  ``nics``  and  ``disks``  respectively.
-        # @!attribute [rw] type
-        #     @return [Com::Vmware::Vcenter::Vm::Hardware::Boot::Device::Type]
-        #     Virtual Boot device type.
-        class EntryCreateSpec < VAPI::Bindings::VapiStruct
-
-            class << self
-                # Holds (gets or creates) the binding type metadata for this structure type.
-                # @scope class
-                # @return [VAPI::Bindings::StructType] the binding type
-                def binding_type
-                    @binding_type ||= VAPI::Bindings::StructType.new(
-                        'com.vmware.vcenter.vm.hardware.boot.device.entry_create_spec',
-                        {
-                            'type' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::Vm::Hardware::Boot::Device::Type'),
-                        },
-                        EntryCreateSpec,
-                        false,
-                        nil)
-                end
-            end
-
-            attr_accessor :type
-
-            # Constructs a new instance.
-            # @param ruby_values [Hash] a map of initial property values (optional)
-            # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
-            def initialize(ruby_values=nil, struct_value=nil)
-                super(self.class.binding_type, ruby_values, struct_value)
-            end
-        end
-
-
-        # The  ``Com::Vmware::Vcenter::Vm::Hardware::Boot::Device::Entry``   class  specifies a bootable virtual device class or specific bootable virtual device(s).
-        # @!attribute [rw] type
-        #     @return [Com::Vmware::Vcenter::Vm::Hardware::Boot::Device::Type]
-        #     Virtual device type.
-        # @!attribute [rw] nic
-        #     @return [String]
-        #     Virtual Ethernet device. Ethernet device to use as boot device for this entry.
-        #     This  field  is optional and it is only relevant when the value of  ``type``  is   :attr:`Com::Vmware::Vcenter::Vm::Hardware::Boot::Device::Type.ETHERNET`  .
-        # @!attribute [rw] disks
-        #     @return [Array<String>]
-        #     Virtual disk device. List of virtual disks in boot order.
-        #     This  field  is optional and it is only relevant when the value of  ``type``  is   :attr:`Com::Vmware::Vcenter::Vm::Hardware::Boot::Device::Type.DISK`  .
-        class Entry < VAPI::Bindings::VapiStruct
-
-            class << self
-                # Holds (gets or creates) the binding type metadata for this structure type.
-                # @scope class
-                # @return [VAPI::Bindings::StructType] the binding type
-                def binding_type
-                    @binding_type ||= VAPI::Bindings::StructType.new(
-                        'com.vmware.vcenter.vm.hardware.boot.device.entry',
-                        {
-                            'type' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::Vm::Hardware::Boot::Device::Type'),
-                            'nic' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::IdType.new),
-                            'disks' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::ListType.new(VAPI::Bindings::IdType.new)),
-                        },
-                        Entry,
-                        false,
-                        nil)
-                end
-            end
-
-            attr_accessor :type,
-                          :nic,
-                          :disks
-
-            # Constructs a new instance.
-            # @param ruby_values [Hash] a map of initial property values (optional)
-            # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
-            def initialize(ruby_values=nil, struct_value=nil)
-                super(self.class.binding_type, ruby_values, struct_value)
-            end
-        end
-
-
-
-        # The  ``Com::Vmware::Vcenter::Vm::Hardware::Boot::Device::Type``   enumerated type  defines the valid device types that may be used as bootable devices.
-        # @!attribute [rw] cdrom
-        #     @return [Com::Vmware::Vcenter::Vm::Hardware::Boot::Device::Type]
-        #     Virtual CD-ROM device.
-        # @!attribute [rw] disk
-        #     @return [Com::Vmware::Vcenter::Vm::Hardware::Boot::Device::Type]
-        #     Virtual disk device.
-        # @!attribute [rw] ethernet
-        #     @return [Com::Vmware::Vcenter::Vm::Hardware::Boot::Device::Type]
-        #     Virtual Ethernet adapter.
-        # @!attribute [rw] floppy
-        #     @return [Com::Vmware::Vcenter::Vm::Hardware::Boot::Device::Type]
-        #     Virtual floppy drive.
-        class Type < VAPI::Bindings::VapiEnum
-
-            class << self
-                # Holds (gets or creates) the binding type metadata for this enumeration type.
-                # @scope class
-                # @return [VAPI::Bindings::EnumType] the binding type
-                def binding_type
-                    @binding_type ||= VAPI::Bindings::EnumType.new(
-                        'com.vmware.vcenter.vm.hardware.boot.device.type',
-                        Type)
-                end
-
-                # Converts from a string value (perhaps off the wire) to an instance
-                # of this enum type.
-                # @param value [String] the actual value of the enum instance
-                # @return [Type] the instance found for the value, otherwise
-                #         an unknown instance will be built for the value
-                def from_string(value)
-                    begin
-                        const_get(value)
-                    rescue NameError
-                        Type.new('UNKNOWN', value)
-                    end
-                end
-            end
-
-            private
-
-            # Constructs a new instance.
-            # @param value [String] the actual value of the enum instance
-            # @param unknown [String] the unknown value when value is 'UKNOWN'
-            def initialize(value, unknown=nil)
-                super(self.class.binding_type, value, unknown)
-            end
-
-            public
-
-            # @!attribute [rw] cdrom
-            #     @return [Com::Vmware::Vcenter::Vm::Hardware::Boot::Device::Type]
-            #     Virtual CD-ROM device.
-            CDROM = Type.new('CDROM')
-
-            # @!attribute [rw] disk
-            #     @return [Com::Vmware::Vcenter::Vm::Hardware::Boot::Device::Type]
-            #     Virtual disk device.
-            DISK = Type.new('DISK')
-
-            # @!attribute [rw] ethernet
-            #     @return [Com::Vmware::Vcenter::Vm::Hardware::Boot::Device::Type]
-            #     Virtual Ethernet adapter.
-            ETHERNET = Type.new('ETHERNET')
-
-            # @!attribute [rw] floppy
-            #     @return [Com::Vmware::Vcenter::Vm::Hardware::Boot::Device::Type]
-            #     Virtual floppy drive.
-            FLOPPY = Type.new('FLOPPY')
-
-        end
-
-
+    # Constructs a new instance.
+    #
+    # @param config [VAPI::Bindings::StubConfig] A hash with the api provider details.
+    def initialize(config)
+      super(config, SERVICE_INFO)
     end
 
+    # Returns an ordered list of boot devices for the virtual machine. If the  list  is empty, the virtual machine uses a default boot sequence.
+    #
+    # @param vm [String]
+    #     Virtual machine identifier.
+    # @return [Array<Com::Vmware::Vcenter::VM::Hardware::Boot::Device::Entry>]
+    #     Ordered list of configured boot devices.
+    # @raise [Com::Vmware::Vapi::Std::Errors::Error]
+    #     if the system reports an error while responding to the request.
+    # @raise [Com::Vmware::Vapi::Std::Errors::NotFound]
+    #     if the virtual machine is not found.
+    # @raise [Com::Vmware::Vapi::Std::Errors::ResourceInaccessible]
+    #     if the virtual machine's configuration state cannot be accessed.
+    # @raise [Com::Vmware::Vapi::Std::Errors::ServiceUnavailable]
+    #     if the system is unable to communicate with a service to complete the request.
+    # @raise [Com::Vmware::Vapi::Std::Errors::Unauthenticated]
+    #     if the user can not be authenticated.
+    # @raise [Com::Vmware::Vapi::Std::Errors::Unauthorized]
+    #     if the user doesn't have the required privileges.
+    def get(vm)
+      invoke_with_info(GET_INFO,
+                       'vm' => vm)
+    end
 
+    # Sets the virtual devices that will be used to boot the virtual machine. The virtual machine will check the devices in order, attempting to boot from each, until the virtual machine boots successfully. If the  list  is empty, the virtual machine will use a default boot sequence. There should be no more than one instance of   :class:`Com::Vmware::Vcenter::VM::Hardware::Boot::Device::Entry`   for a given device type except   :attr:`Com::Vmware::Vcenter::VM::Hardware::Boot::Device::Type.ETHERNET`   in the  list .
+    #
+    # @param vm [String]
+    #     Virtual machine identifier.
+    # @param devices [Array<Com::Vmware::Vcenter::VM::Hardware::Boot::Device::Entry>]
+    #     Ordered list of boot devices.
+    # @return [Void]
+    # @raise [Com::Vmware::Vapi::Std::Errors::Error]
+    #     if the system reports an error while responding to the request.
+    # @raise [Com::Vmware::Vapi::Std::Errors::NotFound]
+    #     if the virtual machine is not found, or if any of the specified virtual devices is not found.
+    # @raise [Com::Vmware::Vapi::Std::Errors::InvalidArgument]
+    #     if a any of the  ``CDROM``, ``DISK``, ``ETHERNET``, ``FLOPPY``  values appears in more than one  ``Com::Vmware::Vcenter::VM::Hardware::Boot::Device::Entry``  with the exception of   :attr:`Com::Vmware::Vcenter::VM::Hardware::Boot::Device::Type.ETHERNET`  , which may appear multiple times if the virtual machine has been configured with multiple Ethernet adapters.
+    # @raise [Com::Vmware::Vapi::Std::Errors::ResourceBusy]
+    #     if the virtual machine is busy performing another operation.
+    # @raise [Com::Vmware::Vapi::Std::Errors::ResourceInaccessible]
+    #     if the virtual machine's configuration state cannot be accessed.
+    # @raise [Com::Vmware::Vapi::Std::Errors::ServiceUnavailable]
+    #     if the system is unable to communicate with a service to complete the request.
+    # @raise [Com::Vmware::Vapi::Std::Errors::Unauthenticated]
+    #     if the user can not be authenticated.
+    # @raise [Com::Vmware::Vapi::Std::Errors::Unauthorized]
+    #     if the user doesn't have the required privileges.
+    def set(vm, devices)
+      invoke_with_info(SET_INFO,
+                       'vm' => vm,
+                       'devices' => devices)
+    end
+
+    # The  class   ``Com::Vmware::Vcenter::VM::Hardware::Boot::Device::EntryCreateSpec``  specifies a list of bootable virtual device classes. When a VM is being created and a  list  of  ``Com::Vmware::Vcenter::VM::Hardware::Boot::Device::EntryCreateSpec``  is specified, the boot order of the specific device instances are not specified in this  class . The boot order of the specific device instance will be the order in which the Ethernet and Disk devices appear in the  ``nics``  and  ``disks``  respectively.
+    # @!attribute [rw] type
+    #     @return [Com::Vmware::Vcenter::VM::Hardware::Boot::Device::Type]
+    #     Virtual Boot device type.
+    class EntryCreateSpec < VAPI::Bindings::VapiStruct
+      class << self
+        # Holds (gets or creates) the binding type metadata for this structure type.
+        # @scope class
+        # @return [VAPI::Bindings::StructType] the binding type
+        def binding_type
+          @binding_type ||= VAPI::Bindings::StructType.new(
+            'com.vmware.vcenter.vm.hardware.boot.device.entry_create_spec',
+            {
+              'type' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::VM::Hardware::Boot::Device::Type')
+            },
+            EntryCreateSpec,
+            false,
+            nil
+          )
+        end
+      end
+
+      attr_accessor :type
+
+      # Constructs a new instance.
+      # @param ruby_values [Hash] a map of initial property values (optional)
+      # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
+      def initialize(ruby_values = nil, struct_value = nil)
+        super(self.class.binding_type, ruby_values, struct_value)
+      end
+    end
+
+    # The  ``Com::Vmware::Vcenter::VM::Hardware::Boot::Device::Entry``   class  specifies a bootable virtual device class or specific bootable virtual device(s).
+    # @!attribute [rw] type
+    #     @return [Com::Vmware::Vcenter::VM::Hardware::Boot::Device::Type]
+    #     Virtual device type.
+    # @!attribute [rw] nic
+    #     @return [String]
+    #     Virtual Ethernet device. Ethernet device to use as boot device for this entry.
+    #     This  field  is optional and it is only relevant when the value of  ``type``  is   :attr:`Com::Vmware::Vcenter::VM::Hardware::Boot::Device::Type.ETHERNET`  .
+    # @!attribute [rw] disks
+    #     @return [Array<String>]
+    #     Virtual disk device. List of virtual disks in boot order.
+    #     This  field  is optional and it is only relevant when the value of  ``type``  is   :attr:`Com::Vmware::Vcenter::VM::Hardware::Boot::Device::Type.DISK`  .
+    class Entry < VAPI::Bindings::VapiStruct
+      class << self
+        # Holds (gets or creates) the binding type metadata for this structure type.
+        # @scope class
+        # @return [VAPI::Bindings::StructType] the binding type
+        def binding_type
+          @binding_type ||= VAPI::Bindings::StructType.new(
+            'com.vmware.vcenter.vm.hardware.boot.device.entry',
+            {
+              'type' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::VM::Hardware::Boot::Device::Type'),
+              'nic' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::IdType.new),
+              'disks' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::ListType.new(VAPI::Bindings::IdType.new))
+            },
+            Entry,
+            false,
+            nil
+          )
+        end
+      end
+
+      attr_accessor :type,
+                    :nic,
+                    :disks
+
+      # Constructs a new instance.
+      # @param ruby_values [Hash] a map of initial property values (optional)
+      # @param struct_value [VAPI::Data::StructValue] a raw StructValue from the wire (optional)
+      def initialize(ruby_values = nil, struct_value = nil)
+        super(self.class.binding_type, ruby_values, struct_value)
+      end
+    end
+
+    # The  ``Com::Vmware::Vcenter::VM::Hardware::Boot::Device::Type``   enumerated type  defines the valid device types that may be used as bootable devices.
+    # @!attribute [rw] cdrom
+    #     @return [Com::Vmware::Vcenter::VM::Hardware::Boot::Device::Type]
+    #     Virtual CD-ROM device.
+    # @!attribute [rw] disk
+    #     @return [Com::Vmware::Vcenter::VM::Hardware::Boot::Device::Type]
+    #     Virtual disk device.
+    # @!attribute [rw] ethernet
+    #     @return [Com::Vmware::Vcenter::VM::Hardware::Boot::Device::Type]
+    #     Virtual Ethernet adapter.
+    # @!attribute [rw] floppy
+    #     @return [Com::Vmware::Vcenter::VM::Hardware::Boot::Device::Type]
+    #     Virtual floppy drive.
+    class Type < VAPI::Bindings::VapiEnum
+      class << self
+        # Holds (gets or creates) the binding type metadata for this enumeration type.
+        # @scope class
+        # @return [VAPI::Bindings::EnumType] the binding type
+        def binding_type
+          @binding_type ||= VAPI::Bindings::EnumType.new(
+            'com.vmware.vcenter.vm.hardware.boot.device.type',
+            Type
+          )
+        end
+
+        # Converts from a string value (perhaps off the wire) to an instance
+        # of this enum type.
+        # @param value [String] the actual value of the enum instance
+        # @return [Type] the instance found for the value, otherwise
+        #         an unknown instance will be built for the value
+        def from_string(value)
+          const_get(value)
+        rescue NameError
+          Type.send(:new, 'UNKNOWN', value)
+        end
+      end
+
+      # Constructs a new instance.
+      # @param value [String] the actual value of the enum instance
+      # @param unknown [String] the unknown value when value is 'UKNOWN'
+      def initialize(value, unknown = nil)
+        super(self.class.binding_type, value, unknown)
+      end
+
+      private_class_method :new
+
+      # @!attribute [rw] cdrom
+      #     @return [Com::Vmware::Vcenter::VM::Hardware::Boot::Device::Type]
+      #     Virtual CD-ROM device.
+      CDROM = Type.send(:new, 'CDROM')
+
+      # @!attribute [rw] disk
+      #     @return [Com::Vmware::Vcenter::VM::Hardware::Boot::Device::Type]
+      #     Virtual disk device.
+      DISK = Type.send(:new, 'DISK')
+
+      # @!attribute [rw] ethernet
+      #     @return [Com::Vmware::Vcenter::VM::Hardware::Boot::Device::Type]
+      #     Virtual Ethernet adapter.
+      ETHERNET = Type.send(:new, 'ETHERNET')
+
+      # @!attribute [rw] floppy
+      #     @return [Com::Vmware::Vcenter::VM::Hardware::Boot::Device::Type]
+      #     Virtual floppy drive.
+      FLOPPY = Type.send(:new, 'FLOPPY')
+    end
+  end
 end


### PR DESCRIPTION
Regenerated code to fix stylistic issues. This includes using two spaces
instead of four, using constants instead of class variables, making the
constructor on "enums" private, and minor formatting changes (e.g. where
parentheses go at end of expression, trailing commas, etc.).