### PR TITLE
Fix casing of VM (vs Vm)

### DIFF
--- a/client/sdk/com/vmware/vcenter.rb
+++ b/client/sdk/com/vmware/vcenter.rb
@@ -2503,7 +2503,7 @@ module Com::Vmware::Vcenter
 
     # Document-based creation spec.
     # @!attribute [rw] guest_OS
-    #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+    #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
     #     Guest OS.
     # @!attribute [rw] name
     #     @return [String, nil]
@@ -2514,55 +2514,55 @@ module Com::Vmware::Vcenter
     #     Virtual machine placement information.
     #     This  field  is currently required. In the future, if this  field  is  nil , the system will attempt to choose suitable resources on which to place the virtual machine.
     # @!attribute [rw] hardware_version
-    #     @return [Com::Vmware::Vcenter::VM::Hardware::Version, nil]
+    #     @return [Com::Vmware::Vcenter::Vm::Hardware::Version, nil]
     #     Virtual hardware version.
     #     If  nil , defaults to the most recent version supported by the server.
     # @!attribute [rw] boot
-    #     @return [Com::Vmware::Vcenter::VM::Hardware::Boot::CreateSpec, nil]
+    #     @return [Com::Vmware::Vcenter::Vm::Hardware::Boot::CreateSpec, nil]
     #     Boot configuration.
     #     If  nil , guest-specific default values will be used.
     # @!attribute [rw] boot_devices
-    #     @return [Array<Com::Vmware::Vcenter::VM::Hardware::Boot::Device::EntryCreateSpec>, nil]
+    #     @return [Array<Com::Vmware::Vcenter::Vm::Hardware::Boot::Device::EntryCreateSpec>, nil]
     #     Boot device configuration.
     #     If  nil , a server-specific boot sequence will be used.
     # @!attribute [rw] cpu
-    #     @return [Com::Vmware::Vcenter::VM::Hardware::Cpu::UpdateSpec, nil]
+    #     @return [Com::Vmware::Vcenter::Vm::Hardware::Cpu::UpdateSpec, nil]
     #     CPU configuration.
     #     If  nil , guest-specific default values will be used.
     # @!attribute [rw] memory
-    #     @return [Com::Vmware::Vcenter::VM::Hardware::Memory::UpdateSpec, nil]
+    #     @return [Com::Vmware::Vcenter::Vm::Hardware::Memory::UpdateSpec, nil]
     #     Memory configuration.
     #     If  nil , guest-specific default values will be used.
     # @!attribute [rw] disks
-    #     @return [Array<Com::Vmware::Vcenter::VM::Hardware::Disk::CreateSpec>, nil]
+    #     @return [Array<Com::Vmware::Vcenter::Vm::Hardware::Disk::CreateSpec>, nil]
     #     List of disks.
     #     If  nil , a single blank virtual disk of a guest-specific size will be created on the same storage as the virtual machine configuration, and will use a guest-specific host bus adapter type. If the guest-specific size is 0, no virtual disk will be created.
     # @!attribute [rw] nics
-    #     @return [Array<Com::Vmware::Vcenter::VM::Hardware::Ethernet::CreateSpec>, nil]
+    #     @return [Array<Com::Vmware::Vcenter::Vm::Hardware::Ethernet::CreateSpec>, nil]
     #     List of Ethernet adapters.
     #     If  nil , no Ethernet adapters will be created.
     # @!attribute [rw] cdroms
-    #     @return [Array<Com::Vmware::Vcenter::VM::Hardware::Cdrom::CreateSpec>, nil]
+    #     @return [Array<Com::Vmware::Vcenter::Vm::Hardware::Cdrom::CreateSpec>, nil]
     #     List of CD-ROMs.
     #     If  nil , no CD-ROM devices will be created.
     # @!attribute [rw] floppies
-    #     @return [Array<Com::Vmware::Vcenter::VM::Hardware::Floppy::CreateSpec>, nil]
+    #     @return [Array<Com::Vmware::Vcenter::Vm::Hardware::Floppy::CreateSpec>, nil]
     #     List of floppy drives.
     #     If  nil , no floppy drives will be created.
     # @!attribute [rw] parallel_ports
-    #     @return [Array<Com::Vmware::Vcenter::VM::Hardware::Parallel::CreateSpec>, nil]
+    #     @return [Array<Com::Vmware::Vcenter::Vm::Hardware::Parallel::CreateSpec>, nil]
     #     List of parallel ports.
     #     If  nil , no parallel ports will be created.
     # @!attribute [rw] serial_ports
-    #     @return [Array<Com::Vmware::Vcenter::VM::Hardware::Serial::CreateSpec>, nil]
+    #     @return [Array<Com::Vmware::Vcenter::Vm::Hardware::Serial::CreateSpec>, nil]
     #     List of serial ports.
     #     If  nil , no serial ports will be created.
     # @!attribute [rw] sata_adapters
-    #     @return [Array<Com::Vmware::Vcenter::VM::Hardware::Adapter::Sata::CreateSpec>, nil]
+    #     @return [Array<Com::Vmware::Vcenter::Vm::Hardware::Adapter::Sata::CreateSpec>, nil]
     #     List of SATA adapters.
     #     If  nil , any adapters necessary to connect the virtual machine's storage devices will be created; this includes any devices that explicitly specify a SATA host bus adapter, as well as any devices that do not specify a host bus adapter if the guest's preferred adapter type is SATA.
     # @!attribute [rw] scsi_adapters
-    #     @return [Array<Com::Vmware::Vcenter::VM::Hardware::Adapter::Scsi::CreateSpec>, nil]
+    #     @return [Array<Com::Vmware::Vcenter::Vm::Hardware::Adapter::Scsi::CreateSpec>, nil]
     #     List of SCSI adapters.
     #     If  nil , any adapters necessary to connect the virtual machine's storage devices will be created; this includes any devices that explicitly specify a SCSI host bus adapter, as well as any devices that do not specify a host bus adapter if the guest's preferred adapter type is SCSI. The type of the SCSI adapter will be a guest-specific default type.
     class CreateSpec < VAPI::Bindings::VapiStruct
@@ -2574,22 +2574,22 @@ module Com::Vmware::Vcenter
           @binding_type ||= VAPI::Bindings::StructType.new(
             'com.vmware.vcenter.VM.create_spec',
             {
-              'guest_OS' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::VM::GuestOS'),
+              'guest_OS' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::Vm::GuestOS'),
               'name' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::StringType.instance),
               'placement' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::VM::PlacementSpec')),
-              'hardware_version' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::VM::Hardware::Version')),
-              'boot' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::VM::Hardware::Boot::CreateSpec')),
-              'boot_devices' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::ListType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::VM::Hardware::Boot::Device::EntryCreateSpec'))),
-              'cpu' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::VM::Hardware::Cpu::UpdateSpec')),
-              'memory' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::VM::Hardware::Memory::UpdateSpec')),
-              'disks' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::ListType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::VM::Hardware::Disk::CreateSpec'))),
-              'nics' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::ListType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::VM::Hardware::Ethernet::CreateSpec'))),
-              'cdroms' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::ListType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::VM::Hardware::Cdrom::CreateSpec'))),
-              'floppies' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::ListType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::VM::Hardware::Floppy::CreateSpec'))),
-              'parallel_ports' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::ListType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::VM::Hardware::Parallel::CreateSpec'))),
-              'serial_ports' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::ListType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::VM::Hardware::Serial::CreateSpec'))),
-              'sata_adapters' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::ListType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::VM::Hardware::Adapter::Sata::CreateSpec'))),
-              'scsi_adapters' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::ListType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::VM::Hardware::Adapter::Scsi::CreateSpec')))
+              'hardware_version' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::Vm::Hardware::Version')),
+              'boot' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::Vm::Hardware::Boot::CreateSpec')),
+              'boot_devices' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::ListType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::Vm::Hardware::Boot::Device::EntryCreateSpec'))),
+              'cpu' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::Vm::Hardware::Cpu::UpdateSpec')),
+              'memory' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::Vm::Hardware::Memory::UpdateSpec')),
+              'disks' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::ListType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::Vm::Hardware::Disk::CreateSpec'))),
+              'nics' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::ListType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::Vm::Hardware::Ethernet::CreateSpec'))),
+              'cdroms' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::ListType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::Vm::Hardware::Cdrom::CreateSpec'))),
+              'floppies' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::ListType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::Vm::Hardware::Floppy::CreateSpec'))),
+              'parallel_ports' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::ListType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::Vm::Hardware::Parallel::CreateSpec'))),
+              'serial_ports' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::ListType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::Vm::Hardware::Serial::CreateSpec'))),
+              'sata_adapters' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::ListType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::Vm::Hardware::Adapter::Sata::CreateSpec'))),
+              'scsi_adapters' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::ListType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::Vm::Hardware::Adapter::Scsi::CreateSpec')))
             },
             CreateSpec,
             false,
@@ -2625,7 +2625,7 @@ module Com::Vmware::Vcenter
 
     # Document-based info.
     # @!attribute [rw] guest_OS
-    #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+    #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
     #     Guest OS.
     # @!attribute [rw] name
     #     @return [String]
@@ -2634,43 +2634,43 @@ module Com::Vmware::Vcenter
     #     @return [Com::Vmware::Vcenter::Vm::Power::State]
     #     Power state of the virtual machine.
     # @!attribute [rw] hardware
-    #     @return [Com::Vmware::Vcenter::VM::Hardware::Info]
+    #     @return [Com::Vmware::Vcenter::Vm::Hardware::Info]
     #     Virtual hardware version information.
     # @!attribute [rw] boot
-    #     @return [Com::Vmware::Vcenter::VM::Hardware::Boot::Info]
+    #     @return [Com::Vmware::Vcenter::Vm::Hardware::Boot::Info]
     #     Boot configuration.
     # @!attribute [rw] boot_devices
-    #     @return [Array<Com::Vmware::Vcenter::VM::Hardware::Boot::Device::Entry>]
+    #     @return [Array<Com::Vmware::Vcenter::Vm::Hardware::Boot::Device::Entry>]
     #     Boot device configuration. If the  list  has no entries, a server-specific default boot sequence is used.
     # @!attribute [rw] cpu
-    #     @return [Com::Vmware::Vcenter::VM::Hardware::Cpu::Info]
+    #     @return [Com::Vmware::Vcenter::Vm::Hardware::Cpu::Info]
     #     CPU configuration.
     # @!attribute [rw] memory
-    #     @return [Com::Vmware::Vcenter::VM::Hardware::Memory::Info]
+    #     @return [Com::Vmware::Vcenter::Vm::Hardware::Memory::Info]
     #     Memory configuration.
     # @!attribute [rw] disks
-    #     @return [Hash<String, Com::Vmware::Vcenter::VM::Hardware::Disk::Info>]
+    #     @return [Hash<String, Com::Vmware::Vcenter::Vm::Hardware::Disk::Info>]
     #     List of disks.
     # @!attribute [rw] nics
-    #     @return [Hash<String, Com::Vmware::Vcenter::VM::Hardware::Ethernet::Info>]
+    #     @return [Hash<String, Com::Vmware::Vcenter::Vm::Hardware::Ethernet::Info>]
     #     List of Ethernet adapters.
     # @!attribute [rw] cdroms
-    #     @return [Hash<String, Com::Vmware::Vcenter::VM::Hardware::Cdrom::Info>]
+    #     @return [Hash<String, Com::Vmware::Vcenter::Vm::Hardware::Cdrom::Info>]
     #     List of CD-ROMs.
     # @!attribute [rw] floppies
-    #     @return [Hash<String, Com::Vmware::Vcenter::VM::Hardware::Floppy::Info>]
+    #     @return [Hash<String, Com::Vmware::Vcenter::Vm::Hardware::Floppy::Info>]
     #     List of floppy drives.
     # @!attribute [rw] parallel_ports
-    #     @return [Hash<String, Com::Vmware::Vcenter::VM::Hardware::Parallel::Info>]
+    #     @return [Hash<String, Com::Vmware::Vcenter::Vm::Hardware::Parallel::Info>]
     #     List of parallel ports.
     # @!attribute [rw] serial_ports
-    #     @return [Hash<String, Com::Vmware::Vcenter::VM::Hardware::Serial::Info>]
+    #     @return [Hash<String, Com::Vmware::Vcenter::Vm::Hardware::Serial::Info>]
     #     List of serial ports.
     # @!attribute [rw] sata_adapters
-    #     @return [Hash<String, Com::Vmware::Vcenter::VM::Hardware::Adapter::Sata::Info>]
+    #     @return [Hash<String, Com::Vmware::Vcenter::Vm::Hardware::Adapter::Sata::Info>]
     #     List of SATA adapters.
     # @!attribute [rw] scsi_adapters
-    #     @return [Hash<String, Com::Vmware::Vcenter::VM::Hardware::Adapter::Scsi::Info>]
+    #     @return [Hash<String, Com::Vmware::Vcenter::Vm::Hardware::Adapter::Scsi::Info>]
     #     List of SCSI adapters.
     class Info < VAPI::Bindings::VapiStruct
       class << self
@@ -2681,22 +2681,22 @@ module Com::Vmware::Vcenter
           @binding_type ||= VAPI::Bindings::StructType.new(
             'com.vmware.vcenter.VM.info',
             {
-              'guest_OS' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::VM::GuestOS'),
+              'guest_OS' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::Vm::GuestOS'),
               'name' => VAPI::Bindings::StringType.instance,
               'power_state' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::Vm::Power::State'),
-              'hardware' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::VM::Hardware::Info'),
-              'boot' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::VM::Hardware::Boot::Info'),
-              'boot_devices' => VAPI::Bindings::ListType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::VM::Hardware::Boot::Device::Entry')),
-              'cpu' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::VM::Hardware::Cpu::Info'),
-              'memory' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::VM::Hardware::Memory::Info'),
-              'disks' => VAPI::Bindings::MapType.new(VAPI::Bindings::IdType.new, VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::VM::Hardware::Disk::Info')),
-              'nics' => VAPI::Bindings::MapType.new(VAPI::Bindings::IdType.new, VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::VM::Hardware::Ethernet::Info')),
-              'cdroms' => VAPI::Bindings::MapType.new(VAPI::Bindings::IdType.new, VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::VM::Hardware::Cdrom::Info')),
-              'floppies' => VAPI::Bindings::MapType.new(VAPI::Bindings::IdType.new, VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::VM::Hardware::Floppy::Info')),
-              'parallel_ports' => VAPI::Bindings::MapType.new(VAPI::Bindings::IdType.new, VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::VM::Hardware::Parallel::Info')),
-              'serial_ports' => VAPI::Bindings::MapType.new(VAPI::Bindings::IdType.new, VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::VM::Hardware::Serial::Info')),
-              'sata_adapters' => VAPI::Bindings::MapType.new(VAPI::Bindings::IdType.new, VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::VM::Hardware::Adapter::Sata::Info')),
-              'scsi_adapters' => VAPI::Bindings::MapType.new(VAPI::Bindings::IdType.new, VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::VM::Hardware::Adapter::Scsi::Info'))
+              'hardware' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::Vm::Hardware::Info'),
+              'boot' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::Vm::Hardware::Boot::Info'),
+              'boot_devices' => VAPI::Bindings::ListType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::Vm::Hardware::Boot::Device::Entry')),
+              'cpu' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::Vm::Hardware::Cpu::Info'),
+              'memory' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::Vm::Hardware::Memory::Info'),
+              'disks' => VAPI::Bindings::MapType.new(VAPI::Bindings::IdType.new, VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::Vm::Hardware::Disk::Info')),
+              'nics' => VAPI::Bindings::MapType.new(VAPI::Bindings::IdType.new, VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::Vm::Hardware::Ethernet::Info')),
+              'cdroms' => VAPI::Bindings::MapType.new(VAPI::Bindings::IdType.new, VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::Vm::Hardware::Cdrom::Info')),
+              'floppies' => VAPI::Bindings::MapType.new(VAPI::Bindings::IdType.new, VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::Vm::Hardware::Floppy::Info')),
+              'parallel_ports' => VAPI::Bindings::MapType.new(VAPI::Bindings::IdType.new, VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::Vm::Hardware::Parallel::Info')),
+              'serial_ports' => VAPI::Bindings::MapType.new(VAPI::Bindings::IdType.new, VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::Vm::Hardware::Serial::Info')),
+              'sata_adapters' => VAPI::Bindings::MapType.new(VAPI::Bindings::IdType.new, VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::Vm::Hardware::Adapter::Sata::Info')),
+              'scsi_adapters' => VAPI::Bindings::MapType.new(VAPI::Bindings::IdType.new, VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::Vm::Hardware::Adapter::Scsi::Info'))
             },
             Info,
             false,

--- a/client/sdk/com/vmware/vcenter/vm.rb
+++ b/client/sdk/com/vmware/vcenter/vm.rb
@@ -19,7 +19,7 @@ end
 
 # The  ``com.vmware.vcenter.vm``   package  provides  classs  for managing virtual machines.
 module Com::Vmware::Vcenter::Vm
-  # The  ``Com::Vmware::Vcenter::VM::Hardware``   class  provides  methods  for configuring the virtual hardware of a virtual machine.
+  # The  ``Com::Vmware::Vcenter::Vm::Hardware``   class  provides  methods  for configuring the virtual hardware of a virtual machine.
   class HardwareService < VAPI::Bindings::VapiService
     # static metamodel definitions
     SERVICE_ID = VAPI::Core::ServiceIdentifier.new('com.vmware.vcenter.vm.hardware')
@@ -29,7 +29,7 @@ module Com::Vmware::Vcenter::Vm
       VAPI::Bindings::OperationInputType.new(
         'vm' => VAPI::Bindings::IdType.new('VirtualMachine')
       ),
-      VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::VM::Hardware::Info'),
+      VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::Vm::Hardware::Info'),
       {
         'com.vmware.vapi.std.errors.error' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Error'),
         'com.vmware.vapi.std.errors.not_found' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::NotFound'),
@@ -46,7 +46,7 @@ module Com::Vmware::Vcenter::Vm
       VAPI::Core::OperationIdentifier.new('update', SERVICE_ID),
       VAPI::Bindings::OperationInputType.new(
         'vm' => VAPI::Bindings::IdType.new('VirtualMachine'),
-        'spec' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::VM::Hardware::UpdateSpec')
+        'spec' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::Vm::Hardware::UpdateSpec')
       ),
       VAPI::Bindings::VoidType.instance,
       {
@@ -69,7 +69,7 @@ module Com::Vmware::Vcenter::Vm
       VAPI::Core::OperationIdentifier.new('upgrade', SERVICE_ID),
       VAPI::Bindings::OperationInputType.new(
         'vm' => VAPI::Bindings::IdType.new('VirtualMachine'),
-        'version' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::VM::Hardware::Version'))
+        'version' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::Vm::Hardware::Version'))
       ),
       VAPI::Bindings::VoidType.instance,
       {
@@ -107,7 +107,7 @@ module Com::Vmware::Vcenter::Vm
     #
     # @param vm [String]
     #     Virtual machine identifier.
-    # @return [Com::Vmware::Vcenter::VM::Hardware::Info]
+    # @return [Com::Vmware::Vcenter::Vm::Hardware::Info]
     #     Virtual hardware settings of the virtual machine.
     # @raise [Com::Vmware::Vapi::Std::Errors::Error]
     #     if the system reports an error while responding to the request.
@@ -130,7 +130,7 @@ module Com::Vmware::Vcenter::Vm
     #
     # @param vm [String]
     #     Virtual machine identifier.
-    # @param spec [Com::Vmware::Vcenter::VM::Hardware::UpdateSpec]
+    # @param spec [Com::Vmware::Vcenter::Vm::Hardware::UpdateSpec]
     #     Specification for updating the virtual hardware settings of the virtual machine.
     # @return [Void]
     # @raise [Com::Vmware::Vapi::Std::Errors::Error]
@@ -163,7 +163,7 @@ module Com::Vmware::Vcenter::Vm
     #
     # @param vm [String]
     #     Virtual machine identifier.
-    # @param version [Com::Vmware::Vcenter::VM::Hardware::Version, nil]
+    # @param version [Com::Vmware::Vcenter::Vm::Hardware::Version, nil]
     #     New virtual machine version.
     #     If  nil , defaults to the most recent virtual hardware version supported by the server.
     # @return [Void]
@@ -195,24 +195,24 @@ module Com::Vmware::Vcenter::Vm
                        'version' => version)
     end
 
-    # The  ``Com::Vmware::Vcenter::VM::Hardware::Info``   class  contains information related to the virtual hardware of a virtual machine.
+    # The  ``Com::Vmware::Vcenter::Vm::Hardware::Info``   class  contains information related to the virtual hardware of a virtual machine.
     # @!attribute [rw] version
-    #     @return [Com::Vmware::Vcenter::VM::Hardware::Version]
+    #     @return [Com::Vmware::Vcenter::Vm::Hardware::Version]
     #     Virtual hardware version.
     # @!attribute [rw] upgrade_policy
-    #     @return [Com::Vmware::Vcenter::VM::Hardware::UpgradePolicy]
+    #     @return [Com::Vmware::Vcenter::Vm::Hardware::UpgradePolicy]
     #     Scheduled upgrade policy.
     # @!attribute [rw] upgrade_version
-    #     @return [Com::Vmware::Vcenter::VM::Hardware::Version]
+    #     @return [Com::Vmware::Vcenter::Vm::Hardware::Version]
     #     Target hardware version to be used on the next scheduled virtual hardware upgrade.
-    #     This  field  is optional and it is only relevant when the value of  ``upgradePolicy``  is one of   :attr:`Com::Vmware::Vcenter::VM::Hardware::UpgradePolicy.AFTER_CLEAN_SHUTDOWN`   or   :attr:`Com::Vmware::Vcenter::VM::Hardware::UpgradePolicy.ALWAYS`  .
+    #     This  field  is optional and it is only relevant when the value of  ``upgradePolicy``  is one of   :attr:`Com::Vmware::Vcenter::Vm::Hardware::UpgradePolicy.AFTER_CLEAN_SHUTDOWN`   or   :attr:`Com::Vmware::Vcenter::Vm::Hardware::UpgradePolicy.ALWAYS`  .
     # @!attribute [rw] upgrade_status
-    #     @return [Com::Vmware::Vcenter::VM::Hardware::UpgradeStatus]
+    #     @return [Com::Vmware::Vcenter::Vm::Hardware::UpgradeStatus]
     #     Scheduled upgrade status.
     # @!attribute [rw] upgrade_error
     #     @return [Exception]
     #     Reason for the scheduled upgrade failure.
-    #     This  field  is optional and it is only relevant when the value of  ``upgradeStatus``  is   :attr:`Com::Vmware::Vcenter::VM::Hardware::UpgradeStatus.FAILED`  .
+    #     This  field  is optional and it is only relevant when the value of  ``upgradeStatus``  is   :attr:`Com::Vmware::Vcenter::Vm::Hardware::UpgradeStatus.FAILED`  .
     class Info < VAPI::Bindings::VapiStruct
       class << self
         # Holds (gets or creates) the binding type metadata for this structure type.
@@ -222,10 +222,10 @@ module Com::Vmware::Vcenter::Vm
           @binding_type ||= VAPI::Bindings::StructType.new(
             'com.vmware.vcenter.vm.hardware.info',
             {
-              'version' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::VM::Hardware::Version'),
-              'upgrade_policy' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::VM::Hardware::UpgradePolicy'),
-              'upgrade_version' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::VM::Hardware::Version')),
-              'upgrade_status' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::VM::Hardware::UpgradeStatus'),
+              'version' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::Vm::Hardware::Version'),
+              'upgrade_policy' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::Vm::Hardware::UpgradePolicy'),
+              'upgrade_version' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::Vm::Hardware::Version')),
+              'upgrade_status' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::Vm::Hardware::UpgradeStatus'),
               'upgrade_error' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::AnyErrorType.instance)
             },
             Info,
@@ -249,19 +249,19 @@ module Com::Vmware::Vcenter::Vm
       end
     end
 
-    # The  ``Com::Vmware::Vcenter::VM::Hardware::UpdateSpec``   class  describes the updates to virtual hardware settings of a virtual machine.
+    # The  ``Com::Vmware::Vcenter::Vm::Hardware::UpdateSpec``   class  describes the updates to virtual hardware settings of a virtual machine.
     # @!attribute [rw] upgrade_policy
-    #     @return [Com::Vmware::Vcenter::VM::Hardware::UpgradePolicy, nil]
+    #     @return [Com::Vmware::Vcenter::Vm::Hardware::UpgradePolicy, nil]
     #     Scheduled upgrade policy.  
     #     
-    #      If set to   :attr:`Com::Vmware::Vcenter::VM::Hardware::UpgradePolicy.NEVER`  , the   :attr:`Com::Vmware::Vcenter::VM::Hardware::Info.upgrade_version`    field  will be reset to  nil .
+    #      If set to   :attr:`Com::Vmware::Vcenter::Vm::Hardware::UpgradePolicy.NEVER`  , the   :attr:`Com::Vmware::Vcenter::Vm::Hardware::Info.upgrade_version`    field  will be reset to  nil .
     #     If  nil , the value is unchanged.
     # @!attribute [rw] upgrade_version
-    #     @return [Com::Vmware::Vcenter::VM::Hardware::Version, nil]
+    #     @return [Com::Vmware::Vcenter::Vm::Hardware::Version, nil]
     #     Target hardware version to be used on the next scheduled virtual hardware upgrade.  
     #     
-    #      If specified, this  field  must represent a newer virtual hardware version than the current virtual hardware version reported in   :attr:`Com::Vmware::Vcenter::VM::Hardware::Info.version`  .
-    #     If   :attr:`Com::Vmware::Vcenter::VM::Hardware::UpdateSpec.upgrade_policy`   is set to   :attr:`Com::Vmware::Vcenter::VM::Hardware::UpgradePolicy.NEVER`  , this  field  must be  nil . Otherwise, if this  field  is  nil , default to the most recent virtual hardware version supported by the server.
+    #      If specified, this  field  must represent a newer virtual hardware version than the current virtual hardware version reported in   :attr:`Com::Vmware::Vcenter::Vm::Hardware::Info.version`  .
+    #     If   :attr:`Com::Vmware::Vcenter::Vm::Hardware::UpdateSpec.upgrade_policy`   is set to   :attr:`Com::Vmware::Vcenter::Vm::Hardware::UpgradePolicy.NEVER`  , this  field  must be  nil . Otherwise, if this  field  is  nil , default to the most recent virtual hardware version supported by the server.
     class UpdateSpec < VAPI::Bindings::VapiStruct
       class << self
         # Holds (gets or creates) the binding type metadata for this structure type.
@@ -271,8 +271,8 @@ module Com::Vmware::Vcenter::Vm
           @binding_type ||= VAPI::Bindings::StructType.new(
             'com.vmware.vcenter.vm.hardware.update_spec',
             {
-              'upgrade_policy' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::VM::Hardware::UpgradePolicy')),
-              'upgrade_version' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::VM::Hardware::Version'))
+              'upgrade_policy' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::Vm::Hardware::UpgradePolicy')),
+              'upgrade_version' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::Vm::Hardware::Version'))
             },
             UpdateSpec,
             false,
@@ -292,36 +292,36 @@ module Com::Vmware::Vcenter::Vm
       end
     end
 
-    # The  ``Com::Vmware::Vcenter::VM::Hardware::Version``   enumerated type  defines the valid virtual hardware versions for a virtual machine.
+    # The  ``Com::Vmware::Vcenter::Vm::Hardware::Version``   enumerated type  defines the valid virtual hardware versions for a virtual machine.
     # @!attribute [rw] vmx_03
-    #     @return [Com::Vmware::Vcenter::VM::Hardware::Version]
+    #     @return [Com::Vmware::Vcenter::Vm::Hardware::Version]
     #     Hardware version 3.
     # @!attribute [rw] vmx_04
-    #     @return [Com::Vmware::Vcenter::VM::Hardware::Version]
+    #     @return [Com::Vmware::Vcenter::Vm::Hardware::Version]
     #     Hardware version 4.
     # @!attribute [rw] vmx_06
-    #     @return [Com::Vmware::Vcenter::VM::Hardware::Version]
+    #     @return [Com::Vmware::Vcenter::Vm::Hardware::Version]
     #     Hardware version 6.
     # @!attribute [rw] vmx_07
-    #     @return [Com::Vmware::Vcenter::VM::Hardware::Version]
+    #     @return [Com::Vmware::Vcenter::Vm::Hardware::Version]
     #     Hardware version 7.
     # @!attribute [rw] vmx_08
-    #     @return [Com::Vmware::Vcenter::VM::Hardware::Version]
+    #     @return [Com::Vmware::Vcenter::Vm::Hardware::Version]
     #     Hardware version 8.
     # @!attribute [rw] vmx_09
-    #     @return [Com::Vmware::Vcenter::VM::Hardware::Version]
+    #     @return [Com::Vmware::Vcenter::Vm::Hardware::Version]
     #     Hardware version 9.
     # @!attribute [rw] vmx_10
-    #     @return [Com::Vmware::Vcenter::VM::Hardware::Version]
+    #     @return [Com::Vmware::Vcenter::Vm::Hardware::Version]
     #     Hardware version 10.
     # @!attribute [rw] vmx_11
-    #     @return [Com::Vmware::Vcenter::VM::Hardware::Version]
+    #     @return [Com::Vmware::Vcenter::Vm::Hardware::Version]
     #     Hardware version 11.
     # @!attribute [rw] vmx_12
-    #     @return [Com::Vmware::Vcenter::VM::Hardware::Version]
+    #     @return [Com::Vmware::Vcenter::Vm::Hardware::Version]
     #     Hardware version 12.
     # @!attribute [rw] vmx_13
-    #     @return [Com::Vmware::Vcenter::VM::Hardware::Version]
+    #     @return [Com::Vmware::Vcenter::Vm::Hardware::Version]
     #     Hardware version 13.
     class Version < VAPI::Bindings::VapiEnum
       class << self
@@ -357,64 +357,64 @@ module Com::Vmware::Vcenter::Vm
       private_class_method :new
 
       # @!attribute [rw] vmx_03
-      #     @return [Com::Vmware::Vcenter::VM::Hardware::Version]
+      #     @return [Com::Vmware::Vcenter::Vm::Hardware::Version]
       #     Hardware version 3.
       VMX_03 = Version.send(:new, 'VMX_03')
 
       # @!attribute [rw] vmx_04
-      #     @return [Com::Vmware::Vcenter::VM::Hardware::Version]
+      #     @return [Com::Vmware::Vcenter::Vm::Hardware::Version]
       #     Hardware version 4.
       VMX_04 = Version.send(:new, 'VMX_04')
 
       # @!attribute [rw] vmx_06
-      #     @return [Com::Vmware::Vcenter::VM::Hardware::Version]
+      #     @return [Com::Vmware::Vcenter::Vm::Hardware::Version]
       #     Hardware version 6.
       VMX_06 = Version.send(:new, 'VMX_06')
 
       # @!attribute [rw] vmx_07
-      #     @return [Com::Vmware::Vcenter::VM::Hardware::Version]
+      #     @return [Com::Vmware::Vcenter::Vm::Hardware::Version]
       #     Hardware version 7.
       VMX_07 = Version.send(:new, 'VMX_07')
 
       # @!attribute [rw] vmx_08
-      #     @return [Com::Vmware::Vcenter::VM::Hardware::Version]
+      #     @return [Com::Vmware::Vcenter::Vm::Hardware::Version]
       #     Hardware version 8.
       VMX_08 = Version.send(:new, 'VMX_08')
 
       # @!attribute [rw] vmx_09
-      #     @return [Com::Vmware::Vcenter::VM::Hardware::Version]
+      #     @return [Com::Vmware::Vcenter::Vm::Hardware::Version]
       #     Hardware version 9.
       VMX_09 = Version.send(:new, 'VMX_09')
 
       # @!attribute [rw] vmx_10
-      #     @return [Com::Vmware::Vcenter::VM::Hardware::Version]
+      #     @return [Com::Vmware::Vcenter::Vm::Hardware::Version]
       #     Hardware version 10.
       VMX_10 = Version.send(:new, 'VMX_10')
 
       # @!attribute [rw] vmx_11
-      #     @return [Com::Vmware::Vcenter::VM::Hardware::Version]
+      #     @return [Com::Vmware::Vcenter::Vm::Hardware::Version]
       #     Hardware version 11.
       VMX_11 = Version.send(:new, 'VMX_11')
 
       # @!attribute [rw] vmx_12
-      #     @return [Com::Vmware::Vcenter::VM::Hardware::Version]
+      #     @return [Com::Vmware::Vcenter::Vm::Hardware::Version]
       #     Hardware version 12.
       VMX_12 = Version.send(:new, 'VMX_12')
 
       # @!attribute [rw] vmx_13
-      #     @return [Com::Vmware::Vcenter::VM::Hardware::Version]
+      #     @return [Com::Vmware::Vcenter::Vm::Hardware::Version]
       #     Hardware version 13.
       VMX_13 = Version.send(:new, 'VMX_13')
     end
-    # The  ``Com::Vmware::Vcenter::VM::Hardware::UpgradePolicy``   enumerated type  defines the valid virtual hardware upgrade policies for a virtual machine.
+    # The  ``Com::Vmware::Vcenter::Vm::Hardware::UpgradePolicy``   enumerated type  defines the valid virtual hardware upgrade policies for a virtual machine.
     # @!attribute [rw] never
-    #     @return [Com::Vmware::Vcenter::VM::Hardware::UpgradePolicy]
+    #     @return [Com::Vmware::Vcenter::Vm::Hardware::UpgradePolicy]
     #     Do not upgrade the virtual machine when it is powered on.
     # @!attribute [rw] after_clean_shutdown
-    #     @return [Com::Vmware::Vcenter::VM::Hardware::UpgradePolicy]
+    #     @return [Com::Vmware::Vcenter::Vm::Hardware::UpgradePolicy]
     #     Run scheduled upgrade when the virtual machine is powered on after a clean shutdown of the guest operating system.
     # @!attribute [rw] always
-    #     @return [Com::Vmware::Vcenter::VM::Hardware::UpgradePolicy]
+    #     @return [Com::Vmware::Vcenter::Vm::Hardware::UpgradePolicy]
     #     Run scheduled upgrade when the virtual machine is powered on.
     class UpgradePolicy < VAPI::Bindings::VapiEnum
       class << self
@@ -450,32 +450,32 @@ module Com::Vmware::Vcenter::Vm
       private_class_method :new
 
       # @!attribute [rw] never
-      #     @return [Com::Vmware::Vcenter::VM::Hardware::UpgradePolicy]
+      #     @return [Com::Vmware::Vcenter::Vm::Hardware::UpgradePolicy]
       #     Do not upgrade the virtual machine when it is powered on.
       NEVER = UpgradePolicy.send(:new, 'NEVER')
 
       # @!attribute [rw] after_clean_shutdown
-      #     @return [Com::Vmware::Vcenter::VM::Hardware::UpgradePolicy]
+      #     @return [Com::Vmware::Vcenter::Vm::Hardware::UpgradePolicy]
       #     Run scheduled upgrade when the virtual machine is powered on after a clean shutdown of the guest operating system.
       AFTER_CLEAN_SHUTDOWN = UpgradePolicy.send(:new, 'AFTER_CLEAN_SHUTDOWN')
 
       # @!attribute [rw] always
-      #     @return [Com::Vmware::Vcenter::VM::Hardware::UpgradePolicy]
+      #     @return [Com::Vmware::Vcenter::Vm::Hardware::UpgradePolicy]
       #     Run scheduled upgrade when the virtual machine is powered on.
       ALWAYS = UpgradePolicy.send(:new, 'ALWAYS')
     end
-    # The  ``Com::Vmware::Vcenter::VM::Hardware::UpgradeStatus``   enumerated type  defines the valid virtual hardware upgrade statuses for a virtual machine.
+    # The  ``Com::Vmware::Vcenter::Vm::Hardware::UpgradeStatus``   enumerated type  defines the valid virtual hardware upgrade statuses for a virtual machine.
     # @!attribute [rw] none
-    #     @return [Com::Vmware::Vcenter::VM::Hardware::UpgradeStatus]
+    #     @return [Com::Vmware::Vcenter::Vm::Hardware::UpgradeStatus]
     #     No scheduled upgrade has been attempted.
     # @!attribute [rw] pending
-    #     @return [Com::Vmware::Vcenter::VM::Hardware::UpgradeStatus]
+    #     @return [Com::Vmware::Vcenter::Vm::Hardware::UpgradeStatus]
     #     Upgrade is scheduled but has not yet been run.
     # @!attribute [rw] success
-    #     @return [Com::Vmware::Vcenter::VM::Hardware::UpgradeStatus]
+    #     @return [Com::Vmware::Vcenter::Vm::Hardware::UpgradeStatus]
     #     The most recent scheduled upgrade was successful.
     # @!attribute [rw] failed
-    #     @return [Com::Vmware::Vcenter::VM::Hardware::UpgradeStatus]
+    #     @return [Com::Vmware::Vcenter::Vm::Hardware::UpgradeStatus]
     #     The most recent scheduled upgrade was not successful.
     class UpgradeStatus < VAPI::Bindings::VapiEnum
       class << self
@@ -511,22 +511,22 @@ module Com::Vmware::Vcenter::Vm
       private_class_method :new
 
       # @!attribute [rw] none
-      #     @return [Com::Vmware::Vcenter::VM::Hardware::UpgradeStatus]
+      #     @return [Com::Vmware::Vcenter::Vm::Hardware::UpgradeStatus]
       #     No scheduled upgrade has been attempted.
       NONE = UpgradeStatus.send(:new, 'NONE')
 
       # @!attribute [rw] pending
-      #     @return [Com::Vmware::Vcenter::VM::Hardware::UpgradeStatus]
+      #     @return [Com::Vmware::Vcenter::Vm::Hardware::UpgradeStatus]
       #     Upgrade is scheduled but has not yet been run.
       PENDING = UpgradeStatus.send(:new, 'PENDING')
 
       # @!attribute [rw] success
-      #     @return [Com::Vmware::Vcenter::VM::Hardware::UpgradeStatus]
+      #     @return [Com::Vmware::Vcenter::Vm::Hardware::UpgradeStatus]
       #     The most recent scheduled upgrade was successful.
       SUCCESS = UpgradeStatus.send(:new, 'SUCCESS')
 
       # @!attribute [rw] failed
-      #     @return [Com::Vmware::Vcenter::VM::Hardware::UpgradeStatus]
+      #     @return [Com::Vmware::Vcenter::Vm::Hardware::UpgradeStatus]
       #     The most recent scheduled upgrade was not successful.
       FAILED = UpgradeStatus.send(:new, 'FAILED')
     end
@@ -877,450 +877,450 @@ module Com::Vmware::Vcenter::Vm
       SUSPENDED = State.send(:new, 'SUSPENDED')
     end
   end
-  # The  ``Com::Vmware::Vcenter::VM::GuestOS``   enumerated type  defines the valid guest operating system types used for configuring a virtual machine.
+  # The  ``Com::Vmware::Vcenter::Vm::GuestOS``   enumerated type  defines the valid guest operating system types used for configuring a virtual machine.
   # @!attribute [rw] dos
-  #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+  #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
   #     MS-DOS.
   # @!attribute [rw] win_31
-  #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+  #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
   #     Windows 3.1
   # @!attribute [rw] win_95
-  #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+  #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
   #     Windows 95
   # @!attribute [rw] win_98
-  #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+  #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
   #     Windows 98
   # @!attribute [rw] win_me
-  #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+  #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
   #     Windows Millennium Edition
   # @!attribute [rw] win_nt
-  #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+  #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
   #     Windows NT 4
   # @!attribute [rw] win_2000_pro
-  #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+  #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
   #     Windows 2000 Professional
   # @!attribute [rw] win_2000_serv
-  #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+  #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
   #     Windows 2000 Server
   # @!attribute [rw] win_2000_adv_serv
-  #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+  #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
   #     Windows 2000 Advanced Server
   # @!attribute [rw] win_xp_home
-  #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+  #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
   #     Windows XP Home Edition
   # @!attribute [rw] win_xp_pro
-  #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+  #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
   #     Windows XP Professional
   # @!attribute [rw] win_xp_pro_64
-  #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+  #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
   #     Windows XP Professional Edition (64 bit)
   # @!attribute [rw] win_net_web
-  #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+  #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
   #     Windows Server 2003, Web Edition
   # @!attribute [rw] win_net_standard
-  #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+  #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
   #     Windows Server 2003, Standard Edition
   # @!attribute [rw] win_net_enterprise
-  #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+  #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
   #     Windows Server 2003, Enterprise Edition
   # @!attribute [rw] win_net_datacenter
-  #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+  #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
   #     Windows Server 2003, Datacenter Edition
   # @!attribute [rw] win_net_business
-  #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+  #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
   #     Windows Small Business Server 2003
   # @!attribute [rw] win_net_standard_64
-  #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+  #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
   #     Windows Server 2003, Standard Edition (64 bit)
   # @!attribute [rw] win_net_enterprise_64
-  #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+  #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
   #     Windows Server 2003, Enterprise Edition (64 bit)
   # @!attribute [rw] win_longhorn
-  #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+  #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
   #     Windows Longhorn (experimental)
   # @!attribute [rw] win_longhorn_64
-  #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+  #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
   #     Windows Longhorn (64 bit) (experimental)
   # @!attribute [rw] win_net_datacenter_64
-  #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+  #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
   #     Windows Server 2003, Datacenter Edition (64 bit) (experimental)
   # @!attribute [rw] win_vista
-  #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+  #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
   #     Windows Vista
   # @!attribute [rw] win_vista_64
-  #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+  #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
   #     Windows Vista (64 bit)
   # @!attribute [rw] windows_7
-  #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+  #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
   #     Windows 7
   # @!attribute [rw] windows_7_64
-  #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+  #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
   #     Windows 7 (64 bit)
   # @!attribute [rw] windows_7_server_64
-  #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+  #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
   #     Windows Server 2008 R2 (64 bit)
   # @!attribute [rw] windows_8
-  #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+  #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
   #     Windows 8
   # @!attribute [rw] windows_8_64
-  #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+  #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
   #     Windows 8 (64 bit)
   # @!attribute [rw] windows_8_server_64
-  #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+  #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
   #     Windows 8 Server (64 bit)
   # @!attribute [rw] windows_9
-  #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+  #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
   #     Windows 10
   # @!attribute [rw] windows_9_64
-  #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+  #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
   #     Windows 10 (64 bit)
   # @!attribute [rw] windows_9_server_64
-  #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+  #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
   #     Windows 10 Server (64 bit)
   # @!attribute [rw] windows_hyperv
-  #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+  #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
   #     Windows Hyper-V
   # @!attribute [rw] freebsd
-  #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+  #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
   #     FreeBSD
   # @!attribute [rw] freebsd_64
-  #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+  #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
   #     FreeBSD x64
   # @!attribute [rw] redhat
-  #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+  #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
   #     Red Hat Linux 2.1
   # @!attribute [rw] rhel_2
-  #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+  #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
   #     Red Hat Enterprise Linux 2
   # @!attribute [rw] rhel_3
-  #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+  #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
   #     Red Hat Enterprise Linux 3
   # @!attribute [rw] rhel_3_64
-  #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+  #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
   #     Red Hat Enterprise Linux 3 (64 bit)
   # @!attribute [rw] rhel_4
-  #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+  #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
   #     Red Hat Enterprise Linux 4
   # @!attribute [rw] rhel_4_64
-  #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+  #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
   #     Red Hat Enterprise Linux 4 (64 bit)
   # @!attribute [rw] rhel_5
-  #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+  #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
   #     Red Hat Enterprise Linux 5
   # @!attribute [rw] rhel_5_64
-  #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+  #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
   #     Red Hat Enterprise Linux 5 (64 bit) (experimental)
   # @!attribute [rw] rhel_6
-  #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+  #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
   #     Red Hat Enterprise Linux 6
   # @!attribute [rw] rhel_6_64
-  #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+  #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
   #     Red Hat Enterprise Linux 6 (64 bit)
   # @!attribute [rw] rhel_7
-  #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+  #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
   #     Red Hat Enterprise Linux 7
   # @!attribute [rw] rhel_7_64
-  #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+  #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
   #     Red Hat Enterprise Linux 7 (64 bit)
   # @!attribute [rw] centos
-  #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+  #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
   #     CentOS 4/5
   # @!attribute [rw] centos_64
-  #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+  #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
   #     CentOS 4/5 (64-bit)
   # @!attribute [rw] centos_6
-  #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+  #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
   #     CentOS 6
   # @!attribute [rw] centos_6_64
-  #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+  #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
   #     CentOS 6 (64-bit)
   # @!attribute [rw] centos_7
-  #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+  #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
   #     CentOS 7
   # @!attribute [rw] centos_7_64
-  #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+  #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
   #     CentOS 7 (64-bit)
   # @!attribute [rw] oracle_linux
-  #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+  #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
   #     Oracle Linux 4/5
   # @!attribute [rw] oracle_linux_64
-  #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+  #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
   #     Oracle Linux 4/5 (64-bit)
   # @!attribute [rw] oracle_linux_6
-  #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+  #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
   #     Oracle Linux 6
   # @!attribute [rw] oracle_linux_6_64
-  #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+  #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
   #     Oracle Linux 6 (64-bit)
   # @!attribute [rw] oracle_linux_7
-  #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+  #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
   #     Oracle Linux 7
   # @!attribute [rw] oracle_linux_7_64
-  #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+  #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
   #     Oracle Linux 7 (64-bit)
   # @!attribute [rw] suse
-  #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+  #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
   #     Suse Linux
   # @!attribute [rw] suse_64
-  #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+  #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
   #     Suse Linux (64 bit)
   # @!attribute [rw] sles
-  #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+  #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
   #     Suse Linux Enterprise Server 9
   # @!attribute [rw] sles_64
-  #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+  #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
   #     Suse Linux Enterprise Server 9 (64 bit)
   # @!attribute [rw] sles_10
-  #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+  #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
   #     Suse linux Enterprise Server 10
   # @!attribute [rw] sles_10_64
-  #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+  #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
   #     Suse Linux Enterprise Server 10 (64 bit) (experimental)
   # @!attribute [rw] sles_11
-  #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+  #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
   #     Suse linux Enterprise Server 11
   # @!attribute [rw] sles_11_64
-  #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+  #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
   #     Suse Linux Enterprise Server 11 (64 bit)
   # @!attribute [rw] sles_12
-  #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+  #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
   #     Suse linux Enterprise Server 12
   # @!attribute [rw] sles_12_64
-  #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+  #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
   #     Suse Linux Enterprise Server 12 (64 bit)
   # @!attribute [rw] nld_9
-  #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+  #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
   #     Novell Linux Desktop 9
   # @!attribute [rw] oes
-  #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+  #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
   #     Open Enterprise Server
   # @!attribute [rw] sjds
-  #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+  #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
   #     Sun Java Desktop System
   # @!attribute [rw] mandrake
-  #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+  #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
   #     Mandrake Linux
   # @!attribute [rw] mandriva
-  #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+  #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
   #     Mandriva Linux
   # @!attribute [rw] mandriva_64
-  #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+  #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
   #     Mandriva Linux (64 bit)
   # @!attribute [rw] turbo_linux
-  #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+  #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
   #     Turbolinux
   # @!attribute [rw] turbo_linux_64
-  #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+  #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
   #     Turbolinux (64 bit)
   # @!attribute [rw] ubuntu
-  #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+  #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
   #     Ubuntu Linux
   # @!attribute [rw] ubuntu_64
-  #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+  #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
   #     Ubuntu Linux (64 bit)
   # @!attribute [rw] debian_4
-  #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+  #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
   #     Debian GNU/Linux 4
   # @!attribute [rw] debian_4_64
-  #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+  #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
   #     Debian GNU/Linux 4 (64 bit)
   # @!attribute [rw] debian_5
-  #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+  #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
   #     Debian GNU/Linux 5
   # @!attribute [rw] debian_5_64
-  #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+  #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
   #     Debian GNU/Linux 5 (64 bit)
   # @!attribute [rw] debian_6
-  #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+  #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
   #     Debian GNU/Linux 6
   # @!attribute [rw] debian_6_64
-  #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+  #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
   #     Debian GNU/Linux 6 (64 bit)
   # @!attribute [rw] debian_7
-  #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+  #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
   #     Debian GNU/Linux 7
   # @!attribute [rw] debian_7_64
-  #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+  #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
   #     Debian GNU/Linux 7 (64 bit)
   # @!attribute [rw] debian_8
-  #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+  #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
   #     Debian GNU/Linux 8
   # @!attribute [rw] debian_8_64
-  #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+  #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
   #     Debian GNU/Linux 8 (64 bit)
   # @!attribute [rw] debian_9
-  #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+  #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
   #     Debian GNU/Linux 9
   # @!attribute [rw] debian_9_64
-  #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+  #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
   #     Debian GNU/Linux 9 (64 bit)
   # @!attribute [rw] debian_10
-  #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+  #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
   #     Debian GNU/Linux 10
   # @!attribute [rw] debian_10_64
-  #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+  #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
   #     Debian GNU/Linux 10 (64 bit)
   # @!attribute [rw] asianux_3
-  #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+  #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
   #     Asianux Server 3
   # @!attribute [rw] asianux_3_64
-  #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+  #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
   #     Asianux Server 3 (64 bit)
   # @!attribute [rw] asianux_4
-  #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+  #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
   #     Asianux Server 4
   # @!attribute [rw] asianux_4_64
-  #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+  #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
   #     Asianux Server 4 (64 bit)
   # @!attribute [rw] asianux_5_64
-  #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+  #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
   #     Asianux Server 5 (64 bit)
   # @!attribute [rw] asianux_7_64
-  #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+  #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
   #     Asianux Server 7 (64 bit)
   # @!attribute [rw] opensuse
-  #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+  #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
   #     OpenSUSE Linux
   # @!attribute [rw] opensuse_64
-  #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+  #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
   #     OpenSUSE Linux (64 bit)
   # @!attribute [rw] fedora
-  #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+  #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
   #     Fedora Linux
   # @!attribute [rw] fedora_64
-  #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+  #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
   #     Fedora Linux (64 bit)
   # @!attribute [rw] coreos_64
-  #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+  #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
   #     CoreOS Linux (64 bit)
   # @!attribute [rw] vmware_photon_64
-  #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+  #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
   #     VMware Photon (64 bit)
   # @!attribute [rw] other_24x_linux
-  #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+  #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
   #     Linux 2.4x Kernel
   # @!attribute [rw] other_24x_linux_64
-  #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+  #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
   #     Linux 2.4x Kernel (64 bit) (experimental)
   # @!attribute [rw] other_26x_linux
-  #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+  #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
   #     Linux 2.6x Kernel
   # @!attribute [rw] other_26x_linux_64
-  #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+  #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
   #     Linux 2.6x Kernel (64 bit) (experimental)
   # @!attribute [rw] other_3x_linux
-  #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+  #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
   #     Linux 3.x Kernel
   # @!attribute [rw] other_3x_linux_64
-  #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+  #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
   #     Linux 3.x Kernel (64 bit)
   # @!attribute [rw] other_linux
-  #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+  #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
   #     Linux 2.2x Kernel
   # @!attribute [rw] generic_linux
-  #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+  #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
   #     Other Linux
   # @!attribute [rw] other_linux_64
-  #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+  #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
   #     Linux (64 bit) (experimental)
   # @!attribute [rw] solaris_6
-  #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+  #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
   #     Solaris 6
   # @!attribute [rw] solaris_7
-  #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+  #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
   #     Solaris 7
   # @!attribute [rw] solaris_8
-  #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+  #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
   #     Solaris 8
   # @!attribute [rw] solaris_9
-  #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+  #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
   #     Solaris 9
   # @!attribute [rw] solaris_10
-  #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+  #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
   #     Solaris 10 (32 bit) (experimental)
   # @!attribute [rw] solaris_10_64
-  #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+  #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
   #     Solaris 10 (64 bit) (experimental)
   # @!attribute [rw] solaris_11_64
-  #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+  #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
   #     Solaris 11 (64 bit)
   # @!attribute [rw] o_s2
-  #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+  #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
   #     OS/2
   # @!attribute [rw] ecomstation
-  #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+  #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
   #     eComStation 1.x
   # @!attribute [rw] ecomstation_2
-  #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+  #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
   #     eComStation 2.0
   # @!attribute [rw] netware_4
-  #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+  #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
   #     Novell NetWare 4
   # @!attribute [rw] netware_5
-  #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+  #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
   #     Novell NetWare 5.1
   # @!attribute [rw] netware_6
-  #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+  #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
   #     Novell NetWare 6.x
   # @!attribute [rw] openserver_5
-  #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+  #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
   #     SCO OpenServer 5
   # @!attribute [rw] openserver_6
-  #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+  #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
   #     SCO OpenServer 6
   # @!attribute [rw] unixware_7
-  #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+  #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
   #     SCO UnixWare 7
   # @!attribute [rw] darwin
-  #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+  #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
   #     Mac OS 10.5
   # @!attribute [rw] darwin_64
-  #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+  #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
   #     Mac OS 10.5 (64 bit)
   # @!attribute [rw] darwin_10
-  #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+  #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
   #     Mac OS 10.6
   # @!attribute [rw] darwin_10_64
-  #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+  #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
   #     Mac OS 10.6 (64 bit)
   # @!attribute [rw] darwin_11
-  #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+  #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
   #     Mac OS 10.7
   # @!attribute [rw] darwin_11_64
-  #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+  #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
   #     Mac OS 10.7 (64 bit)
   # @!attribute [rw] darwin_12_64
-  #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+  #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
   #     Mac OS 10.8 (64 bit)
   # @!attribute [rw] darwin_13_64
-  #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+  #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
   #     Mac OS 10.9 (64 bit)
   # @!attribute [rw] darwin_14_64
-  #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+  #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
   #     Mac OS 10.10 (64 bit)
   # @!attribute [rw] darwin_15_64
-  #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+  #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
   #     Mac OS 10.11 (64 bit)
   # @!attribute [rw] darwin_16_64
-  #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+  #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
   #     Mac OS 10.12 (64 bit)
   # @!attribute [rw] vmkernel
-  #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+  #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
   #     VMware ESX 4
   # @!attribute [rw] vmkernel_5
-  #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+  #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
   #     VMware ESX 5
   # @!attribute [rw] vmkernel_6
-  #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+  #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
   #     VMware ESX 6
   # @!attribute [rw] vmkernel_65
-  #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+  #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
   #     VMware ESX 6.5
   # @!attribute [rw] other
-  #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+  #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
   #     Other Operating System
   # @!attribute [rw] other_64
-  #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+  #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
   #     Other Operating System (64 bit) (experimental)
   class GuestOS < VAPI::Bindings::VapiEnum
     class << self
@@ -1356,742 +1356,742 @@ module Com::Vmware::Vcenter::Vm
     private_class_method :new
 
     # @!attribute [rw] dos
-    #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+    #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
     #     MS-DOS.
     DOS = GuestOS.send(:new, 'DOS')
 
     # @!attribute [rw] win_31
-    #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+    #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
     #     Windows 3.1
     WIN_31 = GuestOS.send(:new, 'WIN_31')
 
     # @!attribute [rw] win_95
-    #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+    #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
     #     Windows 95
     WIN_95 = GuestOS.send(:new, 'WIN_95')
 
     # @!attribute [rw] win_98
-    #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+    #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
     #     Windows 98
     WIN_98 = GuestOS.send(:new, 'WIN_98')
 
     # @!attribute [rw] win_me
-    #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+    #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
     #     Windows Millennium Edition
     WIN_ME = GuestOS.send(:new, 'WIN_ME')
 
     # @!attribute [rw] win_nt
-    #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+    #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
     #     Windows NT 4
     WIN_NT = GuestOS.send(:new, 'WIN_NT')
 
     # @!attribute [rw] win_2000_pro
-    #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+    #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
     #     Windows 2000 Professional
     WIN_2000_PRO = GuestOS.send(:new, 'WIN_2000_PRO')
 
     # @!attribute [rw] win_2000_serv
-    #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+    #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
     #     Windows 2000 Server
     WIN_2000_SERV = GuestOS.send(:new, 'WIN_2000_SERV')
 
     # @!attribute [rw] win_2000_adv_serv
-    #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+    #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
     #     Windows 2000 Advanced Server
     WIN_2000_ADV_SERV = GuestOS.send(:new, 'WIN_2000_ADV_SERV')
 
     # @!attribute [rw] win_xp_home
-    #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+    #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
     #     Windows XP Home Edition
     WIN_XP_HOME = GuestOS.send(:new, 'WIN_XP_HOME')
 
     # @!attribute [rw] win_xp_pro
-    #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+    #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
     #     Windows XP Professional
     WIN_XP_PRO = GuestOS.send(:new, 'WIN_XP_PRO')
 
     # @!attribute [rw] win_xp_pro_64
-    #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+    #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
     #     Windows XP Professional Edition (64 bit)
     WIN_XP_PRO_64 = GuestOS.send(:new, 'WIN_XP_PRO_64')
 
     # @!attribute [rw] win_net_web
-    #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+    #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
     #     Windows Server 2003, Web Edition
     WIN_NET_WEB = GuestOS.send(:new, 'WIN_NET_WEB')
 
     # @!attribute [rw] win_net_standard
-    #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+    #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
     #     Windows Server 2003, Standard Edition
     WIN_NET_STANDARD = GuestOS.send(:new, 'WIN_NET_STANDARD')
 
     # @!attribute [rw] win_net_enterprise
-    #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+    #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
     #     Windows Server 2003, Enterprise Edition
     WIN_NET_ENTERPRISE = GuestOS.send(:new, 'WIN_NET_ENTERPRISE')
 
     # @!attribute [rw] win_net_datacenter
-    #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+    #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
     #     Windows Server 2003, Datacenter Edition
     WIN_NET_DATACENTER = GuestOS.send(:new, 'WIN_NET_DATACENTER')
 
     # @!attribute [rw] win_net_business
-    #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+    #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
     #     Windows Small Business Server 2003
     WIN_NET_BUSINESS = GuestOS.send(:new, 'WIN_NET_BUSINESS')
 
     # @!attribute [rw] win_net_standard_64
-    #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+    #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
     #     Windows Server 2003, Standard Edition (64 bit)
     WIN_NET_STANDARD_64 = GuestOS.send(:new, 'WIN_NET_STANDARD_64')
 
     # @!attribute [rw] win_net_enterprise_64
-    #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+    #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
     #     Windows Server 2003, Enterprise Edition (64 bit)
     WIN_NET_ENTERPRISE_64 = GuestOS.send(:new, 'WIN_NET_ENTERPRISE_64')
 
     # @!attribute [rw] win_longhorn
-    #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+    #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
     #     Windows Longhorn (experimental)
     WIN_LONGHORN = GuestOS.send(:new, 'WIN_LONGHORN')
 
     # @!attribute [rw] win_longhorn_64
-    #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+    #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
     #     Windows Longhorn (64 bit) (experimental)
     WIN_LONGHORN_64 = GuestOS.send(:new, 'WIN_LONGHORN_64')
 
     # @!attribute [rw] win_net_datacenter_64
-    #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+    #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
     #     Windows Server 2003, Datacenter Edition (64 bit) (experimental)
     WIN_NET_DATACENTER_64 = GuestOS.send(:new, 'WIN_NET_DATACENTER_64')
 
     # @!attribute [rw] win_vista
-    #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+    #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
     #     Windows Vista
     WIN_VISTA = GuestOS.send(:new, 'WIN_VISTA')
 
     # @!attribute [rw] win_vista_64
-    #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+    #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
     #     Windows Vista (64 bit)
     WIN_VISTA_64 = GuestOS.send(:new, 'WIN_VISTA_64')
 
     # @!attribute [rw] windows_7
-    #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+    #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
     #     Windows 7
     WINDOWS_7 = GuestOS.send(:new, 'WINDOWS_7')
 
     # @!attribute [rw] windows_7_64
-    #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+    #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
     #     Windows 7 (64 bit)
     WINDOWS_7_64 = GuestOS.send(:new, 'WINDOWS_7_64')
 
     # @!attribute [rw] windows_7_server_64
-    #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+    #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
     #     Windows Server 2008 R2 (64 bit)
     WINDOWS_7_SERVER_64 = GuestOS.send(:new, 'WINDOWS_7_SERVER_64')
 
     # @!attribute [rw] windows_8
-    #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+    #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
     #     Windows 8
     WINDOWS_8 = GuestOS.send(:new, 'WINDOWS_8')
 
     # @!attribute [rw] windows_8_64
-    #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+    #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
     #     Windows 8 (64 bit)
     WINDOWS_8_64 = GuestOS.send(:new, 'WINDOWS_8_64')
 
     # @!attribute [rw] windows_8_server_64
-    #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+    #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
     #     Windows 8 Server (64 bit)
     WINDOWS_8_SERVER_64 = GuestOS.send(:new, 'WINDOWS_8_SERVER_64')
 
     # @!attribute [rw] windows_9
-    #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+    #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
     #     Windows 10
     WINDOWS_9 = GuestOS.send(:new, 'WINDOWS_9')
 
     # @!attribute [rw] windows_9_64
-    #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+    #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
     #     Windows 10 (64 bit)
     WINDOWS_9_64 = GuestOS.send(:new, 'WINDOWS_9_64')
 
     # @!attribute [rw] windows_9_server_64
-    #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+    #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
     #     Windows 10 Server (64 bit)
     WINDOWS_9_SERVER_64 = GuestOS.send(:new, 'WINDOWS_9_SERVER_64')
 
     # @!attribute [rw] windows_hyperv
-    #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+    #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
     #     Windows Hyper-V
     WINDOWS_HYPERV = GuestOS.send(:new, 'WINDOWS_HYPERV')
 
     # @!attribute [rw] freebsd
-    #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+    #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
     #     FreeBSD
     FREEBSD = GuestOS.send(:new, 'FREEBSD')
 
     # @!attribute [rw] freebsd_64
-    #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+    #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
     #     FreeBSD x64
     FREEBSD_64 = GuestOS.send(:new, 'FREEBSD_64')
 
     # @!attribute [rw] redhat
-    #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+    #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
     #     Red Hat Linux 2.1
     REDHAT = GuestOS.send(:new, 'REDHAT')
 
     # @!attribute [rw] rhel_2
-    #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+    #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
     #     Red Hat Enterprise Linux 2
     RHEL_2 = GuestOS.send(:new, 'RHEL_2')
 
     # @!attribute [rw] rhel_3
-    #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+    #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
     #     Red Hat Enterprise Linux 3
     RHEL_3 = GuestOS.send(:new, 'RHEL_3')
 
     # @!attribute [rw] rhel_3_64
-    #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+    #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
     #     Red Hat Enterprise Linux 3 (64 bit)
     RHEL_3_64 = GuestOS.send(:new, 'RHEL_3_64')
 
     # @!attribute [rw] rhel_4
-    #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+    #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
     #     Red Hat Enterprise Linux 4
     RHEL_4 = GuestOS.send(:new, 'RHEL_4')
 
     # @!attribute [rw] rhel_4_64
-    #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+    #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
     #     Red Hat Enterprise Linux 4 (64 bit)
     RHEL_4_64 = GuestOS.send(:new, 'RHEL_4_64')
 
     # @!attribute [rw] rhel_5
-    #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+    #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
     #     Red Hat Enterprise Linux 5
     RHEL_5 = GuestOS.send(:new, 'RHEL_5')
 
     # @!attribute [rw] rhel_5_64
-    #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+    #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
     #     Red Hat Enterprise Linux 5 (64 bit) (experimental)
     RHEL_5_64 = GuestOS.send(:new, 'RHEL_5_64')
 
     # @!attribute [rw] rhel_6
-    #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+    #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
     #     Red Hat Enterprise Linux 6
     RHEL_6 = GuestOS.send(:new, 'RHEL_6')
 
     # @!attribute [rw] rhel_6_64
-    #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+    #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
     #     Red Hat Enterprise Linux 6 (64 bit)
     RHEL_6_64 = GuestOS.send(:new, 'RHEL_6_64')
 
     # @!attribute [rw] rhel_7
-    #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+    #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
     #     Red Hat Enterprise Linux 7
     RHEL_7 = GuestOS.send(:new, 'RHEL_7')
 
     # @!attribute [rw] rhel_7_64
-    #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+    #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
     #     Red Hat Enterprise Linux 7 (64 bit)
     RHEL_7_64 = GuestOS.send(:new, 'RHEL_7_64')
 
     # @!attribute [rw] centos
-    #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+    #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
     #     CentOS 4/5
     CENTOS = GuestOS.send(:new, 'CENTOS')
 
     # @!attribute [rw] centos_64
-    #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+    #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
     #     CentOS 4/5 (64-bit)
     CENTOS_64 = GuestOS.send(:new, 'CENTOS_64')
 
     # @!attribute [rw] centos_6
-    #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+    #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
     #     CentOS 6
     CENTOS_6 = GuestOS.send(:new, 'CENTOS_6')
 
     # @!attribute [rw] centos_6_64
-    #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+    #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
     #     CentOS 6 (64-bit)
     CENTOS_6_64 = GuestOS.send(:new, 'CENTOS_6_64')
 
     # @!attribute [rw] centos_7
-    #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+    #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
     #     CentOS 7
     CENTOS_7 = GuestOS.send(:new, 'CENTOS_7')
 
     # @!attribute [rw] centos_7_64
-    #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+    #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
     #     CentOS 7 (64-bit)
     CENTOS_7_64 = GuestOS.send(:new, 'CENTOS_7_64')
 
     # @!attribute [rw] oracle_linux
-    #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+    #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
     #     Oracle Linux 4/5
     ORACLE_LINUX = GuestOS.send(:new, 'ORACLE_LINUX')
 
     # @!attribute [rw] oracle_linux_64
-    #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+    #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
     #     Oracle Linux 4/5 (64-bit)
     ORACLE_LINUX_64 = GuestOS.send(:new, 'ORACLE_LINUX_64')
 
     # @!attribute [rw] oracle_linux_6
-    #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+    #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
     #     Oracle Linux 6
     ORACLE_LINUX_6 = GuestOS.send(:new, 'ORACLE_LINUX_6')
 
     # @!attribute [rw] oracle_linux_6_64
-    #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+    #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
     #     Oracle Linux 6 (64-bit)
     ORACLE_LINUX_6_64 = GuestOS.send(:new, 'ORACLE_LINUX_6_64')
 
     # @!attribute [rw] oracle_linux_7
-    #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+    #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
     #     Oracle Linux 7
     ORACLE_LINUX_7 = GuestOS.send(:new, 'ORACLE_LINUX_7')
 
     # @!attribute [rw] oracle_linux_7_64
-    #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+    #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
     #     Oracle Linux 7 (64-bit)
     ORACLE_LINUX_7_64 = GuestOS.send(:new, 'ORACLE_LINUX_7_64')
 
     # @!attribute [rw] suse
-    #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+    #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
     #     Suse Linux
     SUSE = GuestOS.send(:new, 'SUSE')
 
     # @!attribute [rw] suse_64
-    #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+    #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
     #     Suse Linux (64 bit)
     SUSE_64 = GuestOS.send(:new, 'SUSE_64')
 
     # @!attribute [rw] sles
-    #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+    #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
     #     Suse Linux Enterprise Server 9
     SLES = GuestOS.send(:new, 'SLES')
 
     # @!attribute [rw] sles_64
-    #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+    #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
     #     Suse Linux Enterprise Server 9 (64 bit)
     SLES_64 = GuestOS.send(:new, 'SLES_64')
 
     # @!attribute [rw] sles_10
-    #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+    #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
     #     Suse linux Enterprise Server 10
     SLES_10 = GuestOS.send(:new, 'SLES_10')
 
     # @!attribute [rw] sles_10_64
-    #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+    #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
     #     Suse Linux Enterprise Server 10 (64 bit) (experimental)
     SLES_10_64 = GuestOS.send(:new, 'SLES_10_64')
 
     # @!attribute [rw] sles_11
-    #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+    #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
     #     Suse linux Enterprise Server 11
     SLES_11 = GuestOS.send(:new, 'SLES_11')
 
     # @!attribute [rw] sles_11_64
-    #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+    #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
     #     Suse Linux Enterprise Server 11 (64 bit)
     SLES_11_64 = GuestOS.send(:new, 'SLES_11_64')
 
     # @!attribute [rw] sles_12
-    #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+    #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
     #     Suse linux Enterprise Server 12
     SLES_12 = GuestOS.send(:new, 'SLES_12')
 
     # @!attribute [rw] sles_12_64
-    #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+    #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
     #     Suse Linux Enterprise Server 12 (64 bit)
     SLES_12_64 = GuestOS.send(:new, 'SLES_12_64')
 
     # @!attribute [rw] nld_9
-    #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+    #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
     #     Novell Linux Desktop 9
     NLD_9 = GuestOS.send(:new, 'NLD_9')
 
     # @!attribute [rw] oes
-    #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+    #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
     #     Open Enterprise Server
     OES = GuestOS.send(:new, 'OES')
 
     # @!attribute [rw] sjds
-    #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+    #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
     #     Sun Java Desktop System
     SJDS = GuestOS.send(:new, 'SJDS')
 
     # @!attribute [rw] mandrake
-    #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+    #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
     #     Mandrake Linux
     MANDRAKE = GuestOS.send(:new, 'MANDRAKE')
 
     # @!attribute [rw] mandriva
-    #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+    #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
     #     Mandriva Linux
     MANDRIVA = GuestOS.send(:new, 'MANDRIVA')
 
     # @!attribute [rw] mandriva_64
-    #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+    #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
     #     Mandriva Linux (64 bit)
     MANDRIVA_64 = GuestOS.send(:new, 'MANDRIVA_64')
 
     # @!attribute [rw] turbo_linux
-    #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+    #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
     #     Turbolinux
     TURBO_LINUX = GuestOS.send(:new, 'TURBO_LINUX')
 
     # @!attribute [rw] turbo_linux_64
-    #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+    #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
     #     Turbolinux (64 bit)
     TURBO_LINUX_64 = GuestOS.send(:new, 'TURBO_LINUX_64')
 
     # @!attribute [rw] ubuntu
-    #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+    #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
     #     Ubuntu Linux
     UBUNTU = GuestOS.send(:new, 'UBUNTU')
 
     # @!attribute [rw] ubuntu_64
-    #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+    #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
     #     Ubuntu Linux (64 bit)
     UBUNTU_64 = GuestOS.send(:new, 'UBUNTU_64')
 
     # @!attribute [rw] debian_4
-    #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+    #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
     #     Debian GNU/Linux 4
     DEBIAN_4 = GuestOS.send(:new, 'DEBIAN_4')
 
     # @!attribute [rw] debian_4_64
-    #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+    #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
     #     Debian GNU/Linux 4 (64 bit)
     DEBIAN_4_64 = GuestOS.send(:new, 'DEBIAN_4_64')
 
     # @!attribute [rw] debian_5
-    #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+    #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
     #     Debian GNU/Linux 5
     DEBIAN_5 = GuestOS.send(:new, 'DEBIAN_5')
 
     # @!attribute [rw] debian_5_64
-    #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+    #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
     #     Debian GNU/Linux 5 (64 bit)
     DEBIAN_5_64 = GuestOS.send(:new, 'DEBIAN_5_64')
 
     # @!attribute [rw] debian_6
-    #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+    #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
     #     Debian GNU/Linux 6
     DEBIAN_6 = GuestOS.send(:new, 'DEBIAN_6')
 
     # @!attribute [rw] debian_6_64
-    #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+    #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
     #     Debian GNU/Linux 6 (64 bit)
     DEBIAN_6_64 = GuestOS.send(:new, 'DEBIAN_6_64')
 
     # @!attribute [rw] debian_7
-    #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+    #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
     #     Debian GNU/Linux 7
     DEBIAN_7 = GuestOS.send(:new, 'DEBIAN_7')
 
     # @!attribute [rw] debian_7_64
-    #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+    #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
     #     Debian GNU/Linux 7 (64 bit)
     DEBIAN_7_64 = GuestOS.send(:new, 'DEBIAN_7_64')
 
     # @!attribute [rw] debian_8
-    #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+    #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
     #     Debian GNU/Linux 8
     DEBIAN_8 = GuestOS.send(:new, 'DEBIAN_8')
 
     # @!attribute [rw] debian_8_64
-    #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+    #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
     #     Debian GNU/Linux 8 (64 bit)
     DEBIAN_8_64 = GuestOS.send(:new, 'DEBIAN_8_64')
 
     # @!attribute [rw] debian_9
-    #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+    #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
     #     Debian GNU/Linux 9
     DEBIAN_9 = GuestOS.send(:new, 'DEBIAN_9')
 
     # @!attribute [rw] debian_9_64
-    #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+    #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
     #     Debian GNU/Linux 9 (64 bit)
     DEBIAN_9_64 = GuestOS.send(:new, 'DEBIAN_9_64')
 
     # @!attribute [rw] debian_10
-    #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+    #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
     #     Debian GNU/Linux 10
     DEBIAN_10 = GuestOS.send(:new, 'DEBIAN_10')
 
     # @!attribute [rw] debian_10_64
-    #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+    #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
     #     Debian GNU/Linux 10 (64 bit)
     DEBIAN_10_64 = GuestOS.send(:new, 'DEBIAN_10_64')
 
     # @!attribute [rw] asianux_3
-    #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+    #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
     #     Asianux Server 3
     ASIANUX_3 = GuestOS.send(:new, 'ASIANUX_3')
 
     # @!attribute [rw] asianux_3_64
-    #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+    #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
     #     Asianux Server 3 (64 bit)
     ASIANUX_3_64 = GuestOS.send(:new, 'ASIANUX_3_64')
 
     # @!attribute [rw] asianux_4
-    #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+    #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
     #     Asianux Server 4
     ASIANUX_4 = GuestOS.send(:new, 'ASIANUX_4')
 
     # @!attribute [rw] asianux_4_64
-    #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+    #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
     #     Asianux Server 4 (64 bit)
     ASIANUX_4_64 = GuestOS.send(:new, 'ASIANUX_4_64')
 
     # @!attribute [rw] asianux_5_64
-    #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+    #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
     #     Asianux Server 5 (64 bit)
     ASIANUX_5_64 = GuestOS.send(:new, 'ASIANUX_5_64')
 
     # @!attribute [rw] asianux_7_64
-    #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+    #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
     #     Asianux Server 7 (64 bit)
     ASIANUX_7_64 = GuestOS.send(:new, 'ASIANUX_7_64')
 
     # @!attribute [rw] opensuse
-    #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+    #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
     #     OpenSUSE Linux
     OPENSUSE = GuestOS.send(:new, 'OPENSUSE')
 
     # @!attribute [rw] opensuse_64
-    #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+    #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
     #     OpenSUSE Linux (64 bit)
     OPENSUSE_64 = GuestOS.send(:new, 'OPENSUSE_64')
 
     # @!attribute [rw] fedora
-    #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+    #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
     #     Fedora Linux
     FEDORA = GuestOS.send(:new, 'FEDORA')
 
     # @!attribute [rw] fedora_64
-    #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+    #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
     #     Fedora Linux (64 bit)
     FEDORA_64 = GuestOS.send(:new, 'FEDORA_64')
 
     # @!attribute [rw] coreos_64
-    #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+    #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
     #     CoreOS Linux (64 bit)
     COREOS_64 = GuestOS.send(:new, 'COREOS_64')
 
     # @!attribute [rw] vmware_photon_64
-    #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+    #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
     #     VMware Photon (64 bit)
     VMWARE_PHOTON_64 = GuestOS.send(:new, 'VMWARE_PHOTON_64')
 
     # @!attribute [rw] other_24x_linux
-    #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+    #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
     #     Linux 2.4x Kernel
     OTHER_24X_LINUX = GuestOS.send(:new, 'OTHER_24X_LINUX')
 
     # @!attribute [rw] other_24x_linux_64
-    #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+    #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
     #     Linux 2.4x Kernel (64 bit) (experimental)
     OTHER_24X_LINUX_64 = GuestOS.send(:new, 'OTHER_24X_LINUX_64')
 
     # @!attribute [rw] other_26x_linux
-    #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+    #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
     #     Linux 2.6x Kernel
     OTHER_26X_LINUX = GuestOS.send(:new, 'OTHER_26X_LINUX')
 
     # @!attribute [rw] other_26x_linux_64
-    #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+    #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
     #     Linux 2.6x Kernel (64 bit) (experimental)
     OTHER_26X_LINUX_64 = GuestOS.send(:new, 'OTHER_26X_LINUX_64')
 
     # @!attribute [rw] other_3x_linux
-    #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+    #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
     #     Linux 3.x Kernel
     OTHER_3X_LINUX = GuestOS.send(:new, 'OTHER_3X_LINUX')
 
     # @!attribute [rw] other_3x_linux_64
-    #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+    #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
     #     Linux 3.x Kernel (64 bit)
     OTHER_3X_LINUX_64 = GuestOS.send(:new, 'OTHER_3X_LINUX_64')
 
     # @!attribute [rw] other_linux
-    #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+    #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
     #     Linux 2.2x Kernel
     OTHER_LINUX = GuestOS.send(:new, 'OTHER_LINUX')
 
     # @!attribute [rw] generic_linux
-    #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+    #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
     #     Other Linux
     GENERIC_LINUX = GuestOS.send(:new, 'GENERIC_LINUX')
 
     # @!attribute [rw] other_linux_64
-    #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+    #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
     #     Linux (64 bit) (experimental)
     OTHER_LINUX_64 = GuestOS.send(:new, 'OTHER_LINUX_64')
 
     # @!attribute [rw] solaris_6
-    #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+    #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
     #     Solaris 6
     SOLARIS_6 = GuestOS.send(:new, 'SOLARIS_6')
 
     # @!attribute [rw] solaris_7
-    #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+    #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
     #     Solaris 7
     SOLARIS_7 = GuestOS.send(:new, 'SOLARIS_7')
 
     # @!attribute [rw] solaris_8
-    #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+    #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
     #     Solaris 8
     SOLARIS_8 = GuestOS.send(:new, 'SOLARIS_8')
 
     # @!attribute [rw] solaris_9
-    #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+    #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
     #     Solaris 9
     SOLARIS_9 = GuestOS.send(:new, 'SOLARIS_9')
 
     # @!attribute [rw] solaris_10
-    #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+    #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
     #     Solaris 10 (32 bit) (experimental)
     SOLARIS_10 = GuestOS.send(:new, 'SOLARIS_10')
 
     # @!attribute [rw] solaris_10_64
-    #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+    #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
     #     Solaris 10 (64 bit) (experimental)
     SOLARIS_10_64 = GuestOS.send(:new, 'SOLARIS_10_64')
 
     # @!attribute [rw] solaris_11_64
-    #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+    #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
     #     Solaris 11 (64 bit)
     SOLARIS_11_64 = GuestOS.send(:new, 'SOLARIS_11_64')
 
     # @!attribute [rw] o_s2
-    #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+    #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
     #     OS/2
     O_S2 = GuestOS.send(:new, 'O_S2')
 
     # @!attribute [rw] ecomstation
-    #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+    #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
     #     eComStation 1.x
     ECOMSTATION = GuestOS.send(:new, 'ECOMSTATION')
 
     # @!attribute [rw] ecomstation_2
-    #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+    #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
     #     eComStation 2.0
     ECOMSTATION_2 = GuestOS.send(:new, 'ECOMSTATION_2')
 
     # @!attribute [rw] netware_4
-    #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+    #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
     #     Novell NetWare 4
     NETWARE_4 = GuestOS.send(:new, 'NETWARE_4')
 
     # @!attribute [rw] netware_5
-    #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+    #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
     #     Novell NetWare 5.1
     NETWARE_5 = GuestOS.send(:new, 'NETWARE_5')
 
     # @!attribute [rw] netware_6
-    #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+    #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
     #     Novell NetWare 6.x
     NETWARE_6 = GuestOS.send(:new, 'NETWARE_6')
 
     # @!attribute [rw] openserver_5
-    #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+    #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
     #     SCO OpenServer 5
     OPENSERVER_5 = GuestOS.send(:new, 'OPENSERVER_5')
 
     # @!attribute [rw] openserver_6
-    #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+    #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
     #     SCO OpenServer 6
     OPENSERVER_6 = GuestOS.send(:new, 'OPENSERVER_6')
 
     # @!attribute [rw] unixware_7
-    #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+    #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
     #     SCO UnixWare 7
     UNIXWARE_7 = GuestOS.send(:new, 'UNIXWARE_7')
 
     # @!attribute [rw] darwin
-    #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+    #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
     #     Mac OS 10.5
     DARWIN = GuestOS.send(:new, 'DARWIN')
 
     # @!attribute [rw] darwin_64
-    #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+    #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
     #     Mac OS 10.5 (64 bit)
     DARWIN_64 = GuestOS.send(:new, 'DARWIN_64')
 
     # @!attribute [rw] darwin_10
-    #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+    #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
     #     Mac OS 10.6
     DARWIN_10 = GuestOS.send(:new, 'DARWIN_10')
 
     # @!attribute [rw] darwin_10_64
-    #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+    #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
     #     Mac OS 10.6 (64 bit)
     DARWIN_10_64 = GuestOS.send(:new, 'DARWIN_10_64')
 
     # @!attribute [rw] darwin_11
-    #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+    #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
     #     Mac OS 10.7
     DARWIN_11 = GuestOS.send(:new, 'DARWIN_11')
 
     # @!attribute [rw] darwin_11_64
-    #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+    #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
     #     Mac OS 10.7 (64 bit)
     DARWIN_11_64 = GuestOS.send(:new, 'DARWIN_11_64')
 
     # @!attribute [rw] darwin_12_64
-    #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+    #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
     #     Mac OS 10.8 (64 bit)
     DARWIN_12_64 = GuestOS.send(:new, 'DARWIN_12_64')
 
     # @!attribute [rw] darwin_13_64
-    #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+    #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
     #     Mac OS 10.9 (64 bit)
     DARWIN_13_64 = GuestOS.send(:new, 'DARWIN_13_64')
 
     # @!attribute [rw] darwin_14_64
-    #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+    #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
     #     Mac OS 10.10 (64 bit)
     DARWIN_14_64 = GuestOS.send(:new, 'DARWIN_14_64')
 
     # @!attribute [rw] darwin_15_64
-    #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+    #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
     #     Mac OS 10.11 (64 bit)
     DARWIN_15_64 = GuestOS.send(:new, 'DARWIN_15_64')
 
     # @!attribute [rw] darwin_16_64
-    #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+    #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
     #     Mac OS 10.12 (64 bit)
     DARWIN_16_64 = GuestOS.send(:new, 'DARWIN_16_64')
 
     # @!attribute [rw] vmkernel
-    #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+    #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
     #     VMware ESX 4
     VMKERNEL = GuestOS.send(:new, 'VMKERNEL')
 
     # @!attribute [rw] vmkernel_5
-    #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+    #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
     #     VMware ESX 5
     VMKERNEL_5 = GuestOS.send(:new, 'VMKERNEL_5')
 
     # @!attribute [rw] vmkernel_6
-    #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+    #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
     #     VMware ESX 6
     VMKERNEL_6 = GuestOS.send(:new, 'VMKERNEL_6')
 
     # @!attribute [rw] vmkernel_65
-    #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+    #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
     #     VMware ESX 6.5
     VMKERNEL_65 = GuestOS.send(:new, 'VMKERNEL_65')
 
     # @!attribute [rw] other
-    #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+    #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
     #     Other Operating System
     OTHER = GuestOS.send(:new, 'OTHER')
 
     # @!attribute [rw] other_64
-    #     @return [Com::Vmware::Vcenter::VM::GuestOS]
+    #     @return [Com::Vmware::Vcenter::Vm::GuestOS]
     #     Other Operating System (64 bit) (experimental)
     OTHER_64 = GuestOS.send(:new, 'OTHER_64')
   end

--- a/client/sdk/com/vmware/vcenter/vm/hardware.rb
+++ b/client/sdk/com/vmware/vcenter/vm/hardware.rb
@@ -21,7 +21,7 @@ end
 
 # The  ``com.vmware.vcenter.vm.hardware``   package  provides  classs  for managing the virtual hardware configuration and state of a virtual machine. This includes  methods  for reading and manipulating virtual device configuration and for querying the runtime state of the devices.
 module Com::Vmware::Vcenter::Vm::Hardware
-  # The  ``Com::Vmware::Vcenter::VM::Hardware::Boot``   class  provides  methods  for configuring the settings used when booting a virtual machine.
+  # The  ``Com::Vmware::Vcenter::Vm::Hardware::Boot``   class  provides  methods  for configuring the settings used when booting a virtual machine.
   class BootService < VAPI::Bindings::VapiService
     # static metamodel definitions
     SERVICE_ID = VAPI::Core::ServiceIdentifier.new('com.vmware.vcenter.vm.hardware.boot')
@@ -31,7 +31,7 @@ module Com::Vmware::Vcenter::Vm::Hardware
       VAPI::Bindings::OperationInputType.new(
         'vm' => VAPI::Bindings::IdType.new('VirtualMachine')
       ),
-      VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::VM::Hardware::Boot::Info'),
+      VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::Vm::Hardware::Boot::Info'),
       {
         'com.vmware.vapi.std.errors.error' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Error'),
         'com.vmware.vapi.std.errors.not_found' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::NotFound'),
@@ -48,7 +48,7 @@ module Com::Vmware::Vcenter::Vm::Hardware
       VAPI::Core::OperationIdentifier.new('update', SERVICE_ID),
       VAPI::Bindings::OperationInputType.new(
         'vm' => VAPI::Bindings::IdType.new('VirtualMachine'),
-        'spec' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::VM::Hardware::Boot::UpdateSpec')
+        'spec' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::Vm::Hardware::Boot::UpdateSpec')
       ),
       VAPI::Bindings::VoidType.instance,
       {
@@ -82,7 +82,7 @@ module Com::Vmware::Vcenter::Vm::Hardware
     #
     # @param vm [String]
     #     Virtual machine identifier.
-    # @return [Com::Vmware::Vcenter::VM::Hardware::Boot::Info]
+    # @return [Com::Vmware::Vcenter::Vm::Hardware::Boot::Info]
     #     Boot-related settings of the virtual machine.
     # @raise [Com::Vmware::Vapi::Std::Errors::Error]
     #     if the system reports an error while responding to the request.
@@ -105,7 +105,7 @@ module Com::Vmware::Vcenter::Vm::Hardware
     #
     # @param vm [String]
     #     Virtual machine identifier.
-    # @param spec [Com::Vmware::Vcenter::VM::Hardware::Boot::UpdateSpec]
+    # @param spec [Com::Vmware::Vcenter::Vm::Hardware::Boot::UpdateSpec]
     #     Specification for updating the boot-related settings of the virtual machine.
     # @return [Void]
     # @raise [Com::Vmware::Vapi::Std::Errors::Error]
@@ -130,18 +130,18 @@ module Com::Vmware::Vcenter::Vm::Hardware
                        'spec' => spec)
     end
 
-    # The  ``Com::Vmware::Vcenter::VM::Hardware::Boot::Info``   class  contains information about the virtual machine boot process.
+    # The  ``Com::Vmware::Vcenter::Vm::Hardware::Boot::Info``   class  contains information about the virtual machine boot process.
     # @!attribute [rw] type
-    #     @return [Com::Vmware::Vcenter::VM::Hardware::Boot::Type]
+    #     @return [Com::Vmware::Vcenter::Vm::Hardware::Boot::Type]
     #     Firmware type used by the virtual machine.
     # @!attribute [rw] efi_legacy_boot
     #     @return [Boolean]
     #     Flag indicating whether to use EFI legacy boot mode.
-    #     This  field  is optional and it is only relevant when the value of  ``type``  is   :attr:`Com::Vmware::Vcenter::VM::Hardware::Boot::Type.EFI`  .
+    #     This  field  is optional and it is only relevant when the value of  ``type``  is   :attr:`Com::Vmware::Vcenter::Vm::Hardware::Boot::Type.EFI`  .
     # @!attribute [rw] network_protocol
-    #     @return [Com::Vmware::Vcenter::VM::Hardware::Boot::NetworkProtocol]
+    #     @return [Com::Vmware::Vcenter::Vm::Hardware::Boot::NetworkProtocol]
     #     Protocol to use when attempting to boot the virtual machine over the network.
-    #     This  field  is optional and it is only relevant when the value of  ``type``  is   :attr:`Com::Vmware::Vcenter::VM::Hardware::Boot::Type.EFI`  .
+    #     This  field  is optional and it is only relevant when the value of  ``type``  is   :attr:`Com::Vmware::Vcenter::Vm::Hardware::Boot::Type.EFI`  .
     # @!attribute [rw] delay
     #     @return [Fixnum]
     #     Delay in milliseconds before beginning the firmware boot process when the virtual machine is powered on. This delay may be used to provide a time window for users to connect to the virtual machine console and enter BIOS setup mode.
@@ -150,7 +150,7 @@ module Com::Vmware::Vcenter::Vm::Hardware
     #     Flag indicating whether the virtual machine will automatically retry the boot process after a failure.
     # @!attribute [rw] retry_delay
     #     @return [Fixnum]
-    #     Delay in milliseconds before retrying the boot process after a failure; applicable only when   :attr:`Com::Vmware::Vcenter::VM::Hardware::Boot::Info.retry_`   is true.
+    #     Delay in milliseconds before retrying the boot process after a failure; applicable only when   :attr:`Com::Vmware::Vcenter::Vm::Hardware::Boot::Info.retry_`   is true.
     # @!attribute [rw] enter_setup_mode
     #     @return [Boolean]
     #     Flag indicating whether the firmware boot process will automatically enter setup mode the next time the virtual machine boots. Note that this flag will automatically be reset to false once the virtual machine enters setup mode.
@@ -163,9 +163,9 @@ module Com::Vmware::Vcenter::Vm::Hardware
           @binding_type ||= VAPI::Bindings::StructType.new(
             'com.vmware.vcenter.vm.hardware.boot.info',
             {
-              'type' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::VM::Hardware::Boot::Type'),
+              'type' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::Vm::Hardware::Boot::Type'),
               'efi_legacy_boot' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::BooleanType.instance),
-              'network_protocol' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::VM::Hardware::Boot::NetworkProtocol')),
+              'network_protocol' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::Vm::Hardware::Boot::NetworkProtocol')),
               'delay' => VAPI::Bindings::IntegerType.instance,
               'retry' => VAPI::Bindings::BooleanType.instance,
               'retry_delay' => VAPI::Bindings::IntegerType.instance,
@@ -194,9 +194,9 @@ module Com::Vmware::Vcenter::Vm::Hardware
       end
     end
 
-    # The  ``Com::Vmware::Vcenter::VM::Hardware::Boot::CreateSpec``   class  describes settings used when booting a virtual machine.
+    # The  ``Com::Vmware::Vcenter::Vm::Hardware::Boot::CreateSpec``   class  describes settings used when booting a virtual machine.
     # @!attribute [rw] type
-    #     @return [Com::Vmware::Vcenter::VM::Hardware::Boot::Type, nil]
+    #     @return [Com::Vmware::Vcenter::Vm::Hardware::Boot::Type, nil]
     #     Firmware type to be used by the virtual machine.
     #     If  nil , defaults to value that is recommended for the guest OS and is supported for the virtual hardware version.
     # @!attribute [rw] efi_legacy_boot
@@ -204,7 +204,7 @@ module Com::Vmware::Vcenter::Vm::Hardware
     #     Flag indicating whether to use EFI legacy boot mode.
     #     If  nil , defaults to value that is recommended for the guest OS and is supported for the virtual hardware version.
     # @!attribute [rw] network_protocol
-    #     @return [Com::Vmware::Vcenter::VM::Hardware::Boot::NetworkProtocol, nil]
+    #     @return [Com::Vmware::Vcenter::Vm::Hardware::Boot::NetworkProtocol, nil]
     #     Protocol to use when attempting to boot the virtual machine over the network.
     #     If  nil , defaults to a system defined default value.
     # @!attribute [rw] delay
@@ -217,7 +217,7 @@ module Com::Vmware::Vcenter::Vm::Hardware
     #     If  nil , default value is false.
     # @!attribute [rw] retry_delay
     #     @return [Fixnum, nil]
-    #     Delay in milliseconds before retrying the boot process after a failure; applicable only when   :attr:`Com::Vmware::Vcenter::VM::Hardware::Boot::Info.retry_`   is true.
+    #     Delay in milliseconds before retrying the boot process after a failure; applicable only when   :attr:`Com::Vmware::Vcenter::Vm::Hardware::Boot::Info.retry_`   is true.
     #     If  nil , default value is 10000.
     # @!attribute [rw] enter_setup_mode
     #     @return [Boolean, nil]
@@ -232,9 +232,9 @@ module Com::Vmware::Vcenter::Vm::Hardware
           @binding_type ||= VAPI::Bindings::StructType.new(
             'com.vmware.vcenter.vm.hardware.boot.create_spec',
             {
-              'type' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::VM::Hardware::Boot::Type')),
+              'type' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::Vm::Hardware::Boot::Type')),
               'efi_legacy_boot' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::BooleanType.instance),
-              'network_protocol' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::VM::Hardware::Boot::NetworkProtocol')),
+              'network_protocol' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::Vm::Hardware::Boot::NetworkProtocol')),
               'delay' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::IntegerType.instance),
               'retry' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::BooleanType.instance),
               'retry_delay' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::IntegerType.instance),
@@ -263,9 +263,9 @@ module Com::Vmware::Vcenter::Vm::Hardware
       end
     end
 
-    # The  ``Com::Vmware::Vcenter::VM::Hardware::Boot::UpdateSpec``   class  describes the updates to the settings used when booting a virtual machine.
+    # The  ``Com::Vmware::Vcenter::Vm::Hardware::Boot::UpdateSpec``   class  describes the updates to the settings used when booting a virtual machine.
     # @!attribute [rw] type
-    #     @return [Com::Vmware::Vcenter::VM::Hardware::Boot::Type, nil]
+    #     @return [Com::Vmware::Vcenter::Vm::Hardware::Boot::Type, nil]
     #     Firmware type to be used by the virtual machine.
     #     If  nil , the value is unchanged.
     # @!attribute [rw] efi_legacy_boot
@@ -273,7 +273,7 @@ module Com::Vmware::Vcenter::Vm::Hardware
     #     Flag indicating whether to use EFI legacy boot mode.
     #     If  nil , the value is unchanged.
     # @!attribute [rw] network_protocol
-    #     @return [Com::Vmware::Vcenter::VM::Hardware::Boot::NetworkProtocol, nil]
+    #     @return [Com::Vmware::Vcenter::Vm::Hardware::Boot::NetworkProtocol, nil]
     #     Protocol to use when attempting to boot the virtual machine over the network.
     #     If  nil , the value is unchanged.
     # @!attribute [rw] delay
@@ -286,7 +286,7 @@ module Com::Vmware::Vcenter::Vm::Hardware
     #     If  nil , the value is unchanged.
     # @!attribute [rw] retry_delay
     #     @return [Fixnum, nil]
-    #     Delay in milliseconds before retrying the boot process after a failure; applicable only when   :attr:`Com::Vmware::Vcenter::VM::Hardware::Boot::Info.retry_`   is true.
+    #     Delay in milliseconds before retrying the boot process after a failure; applicable only when   :attr:`Com::Vmware::Vcenter::Vm::Hardware::Boot::Info.retry_`   is true.
     #     If  nil , the value is unchanged.
     # @!attribute [rw] enter_setup_mode
     #     @return [Boolean, nil]
@@ -301,9 +301,9 @@ module Com::Vmware::Vcenter::Vm::Hardware
           @binding_type ||= VAPI::Bindings::StructType.new(
             'com.vmware.vcenter.vm.hardware.boot.update_spec',
             {
-              'type' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::VM::Hardware::Boot::Type')),
+              'type' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::Vm::Hardware::Boot::Type')),
               'efi_legacy_boot' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::BooleanType.instance),
-              'network_protocol' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::VM::Hardware::Boot::NetworkProtocol')),
+              'network_protocol' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::Vm::Hardware::Boot::NetworkProtocol')),
               'delay' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::IntegerType.instance),
               'retry' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::BooleanType.instance),
               'retry_delay' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::IntegerType.instance),
@@ -332,12 +332,12 @@ module Com::Vmware::Vcenter::Vm::Hardware
       end
     end
 
-    # The  ``Com::Vmware::Vcenter::VM::Hardware::Boot::Type``   enumerated type  defines the valid firmware types for a virtual machine.
+    # The  ``Com::Vmware::Vcenter::Vm::Hardware::Boot::Type``   enumerated type  defines the valid firmware types for a virtual machine.
     # @!attribute [rw] bios
-    #     @return [Com::Vmware::Vcenter::VM::Hardware::Boot::Type]
+    #     @return [Com::Vmware::Vcenter::Vm::Hardware::Boot::Type]
     #     Basic Input/Output System (BIOS) firmware.
     # @!attribute [rw] efi
-    #     @return [Com::Vmware::Vcenter::VM::Hardware::Boot::Type]
+    #     @return [Com::Vmware::Vcenter::Vm::Hardware::Boot::Type]
     #     Extensible Firmware Interface (EFI) firmware.
     class Type < VAPI::Bindings::VapiEnum
       class << self
@@ -373,21 +373,21 @@ module Com::Vmware::Vcenter::Vm::Hardware
       private_class_method :new
 
       # @!attribute [rw] bios
-      #     @return [Com::Vmware::Vcenter::VM::Hardware::Boot::Type]
+      #     @return [Com::Vmware::Vcenter::Vm::Hardware::Boot::Type]
       #     Basic Input/Output System (BIOS) firmware.
       BIOS = Type.send(:new, 'BIOS')
 
       # @!attribute [rw] efi
-      #     @return [Com::Vmware::Vcenter::VM::Hardware::Boot::Type]
+      #     @return [Com::Vmware::Vcenter::Vm::Hardware::Boot::Type]
       #     Extensible Firmware Interface (EFI) firmware.
       EFI = Type.send(:new, 'EFI')
     end
-    # The  ``Com::Vmware::Vcenter::VM::Hardware::Boot::NetworkProtocol``   enumerated type  defines the valid network boot protocols supported when booting a virtual machine with   :attr:`Com::Vmware::Vcenter::VM::Hardware::Boot::Type.EFI`   firmware over the network.
+    # The  ``Com::Vmware::Vcenter::Vm::Hardware::Boot::NetworkProtocol``   enumerated type  defines the valid network boot protocols supported when booting a virtual machine with   :attr:`Com::Vmware::Vcenter::Vm::Hardware::Boot::Type.EFI`   firmware over the network.
     # @!attribute [rw] ip_v4
-    #     @return [Com::Vmware::Vcenter::VM::Hardware::Boot::NetworkProtocol]
+    #     @return [Com::Vmware::Vcenter::Vm::Hardware::Boot::NetworkProtocol]
     #     PXE or Apple NetBoot over IPv4.
     # @!attribute [rw] ip_v6
-    #     @return [Com::Vmware::Vcenter::VM::Hardware::Boot::NetworkProtocol]
+    #     @return [Com::Vmware::Vcenter::Vm::Hardware::Boot::NetworkProtocol]
     #     PXE over IPv6.
     class NetworkProtocol < VAPI::Bindings::VapiEnum
       class << self
@@ -423,17 +423,17 @@ module Com::Vmware::Vcenter::Vm::Hardware
       private_class_method :new
 
       # @!attribute [rw] ip_v4
-      #     @return [Com::Vmware::Vcenter::VM::Hardware::Boot::NetworkProtocol]
+      #     @return [Com::Vmware::Vcenter::Vm::Hardware::Boot::NetworkProtocol]
       #     PXE or Apple NetBoot over IPv4.
       IP_V4 = NetworkProtocol.send(:new, 'IP_V4')
 
       # @!attribute [rw] ip_v6
-      #     @return [Com::Vmware::Vcenter::VM::Hardware::Boot::NetworkProtocol]
+      #     @return [Com::Vmware::Vcenter::Vm::Hardware::Boot::NetworkProtocol]
       #     PXE over IPv6.
       IP_V6 = NetworkProtocol.send(:new, 'IP_V6')
     end
   end
-  # The  ``Com::Vmware::Vcenter::VM::Hardware::Cdrom``   class  provides  methods  for configuring the virtual CD-ROM devices of a virtual machine.
+  # The  ``Com::Vmware::Vcenter::Vm::Hardware::Cdrom``   class  provides  methods  for configuring the virtual CD-ROM devices of a virtual machine.
   class Cdrom < VAPI::Bindings::VapiService
     # static metamodel definitions
     SERVICE_ID = VAPI::Core::ServiceIdentifier.new('com.vmware.vcenter.vm.hardware.cdrom')
@@ -443,7 +443,7 @@ module Com::Vmware::Vcenter::Vm::Hardware
       VAPI::Bindings::OperationInputType.new(
         'vm' => VAPI::Bindings::IdType.new('VirtualMachine')
       ),
-      VAPI::Bindings::ListType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::VM::Hardware::Cdrom::Summary')),
+      VAPI::Bindings::ListType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::Vm::Hardware::Cdrom::Summary')),
       {
         'com.vmware.vapi.std.errors.error' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Error'),
         'com.vmware.vapi.std.errors.not_found' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::NotFound'),
@@ -462,7 +462,7 @@ module Com::Vmware::Vcenter::Vm::Hardware
         'vm' => VAPI::Bindings::IdType.new('VirtualMachine'),
         'cdrom' => VAPI::Bindings::IdType.new('com.vmware.vcenter.vm.hardware.Cdrom')
       ),
-      VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::VM::Hardware::Cdrom::Info'),
+      VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::Vm::Hardware::Cdrom::Info'),
       {
         'com.vmware.vapi.std.errors.error' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Error'),
         'com.vmware.vapi.std.errors.not_found' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::NotFound'),
@@ -479,7 +479,7 @@ module Com::Vmware::Vcenter::Vm::Hardware
       VAPI::Core::OperationIdentifier.new('create', SERVICE_ID),
       VAPI::Bindings::OperationInputType.new(
         'vm' => VAPI::Bindings::IdType.new('VirtualMachine'),
-        'spec' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::VM::Hardware::Cdrom::CreateSpec')
+        'spec' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::Vm::Hardware::Cdrom::CreateSpec')
       ),
       VAPI::Bindings::IdType.new('com.vmware.vcenter.vm.hardware.Cdrom'),
       {
@@ -505,7 +505,7 @@ module Com::Vmware::Vcenter::Vm::Hardware
       VAPI::Bindings::OperationInputType.new(
         'vm' => VAPI::Bindings::IdType.new('VirtualMachine'),
         'cdrom' => VAPI::Bindings::IdType.new('com.vmware.vcenter.vm.hardware.Cdrom'),
-        'spec' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::VM::Hardware::Cdrom::UpdateSpec')
+        'spec' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::Vm::Hardware::Cdrom::UpdateSpec')
       ),
       VAPI::Bindings::VoidType.instance,
       {
@@ -610,7 +610,7 @@ module Com::Vmware::Vcenter::Vm::Hardware
     #
     # @param vm [String]
     #     Virtual machine identifier.
-    # @return [Array<Com::Vmware::Vcenter::VM::Hardware::Cdrom::Summary>]
+    # @return [Array<Com::Vmware::Vcenter::Vm::Hardware::Cdrom::Summary>]
     #     List of commonly used information about virtual CD-ROM devices.
     # @raise [Com::Vmware::Vapi::Std::Errors::Error]
     #     if the system reports an error while responding to the request.
@@ -635,7 +635,7 @@ module Com::Vmware::Vcenter::Vm::Hardware
     #     Virtual machine identifier.
     # @param cdrom [String]
     #     Virtual CD-ROM device identifier.
-    # @return [Com::Vmware::Vcenter::VM::Hardware::Cdrom::Info]
+    # @return [Com::Vmware::Vcenter::Vm::Hardware::Cdrom::Info]
     #     Information about the specified virtual CD-ROM device.
     # @raise [Com::Vmware::Vapi::Std::Errors::Error]
     #     if the system reports an error while responding to the request.
@@ -659,7 +659,7 @@ module Com::Vmware::Vcenter::Vm::Hardware
     #
     # @param vm [String]
     #     Virtual machine identifier.
-    # @param spec [Com::Vmware::Vcenter::VM::Hardware::Cdrom::CreateSpec]
+    # @param spec [Com::Vmware::Vcenter::Vm::Hardware::Cdrom::CreateSpec]
     #     Specification for the new virtual CD-ROM device.
     # @return [String]
     #     Virtual CD-ROM device identifier.
@@ -701,7 +701,7 @@ module Com::Vmware::Vcenter::Vm::Hardware
     #     Virtual machine identifier.
     # @param cdrom [String]
     #     Virtual CD-ROM device identifier.
-    # @param spec [Com::Vmware::Vcenter::VM::Hardware::Cdrom::UpdateSpec]
+    # @param spec [Com::Vmware::Vcenter::Vm::Hardware::Cdrom::UpdateSpec]
     #     Specification for updating the virtual CD-ROM device.
     # @return [Void]
     # @raise [Com::Vmware::Vapi::Std::Errors::Error]
@@ -758,7 +758,7 @@ module Com::Vmware::Vcenter::Vm::Hardware
 
     # Connects a virtual CD-ROM device of a powered-on virtual machine to its backing. Connecting the virtual device makes the backing accessible from the perspective of the guest operating system.  
     # 
-    #  For a powered-off virtual machine, the   :func:`Com::Vmware::Vcenter::VM::Hardware::Cdrom.update`    method  may be used to configure the virtual CD-ROM device to start in the connected state when the virtual machine is powered on.
+    #  For a powered-off virtual machine, the   :func:`Com::Vmware::Vcenter::Vm::Hardware::Cdrom.update`    method  may be used to configure the virtual CD-ROM device to start in the connected state when the virtual machine is powered on.
     #
     # @param vm [String]
     #     Virtual machine identifier.
@@ -791,7 +791,7 @@ module Com::Vmware::Vcenter::Vm::Hardware
 
     # Disconnects a virtual CD-ROM device of a powered-on virtual machine from its backing. The virtual device is still present and its backing configuration is unchanged, but from the perspective of the guest operating system, the CD-ROM device is not connected to its backing resource.  
     # 
-    #  For a powered-off virtual machine, the   :func:`Com::Vmware::Vcenter::VM::Hardware::Cdrom.update`    method  may be used to configure the virtual CD-ROM device to start in the disconnected state when the virtual machine is powered on.
+    #  For a powered-off virtual machine, the   :func:`Com::Vmware::Vcenter::Vm::Hardware::Cdrom.update`    method  may be used to configure the virtual CD-ROM device to start in the disconnected state when the virtual machine is powered on.
     #
     # @param vm [String]
     #     Virtual machine identifier.
@@ -822,14 +822,14 @@ module Com::Vmware::Vcenter::Vm::Hardware
                        'cdrom' => cdrom)
     end
 
-    # The  ``Com::Vmware::Vcenter::VM::Hardware::Cdrom::BackingInfo``   class  contains information about the physical resource backing a virtual CD-ROM device.
+    # The  ``Com::Vmware::Vcenter::Vm::Hardware::Cdrom::BackingInfo``   class  contains information about the physical resource backing a virtual CD-ROM device.
     # @!attribute [rw] type
-    #     @return [Com::Vmware::Vcenter::VM::Hardware::Cdrom::BackingType]
+    #     @return [Com::Vmware::Vcenter::Vm::Hardware::Cdrom::BackingType]
     #     Backing type for the virtual CD-ROM device.
     # @!attribute [rw] iso_file
     #     @return [String]
     #     Path of the image file backing the virtual CD-ROM device.
-    #     This  field  is optional and it is only relevant when the value of  ``type``  is   :attr:`Com::Vmware::Vcenter::VM::Hardware::Cdrom::BackingType.ISO_FILE`  .
+    #     This  field  is optional and it is only relevant when the value of  ``type``  is   :attr:`Com::Vmware::Vcenter::Vm::Hardware::Cdrom::BackingType.ISO_FILE`  .
     # @!attribute [rw] host_device
     #     @return [String, nil]
     #     Name of the host device backing the virtual CD-ROM device.  
@@ -837,11 +837,11 @@ module Com::Vmware::Vcenter::Vm::Hardware
     # @!attribute [rw] auto_detect
     #     @return [Boolean]
     #     Flag indicating whether the virtual CD-ROM device is configured to automatically detect a suitable host device.
-    #     This  field  is optional and it is only relevant when the value of  ``type``  is   :attr:`Com::Vmware::Vcenter::VM::Hardware::Cdrom::BackingType.HOST_DEVICE`  .
+    #     This  field  is optional and it is only relevant when the value of  ``type``  is   :attr:`Com::Vmware::Vcenter::Vm::Hardware::Cdrom::BackingType.HOST_DEVICE`  .
     # @!attribute [rw] device_access_type
-    #     @return [Com::Vmware::Vcenter::VM::Hardware::Cdrom::DeviceAccessType]
+    #     @return [Com::Vmware::Vcenter::Vm::Hardware::Cdrom::DeviceAccessType]
     #     Access type for the device backing.
-    #     This  field  is optional and it is only relevant when the value of  ``type``  is one of   :attr:`Com::Vmware::Vcenter::VM::Hardware::Cdrom::BackingType.HOST_DEVICE`   or   :attr:`Com::Vmware::Vcenter::VM::Hardware::Cdrom::BackingType.CLIENT_DEVICE`  .
+    #     This  field  is optional and it is only relevant when the value of  ``type``  is one of   :attr:`Com::Vmware::Vcenter::Vm::Hardware::Cdrom::BackingType.HOST_DEVICE`   or   :attr:`Com::Vmware::Vcenter::Vm::Hardware::Cdrom::BackingType.CLIENT_DEVICE`  .
     class BackingInfo < VAPI::Bindings::VapiStruct
       class << self
         # Holds (gets or creates) the binding type metadata for this structure type.
@@ -851,11 +851,11 @@ module Com::Vmware::Vcenter::Vm::Hardware
           @binding_type ||= VAPI::Bindings::StructType.new(
             'com.vmware.vcenter.vm.hardware.cdrom.backing_info',
             {
-              'type' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::VM::Hardware::Cdrom::BackingType'),
+              'type' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::Vm::Hardware::Cdrom::BackingType'),
               'iso_file' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::StringType.instance),
               'host_device' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::StringType.instance),
               'auto_detect' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::BooleanType.instance),
-              'device_access_type' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::VM::Hardware::Cdrom::DeviceAccessType'))
+              'device_access_type' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::Vm::Hardware::Cdrom::DeviceAccessType'))
             },
             BackingInfo,
             false,
@@ -878,22 +878,22 @@ module Com::Vmware::Vcenter::Vm::Hardware
       end
     end
 
-    # The  ``Com::Vmware::Vcenter::VM::Hardware::Cdrom::BackingSpec``   class  provides a specification of the physical resource backing a virtual CD-ROM device.
+    # The  ``Com::Vmware::Vcenter::Vm::Hardware::Cdrom::BackingSpec``   class  provides a specification of the physical resource backing a virtual CD-ROM device.
     # @!attribute [rw] type
-    #     @return [Com::Vmware::Vcenter::VM::Hardware::Cdrom::BackingType]
+    #     @return [Com::Vmware::Vcenter::Vm::Hardware::Cdrom::BackingType]
     #     Backing type for the virtual CD-ROM device.
     # @!attribute [rw] iso_file
     #     @return [String]
     #     Path of the image file that should be used as the virtual CD-ROM device backing.
-    #     This  field  is optional and it is only relevant when the value of  ``type``  is   :attr:`Com::Vmware::Vcenter::VM::Hardware::Cdrom::BackingType.ISO_FILE`  .
+    #     This  field  is optional and it is only relevant when the value of  ``type``  is   :attr:`Com::Vmware::Vcenter::Vm::Hardware::Cdrom::BackingType.ISO_FILE`  .
     # @!attribute [rw] host_device
     #     @return [String, nil]
     #     Name of the device that should be used as the virtual CD-ROM device backing.
     #     If  nil , the virtual CD-ROM device will be configured to automatically detect a suitable host device.
     # @!attribute [rw] device_access_type
-    #     @return [Com::Vmware::Vcenter::VM::Hardware::Cdrom::DeviceAccessType, nil]
+    #     @return [Com::Vmware::Vcenter::Vm::Hardware::Cdrom::DeviceAccessType, nil]
     #     Access type for the device backing.
-    #     If  nil , defaults to   :attr:`Com::Vmware::Vcenter::VM::Hardware::Cdrom::DeviceAccessType.EMULATION`  .
+    #     If  nil , defaults to   :attr:`Com::Vmware::Vcenter::Vm::Hardware::Cdrom::DeviceAccessType.EMULATION`  .
     class BackingSpec < VAPI::Bindings::VapiStruct
       class << self
         # Holds (gets or creates) the binding type metadata for this structure type.
@@ -903,10 +903,10 @@ module Com::Vmware::Vcenter::Vm::Hardware
           @binding_type ||= VAPI::Bindings::StructType.new(
             'com.vmware.vcenter.vm.hardware.cdrom.backing_spec',
             {
-              'type' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::VM::Hardware::Cdrom::BackingType'),
+              'type' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::Vm::Hardware::Cdrom::BackingType'),
               'iso_file' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::StringType.instance),
               'host_device' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::StringType.instance),
-              'device_access_type' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::VM::Hardware::Cdrom::DeviceAccessType'))
+              'device_access_type' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::Vm::Hardware::Cdrom::DeviceAccessType'))
             },
             BackingSpec,
             false,
@@ -928,23 +928,23 @@ module Com::Vmware::Vcenter::Vm::Hardware
       end
     end
 
-    # The  ``Com::Vmware::Vcenter::VM::Hardware::Cdrom::Info``   class  contains information about a virtual CD-ROM device.
+    # The  ``Com::Vmware::Vcenter::Vm::Hardware::Cdrom::Info``   class  contains information about a virtual CD-ROM device.
     # @!attribute [rw] type
-    #     @return [Com::Vmware::Vcenter::VM::Hardware::Cdrom::HostBusAdapterType]
+    #     @return [Com::Vmware::Vcenter::Vm::Hardware::Cdrom::HostBusAdapterType]
     #     Type of host bus adapter to which the device is attached.
     # @!attribute [rw] label
     #     @return [String]
     #     Device label.
     # @!attribute [rw] ide
-    #     @return [Com::Vmware::Vcenter::VM::Hardware::IdeAddressInfo]
+    #     @return [Com::Vmware::Vcenter::Vm::Hardware::IdeAddressInfo]
     #     Address of device attached to a virtual IDE adapter.
-    #     This  field  is optional and it is only relevant when the value of  ``type``  is   :attr:`Com::Vmware::Vcenter::VM::Hardware::Cdrom::HostBusAdapterType.IDE`  .
+    #     This  field  is optional and it is only relevant when the value of  ``type``  is   :attr:`Com::Vmware::Vcenter::Vm::Hardware::Cdrom::HostBusAdapterType.IDE`  .
     # @!attribute [rw] sata
-    #     @return [Com::Vmware::Vcenter::VM::Hardware::SataAddressInfo]
+    #     @return [Com::Vmware::Vcenter::Vm::Hardware::SataAddressInfo]
     #     Address of device attached to a virtual SATA adapter.
-    #     This  field  is optional and it is only relevant when the value of  ``type``  is   :attr:`Com::Vmware::Vcenter::VM::Hardware::Cdrom::HostBusAdapterType.SATA`  .
+    #     This  field  is optional and it is only relevant when the value of  ``type``  is   :attr:`Com::Vmware::Vcenter::Vm::Hardware::Cdrom::HostBusAdapterType.SATA`  .
     # @!attribute [rw] backing
-    #     @return [Com::Vmware::Vcenter::VM::Hardware::Cdrom::BackingInfo]
+    #     @return [Com::Vmware::Vcenter::Vm::Hardware::Cdrom::BackingInfo]
     #     Physical resource backing for the virtual CD-ROM device.
     class Info < VAPI::Bindings::VapiStruct
       class << self
@@ -955,12 +955,12 @@ module Com::Vmware::Vcenter::Vm::Hardware
           @binding_type ||= VAPI::Bindings::StructType.new(
             'com.vmware.vcenter.vm.hardware.cdrom.info',
             {
-              'type' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::VM::Hardware::Cdrom::HostBusAdapterType'),
+              'type' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::Vm::Hardware::Cdrom::HostBusAdapterType'),
               'label' => VAPI::Bindings::StringType.instance,
-              'ide' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::VM::Hardware::IdeAddressInfo')),
-              'sata' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::VM::Hardware::SataAddressInfo')),
-              'backing' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::VM::Hardware::Cdrom::BackingInfo'),
-              'state' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::VM::Hardware::ConnectionState'),
+              'ide' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::Vm::Hardware::IdeAddressInfo')),
+              'sata' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::Vm::Hardware::SataAddressInfo')),
+              'backing' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::Vm::Hardware::Cdrom::BackingInfo'),
+              'state' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::Vm::Hardware::ConnectionState'),
               'start_connected' => VAPI::Bindings::BooleanType.instance,
               'allow_guest_control' => VAPI::Bindings::BooleanType.instance
             },
@@ -988,21 +988,21 @@ module Com::Vmware::Vcenter::Vm::Hardware
       end
     end
 
-    # The  ``Com::Vmware::Vcenter::VM::Hardware::Cdrom::CreateSpec``   class  provides a specification for the configuration of a newly-created virtual CD-ROM device.
+    # The  ``Com::Vmware::Vcenter::Vm::Hardware::Cdrom::CreateSpec``   class  provides a specification for the configuration of a newly-created virtual CD-ROM device.
     # @!attribute [rw] type
-    #     @return [Com::Vmware::Vcenter::VM::Hardware::Cdrom::HostBusAdapterType, nil]
+    #     @return [Com::Vmware::Vcenter::Vm::Hardware::Cdrom::HostBusAdapterType, nil]
     #     Type of host bus adapter to which the device should be attached.
     #     If  nil , guest-specific default values will be used
     # @!attribute [rw] ide
-    #     @return [Com::Vmware::Vcenter::VM::Hardware::IdeAddressSpec, nil]
+    #     @return [Com::Vmware::Vcenter::Vm::Hardware::IdeAddressSpec, nil]
     #     Address for attaching the device to a virtual IDE adapter.
     #     If  nil , the server will choose an available address; if none is available, the request will fail.
     # @!attribute [rw] sata
-    #     @return [Com::Vmware::Vcenter::VM::Hardware::SataAddressSpec, nil]
+    #     @return [Com::Vmware::Vcenter::Vm::Hardware::SataAddressSpec, nil]
     #     Address for attaching the device to a virtual SATA adapter.
     #     If  nil , the server will choose an available address; if none is available, the request will fail.
     # @!attribute [rw] backing
-    #     @return [Com::Vmware::Vcenter::VM::Hardware::Cdrom::BackingSpec, nil]
+    #     @return [Com::Vmware::Vcenter::Vm::Hardware::Cdrom::BackingSpec, nil]
     #     Physical resource backing for the virtual CD-ROM device.
     #     If  nil , defaults to automatic detection of a suitable host device.
     class CreateSpec < VAPI::Bindings::VapiStruct
@@ -1014,10 +1014,10 @@ module Com::Vmware::Vcenter::Vm::Hardware
           @binding_type ||= VAPI::Bindings::StructType.new(
             'com.vmware.vcenter.vm.hardware.cdrom.create_spec',
             {
-              'type' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::VM::Hardware::Cdrom::HostBusAdapterType')),
-              'ide' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::VM::Hardware::IdeAddressSpec')),
-              'sata' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::VM::Hardware::SataAddressSpec')),
-              'backing' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::VM::Hardware::Cdrom::BackingSpec')),
+              'type' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::Vm::Hardware::Cdrom::HostBusAdapterType')),
+              'ide' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::Vm::Hardware::IdeAddressSpec')),
+              'sata' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::Vm::Hardware::SataAddressSpec')),
+              'backing' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::Vm::Hardware::Cdrom::BackingSpec')),
               'start_connected' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::BooleanType.instance),
               'allow_guest_control' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::BooleanType.instance)
             },
@@ -1043,9 +1043,9 @@ module Com::Vmware::Vcenter::Vm::Hardware
       end
     end
 
-    # The  ``Com::Vmware::Vcenter::VM::Hardware::Cdrom::UpdateSpec``   class  describes the updates to be made to the configuration of a virtual CD-ROM device.
+    # The  ``Com::Vmware::Vcenter::Vm::Hardware::Cdrom::UpdateSpec``   class  describes the updates to be made to the configuration of a virtual CD-ROM device.
     # @!attribute [rw] backing
-    #     @return [Com::Vmware::Vcenter::VM::Hardware::Cdrom::BackingSpec, nil]
+    #     @return [Com::Vmware::Vcenter::Vm::Hardware::Cdrom::BackingSpec, nil]
     #     Physical resource backing for the virtual CD-ROM device.  
     #     
     #      This  field  may only be modified if the virtual machine is not powered on or the virtual CD-ROM device is not connected.
@@ -1059,7 +1059,7 @@ module Com::Vmware::Vcenter::Vm::Hardware
           @binding_type ||= VAPI::Bindings::StructType.new(
             'com.vmware.vcenter.vm.hardware.cdrom.update_spec',
             {
-              'backing' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::VM::Hardware::Cdrom::BackingSpec')),
+              'backing' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::Vm::Hardware::Cdrom::BackingSpec')),
               'start_connected' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::BooleanType.instance),
               'allow_guest_control' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::BooleanType.instance)
             },
@@ -1082,7 +1082,7 @@ module Com::Vmware::Vcenter::Vm::Hardware
       end
     end
 
-    # The  ``Com::Vmware::Vcenter::VM::Hardware::Cdrom::Summary``   class  contains commonly used information about a virtual CD-ROM device.
+    # The  ``Com::Vmware::Vcenter::Vm::Hardware::Cdrom::Summary``   class  contains commonly used information about a virtual CD-ROM device.
     # @!attribute [rw] cdrom
     #     @return [String]
     #     Identifier of the virtual CD-ROM device.
@@ -1114,12 +1114,12 @@ module Com::Vmware::Vcenter::Vm::Hardware
       end
     end
 
-    # The  ``Com::Vmware::Vcenter::VM::Hardware::Cdrom::HostBusAdapterType``   enumerated type  defines the valid types of host bus adapters that may be used for attaching a Cdrom to a virtual machine.
+    # The  ``Com::Vmware::Vcenter::Vm::Hardware::Cdrom::HostBusAdapterType``   enumerated type  defines the valid types of host bus adapters that may be used for attaching a Cdrom to a virtual machine.
     # @!attribute [rw] ide
-    #     @return [Com::Vmware::Vcenter::VM::Hardware::Cdrom::HostBusAdapterType]
+    #     @return [Com::Vmware::Vcenter::Vm::Hardware::Cdrom::HostBusAdapterType]
     #     Cdrom is attached to an IDE adapter.
     # @!attribute [rw] sata
-    #     @return [Com::Vmware::Vcenter::VM::Hardware::Cdrom::HostBusAdapterType]
+    #     @return [Com::Vmware::Vcenter::Vm::Hardware::Cdrom::HostBusAdapterType]
     #     Cdrom is attached to a SATA adapter.
     class HostBusAdapterType < VAPI::Bindings::VapiEnum
       class << self
@@ -1155,24 +1155,24 @@ module Com::Vmware::Vcenter::Vm::Hardware
       private_class_method :new
 
       # @!attribute [rw] ide
-      #     @return [Com::Vmware::Vcenter::VM::Hardware::Cdrom::HostBusAdapterType]
+      #     @return [Com::Vmware::Vcenter::Vm::Hardware::Cdrom::HostBusAdapterType]
       #     Cdrom is attached to an IDE adapter.
       IDE = HostBusAdapterType.send(:new, 'IDE')
 
       # @!attribute [rw] sata
-      #     @return [Com::Vmware::Vcenter::VM::Hardware::Cdrom::HostBusAdapterType]
+      #     @return [Com::Vmware::Vcenter::Vm::Hardware::Cdrom::HostBusAdapterType]
       #     Cdrom is attached to a SATA adapter.
       SATA = HostBusAdapterType.send(:new, 'SATA')
     end
-    # The  ``Com::Vmware::Vcenter::VM::Hardware::Cdrom::BackingType``   enumerated type  defines the valid backing types for a virtual CD-ROM device.
+    # The  ``Com::Vmware::Vcenter::Vm::Hardware::Cdrom::BackingType``   enumerated type  defines the valid backing types for a virtual CD-ROM device.
     # @!attribute [rw] iso_file
-    #     @return [Com::Vmware::Vcenter::VM::Hardware::Cdrom::BackingType]
+    #     @return [Com::Vmware::Vcenter::Vm::Hardware::Cdrom::BackingType]
     #     Virtual CD-ROM device is backed by an ISO file.
     # @!attribute [rw] host_device
-    #     @return [Com::Vmware::Vcenter::VM::Hardware::Cdrom::BackingType]
+    #     @return [Com::Vmware::Vcenter::Vm::Hardware::Cdrom::BackingType]
     #     Virtual CD-ROM device is backed by a device on the host where the virtual machine is running.
     # @!attribute [rw] client_device
-    #     @return [Com::Vmware::Vcenter::VM::Hardware::Cdrom::BackingType]
+    #     @return [Com::Vmware::Vcenter::Vm::Hardware::Cdrom::BackingType]
     #     Virtual CD-ROM device is backed by a device on the client that is connected to the virtual machine console.
     class BackingType < VAPI::Bindings::VapiEnum
       class << self
@@ -1208,29 +1208,29 @@ module Com::Vmware::Vcenter::Vm::Hardware
       private_class_method :new
 
       # @!attribute [rw] iso_file
-      #     @return [Com::Vmware::Vcenter::VM::Hardware::Cdrom::BackingType]
+      #     @return [Com::Vmware::Vcenter::Vm::Hardware::Cdrom::BackingType]
       #     Virtual CD-ROM device is backed by an ISO file.
       ISO_FILE = BackingType.send(:new, 'ISO_FILE')
 
       # @!attribute [rw] host_device
-      #     @return [Com::Vmware::Vcenter::VM::Hardware::Cdrom::BackingType]
+      #     @return [Com::Vmware::Vcenter::Vm::Hardware::Cdrom::BackingType]
       #     Virtual CD-ROM device is backed by a device on the host where the virtual machine is running.
       HOST_DEVICE = BackingType.send(:new, 'HOST_DEVICE')
 
       # @!attribute [rw] client_device
-      #     @return [Com::Vmware::Vcenter::VM::Hardware::Cdrom::BackingType]
+      #     @return [Com::Vmware::Vcenter::Vm::Hardware::Cdrom::BackingType]
       #     Virtual CD-ROM device is backed by a device on the client that is connected to the virtual machine console.
       CLIENT_DEVICE = BackingType.send(:new, 'CLIENT_DEVICE')
     end
-    # The  ``Com::Vmware::Vcenter::VM::Hardware::Cdrom::DeviceAccessType``   enumerated type  defines the valid device access types for a physical device packing of a virtual CD-ROM device.
+    # The  ``Com::Vmware::Vcenter::Vm::Hardware::Cdrom::DeviceAccessType``   enumerated type  defines the valid device access types for a physical device packing of a virtual CD-ROM device.
     # @!attribute [rw] emulation
-    #     @return [Com::Vmware::Vcenter::VM::Hardware::Cdrom::DeviceAccessType]
+    #     @return [Com::Vmware::Vcenter::Vm::Hardware::Cdrom::DeviceAccessType]
     #     ATAPI or SCSI device emulation.
     # @!attribute [rw] passthru
-    #     @return [Com::Vmware::Vcenter::VM::Hardware::Cdrom::DeviceAccessType]
+    #     @return [Com::Vmware::Vcenter::Vm::Hardware::Cdrom::DeviceAccessType]
     #     Raw passthru device access.
     # @!attribute [rw] passthru_exclusive
-    #     @return [Com::Vmware::Vcenter::VM::Hardware::Cdrom::DeviceAccessType]
+    #     @return [Com::Vmware::Vcenter::Vm::Hardware::Cdrom::DeviceAccessType]
     #     Raw passthru device access, with exclusive access to the device.
     class DeviceAccessType < VAPI::Bindings::VapiEnum
       class << self
@@ -1266,22 +1266,22 @@ module Com::Vmware::Vcenter::Vm::Hardware
       private_class_method :new
 
       # @!attribute [rw] emulation
-      #     @return [Com::Vmware::Vcenter::VM::Hardware::Cdrom::DeviceAccessType]
+      #     @return [Com::Vmware::Vcenter::Vm::Hardware::Cdrom::DeviceAccessType]
       #     ATAPI or SCSI device emulation.
       EMULATION = DeviceAccessType.send(:new, 'EMULATION')
 
       # @!attribute [rw] passthru
-      #     @return [Com::Vmware::Vcenter::VM::Hardware::Cdrom::DeviceAccessType]
+      #     @return [Com::Vmware::Vcenter::Vm::Hardware::Cdrom::DeviceAccessType]
       #     Raw passthru device access.
       PASSTHRU = DeviceAccessType.send(:new, 'PASSTHRU')
 
       # @!attribute [rw] passthru_exclusive
-      #     @return [Com::Vmware::Vcenter::VM::Hardware::Cdrom::DeviceAccessType]
+      #     @return [Com::Vmware::Vcenter::Vm::Hardware::Cdrom::DeviceAccessType]
       #     Raw passthru device access, with exclusive access to the device.
       PASSTHRU_EXCLUSIVE = DeviceAccessType.send(:new, 'PASSTHRU_EXCLUSIVE')
     end
   end
-  # The  ``Com::Vmware::Vcenter::VM::Hardware::Cpu``   class  provides  methods  for configuring the CPU settings of a virtual machine.
+  # The  ``Com::Vmware::Vcenter::Vm::Hardware::Cpu``   class  provides  methods  for configuring the CPU settings of a virtual machine.
   class Cpu < VAPI::Bindings::VapiService
     # static metamodel definitions
     SERVICE_ID = VAPI::Core::ServiceIdentifier.new('com.vmware.vcenter.vm.hardware.cpu')
@@ -1291,7 +1291,7 @@ module Com::Vmware::Vcenter::Vm::Hardware
       VAPI::Bindings::OperationInputType.new(
         'vm' => VAPI::Bindings::IdType.new('VirtualMachine')
       ),
-      VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::VM::Hardware::Cpu::Info'),
+      VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::Vm::Hardware::Cpu::Info'),
       {
         'com.vmware.vapi.std.errors.error' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Error'),
         'com.vmware.vapi.std.errors.not_found' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::NotFound'),
@@ -1308,7 +1308,7 @@ module Com::Vmware::Vcenter::Vm::Hardware
       VAPI::Core::OperationIdentifier.new('update', SERVICE_ID),
       VAPI::Bindings::OperationInputType.new(
         'vm' => VAPI::Bindings::IdType.new('VirtualMachine'),
-        'spec' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::VM::Hardware::Cpu::UpdateSpec')
+        'spec' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::Vm::Hardware::Cpu::UpdateSpec')
       ),
       VAPI::Bindings::VoidType.instance,
       {
@@ -1343,7 +1343,7 @@ module Com::Vmware::Vcenter::Vm::Hardware
     #
     # @param vm [String]
     #     Virtual machine identifier.
-    # @return [Com::Vmware::Vcenter::VM::Hardware::Cpu::Info]
+    # @return [Com::Vmware::Vcenter::Vm::Hardware::Cpu::Info]
     #     CPU-related settings of the virtual machine.
     # @raise [Com::Vmware::Vapi::Std::Errors::Error]
     #     if the system reports an error while responding to the request.
@@ -1366,7 +1366,7 @@ module Com::Vmware::Vcenter::Vm::Hardware
     #
     # @param vm [String]
     #     Virtual machine identifier.
-    # @param spec [Com::Vmware::Vcenter::VM::Hardware::Cpu::UpdateSpec]
+    # @param spec [Com::Vmware::Vcenter::Vm::Hardware::Cpu::UpdateSpec]
     #     Specification for updating the CPU-related settings of the virtual machine.
     # @return [Void]
     # @raise [Com::Vmware::Vapi::Std::Errors::Error]
@@ -1397,7 +1397,7 @@ module Com::Vmware::Vcenter::Vm::Hardware
                        'spec' => spec)
     end
 
-    # The  ``Com::Vmware::Vcenter::VM::Hardware::Cpu::Info``   class  contains CPU-related information about a virtual machine.
+    # The  ``Com::Vmware::Vcenter::Vm::Hardware::Cpu::Info``   class  contains CPU-related information about a virtual machine.
     # @!attribute [rw] count
     #     @return [Fixnum]
     #     Number of CPU cores.
@@ -1444,14 +1444,14 @@ module Com::Vmware::Vcenter::Vm::Hardware
       end
     end
 
-    # The  ``Com::Vmware::Vcenter::VM::Hardware::Cpu::UpdateSpec``   class  describes the updates to be made to the CPU-related settings of a virtual machine.
+    # The  ``Com::Vmware::Vcenter::Vm::Hardware::Cpu::UpdateSpec``   class  describes the updates to be made to the CPU-related settings of a virtual machine.
     # @!attribute [rw] count
     #     @return [Fixnum, nil]
     #     New number of CPU cores. The number of CPU cores in the virtual machine must be a multiple of the number of cores per socket.  
     #     
     #      The supported range of CPU counts is constrained by the configured guest operating system and virtual hardware version of the virtual machine.  
     #     
-    #      If the virtual machine is running, the number of CPU cores may only be increased if   :attr:`Com::Vmware::Vcenter::VM::Hardware::Cpu::Info.hot_add_enabled`   is true, and may only be decreased if   :attr:`Com::Vmware::Vcenter::VM::Hardware::Cpu::Info.hot_remove_enabled`   is true.
+    #      If the virtual machine is running, the number of CPU cores may only be increased if   :attr:`Com::Vmware::Vcenter::Vm::Hardware::Cpu::Info.hot_add_enabled`   is true, and may only be decreased if   :attr:`Com::Vmware::Vcenter::Vm::Hardware::Cpu::Info.hot_remove_enabled`   is true.
     #     If  nil , the value is unchanged.
     # @!attribute [rw] cores_per_socket
     #     @return [Fixnum, nil]
@@ -1504,7 +1504,7 @@ module Com::Vmware::Vcenter::Vm::Hardware
     end
 
   end
-  # The  ``Com::Vmware::Vcenter::VM::Hardware::Disk``   class  provides  methods  for configuring the virtual disks of a virtual machine. A virtual disk has a backing such as a VMDK file. The backing has an independent lifecycle from the virtual machine when it is detached from the virtual machine. The   :func:`Com::Vmware::Vcenter::VM::Hardware::Disk.create`    method  provides the ability to create a new virtual disk. When creating a virtual disk, a new VMDK file may be created or an existing VMDK file may used as a backing. Once a VMDK file is associated with a virtual machine, its lifecycle will be bound to the virtual machine. In other words, it will be deleted when the virtual machine is deleted. The   :func:`Com::Vmware::Vcenter::VM::Hardware::Disk.delete`    method  provides the ability to detach a VMDK file from the virtual machine. The   :func:`Com::Vmware::Vcenter::VM::Hardware::Disk.delete`    method  does not delete the VMDK file that backs the virtual disk. Once detached, the VMDK file will not be destroyed when the virtual machine to which it was associated is deleted.
+  # The  ``Com::Vmware::Vcenter::Vm::Hardware::Disk``   class  provides  methods  for configuring the virtual disks of a virtual machine. A virtual disk has a backing such as a VMDK file. The backing has an independent lifecycle from the virtual machine when it is detached from the virtual machine. The   :func:`Com::Vmware::Vcenter::Vm::Hardware::Disk.create`    method  provides the ability to create a new virtual disk. When creating a virtual disk, a new VMDK file may be created or an existing VMDK file may used as a backing. Once a VMDK file is associated with a virtual machine, its lifecycle will be bound to the virtual machine. In other words, it will be deleted when the virtual machine is deleted. The   :func:`Com::Vmware::Vcenter::Vm::Hardware::Disk.delete`    method  provides the ability to detach a VMDK file from the virtual machine. The   :func:`Com::Vmware::Vcenter::Vm::Hardware::Disk.delete`    method  does not delete the VMDK file that backs the virtual disk. Once detached, the VMDK file will not be destroyed when the virtual machine to which it was associated is deleted.
   class Disk < VAPI::Bindings::VapiService
     # static metamodel definitions
     SERVICE_ID = VAPI::Core::ServiceIdentifier.new('com.vmware.vcenter.vm.hardware.disk')
@@ -1514,7 +1514,7 @@ module Com::Vmware::Vcenter::Vm::Hardware
       VAPI::Bindings::OperationInputType.new(
         'vm' => VAPI::Bindings::IdType.new('VirtualMachine')
       ),
-      VAPI::Bindings::ListType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::VM::Hardware::Disk::Summary')),
+      VAPI::Bindings::ListType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::Vm::Hardware::Disk::Summary')),
       {
         'com.vmware.vapi.std.errors.error' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Error'),
         'com.vmware.vapi.std.errors.not_found' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::NotFound'),
@@ -1533,7 +1533,7 @@ module Com::Vmware::Vcenter::Vm::Hardware
         'vm' => VAPI::Bindings::IdType.new('VirtualMachine'),
         'disk' => VAPI::Bindings::IdType.new('com.vmware.vcenter.vm.hardware.Disk')
       ),
-      VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::VM::Hardware::Disk::Info'),
+      VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::Vm::Hardware::Disk::Info'),
       {
         'com.vmware.vapi.std.errors.error' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Error'),
         'com.vmware.vapi.std.errors.not_found' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::NotFound'),
@@ -1550,7 +1550,7 @@ module Com::Vmware::Vcenter::Vm::Hardware
       VAPI::Core::OperationIdentifier.new('create', SERVICE_ID),
       VAPI::Bindings::OperationInputType.new(
         'vm' => VAPI::Bindings::IdType.new('VirtualMachine'),
-        'spec' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::VM::Hardware::Disk::CreateSpec')
+        'spec' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::Vm::Hardware::Disk::CreateSpec')
       ),
       VAPI::Bindings::IdType.new('com.vmware.vcenter.vm.hardware.Disk'),
       {
@@ -1576,7 +1576,7 @@ module Com::Vmware::Vcenter::Vm::Hardware
       VAPI::Bindings::OperationInputType.new(
         'vm' => VAPI::Bindings::IdType.new('VirtualMachine'),
         'disk' => VAPI::Bindings::IdType.new('com.vmware.vcenter.vm.hardware.Disk'),
-        'spec' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::VM::Hardware::Disk::UpdateSpec')
+        'spec' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::Vm::Hardware::Disk::UpdateSpec')
       ),
       VAPI::Bindings::VoidType.instance,
       {
@@ -1635,7 +1635,7 @@ module Com::Vmware::Vcenter::Vm::Hardware
     #
     # @param vm [String]
     #     Virtual machine identifier.
-    # @return [Array<Com::Vmware::Vcenter::VM::Hardware::Disk::Summary>]
+    # @return [Array<Com::Vmware::Vcenter::Vm::Hardware::Disk::Summary>]
     #     List of commonly used information about the virtual disks.
     # @raise [Com::Vmware::Vapi::Std::Errors::Error]
     #     if the system reports an error while responding to the request.
@@ -1660,7 +1660,7 @@ module Com::Vmware::Vcenter::Vm::Hardware
     #     Virtual machine identifier.
     # @param disk [String]
     #     Virtual disk identifier.
-    # @return [Com::Vmware::Vcenter::VM::Hardware::Disk::Info]
+    # @return [Com::Vmware::Vcenter::Vm::Hardware::Disk::Info]
     #     Information about the specified virtual disk.
     # @raise [Com::Vmware::Vapi::Std::Errors::Error]
     #     if the system reports an error while responding to the request.
@@ -1684,7 +1684,7 @@ module Com::Vmware::Vcenter::Vm::Hardware
     #
     # @param vm [String]
     #     Virtual machine identifier.
-    # @param spec [Com::Vmware::Vcenter::VM::Hardware::Disk::CreateSpec]
+    # @param spec [Com::Vmware::Vcenter::Vm::Hardware::Disk::CreateSpec]
     #     Specification for the new virtual disk.
     # @return [String]
     #     Virtual disk identifier.
@@ -1726,7 +1726,7 @@ module Com::Vmware::Vcenter::Vm::Hardware
     #     Virtual machine identifier.
     # @param disk [String]
     #     Virtual disk identifier.
-    # @param spec [Com::Vmware::Vcenter::VM::Hardware::Disk::UpdateSpec]
+    # @param spec [Com::Vmware::Vcenter::Vm::Hardware::Disk::UpdateSpec]
     #     Specification for updating the virtual disk.
     # @return [Void]
     # @raise [Com::Vmware::Vapi::Std::Errors::Error]
@@ -1781,14 +1781,14 @@ module Com::Vmware::Vcenter::Vm::Hardware
                        'disk' => disk)
     end
 
-    # The  ``Com::Vmware::Vcenter::VM::Hardware::Disk::BackingInfo``   class  contains information about the physical resource backing a virtual disk.
+    # The  ``Com::Vmware::Vcenter::Vm::Hardware::Disk::BackingInfo``   class  contains information about the physical resource backing a virtual disk.
     # @!attribute [rw] type
-    #     @return [Com::Vmware::Vcenter::VM::Hardware::Disk::BackingType]
+    #     @return [Com::Vmware::Vcenter::Vm::Hardware::Disk::BackingType]
     #     Backing type for the virtual disk.
     # @!attribute [rw] vmdk_file
     #     @return [String]
     #     Path of the VMDK file backing the virtual disk.
-    #     This  field  is optional and it is only relevant when the value of  ``type``  is   :attr:`Com::Vmware::Vcenter::VM::Hardware::Disk::BackingType.VMDK_FILE`  .
+    #     This  field  is optional and it is only relevant when the value of  ``type``  is   :attr:`Com::Vmware::Vcenter::Vm::Hardware::Disk::BackingType.VMDK_FILE`  .
     class BackingInfo < VAPI::Bindings::VapiStruct
       class << self
         # Holds (gets or creates) the binding type metadata for this structure type.
@@ -1798,7 +1798,7 @@ module Com::Vmware::Vcenter::Vm::Hardware
           @binding_type ||= VAPI::Bindings::StructType.new(
             'com.vmware.vcenter.vm.hardware.disk.backing_info',
             {
-              'type' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::VM::Hardware::Disk::BackingType'),
+              'type' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::Vm::Hardware::Disk::BackingType'),
               'vmdk_file' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::StringType.instance)
             },
             BackingInfo,
@@ -1819,14 +1819,14 @@ module Com::Vmware::Vcenter::Vm::Hardware
       end
     end
 
-    # The  ``Com::Vmware::Vcenter::VM::Hardware::Disk::BackingSpec``   class  provides a specification of the physical resource backing a virtual disk.
+    # The  ``Com::Vmware::Vcenter::Vm::Hardware::Disk::BackingSpec``   class  provides a specification of the physical resource backing a virtual disk.
     # @!attribute [rw] type
-    #     @return [Com::Vmware::Vcenter::VM::Hardware::Disk::BackingType]
+    #     @return [Com::Vmware::Vcenter::Vm::Hardware::Disk::BackingType]
     #     Backing type for the virtual disk.
     # @!attribute [rw] vmdk_file
     #     @return [String]
     #     Path of the VMDK file backing the virtual disk.
-    #     This  field  is optional and it is only relevant when the value of  ``type``  is   :attr:`Com::Vmware::Vcenter::VM::Hardware::Disk::BackingType.VMDK_FILE`  .
+    #     This  field  is optional and it is only relevant when the value of  ``type``  is   :attr:`Com::Vmware::Vcenter::Vm::Hardware::Disk::BackingType.VMDK_FILE`  .
     class BackingSpec < VAPI::Bindings::VapiStruct
       class << self
         # Holds (gets or creates) the binding type metadata for this structure type.
@@ -1836,7 +1836,7 @@ module Com::Vmware::Vcenter::Vm::Hardware
           @binding_type ||= VAPI::Bindings::StructType.new(
             'com.vmware.vcenter.vm.hardware.disk.backing_spec',
             {
-              'type' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::VM::Hardware::Disk::BackingType'),
+              'type' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::Vm::Hardware::Disk::BackingType'),
               'vmdk_file' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::StringType.instance)
             },
             BackingSpec,
@@ -1857,7 +1857,7 @@ module Com::Vmware::Vcenter::Vm::Hardware
       end
     end
 
-    # The  ``Com::Vmware::Vcenter::VM::Hardware::Disk::VmdkCreateSpec``   class  provides a specification for creating a new VMDK file to be used as a backing for a virtual disk. The virtual disk will be stored in the same directory as the virtual machine's configuration file.
+    # The  ``Com::Vmware::Vcenter::Vm::Hardware::Disk::VmdkCreateSpec``   class  provides a specification for creating a new VMDK file to be used as a backing for a virtual disk. The virtual disk will be stored in the same directory as the virtual machine's configuration file.
     # @!attribute [rw] name
     #     @return [String, nil]
     #     Base name of the VMDK file. The name should not include the '.vmdk' file extension.
@@ -1896,27 +1896,27 @@ module Com::Vmware::Vcenter::Vm::Hardware
       end
     end
 
-    # The  ``Com::Vmware::Vcenter::VM::Hardware::Disk::Info``   class  contains information about a virtual disk.
+    # The  ``Com::Vmware::Vcenter::Vm::Hardware::Disk::Info``   class  contains information about a virtual disk.
     # @!attribute [rw] label
     #     @return [String]
     #     Device label.
     # @!attribute [rw] type
-    #     @return [Com::Vmware::Vcenter::VM::Hardware::Disk::HostBusAdapterType]
+    #     @return [Com::Vmware::Vcenter::Vm::Hardware::Disk::HostBusAdapterType]
     #     Type of host bus adapter to which the device is attached.
     # @!attribute [rw] ide
-    #     @return [Com::Vmware::Vcenter::VM::Hardware::IdeAddressInfo]
+    #     @return [Com::Vmware::Vcenter::Vm::Hardware::IdeAddressInfo]
     #     Address of device attached to a virtual IDE adapter.
     #     Workaround for PR1459646
     # @!attribute [rw] scsi
-    #     @return [Com::Vmware::Vcenter::VM::Hardware::ScsiAddressInfo]
+    #     @return [Com::Vmware::Vcenter::Vm::Hardware::ScsiAddressInfo]
     #     Address of device attached to a virtual SCSI adapter.
     #     Workaround for PR1459646
     # @!attribute [rw] sata
-    #     @return [Com::Vmware::Vcenter::VM::Hardware::SataAddressInfo]
+    #     @return [Com::Vmware::Vcenter::Vm::Hardware::SataAddressInfo]
     #     Address of device attached to a virtual SATA adapter.
     #     Workaround for PR1459646
     # @!attribute [rw] backing
-    #     @return [Com::Vmware::Vcenter::VM::Hardware::Disk::BackingInfo]
+    #     @return [Com::Vmware::Vcenter::Vm::Hardware::Disk::BackingInfo]
     #     Physical resource backing for the virtual disk.
     # @!attribute [rw] capacity
     #     @return [Fixnum, nil]
@@ -1932,11 +1932,11 @@ module Com::Vmware::Vcenter::Vm::Hardware
             'com.vmware.vcenter.vm.hardware.disk.info',
             {
               'label' => VAPI::Bindings::StringType.instance,
-              'type' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::VM::Hardware::Disk::HostBusAdapterType'),
-              'ide' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::VM::Hardware::IdeAddressInfo')),
-              'scsi' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::VM::Hardware::ScsiAddressInfo')),
-              'sata' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::VM::Hardware::SataAddressInfo')),
-              'backing' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::VM::Hardware::Disk::BackingInfo'),
+              'type' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::Vm::Hardware::Disk::HostBusAdapterType'),
+              'ide' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::Vm::Hardware::IdeAddressInfo')),
+              'scsi' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::Vm::Hardware::ScsiAddressInfo')),
+              'sata' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::Vm::Hardware::SataAddressInfo')),
+              'backing' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::Vm::Hardware::Disk::BackingInfo'),
               'capacity' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::IntegerType.instance)
             },
             Info,
@@ -1962,29 +1962,29 @@ module Com::Vmware::Vcenter::Vm::Hardware
       end
     end
 
-    # The  ``Com::Vmware::Vcenter::VM::Hardware::Disk::CreateSpec``   class  provides a specification for the configuration of a newly-created virtual disk.
+    # The  ``Com::Vmware::Vcenter::Vm::Hardware::Disk::CreateSpec``   class  provides a specification for the configuration of a newly-created virtual disk.
     # @!attribute [rw] type
-    #     @return [Com::Vmware::Vcenter::VM::Hardware::Disk::HostBusAdapterType, nil]
+    #     @return [Com::Vmware::Vcenter::Vm::Hardware::Disk::HostBusAdapterType, nil]
     #     Type of host bus adapter to which the device should be attached.
     #     If  nil , guest-specific default values will be used
     # @!attribute [rw] ide
-    #     @return [Com::Vmware::Vcenter::VM::Hardware::IdeAddressSpec, nil]
+    #     @return [Com::Vmware::Vcenter::Vm::Hardware::IdeAddressSpec, nil]
     #     Address for attaching the device to a virtual IDE adapter.
     #     If  nil , the server will choose an available address; if none is available, the request will fail.
     # @!attribute [rw] scsi
-    #     @return [Com::Vmware::Vcenter::VM::Hardware::ScsiAddressSpec, nil]
+    #     @return [Com::Vmware::Vcenter::Vm::Hardware::ScsiAddressSpec, nil]
     #     Address for attaching the device to a virtual SCSI adapter.
     #     If  nil , the server will choose an available address; if none is available, the request will fail.
     # @!attribute [rw] sata
-    #     @return [Com::Vmware::Vcenter::VM::Hardware::SataAddressSpec, nil]
+    #     @return [Com::Vmware::Vcenter::Vm::Hardware::SataAddressSpec, nil]
     #     Address for attaching the device to a virtual SATA adapter.
     #     If  nil , the server will choose an available address; if none is available, the request will fail.
     # @!attribute [rw] backing
-    #     @return [Com::Vmware::Vcenter::VM::Hardware::Disk::BackingSpec, nil]
+    #     @return [Com::Vmware::Vcenter::Vm::Hardware::Disk::BackingSpec, nil]
     #     Existing physical resource backing for the virtual disk. Exactly one of  ``backing``  or  ``newVmdk``  must be specified.
     #     If  nil , the virtual disk will not be connected to an existing backing.
     # @!attribute [rw] new_vmdk
-    #     @return [Com::Vmware::Vcenter::VM::Hardware::Disk::VmdkCreateSpec, nil]
+    #     @return [Com::Vmware::Vcenter::Vm::Hardware::Disk::VmdkCreateSpec, nil]
     #     Specification for creating a new VMDK backing for the virtual disk. Exactly one of  ``backing``  or  ``newVmdk``  must be specified.
     #     If  nil , a new VMDK backing will not be created.
     class CreateSpec < VAPI::Bindings::VapiStruct
@@ -1996,12 +1996,12 @@ module Com::Vmware::Vcenter::Vm::Hardware
           @binding_type ||= VAPI::Bindings::StructType.new(
             'com.vmware.vcenter.vm.hardware.disk.create_spec',
             {
-              'type' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::VM::Hardware::Disk::HostBusAdapterType')),
-              'ide' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::VM::Hardware::IdeAddressSpec')),
-              'scsi' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::VM::Hardware::ScsiAddressSpec')),
-              'sata' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::VM::Hardware::SataAddressSpec')),
-              'backing' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::VM::Hardware::Disk::BackingSpec')),
-              'new_vmdk' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::VM::Hardware::Disk::VmdkCreateSpec'))
+              'type' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::Vm::Hardware::Disk::HostBusAdapterType')),
+              'ide' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::Vm::Hardware::IdeAddressSpec')),
+              'scsi' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::Vm::Hardware::ScsiAddressSpec')),
+              'sata' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::Vm::Hardware::SataAddressSpec')),
+              'backing' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::Vm::Hardware::Disk::BackingSpec')),
+              'new_vmdk' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::Vm::Hardware::Disk::VmdkCreateSpec'))
             },
             CreateSpec,
             false,
@@ -2025,9 +2025,9 @@ module Com::Vmware::Vcenter::Vm::Hardware
       end
     end
 
-    # The  ``Com::Vmware::Vcenter::VM::Hardware::Disk::UpdateSpec``   class  describes the updates to be made to the configuration of a virtual disk.
+    # The  ``Com::Vmware::Vcenter::Vm::Hardware::Disk::UpdateSpec``   class  describes the updates to be made to the configuration of a virtual disk.
     # @!attribute [rw] backing
-    #     @return [Com::Vmware::Vcenter::VM::Hardware::Disk::BackingSpec, nil]
+    #     @return [Com::Vmware::Vcenter::Vm::Hardware::Disk::BackingSpec, nil]
     #     Physical resource backing for the virtual disk.  
     #     
     #      This  field  may only be modified if the virtual machine is not powered on.
@@ -2041,7 +2041,7 @@ module Com::Vmware::Vcenter::Vm::Hardware
           @binding_type ||= VAPI::Bindings::StructType.new(
             'com.vmware.vcenter.vm.hardware.disk.update_spec',
             {
-              'backing' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::VM::Hardware::Disk::BackingSpec'))
+              'backing' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::Vm::Hardware::Disk::BackingSpec'))
             },
             UpdateSpec,
             false,
@@ -2060,7 +2060,7 @@ module Com::Vmware::Vcenter::Vm::Hardware
       end
     end
 
-    # The  ``Com::Vmware::Vcenter::VM::Hardware::Disk::Summary``   class  contains commonly used information about a virtual disk.
+    # The  ``Com::Vmware::Vcenter::Vm::Hardware::Disk::Summary``   class  contains commonly used information about a virtual disk.
     # @!attribute [rw] disk
     #     @return [String]
     #     Identifier of the virtual Disk.
@@ -2092,15 +2092,15 @@ module Com::Vmware::Vcenter::Vm::Hardware
       end
     end
 
-    # The  ``Com::Vmware::Vcenter::VM::Hardware::Disk::HostBusAdapterType``   enumerated type  defines the valid types of host bus adapters that may be used for attaching a virtual storage device to a virtual machine.
+    # The  ``Com::Vmware::Vcenter::Vm::Hardware::Disk::HostBusAdapterType``   enumerated type  defines the valid types of host bus adapters that may be used for attaching a virtual storage device to a virtual machine.
     # @!attribute [rw] ide
-    #     @return [Com::Vmware::Vcenter::VM::Hardware::Disk::HostBusAdapterType]
+    #     @return [Com::Vmware::Vcenter::Vm::Hardware::Disk::HostBusAdapterType]
     #     Disk is attached to an IDE adapter.
     # @!attribute [rw] scsi
-    #     @return [Com::Vmware::Vcenter::VM::Hardware::Disk::HostBusAdapterType]
+    #     @return [Com::Vmware::Vcenter::Vm::Hardware::Disk::HostBusAdapterType]
     #     Disk is attached to a SCSI adapter.
     # @!attribute [rw] sata
-    #     @return [Com::Vmware::Vcenter::VM::Hardware::Disk::HostBusAdapterType]
+    #     @return [Com::Vmware::Vcenter::Vm::Hardware::Disk::HostBusAdapterType]
     #     Disk is attached to a SATA adapter.
     class HostBusAdapterType < VAPI::Bindings::VapiEnum
       class << self
@@ -2136,23 +2136,23 @@ module Com::Vmware::Vcenter::Vm::Hardware
       private_class_method :new
 
       # @!attribute [rw] ide
-      #     @return [Com::Vmware::Vcenter::VM::Hardware::Disk::HostBusAdapterType]
+      #     @return [Com::Vmware::Vcenter::Vm::Hardware::Disk::HostBusAdapterType]
       #     Disk is attached to an IDE adapter.
       IDE = HostBusAdapterType.send(:new, 'IDE')
 
       # @!attribute [rw] scsi
-      #     @return [Com::Vmware::Vcenter::VM::Hardware::Disk::HostBusAdapterType]
+      #     @return [Com::Vmware::Vcenter::Vm::Hardware::Disk::HostBusAdapterType]
       #     Disk is attached to a SCSI adapter.
       SCSI = HostBusAdapterType.send(:new, 'SCSI')
 
       # @!attribute [rw] sata
-      #     @return [Com::Vmware::Vcenter::VM::Hardware::Disk::HostBusAdapterType]
+      #     @return [Com::Vmware::Vcenter::Vm::Hardware::Disk::HostBusAdapterType]
       #     Disk is attached to a SATA adapter.
       SATA = HostBusAdapterType.send(:new, 'SATA')
     end
-    # The  ``Com::Vmware::Vcenter::VM::Hardware::Disk::BackingType``   enumerated type  defines the valid backing types for a virtual disk.
+    # The  ``Com::Vmware::Vcenter::Vm::Hardware::Disk::BackingType``   enumerated type  defines the valid backing types for a virtual disk.
     # @!attribute [rw] vmdk_file
-    #     @return [Com::Vmware::Vcenter::VM::Hardware::Disk::BackingType]
+    #     @return [Com::Vmware::Vcenter::Vm::Hardware::Disk::BackingType]
     #     Virtual disk is backed by a VMDK file.
     class BackingType < VAPI::Bindings::VapiEnum
       class << self
@@ -2188,12 +2188,12 @@ module Com::Vmware::Vcenter::Vm::Hardware
       private_class_method :new
 
       # @!attribute [rw] vmdk_file
-      #     @return [Com::Vmware::Vcenter::VM::Hardware::Disk::BackingType]
+      #     @return [Com::Vmware::Vcenter::Vm::Hardware::Disk::BackingType]
       #     Virtual disk is backed by a VMDK file.
       VMDK_FILE = BackingType.send(:new, 'VMDK_FILE')
     end
   end
-  # The  ``Com::Vmware::Vcenter::VM::Hardware::Ethernet``   class  provides  methods  for configuring the virtual Ethernet adapters of a virtual machine.
+  # The  ``Com::Vmware::Vcenter::Vm::Hardware::Ethernet``   class  provides  methods  for configuring the virtual Ethernet adapters of a virtual machine.
   class Ethernet < VAPI::Bindings::VapiService
     # static metamodel definitions
     SERVICE_ID = VAPI::Core::ServiceIdentifier.new('com.vmware.vcenter.vm.hardware.ethernet')
@@ -2203,7 +2203,7 @@ module Com::Vmware::Vcenter::Vm::Hardware
       VAPI::Bindings::OperationInputType.new(
         'vm' => VAPI::Bindings::IdType.new('VirtualMachine')
       ),
-      VAPI::Bindings::ListType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::VM::Hardware::Ethernet::Summary')),
+      VAPI::Bindings::ListType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::Vm::Hardware::Ethernet::Summary')),
       {
         'com.vmware.vapi.std.errors.error' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Error'),
         'com.vmware.vapi.std.errors.not_found' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::NotFound'),
@@ -2222,7 +2222,7 @@ module Com::Vmware::Vcenter::Vm::Hardware
         'vm' => VAPI::Bindings::IdType.new('VirtualMachine'),
         'nic' => VAPI::Bindings::IdType.new('com.vmware.vcenter.vm.hardware.Ethernet')
       ),
-      VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::VM::Hardware::Ethernet::Info'),
+      VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::Vm::Hardware::Ethernet::Info'),
       {
         'com.vmware.vapi.std.errors.error' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Error'),
         'com.vmware.vapi.std.errors.not_found' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::NotFound'),
@@ -2239,7 +2239,7 @@ module Com::Vmware::Vcenter::Vm::Hardware
       VAPI::Core::OperationIdentifier.new('create', SERVICE_ID),
       VAPI::Bindings::OperationInputType.new(
         'vm' => VAPI::Bindings::IdType.new('VirtualMachine'),
-        'spec' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::VM::Hardware::Ethernet::CreateSpec')
+        'spec' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::Vm::Hardware::Ethernet::CreateSpec')
       ),
       VAPI::Bindings::IdType.new('com.vmware.vcenter.vm.hardware.Ethernet'),
       {
@@ -2263,7 +2263,7 @@ module Com::Vmware::Vcenter::Vm::Hardware
       VAPI::Bindings::OperationInputType.new(
         'vm' => VAPI::Bindings::IdType.new('VirtualMachine'),
         'nic' => VAPI::Bindings::IdType.new('com.vmware.vcenter.vm.hardware.Ethernet'),
-        'spec' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::VM::Hardware::Ethernet::UpdateSpec')
+        'spec' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::Vm::Hardware::Ethernet::UpdateSpec')
       ),
       VAPI::Bindings::VoidType.instance,
       {
@@ -2367,7 +2367,7 @@ module Com::Vmware::Vcenter::Vm::Hardware
     #
     # @param vm [String]
     #     Virtual machine identifier.
-    # @return [Array<Com::Vmware::Vcenter::VM::Hardware::Ethernet::Summary>]
+    # @return [Array<Com::Vmware::Vcenter::Vm::Hardware::Ethernet::Summary>]
     #     List of commonly used information about virtual Ethernet adapters.
     # @raise [Com::Vmware::Vapi::Std::Errors::Error]
     #     if the system reports an error while responding to the request.
@@ -2392,7 +2392,7 @@ module Com::Vmware::Vcenter::Vm::Hardware
     #     Virtual machine identifier.
     # @param nic [String]
     #     Virtual Ethernet adapter identifier.
-    # @return [Com::Vmware::Vcenter::VM::Hardware::Ethernet::Info]
+    # @return [Com::Vmware::Vcenter::Vm::Hardware::Ethernet::Info]
     #     Information about the specified virtual Ethernet adapter.
     # @raise [Com::Vmware::Vapi::Std::Errors::Error]
     #     if the system reports an error while responding to the request.
@@ -2416,7 +2416,7 @@ module Com::Vmware::Vcenter::Vm::Hardware
     #
     # @param vm [String]
     #     Virtual machine identifier.
-    # @param spec [Com::Vmware::Vcenter::VM::Hardware::Ethernet::CreateSpec]
+    # @param spec [Com::Vmware::Vcenter::Vm::Hardware::Ethernet::CreateSpec]
     #     Specification for the new virtual Ethernet adapter.
     # @return [String]
     #     Virtual Ethernet adapter identifier.
@@ -2454,7 +2454,7 @@ module Com::Vmware::Vcenter::Vm::Hardware
     #     Virtual machine identifier.
     # @param nic [String]
     #     Virtual Ethernet adapter identifier.
-    # @param spec [Com::Vmware::Vcenter::VM::Hardware::Ethernet::UpdateSpec]
+    # @param spec [Com::Vmware::Vcenter::Vm::Hardware::Ethernet::UpdateSpec]
     #     Specification for updating the virtual Ethernet adapter.
     # @return [Void]
     # @raise [Com::Vmware::Vapi::Std::Errors::Error]
@@ -2509,7 +2509,7 @@ module Com::Vmware::Vcenter::Vm::Hardware
 
     # Connects a virtual Ethernet adapter of a powered-on virtual machine to its backing. Connecting the virtual device makes the backing accessible from the perspective of the guest operating system.  
     # 
-    #  For a powered-off virtual machine, the   :func:`Com::Vmware::Vcenter::VM::Hardware::Ethernet.update`    method  may be used to configure the virtual Ethernet adapter to start in the connected state when the virtual machine is powered on.
+    #  For a powered-off virtual machine, the   :func:`Com::Vmware::Vcenter::Vm::Hardware::Ethernet.update`    method  may be used to configure the virtual Ethernet adapter to start in the connected state when the virtual machine is powered on.
     #
     # @param vm [String]
     #     Virtual machine identifier.
@@ -2542,7 +2542,7 @@ module Com::Vmware::Vcenter::Vm::Hardware
 
     # Disconnects a virtual Ethernet adapter of a powered-on virtual machine from its backing. The virtual device is still present and its backing configuration is unchanged, but from the perspective of the guest operating system, the Ethernet adapter is not connected to its backing resource.  
     # 
-    #  For a powered-off virtual machine, the   :func:`Com::Vmware::Vcenter::VM::Hardware::Ethernet.update`    method  may be used to configure the virtual Ethernet adapter to start in the disconnected state when the virtual machine is powered on.
+    #  For a powered-off virtual machine, the   :func:`Com::Vmware::Vcenter::Vm::Hardware::Ethernet.update`    method  may be used to configure the virtual Ethernet adapter to start in the disconnected state when the virtual machine is powered on.
     #
     # @param vm [String]
     #     Virtual machine identifier.
@@ -2573,9 +2573,9 @@ module Com::Vmware::Vcenter::Vm::Hardware
                        'nic' => nic)
     end
 
-    # The  ``Com::Vmware::Vcenter::VM::Hardware::Ethernet::BackingInfo``   class  contains information about the physical resource backing a virtual Ethernet adapter.
+    # The  ``Com::Vmware::Vcenter::Vm::Hardware::Ethernet::BackingInfo``   class  contains information about the physical resource backing a virtual Ethernet adapter.
     # @!attribute [rw] type
-    #     @return [Com::Vmware::Vcenter::VM::Hardware::Ethernet::BackingType]
+    #     @return [Com::Vmware::Vcenter::Vm::Hardware::Ethernet::BackingType]
     #     Backing type for the virtual Ethernet adapter.
     # @!attribute [rw] network
     #     @return [String, nil]
@@ -2584,15 +2584,15 @@ module Com::Vmware::Vcenter::Vm::Hardware
     # @!attribute [rw] network_name
     #     @return [String]
     #     Name of the standard portgroup backing the virtual Ethernet adapter.
-    #     This  field  is optional and it is only relevant when the value of  ``type``  is   :attr:`Com::Vmware::Vcenter::VM::Hardware::Ethernet::BackingType.STANDARD_PORTGROUP`  .
+    #     This  field  is optional and it is only relevant when the value of  ``type``  is   :attr:`Com::Vmware::Vcenter::Vm::Hardware::Ethernet::BackingType.STANDARD_PORTGROUP`  .
     # @!attribute [rw] host_device
     #     @return [String]
     #     Name of the device backing the virtual Ethernet adapter.
-    #     This  field  is optional and it is only relevant when the value of  ``type``  is   :attr:`Com::Vmware::Vcenter::VM::Hardware::Ethernet::BackingType.HOST_DEVICE`  .
+    #     This  field  is optional and it is only relevant when the value of  ``type``  is   :attr:`Com::Vmware::Vcenter::Vm::Hardware::Ethernet::BackingType.HOST_DEVICE`  .
     # @!attribute [rw] distributed_switch_uuid
     #     @return [String]
     #     UUID of the distributed virtual switch that backs the virtual Ethernet adapter.
-    #     This  field  is optional and it is only relevant when the value of  ``type``  is   :attr:`Com::Vmware::Vcenter::VM::Hardware::Ethernet::BackingType.DISTRIBUTED_PORTGROUP`  .
+    #     This  field  is optional and it is only relevant when the value of  ``type``  is   :attr:`Com::Vmware::Vcenter::Vm::Hardware::Ethernet::BackingType.DISTRIBUTED_PORTGROUP`  .
     # @!attribute [rw] distributed_port
     #     @return [String, nil]
     #     Key of the distributed virtual port that backs the virtual Ethernet adapter.
@@ -2604,11 +2604,11 @@ module Com::Vmware::Vcenter::Vm::Hardware
     # @!attribute [rw] opaque_network_type
     #     @return [String]
     #     Type of the opaque network that backs the virtual Ethernet adapter.
-    #     This  field  is optional and it is only relevant when the value of  ``type``  is   :attr:`Com::Vmware::Vcenter::VM::Hardware::Ethernet::BackingType.OPAQUE_NETWORK`  .
+    #     This  field  is optional and it is only relevant when the value of  ``type``  is   :attr:`Com::Vmware::Vcenter::Vm::Hardware::Ethernet::BackingType.OPAQUE_NETWORK`  .
     # @!attribute [rw] opaque_network_id
     #     @return [String]
     #     Identifier of the opaque network that backs the virtual Ethernet adapter.
-    #     This  field  is optional and it is only relevant when the value of  ``type``  is   :attr:`Com::Vmware::Vcenter::VM::Hardware::Ethernet::BackingType.OPAQUE_NETWORK`  .
+    #     This  field  is optional and it is only relevant when the value of  ``type``  is   :attr:`Com::Vmware::Vcenter::Vm::Hardware::Ethernet::BackingType.OPAQUE_NETWORK`  .
     class BackingInfo < VAPI::Bindings::VapiStruct
       class << self
         # Holds (gets or creates) the binding type metadata for this structure type.
@@ -2618,7 +2618,7 @@ module Com::Vmware::Vcenter::Vm::Hardware
           @binding_type ||= VAPI::Bindings::StructType.new(
             'com.vmware.vcenter.vm.hardware.ethernet.backing_info',
             {
-              'type' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::VM::Hardware::Ethernet::BackingType'),
+              'type' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::Vm::Hardware::Ethernet::BackingType'),
               'network' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::IdType.new),
               'network_name' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::StringType.instance),
               'host_device' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::StringType.instance),
@@ -2653,14 +2653,14 @@ module Com::Vmware::Vcenter::Vm::Hardware
       end
     end
 
-    # The  ``Com::Vmware::Vcenter::VM::Hardware::Ethernet::BackingSpec``   class  provides a specification of the physical resource that backs a virtual Ethernet adapter.
+    # The  ``Com::Vmware::Vcenter::Vm::Hardware::Ethernet::BackingSpec``   class  provides a specification of the physical resource that backs a virtual Ethernet adapter.
     # @!attribute [rw] type
-    #     @return [Com::Vmware::Vcenter::VM::Hardware::Ethernet::BackingType]
+    #     @return [Com::Vmware::Vcenter::Vm::Hardware::Ethernet::BackingType]
     #     Backing type for the virtual Ethernet adapter.
     # @!attribute [rw] network
     #     @return [String]
     #     Identifier of the network that backs the virtual Ethernet adapter.
-    #     This  field  is optional and it is only relevant when the value of  ``type``  is one of   :attr:`Com::Vmware::Vcenter::VM::Hardware::Ethernet::BackingType.STANDARD_PORTGROUP`  ,   :attr:`Com::Vmware::Vcenter::VM::Hardware::Ethernet::BackingType.DISTRIBUTED_PORTGROUP`  , or   :attr:`Com::Vmware::Vcenter::VM::Hardware::Ethernet::BackingType.OPAQUE_NETWORK`  .
+    #     This  field  is optional and it is only relevant when the value of  ``type``  is one of   :attr:`Com::Vmware::Vcenter::Vm::Hardware::Ethernet::BackingType.STANDARD_PORTGROUP`  ,   :attr:`Com::Vmware::Vcenter::Vm::Hardware::Ethernet::BackingType.DISTRIBUTED_PORTGROUP`  , or   :attr:`Com::Vmware::Vcenter::Vm::Hardware::Ethernet::BackingType.OPAQUE_NETWORK`  .
     # @!attribute [rw] distributed_port
     #     @return [String, nil]
     #     Key of the distributed virtual port that backs the virtual Ethernet adapter. Depending on the type of the Portgroup, the port may be specified using this field. If the portgroup type is early-binding (also known as static), a port is assigned when the Ethernet adapter is configured to use the port. The port may be either automatically or specifically assigned based on the value of this  field . If the portgroup type is ephemeral, the port is created and assigned to a virtual machine when it is powered on and the Ethernet adapter is connected. This  field  cannot be specified as no free ports exist before use.
@@ -2674,7 +2674,7 @@ module Com::Vmware::Vcenter::Vm::Hardware
           @binding_type ||= VAPI::Bindings::StructType.new(
             'com.vmware.vcenter.vm.hardware.ethernet.backing_spec',
             {
-              'type' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::VM::Hardware::Ethernet::BackingType'),
+              'type' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::Vm::Hardware::Ethernet::BackingType'),
               'network' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::IdType.new),
               'distributed_port' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::StringType.instance)
             },
@@ -2697,24 +2697,24 @@ module Com::Vmware::Vcenter::Vm::Hardware
       end
     end
 
-    # The  ``Com::Vmware::Vcenter::VM::Hardware::Ethernet::Info``   class  contains information about a virtual Ethernet adapter.
+    # The  ``Com::Vmware::Vcenter::Vm::Hardware::Ethernet::Info``   class  contains information about a virtual Ethernet adapter.
     # @!attribute [rw] label
     #     @return [String]
     #     Device label.
     # @!attribute [rw] type
-    #     @return [Com::Vmware::Vcenter::VM::Hardware::Ethernet::EmulationType]
+    #     @return [Com::Vmware::Vcenter::Vm::Hardware::Ethernet::EmulationType]
     #     Ethernet adapter emulation type.
     # @!attribute [rw] upt_compatibility_enabled
     #     @return [Boolean]
     #     Flag indicating whether Universal Pass-Through (UPT) compatibility is enabled on this virtual Ethernet adapter.
-    #     This  field  is optional and it is only relevant when the value of  ``type``  is   :attr:`Com::Vmware::Vcenter::VM::Hardware::Ethernet::EmulationType.VMXNET3`  .
+    #     This  field  is optional and it is only relevant when the value of  ``type``  is   :attr:`Com::Vmware::Vcenter::Vm::Hardware::Ethernet::EmulationType.VMXNET3`  .
     # @!attribute [rw] mac_type
-    #     @return [Com::Vmware::Vcenter::VM::Hardware::Ethernet::MacAddressType]
+    #     @return [Com::Vmware::Vcenter::Vm::Hardware::Ethernet::MacAddressType]
     #     MAC address type.
     # @!attribute [rw] mac_address
     #     @return [String, nil]
     #     MAC address.
-    #     May be  nil  if   :attr:`Com::Vmware::Vcenter::VM::Hardware::Ethernet::Info.mac_type`   is   :attr:`Com::Vmware::Vcenter::VM::Hardware::Ethernet::MacAddressType.MANUAL`   and has not been specified, or if   :attr:`Com::Vmware::Vcenter::VM::Hardware::Ethernet::Info.mac_type`   is   :attr:`Com::Vmware::Vcenter::VM::Hardware::Ethernet::MacAddressType.GENERATED`   and the virtual machine has never been powered on since the Ethernet adapter was created.
+    #     May be  nil  if   :attr:`Com::Vmware::Vcenter::Vm::Hardware::Ethernet::Info.mac_type`   is   :attr:`Com::Vmware::Vcenter::Vm::Hardware::Ethernet::MacAddressType.MANUAL`   and has not been specified, or if   :attr:`Com::Vmware::Vcenter::Vm::Hardware::Ethernet::Info.mac_type`   is   :attr:`Com::Vmware::Vcenter::Vm::Hardware::Ethernet::MacAddressType.GENERATED`   and the virtual machine has never been powered on since the Ethernet adapter was created.
     # @!attribute [rw] pci_slot_number
     #     @return [Fixnum, nil]
     #     Address of the virtual Ethernet adapter on the PCI bus. If the PCI address is invalid, the server will change it when the VM is started or as the device is hot added.
@@ -2723,7 +2723,7 @@ module Com::Vmware::Vcenter::Vm::Hardware
     #     @return [Boolean]
     #     Flag indicating whether wake-on-LAN is enabled on this virtual Ethernet adapter.
     # @!attribute [rw] backing
-    #     @return [Com::Vmware::Vcenter::VM::Hardware::Ethernet::BackingInfo]
+    #     @return [Com::Vmware::Vcenter::Vm::Hardware::Ethernet::BackingInfo]
     #     Physical resource backing for the virtual Ethernet adapter.
     class Info < VAPI::Bindings::VapiStruct
       class << self
@@ -2735,14 +2735,14 @@ module Com::Vmware::Vcenter::Vm::Hardware
             'com.vmware.vcenter.vm.hardware.ethernet.info',
             {
               'label' => VAPI::Bindings::StringType.instance,
-              'type' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::VM::Hardware::Ethernet::EmulationType'),
+              'type' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::Vm::Hardware::Ethernet::EmulationType'),
               'upt_compatibility_enabled' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::BooleanType.instance),
-              'mac_type' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::VM::Hardware::Ethernet::MacAddressType'),
+              'mac_type' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::Vm::Hardware::Ethernet::MacAddressType'),
               'mac_address' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::StringType.instance),
               'pci_slot_number' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::IntegerType.instance),
               'wake_on_lan_enabled' => VAPI::Bindings::BooleanType.instance,
-              'backing' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::VM::Hardware::Ethernet::BackingInfo'),
-              'state' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::VM::Hardware::ConnectionState'),
+              'backing' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::Vm::Hardware::Ethernet::BackingInfo'),
+              'state' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::Vm::Hardware::ConnectionState'),
               'start_connected' => VAPI::Bindings::BooleanType.instance,
               'allow_guest_control' => VAPI::Bindings::BooleanType.instance
             },
@@ -2773,9 +2773,9 @@ module Com::Vmware::Vcenter::Vm::Hardware
       end
     end
 
-    # The  ``Com::Vmware::Vcenter::VM::Hardware::Ethernet::CreateSpec``   class  provides a specification for the configuration of a newly-created virtual Ethernet adapter.
+    # The  ``Com::Vmware::Vcenter::Vm::Hardware::Ethernet::CreateSpec``   class  provides a specification for the configuration of a newly-created virtual Ethernet adapter.
     # @!attribute [rw] type
-    #     @return [Com::Vmware::Vcenter::VM::Hardware::Ethernet::EmulationType, nil]
+    #     @return [Com::Vmware::Vcenter::Vm::Hardware::Ethernet::EmulationType, nil]
     #     Ethernet adapter emulation type.
     #     If  nil , defaults to a guest-specific type.
     # @!attribute [rw] upt_compatibility_enabled
@@ -2783,9 +2783,9 @@ module Com::Vmware::Vcenter::Vm::Hardware
     #     Flag indicating whether Universal Pass-Through (UPT) compatibility is enabled on this virtual Ethernet adapter.
     #     If  nil , defaults to false.
     # @!attribute [rw] mac_type
-    #     @return [Com::Vmware::Vcenter::VM::Hardware::Ethernet::MacAddressType, nil]
+    #     @return [Com::Vmware::Vcenter::Vm::Hardware::Ethernet::MacAddressType, nil]
     #     MAC address type.
-    #     If  nil , defaults to   :attr:`Com::Vmware::Vcenter::VM::Hardware::Ethernet::MacAddressType.GENERATED`  .
+    #     If  nil , defaults to   :attr:`Com::Vmware::Vcenter::Vm::Hardware::Ethernet::MacAddressType.GENERATED`  .
     # @!attribute [rw] mac_address
     #     @return [String]
     #     MAC address.
@@ -2799,7 +2799,7 @@ module Com::Vmware::Vcenter::Vm::Hardware
     #     Flag indicating whether wake-on-LAN is enabled on this virtual Ethernet adapter.
     #     Defaults to false if  nil .
     # @!attribute [rw] backing
-    #     @return [Com::Vmware::Vcenter::VM::Hardware::Ethernet::BackingSpec, nil]
+    #     @return [Com::Vmware::Vcenter::Vm::Hardware::Ethernet::BackingSpec, nil]
     #     Physical resource backing for the virtual Ethernet adapter.
     #     If  nil , the system may try to find an appropriate backing. If one is not found, the request will fail.
     class CreateSpec < VAPI::Bindings::VapiStruct
@@ -2811,13 +2811,13 @@ module Com::Vmware::Vcenter::Vm::Hardware
           @binding_type ||= VAPI::Bindings::StructType.new(
             'com.vmware.vcenter.vm.hardware.ethernet.create_spec',
             {
-              'type' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::VM::Hardware::Ethernet::EmulationType')),
+              'type' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::Vm::Hardware::Ethernet::EmulationType')),
               'upt_compatibility_enabled' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::BooleanType.instance),
-              'mac_type' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::VM::Hardware::Ethernet::MacAddressType')),
+              'mac_type' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::Vm::Hardware::Ethernet::MacAddressType')),
               'mac_address' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::StringType.instance),
               'pci_slot_number' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::IntegerType.instance),
               'wake_on_lan_enabled' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::BooleanType.instance),
-              'backing' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::VM::Hardware::Ethernet::BackingSpec')),
+              'backing' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::Vm::Hardware::Ethernet::BackingSpec')),
               'start_connected' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::BooleanType.instance),
               'allow_guest_control' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::BooleanType.instance)
             },
@@ -2846,15 +2846,15 @@ module Com::Vmware::Vcenter::Vm::Hardware
       end
     end
 
-    # The  ``Com::Vmware::Vcenter::VM::Hardware::Ethernet::UpdateSpec``   class  describes the updates to be made to the configuration of a virtual Ethernet adapter.
+    # The  ``Com::Vmware::Vcenter::Vm::Hardware::Ethernet::UpdateSpec``   class  describes the updates to be made to the configuration of a virtual Ethernet adapter.
     # @!attribute [rw] upt_compatibility_enabled
     #     @return [Boolean, nil]
     #     Flag indicating whether Universal Pass-Through (UPT) compatibility should be enabled on this virtual Ethernet adapter.  
     #     
     #      This  field  may be modified at any time, and changes will be applied the next time the virtual machine is powered on.
-    #     If  nil , the value is unchanged. Must be  nil  if the emulation type of the virtual Ethernet adapter is not   :attr:`Com::Vmware::Vcenter::VM::Hardware::Ethernet::EmulationType.VMXNET3`  .
+    #     If  nil , the value is unchanged. Must be  nil  if the emulation type of the virtual Ethernet adapter is not   :attr:`Com::Vmware::Vcenter::Vm::Hardware::Ethernet::EmulationType.VMXNET3`  .
     # @!attribute [rw] mac_type
-    #     @return [Com::Vmware::Vcenter::VM::Hardware::Ethernet::MacAddressType, nil]
+    #     @return [Com::Vmware::Vcenter::Vm::Hardware::Ethernet::MacAddressType, nil]
     #     MAC address type.  
     #     
     #      This  field  may be modified at any time, and changes will be applied the next time the virtual machine is powered on.
@@ -2864,7 +2864,7 @@ module Com::Vmware::Vcenter::Vm::Hardware
     #     MAC address.  
     #     
     #      This  field  may be modified at any time, and changes will be applied the next time the virtual machine is powered on.
-    #     If  nil , the value is unchanged. Must be specified if   :attr:`Com::Vmware::Vcenter::VM::Hardware::Ethernet::UpdateSpec.mac_type`   is   :attr:`Com::Vmware::Vcenter::VM::Hardware::Ethernet::MacAddressType.MANUAL`  . Must be  nil  if the MAC address type is not   :attr:`Com::Vmware::Vcenter::VM::Hardware::Ethernet::MacAddressType.MANUAL`  .
+    #     If  nil , the value is unchanged. Must be specified if   :attr:`Com::Vmware::Vcenter::Vm::Hardware::Ethernet::UpdateSpec.mac_type`   is   :attr:`Com::Vmware::Vcenter::Vm::Hardware::Ethernet::MacAddressType.MANUAL`  . Must be  nil  if the MAC address type is not   :attr:`Com::Vmware::Vcenter::Vm::Hardware::Ethernet::MacAddressType.MANUAL`  .
     # @!attribute [rw] wake_on_lan_enabled
     #     @return [Boolean, nil]
     #     Flag indicating whether wake-on-LAN shoud be enabled on this virtual Ethernet adapter.  
@@ -2872,7 +2872,7 @@ module Com::Vmware::Vcenter::Vm::Hardware
     #      This  field  may be modified at any time, and changes will be applied the next time the virtual machine is powered on.
     #     If  nil , the value is unchanged.
     # @!attribute [rw] backing
-    #     @return [Com::Vmware::Vcenter::VM::Hardware::Ethernet::BackingSpec, nil]
+    #     @return [Com::Vmware::Vcenter::Vm::Hardware::Ethernet::BackingSpec, nil]
     #     Physical resource backing for the virtual Ethernet adapter.  
     #     
     #      This  field  may be modified at any time, and changes will be applied the next time the virtual machine is powered on.
@@ -2887,10 +2887,10 @@ module Com::Vmware::Vcenter::Vm::Hardware
             'com.vmware.vcenter.vm.hardware.ethernet.update_spec',
             {
               'upt_compatibility_enabled' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::BooleanType.instance),
-              'mac_type' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::VM::Hardware::Ethernet::MacAddressType')),
+              'mac_type' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::Vm::Hardware::Ethernet::MacAddressType')),
               'mac_address' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::StringType.instance),
               'wake_on_lan_enabled' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::BooleanType.instance),
-              'backing' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::VM::Hardware::Ethernet::BackingSpec')),
+              'backing' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::Vm::Hardware::Ethernet::BackingSpec')),
               'start_connected' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::BooleanType.instance),
               'allow_guest_control' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::BooleanType.instance)
             },
@@ -2917,7 +2917,7 @@ module Com::Vmware::Vcenter::Vm::Hardware
       end
     end
 
-    # The  ``Com::Vmware::Vcenter::VM::Hardware::Ethernet::Summary``   class  contains commonly used information about a virtual Ethernet adapter.
+    # The  ``Com::Vmware::Vcenter::Vm::Hardware::Ethernet::Summary``   class  contains commonly used information about a virtual Ethernet adapter.
     # @!attribute [rw] nic
     #     @return [String]
     #     Identifier of the virtual Ethernet adapter.
@@ -2949,24 +2949,24 @@ module Com::Vmware::Vcenter::Vm::Hardware
       end
     end
 
-    # The  ``Com::Vmware::Vcenter::VM::Hardware::Ethernet::EmulationType``   enumerated type  defines the valid emulation types for a virtual Ethernet adapter.
+    # The  ``Com::Vmware::Vcenter::Vm::Hardware::Ethernet::EmulationType``   enumerated type  defines the valid emulation types for a virtual Ethernet adapter.
     # @!attribute [rw] e1000
-    #     @return [Com::Vmware::Vcenter::VM::Hardware::Ethernet::EmulationType]
+    #     @return [Com::Vmware::Vcenter::Vm::Hardware::Ethernet::EmulationType]
     #     E1000 ethernet adapter.
     # @!attribute [rw] e1000e
-    #     @return [Com::Vmware::Vcenter::VM::Hardware::Ethernet::EmulationType]
+    #     @return [Com::Vmware::Vcenter::Vm::Hardware::Ethernet::EmulationType]
     #     E1000e ethernet adapter.
     # @!attribute [rw] pcne_t32
-    #     @return [Com::Vmware::Vcenter::VM::Hardware::Ethernet::EmulationType]
+    #     @return [Com::Vmware::Vcenter::Vm::Hardware::Ethernet::EmulationType]
     #     AMD Lance PCNet32 Ethernet adapter.
     # @!attribute [rw] vmxnet
-    #     @return [Com::Vmware::Vcenter::VM::Hardware::Ethernet::EmulationType]
+    #     @return [Com::Vmware::Vcenter::Vm::Hardware::Ethernet::EmulationType]
     #     VMware Vmxnet virtual Ethernet adapter.
     # @!attribute [rw] vmxne_t2
-    #     @return [Com::Vmware::Vcenter::VM::Hardware::Ethernet::EmulationType]
+    #     @return [Com::Vmware::Vcenter::Vm::Hardware::Ethernet::EmulationType]
     #     VMware Vmxnet2 virtual Ethernet adapter.
     # @!attribute [rw] vmxne_t3
-    #     @return [Com::Vmware::Vcenter::VM::Hardware::Ethernet::EmulationType]
+    #     @return [Com::Vmware::Vcenter::Vm::Hardware::Ethernet::EmulationType]
     #     VMware Vmxnet3 virtual Ethernet adapter.
     class EmulationType < VAPI::Bindings::VapiEnum
       class << self
@@ -3002,44 +3002,44 @@ module Com::Vmware::Vcenter::Vm::Hardware
       private_class_method :new
 
       # @!attribute [rw] e1000
-      #     @return [Com::Vmware::Vcenter::VM::Hardware::Ethernet::EmulationType]
+      #     @return [Com::Vmware::Vcenter::Vm::Hardware::Ethernet::EmulationType]
       #     E1000 ethernet adapter.
       E1000 = EmulationType.send(:new, 'E1000')
 
       # @!attribute [rw] e1000e
-      #     @return [Com::Vmware::Vcenter::VM::Hardware::Ethernet::EmulationType]
+      #     @return [Com::Vmware::Vcenter::Vm::Hardware::Ethernet::EmulationType]
       #     E1000e ethernet adapter.
       E1000E = EmulationType.send(:new, 'E1000E')
 
       # @!attribute [rw] pcne_t32
-      #     @return [Com::Vmware::Vcenter::VM::Hardware::Ethernet::EmulationType]
+      #     @return [Com::Vmware::Vcenter::Vm::Hardware::Ethernet::EmulationType]
       #     AMD Lance PCNet32 Ethernet adapter.
       PCNE_T32 = EmulationType.send(:new, 'PCNE_T32')
 
       # @!attribute [rw] vmxnet
-      #     @return [Com::Vmware::Vcenter::VM::Hardware::Ethernet::EmulationType]
+      #     @return [Com::Vmware::Vcenter::Vm::Hardware::Ethernet::EmulationType]
       #     VMware Vmxnet virtual Ethernet adapter.
       VMXNET = EmulationType.send(:new, 'VMXNET')
 
       # @!attribute [rw] vmxne_t2
-      #     @return [Com::Vmware::Vcenter::VM::Hardware::Ethernet::EmulationType]
+      #     @return [Com::Vmware::Vcenter::Vm::Hardware::Ethernet::EmulationType]
       #     VMware Vmxnet2 virtual Ethernet adapter.
       VMXNE_T2 = EmulationType.send(:new, 'VMXNE_T2')
 
       # @!attribute [rw] vmxne_t3
-      #     @return [Com::Vmware::Vcenter::VM::Hardware::Ethernet::EmulationType]
+      #     @return [Com::Vmware::Vcenter::Vm::Hardware::Ethernet::EmulationType]
       #     VMware Vmxnet3 virtual Ethernet adapter.
       VMXNE_T3 = EmulationType.send(:new, 'VMXNE_T3')
     end
-    # The  ``Com::Vmware::Vcenter::VM::Hardware::Ethernet::MacAddressType``   enumerated type  defines the valid MAC address origins for a virtual Ethernet adapter.
+    # The  ``Com::Vmware::Vcenter::Vm::Hardware::Ethernet::MacAddressType``   enumerated type  defines the valid MAC address origins for a virtual Ethernet adapter.
     # @!attribute [rw] manual
-    #     @return [Com::Vmware::Vcenter::VM::Hardware::Ethernet::MacAddressType]
+    #     @return [Com::Vmware::Vcenter::Vm::Hardware::Ethernet::MacAddressType]
     #     MAC address is assigned statically.
     # @!attribute [rw] generated
-    #     @return [Com::Vmware::Vcenter::VM::Hardware::Ethernet::MacAddressType]
+    #     @return [Com::Vmware::Vcenter::Vm::Hardware::Ethernet::MacAddressType]
     #     MAC address is generated automatically.
     # @!attribute [rw] assigned
-    #     @return [Com::Vmware::Vcenter::VM::Hardware::Ethernet::MacAddressType]
+    #     @return [Com::Vmware::Vcenter::Vm::Hardware::Ethernet::MacAddressType]
     #     MAC address is assigned by vCenter Server.
     class MacAddressType < VAPI::Bindings::VapiEnum
       class << self
@@ -3075,32 +3075,32 @@ module Com::Vmware::Vcenter::Vm::Hardware
       private_class_method :new
 
       # @!attribute [rw] manual
-      #     @return [Com::Vmware::Vcenter::VM::Hardware::Ethernet::MacAddressType]
+      #     @return [Com::Vmware::Vcenter::Vm::Hardware::Ethernet::MacAddressType]
       #     MAC address is assigned statically.
       MANUAL = MacAddressType.send(:new, 'MANUAL')
 
       # @!attribute [rw] generated
-      #     @return [Com::Vmware::Vcenter::VM::Hardware::Ethernet::MacAddressType]
+      #     @return [Com::Vmware::Vcenter::Vm::Hardware::Ethernet::MacAddressType]
       #     MAC address is generated automatically.
       GENERATED = MacAddressType.send(:new, 'GENERATED')
 
       # @!attribute [rw] assigned
-      #     @return [Com::Vmware::Vcenter::VM::Hardware::Ethernet::MacAddressType]
+      #     @return [Com::Vmware::Vcenter::Vm::Hardware::Ethernet::MacAddressType]
       #     MAC address is assigned by vCenter Server.
       ASSIGNED = MacAddressType.send(:new, 'ASSIGNED')
     end
-    # The  ``Com::Vmware::Vcenter::VM::Hardware::Ethernet::BackingType``   enumerated type  defines the valid backing types for a virtual Ethernet adapter.
+    # The  ``Com::Vmware::Vcenter::Vm::Hardware::Ethernet::BackingType``   enumerated type  defines the valid backing types for a virtual Ethernet adapter.
     # @!attribute [rw] standard_portgroup
-    #     @return [Com::Vmware::Vcenter::VM::Hardware::Ethernet::BackingType]
+    #     @return [Com::Vmware::Vcenter::Vm::Hardware::Ethernet::BackingType]
     #     vSphere standard portgroup network backing.
     # @!attribute [rw] host_device
-    #     @return [Com::Vmware::Vcenter::VM::Hardware::Ethernet::BackingType]
+    #     @return [Com::Vmware::Vcenter::Vm::Hardware::Ethernet::BackingType]
     #     Legacy host device network backing. Imported VMs may have virtual Ethernet adapters with this type of backing, but this type of backing cannot be used to create or to update a virtual Ethernet adapter.
     # @!attribute [rw] distributed_portgroup
-    #     @return [Com::Vmware::Vcenter::VM::Hardware::Ethernet::BackingType]
+    #     @return [Com::Vmware::Vcenter::Vm::Hardware::Ethernet::BackingType]
     #     Distributed virtual switch backing.
     # @!attribute [rw] opaque_network
-    #     @return [Com::Vmware::Vcenter::VM::Hardware::Ethernet::BackingType]
+    #     @return [Com::Vmware::Vcenter::Vm::Hardware::Ethernet::BackingType]
     #     Opaque network backing.
     class BackingType < VAPI::Bindings::VapiEnum
       class << self
@@ -3136,27 +3136,27 @@ module Com::Vmware::Vcenter::Vm::Hardware
       private_class_method :new
 
       # @!attribute [rw] standard_portgroup
-      #     @return [Com::Vmware::Vcenter::VM::Hardware::Ethernet::BackingType]
+      #     @return [Com::Vmware::Vcenter::Vm::Hardware::Ethernet::BackingType]
       #     vSphere standard portgroup network backing.
       STANDARD_PORTGROUP = BackingType.send(:new, 'STANDARD_PORTGROUP')
 
       # @!attribute [rw] host_device
-      #     @return [Com::Vmware::Vcenter::VM::Hardware::Ethernet::BackingType]
+      #     @return [Com::Vmware::Vcenter::Vm::Hardware::Ethernet::BackingType]
       #     Legacy host device network backing. Imported VMs may have virtual Ethernet adapters with this type of backing, but this type of backing cannot be used to create or to update a virtual Ethernet adapter.
       HOST_DEVICE = BackingType.send(:new, 'HOST_DEVICE')
 
       # @!attribute [rw] distributed_portgroup
-      #     @return [Com::Vmware::Vcenter::VM::Hardware::Ethernet::BackingType]
+      #     @return [Com::Vmware::Vcenter::Vm::Hardware::Ethernet::BackingType]
       #     Distributed virtual switch backing.
       DISTRIBUTED_PORTGROUP = BackingType.send(:new, 'DISTRIBUTED_PORTGROUP')
 
       # @!attribute [rw] opaque_network
-      #     @return [Com::Vmware::Vcenter::VM::Hardware::Ethernet::BackingType]
+      #     @return [Com::Vmware::Vcenter::Vm::Hardware::Ethernet::BackingType]
       #     Opaque network backing.
       OPAQUE_NETWORK = BackingType.send(:new, 'OPAQUE_NETWORK')
     end
   end
-  # The  ``Com::Vmware::Vcenter::VM::Hardware::Floppy``   class  provides  methods  for configuring the virtual floppy drives of a virtual machine.
+  # The  ``Com::Vmware::Vcenter::Vm::Hardware::Floppy``   class  provides  methods  for configuring the virtual floppy drives of a virtual machine.
   class Floppy < VAPI::Bindings::VapiService
     # static metamodel definitions
     SERVICE_ID = VAPI::Core::ServiceIdentifier.new('com.vmware.vcenter.vm.hardware.floppy')
@@ -3166,7 +3166,7 @@ module Com::Vmware::Vcenter::Vm::Hardware
       VAPI::Bindings::OperationInputType.new(
         'vm' => VAPI::Bindings::IdType.new('VirtualMachine')
       ),
-      VAPI::Bindings::ListType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::VM::Hardware::Floppy::Summary')),
+      VAPI::Bindings::ListType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::Vm::Hardware::Floppy::Summary')),
       {
         'com.vmware.vapi.std.errors.error' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Error'),
         'com.vmware.vapi.std.errors.not_found' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::NotFound'),
@@ -3185,7 +3185,7 @@ module Com::Vmware::Vcenter::Vm::Hardware
         'vm' => VAPI::Bindings::IdType.new('VirtualMachine'),
         'floppy' => VAPI::Bindings::IdType.new('com.vmware.vcenter.vm.hardware.Floppy')
       ),
-      VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::VM::Hardware::Floppy::Info'),
+      VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::Vm::Hardware::Floppy::Info'),
       {
         'com.vmware.vapi.std.errors.error' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Error'),
         'com.vmware.vapi.std.errors.not_found' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::NotFound'),
@@ -3202,7 +3202,7 @@ module Com::Vmware::Vcenter::Vm::Hardware
       VAPI::Core::OperationIdentifier.new('create', SERVICE_ID),
       VAPI::Bindings::OperationInputType.new(
         'vm' => VAPI::Bindings::IdType.new('VirtualMachine'),
-        'spec' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::VM::Hardware::Floppy::CreateSpec')
+        'spec' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::Vm::Hardware::Floppy::CreateSpec')
       ),
       VAPI::Bindings::IdType.new('com.vmware.vcenter.vm.hardware.Floppy'),
       {
@@ -3225,7 +3225,7 @@ module Com::Vmware::Vcenter::Vm::Hardware
       VAPI::Bindings::OperationInputType.new(
         'vm' => VAPI::Bindings::IdType.new('VirtualMachine'),
         'floppy' => VAPI::Bindings::IdType.new('com.vmware.vcenter.vm.hardware.Floppy'),
-        'spec' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::VM::Hardware::Floppy::UpdateSpec')
+        'spec' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::Vm::Hardware::Floppy::UpdateSpec')
       ),
       VAPI::Bindings::VoidType.instance,
       {
@@ -3330,7 +3330,7 @@ module Com::Vmware::Vcenter::Vm::Hardware
     #
     # @param vm [String]
     #     Virtual machine identifier.
-    # @return [Array<Com::Vmware::Vcenter::VM::Hardware::Floppy::Summary>]
+    # @return [Array<Com::Vmware::Vcenter::Vm::Hardware::Floppy::Summary>]
     #     List of commonly used information about virtual floppy drives.
     # @raise [Com::Vmware::Vapi::Std::Errors::Error]
     #     if the system reports an error while responding to the request.
@@ -3355,7 +3355,7 @@ module Com::Vmware::Vcenter::Vm::Hardware
     #     Virtual machine identifier.
     # @param floppy [String]
     #     Virtual floppy drive identifier.
-    # @return [Com::Vmware::Vcenter::VM::Hardware::Floppy::Info]
+    # @return [Com::Vmware::Vcenter::Vm::Hardware::Floppy::Info]
     #     Information about the specified virtual floppy drive.
     # @raise [Com::Vmware::Vapi::Std::Errors::Error]
     #     if the system reports an error while responding to the request.
@@ -3379,7 +3379,7 @@ module Com::Vmware::Vcenter::Vm::Hardware
     #
     # @param vm [String]
     #     Virtual machine identifier.
-    # @param spec [Com::Vmware::Vcenter::VM::Hardware::Floppy::CreateSpec]
+    # @param spec [Com::Vmware::Vcenter::Vm::Hardware::Floppy::CreateSpec]
     #     Specification for the new virtual floppy drive.
     # @return [String]
     #     Virtual floppy drive identifier.
@@ -3415,7 +3415,7 @@ module Com::Vmware::Vcenter::Vm::Hardware
     #     Virtual machine identifier.
     # @param floppy [String]
     #     Virtual floppy drive identifier.
-    # @param spec [Com::Vmware::Vcenter::VM::Hardware::Floppy::UpdateSpec]
+    # @param spec [Com::Vmware::Vcenter::Vm::Hardware::Floppy::UpdateSpec]
     #     Specification for updating the virtual floppy drive.
     # @return [Void]
     # @raise [Com::Vmware::Vapi::Std::Errors::Error]
@@ -3472,7 +3472,7 @@ module Com::Vmware::Vcenter::Vm::Hardware
 
     # Connects a virtual floppy drive of a powered-on virtual machine to its backing. Connecting the virtual device makes the backing accessible from the perspective of the guest operating system.  
     # 
-    #  For a powered-off virtual machine, the   :func:`Com::Vmware::Vcenter::VM::Hardware::Floppy.update`    method  may be used to configure the virtual floppy drive to start in the connected state when the virtual machine is powered on.
+    #  For a powered-off virtual machine, the   :func:`Com::Vmware::Vcenter::Vm::Hardware::Floppy.update`    method  may be used to configure the virtual floppy drive to start in the connected state when the virtual machine is powered on.
     #
     # @param vm [String]
     #     Virtual machine identifier.
@@ -3505,7 +3505,7 @@ module Com::Vmware::Vcenter::Vm::Hardware
 
     # Disconnects a virtual floppy drive of a powered-on virtual machine from its backing. The virtual device is still present and its backing configuration is unchanged, but from the perspective of the guest operating system, the floppy drive is not connected to its backing resource.  
     # 
-    #  For a powered-off virtual machine, the   :func:`Com::Vmware::Vcenter::VM::Hardware::Floppy.update`    method  may be used to configure the virtual floppy floppy to start in the disconnected state when the virtual machine is powered on.
+    #  For a powered-off virtual machine, the   :func:`Com::Vmware::Vcenter::Vm::Hardware::Floppy.update`    method  may be used to configure the virtual floppy floppy to start in the disconnected state when the virtual machine is powered on.
     #
     # @param vm [String]
     #     Virtual machine identifier.
@@ -3536,14 +3536,14 @@ module Com::Vmware::Vcenter::Vm::Hardware
                        'floppy' => floppy)
     end
 
-    # The  ``Com::Vmware::Vcenter::VM::Hardware::Floppy::BackingInfo``   class  contains information about the physical resource backing a virtual floppy drive.
+    # The  ``Com::Vmware::Vcenter::Vm::Hardware::Floppy::BackingInfo``   class  contains information about the physical resource backing a virtual floppy drive.
     # @!attribute [rw] type
-    #     @return [Com::Vmware::Vcenter::VM::Hardware::Floppy::BackingType]
+    #     @return [Com::Vmware::Vcenter::Vm::Hardware::Floppy::BackingType]
     #     Backing type for the virtual floppy drive.
     # @!attribute [rw] image_file
     #     @return [String]
     #     Path of the image file backing the virtual floppy drive.
-    #     This  field  is optional and it is only relevant when the value of  ``type``  is   :attr:`Com::Vmware::Vcenter::VM::Hardware::Floppy::BackingType.IMAGE_FILE`  .
+    #     This  field  is optional and it is only relevant when the value of  ``type``  is   :attr:`Com::Vmware::Vcenter::Vm::Hardware::Floppy::BackingType.IMAGE_FILE`  .
     # @!attribute [rw] host_device
     #     @return [String, nil]
     #     Name of the host device backing the virtual floppy drive.  
@@ -3551,7 +3551,7 @@ module Com::Vmware::Vcenter::Vm::Hardware
     # @!attribute [rw] auto_detect
     #     @return [Boolean]
     #     Flag indicating whether the virtual floppy drive is configured to automatically detect a suitable host device.
-    #     This  field  is optional and it is only relevant when the value of  ``type``  is   :attr:`Com::Vmware::Vcenter::VM::Hardware::Floppy::BackingType.HOST_DEVICE`  .
+    #     This  field  is optional and it is only relevant when the value of  ``type``  is   :attr:`Com::Vmware::Vcenter::Vm::Hardware::Floppy::BackingType.HOST_DEVICE`  .
     class BackingInfo < VAPI::Bindings::VapiStruct
       class << self
         # Holds (gets or creates) the binding type metadata for this structure type.
@@ -3561,7 +3561,7 @@ module Com::Vmware::Vcenter::Vm::Hardware
           @binding_type ||= VAPI::Bindings::StructType.new(
             'com.vmware.vcenter.vm.hardware.floppy.backing_info',
             {
-              'type' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::VM::Hardware::Floppy::BackingType'),
+              'type' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::Vm::Hardware::Floppy::BackingType'),
               'image_file' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::StringType.instance),
               'host_device' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::StringType.instance),
               'auto_detect' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::BooleanType.instance)
@@ -3586,14 +3586,14 @@ module Com::Vmware::Vcenter::Vm::Hardware
       end
     end
 
-    # The  ``Com::Vmware::Vcenter::VM::Hardware::Floppy::BackingSpec``   class  provides a specification of the physical resource backing a virtual floppy drive.
+    # The  ``Com::Vmware::Vcenter::Vm::Hardware::Floppy::BackingSpec``   class  provides a specification of the physical resource backing a virtual floppy drive.
     # @!attribute [rw] type
-    #     @return [Com::Vmware::Vcenter::VM::Hardware::Floppy::BackingType]
+    #     @return [Com::Vmware::Vcenter::Vm::Hardware::Floppy::BackingType]
     #     Backing type for the virtual floppy drive.
     # @!attribute [rw] image_file
     #     @return [String]
     #     Path of the image file that should be used as the virtual floppy drive backing.
-    #     This  field  is optional and it is only relevant when the value of  ``type``  is   :attr:`Com::Vmware::Vcenter::VM::Hardware::Floppy::BackingType.IMAGE_FILE`  .
+    #     This  field  is optional and it is only relevant when the value of  ``type``  is   :attr:`Com::Vmware::Vcenter::Vm::Hardware::Floppy::BackingType.IMAGE_FILE`  .
     # @!attribute [rw] host_device
     #     @return [String, nil]
     #     Name of the device that should be used as the virtual floppy drive backing.
@@ -3607,7 +3607,7 @@ module Com::Vmware::Vcenter::Vm::Hardware
           @binding_type ||= VAPI::Bindings::StructType.new(
             'com.vmware.vcenter.vm.hardware.floppy.backing_spec',
             {
-              'type' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::VM::Hardware::Floppy::BackingType'),
+              'type' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::Vm::Hardware::Floppy::BackingType'),
               'image_file' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::StringType.instance),
               'host_device' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::StringType.instance)
             },
@@ -3630,12 +3630,12 @@ module Com::Vmware::Vcenter::Vm::Hardware
       end
     end
 
-    # The  ``Com::Vmware::Vcenter::VM::Hardware::Floppy::Info``   class  contains information about a virtual floppy drive.
+    # The  ``Com::Vmware::Vcenter::Vm::Hardware::Floppy::Info``   class  contains information about a virtual floppy drive.
     # @!attribute [rw] label
     #     @return [String]
     #     Device label.
     # @!attribute [rw] backing
-    #     @return [Com::Vmware::Vcenter::VM::Hardware::Floppy::BackingInfo]
+    #     @return [Com::Vmware::Vcenter::Vm::Hardware::Floppy::BackingInfo]
     #     Physical resource backing for the virtual floppy drive.
     class Info < VAPI::Bindings::VapiStruct
       class << self
@@ -3647,8 +3647,8 @@ module Com::Vmware::Vcenter::Vm::Hardware
             'com.vmware.vcenter.vm.hardware.floppy.info',
             {
               'label' => VAPI::Bindings::StringType.instance,
-              'backing' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::VM::Hardware::Floppy::BackingInfo'),
-              'state' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::VM::Hardware::ConnectionState'),
+              'backing' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::Vm::Hardware::Floppy::BackingInfo'),
+              'state' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::Vm::Hardware::ConnectionState'),
               'start_connected' => VAPI::Bindings::BooleanType.instance,
               'allow_guest_control' => VAPI::Bindings::BooleanType.instance
             },
@@ -3673,9 +3673,9 @@ module Com::Vmware::Vcenter::Vm::Hardware
       end
     end
 
-    # The  ``Com::Vmware::Vcenter::VM::Hardware::Floppy::CreateSpec``   class  provides a specification for the configuration of a newly-created virtual floppy drive.
+    # The  ``Com::Vmware::Vcenter::Vm::Hardware::Floppy::CreateSpec``   class  provides a specification for the configuration of a newly-created virtual floppy drive.
     # @!attribute [rw] backing
-    #     @return [Com::Vmware::Vcenter::VM::Hardware::Floppy::BackingSpec, nil]
+    #     @return [Com::Vmware::Vcenter::Vm::Hardware::Floppy::BackingSpec, nil]
     #     Physical resource backing for the virtual floppy drive.
     #     If  nil , defaults to automatic detection of a suitable host device.
     class CreateSpec < VAPI::Bindings::VapiStruct
@@ -3687,7 +3687,7 @@ module Com::Vmware::Vcenter::Vm::Hardware
           @binding_type ||= VAPI::Bindings::StructType.new(
             'com.vmware.vcenter.vm.hardware.floppy.create_spec',
             {
-              'backing' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::VM::Hardware::Floppy::BackingSpec')),
+              'backing' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::Vm::Hardware::Floppy::BackingSpec')),
               'start_connected' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::BooleanType.instance),
               'allow_guest_control' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::BooleanType.instance)
             },
@@ -3710,9 +3710,9 @@ module Com::Vmware::Vcenter::Vm::Hardware
       end
     end
 
-    # The  ``Com::Vmware::Vcenter::VM::Hardware::Floppy::UpdateSpec``   class  describes the updates to be made to the configuration of a virtual floppy drive.
+    # The  ``Com::Vmware::Vcenter::Vm::Hardware::Floppy::UpdateSpec``   class  describes the updates to be made to the configuration of a virtual floppy drive.
     # @!attribute [rw] backing
-    #     @return [Com::Vmware::Vcenter::VM::Hardware::Floppy::BackingSpec, nil]
+    #     @return [Com::Vmware::Vcenter::Vm::Hardware::Floppy::BackingSpec, nil]
     #     Physical resource backing for the virtual floppy drive.  
     #     
     #      This  field  may only be modified if the virtual machine is not powered on or the virtual floppy drive is not connected.
@@ -3726,7 +3726,7 @@ module Com::Vmware::Vcenter::Vm::Hardware
           @binding_type ||= VAPI::Bindings::StructType.new(
             'com.vmware.vcenter.vm.hardware.floppy.update_spec',
             {
-              'backing' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::VM::Hardware::Floppy::BackingSpec')),
+              'backing' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::Vm::Hardware::Floppy::BackingSpec')),
               'start_connected' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::BooleanType.instance),
               'allow_guest_control' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::BooleanType.instance)
             },
@@ -3749,7 +3749,7 @@ module Com::Vmware::Vcenter::Vm::Hardware
       end
     end
 
-    # The  ``Com::Vmware::Vcenter::VM::Hardware::Floppy::Summary``   class  contains commonly used information about a virtual floppy drive.
+    # The  ``Com::Vmware::Vcenter::Vm::Hardware::Floppy::Summary``   class  contains commonly used information about a virtual floppy drive.
     # @!attribute [rw] floppy
     #     @return [String]
     #     Identifier of the virtual floppy drive.
@@ -3781,15 +3781,15 @@ module Com::Vmware::Vcenter::Vm::Hardware
       end
     end
 
-    # The  ``Com::Vmware::Vcenter::VM::Hardware::Floppy::BackingType``   enumerated type  defines the valid backing types for a virtual floppy drive.
+    # The  ``Com::Vmware::Vcenter::Vm::Hardware::Floppy::BackingType``   enumerated type  defines the valid backing types for a virtual floppy drive.
     # @!attribute [rw] image_file
-    #     @return [Com::Vmware::Vcenter::VM::Hardware::Floppy::BackingType]
+    #     @return [Com::Vmware::Vcenter::Vm::Hardware::Floppy::BackingType]
     #     Virtual floppy drive is backed by an image file.
     # @!attribute [rw] host_device
-    #     @return [Com::Vmware::Vcenter::VM::Hardware::Floppy::BackingType]
+    #     @return [Com::Vmware::Vcenter::Vm::Hardware::Floppy::BackingType]
     #     Virtual floppy drive is backed by a device on the host where the virtual machine is running.
     # @!attribute [rw] client_device
-    #     @return [Com::Vmware::Vcenter::VM::Hardware::Floppy::BackingType]
+    #     @return [Com::Vmware::Vcenter::Vm::Hardware::Floppy::BackingType]
     #     Virtual floppy drive is backed by a device on the client that is connected to the virtual machine console.
     class BackingType < VAPI::Bindings::VapiEnum
       class << self
@@ -3825,22 +3825,22 @@ module Com::Vmware::Vcenter::Vm::Hardware
       private_class_method :new
 
       # @!attribute [rw] image_file
-      #     @return [Com::Vmware::Vcenter::VM::Hardware::Floppy::BackingType]
+      #     @return [Com::Vmware::Vcenter::Vm::Hardware::Floppy::BackingType]
       #     Virtual floppy drive is backed by an image file.
       IMAGE_FILE = BackingType.send(:new, 'IMAGE_FILE')
 
       # @!attribute [rw] host_device
-      #     @return [Com::Vmware::Vcenter::VM::Hardware::Floppy::BackingType]
+      #     @return [Com::Vmware::Vcenter::Vm::Hardware::Floppy::BackingType]
       #     Virtual floppy drive is backed by a device on the host where the virtual machine is running.
       HOST_DEVICE = BackingType.send(:new, 'HOST_DEVICE')
 
       # @!attribute [rw] client_device
-      #     @return [Com::Vmware::Vcenter::VM::Hardware::Floppy::BackingType]
+      #     @return [Com::Vmware::Vcenter::Vm::Hardware::Floppy::BackingType]
       #     Virtual floppy drive is backed by a device on the client that is connected to the virtual machine console.
       CLIENT_DEVICE = BackingType.send(:new, 'CLIENT_DEVICE')
     end
   end
-  # The  ``Com::Vmware::Vcenter::VM::Hardware::Memory``   class  provides  methods  for configuring the memory settings of a virtual machine.
+  # The  ``Com::Vmware::Vcenter::Vm::Hardware::Memory``   class  provides  methods  for configuring the memory settings of a virtual machine.
   class Memory < VAPI::Bindings::VapiService
     # static metamodel definitions
     SERVICE_ID = VAPI::Core::ServiceIdentifier.new('com.vmware.vcenter.vm.hardware.memory')
@@ -3850,7 +3850,7 @@ module Com::Vmware::Vcenter::Vm::Hardware
       VAPI::Bindings::OperationInputType.new(
         'vm' => VAPI::Bindings::IdType.new('VirtualMachine')
       ),
-      VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::VM::Hardware::Memory::Info'),
+      VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::Vm::Hardware::Memory::Info'),
       {
         'com.vmware.vapi.std.errors.error' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Error'),
         'com.vmware.vapi.std.errors.not_found' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::NotFound'),
@@ -3867,7 +3867,7 @@ module Com::Vmware::Vcenter::Vm::Hardware
       VAPI::Core::OperationIdentifier.new('update', SERVICE_ID),
       VAPI::Bindings::OperationInputType.new(
         'vm' => VAPI::Bindings::IdType.new('VirtualMachine'),
-        'spec' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::VM::Hardware::Memory::UpdateSpec')
+        'spec' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::Vm::Hardware::Memory::UpdateSpec')
       ),
       VAPI::Bindings::VoidType.instance,
       {
@@ -3902,7 +3902,7 @@ module Com::Vmware::Vcenter::Vm::Hardware
     #
     # @param vm [String]
     #     Virtual machine identifier.
-    # @return [Com::Vmware::Vcenter::VM::Hardware::Memory::Info]
+    # @return [Com::Vmware::Vcenter::Vm::Hardware::Memory::Info]
     #     Memory-related settings of the virtual machine.
     # @raise [Com::Vmware::Vapi::Std::Errors::Error]
     #     if the system reports an error while responding to the request.
@@ -3925,7 +3925,7 @@ module Com::Vmware::Vcenter::Vm::Hardware
     #
     # @param vm [String]
     #     Virtual machine identifier.
-    # @param spec [Com::Vmware::Vcenter::VM::Hardware::Memory::UpdateSpec]
+    # @param spec [Com::Vmware::Vcenter::Vm::Hardware::Memory::UpdateSpec]
     #     Specification for updating the memory-related settings of the virtual machine.
     # @return [Void]
     # @raise [Com::Vmware::Vapi::Std::Errors::Error]
@@ -3954,7 +3954,7 @@ module Com::Vmware::Vcenter::Vm::Hardware
                        'spec' => spec)
     end
 
-    # The  ``Com::Vmware::Vcenter::VM::Hardware::Memory::Info``   class  contains memory-related information about a virtual machine.
+    # The  ``Com::Vmware::Vcenter::Vm::Hardware::Memory::Info``   class  contains memory-related information about a virtual machine.
     # @!attribute [rw] size_mib
     #     @return [Fixnum]
     #     Memory size in mebibytes.
@@ -3967,12 +3967,12 @@ module Com::Vmware::Vcenter::Vm::Hardware
     #     @return [Fixnum, nil]
     #     The granularity, in mebibytes, at which memory can be added to a running virtual machine.  
     #     
-    #      When adding memory to a running virtual machine, the amount of memory added must be at least   :attr:`Com::Vmware::Vcenter::VM::Hardware::Memory::Info.hot_add_increment_size_mib`   and the total memory size of the virtual machine must be a multiple of {\@link>hotAddIncrementSize}.
-    #     Only set when   :attr:`Com::Vmware::Vcenter::VM::Hardware::Memory::Info.hot_add_enabled`   is true and the virtual machine is running.
+    #      When adding memory to a running virtual machine, the amount of memory added must be at least   :attr:`Com::Vmware::Vcenter::Vm::Hardware::Memory::Info.hot_add_increment_size_mib`   and the total memory size of the virtual machine must be a multiple of {\@link>hotAddIncrementSize}.
+    #     Only set when   :attr:`Com::Vmware::Vcenter::Vm::Hardware::Memory::Info.hot_add_enabled`   is true and the virtual machine is running.
     # @!attribute [rw] hot_add_limit_mib
     #     @return [Fixnum, nil]
     #     The maximum amount of memory, in mebibytes, that can be added to a running virtual machine.
-    #     Only set when   :attr:`Com::Vmware::Vcenter::VM::Hardware::Memory::Info.hot_add_enabled`   is true and the virtual machine is running.
+    #     Only set when   :attr:`Com::Vmware::Vcenter::Vm::Hardware::Memory::Info.hot_add_enabled`   is true and the virtual machine is running.
     class Info < VAPI::Bindings::VapiStruct
       class << self
         # Holds (gets or creates) the binding type metadata for this structure type.
@@ -4007,14 +4007,14 @@ module Com::Vmware::Vcenter::Vm::Hardware
       end
     end
 
-    # The  ``Com::Vmware::Vcenter::VM::Hardware::Memory::UpdateSpec``   class  describes the updates to be made to the memory-related settings of a virtual machine.
+    # The  ``Com::Vmware::Vcenter::Vm::Hardware::Memory::UpdateSpec``   class  describes the updates to be made to the memory-related settings of a virtual machine.
     # @!attribute [rw] size_mib
     #     @return [Fixnum, nil]
     #     New memory size in mebibytes.  
     #     
     #      The supported range of memory sizes is constrained by the configured guest operating system and virtual hardware version of the virtual machine.  
     #     
-    #      If the virtual machine is running, this value may only be changed if   :attr:`Com::Vmware::Vcenter::VM::Hardware::Memory::Info.hot_add_enabled`   is true, and the new memory size must satisfy the constraints specified by   :attr:`Com::Vmware::Vcenter::VM::Hardware::Memory::Info.hot_add_increment_size_mib`   and   :attr:`Com::Vmware::Vcenter::VM::Hardware::Memory::Info.hot_add_limit_mib`  .
+    #      If the virtual machine is running, this value may only be changed if   :attr:`Com::Vmware::Vcenter::Vm::Hardware::Memory::Info.hot_add_enabled`   is true, and the new memory size must satisfy the constraints specified by   :attr:`Com::Vmware::Vcenter::Vm::Hardware::Memory::Info.hot_add_increment_size_mib`   and   :attr:`Com::Vmware::Vcenter::Vm::Hardware::Memory::Info.hot_add_limit_mib`  .
     #     If  nil , the value is unchanged.
     # @!attribute [rw] hot_add_enabled
     #     @return [Boolean, nil]
@@ -4055,7 +4055,7 @@ module Com::Vmware::Vcenter::Vm::Hardware
     end
 
   end
-  # The  ``Com::Vmware::Vcenter::VM::Hardware::Parallel``   class  provides  methods  for configuring the virtual parallel ports of a virtual machine.
+  # The  ``Com::Vmware::Vcenter::Vm::Hardware::Parallel``   class  provides  methods  for configuring the virtual parallel ports of a virtual machine.
   class Parallel < VAPI::Bindings::VapiService
     # static metamodel definitions
     SERVICE_ID = VAPI::Core::ServiceIdentifier.new('com.vmware.vcenter.vm.hardware.parallel')
@@ -4065,7 +4065,7 @@ module Com::Vmware::Vcenter::Vm::Hardware
       VAPI::Bindings::OperationInputType.new(
         'vm' => VAPI::Bindings::IdType.new('VirtualMachine')
       ),
-      VAPI::Bindings::ListType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::VM::Hardware::Parallel::Summary')),
+      VAPI::Bindings::ListType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::Vm::Hardware::Parallel::Summary')),
       {
         'com.vmware.vapi.std.errors.error' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Error'),
         'com.vmware.vapi.std.errors.not_found' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::NotFound'),
@@ -4084,7 +4084,7 @@ module Com::Vmware::Vcenter::Vm::Hardware
         'vm' => VAPI::Bindings::IdType.new('VirtualMachine'),
         'port' => VAPI::Bindings::IdType.new('com.vmware.vcenter.vm.hardware.ParallelPort')
       ),
-      VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::VM::Hardware::Parallel::Info'),
+      VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::Vm::Hardware::Parallel::Info'),
       {
         'com.vmware.vapi.std.errors.error' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Error'),
         'com.vmware.vapi.std.errors.not_found' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::NotFound'),
@@ -4101,7 +4101,7 @@ module Com::Vmware::Vcenter::Vm::Hardware
       VAPI::Core::OperationIdentifier.new('create', SERVICE_ID),
       VAPI::Bindings::OperationInputType.new(
         'vm' => VAPI::Bindings::IdType.new('VirtualMachine'),
-        'spec' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::VM::Hardware::Parallel::CreateSpec')
+        'spec' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::Vm::Hardware::Parallel::CreateSpec')
       ),
       VAPI::Bindings::IdType.new('com.vmware.vcenter.vm.hardware.ParallelPort'),
       {
@@ -4124,7 +4124,7 @@ module Com::Vmware::Vcenter::Vm::Hardware
       VAPI::Bindings::OperationInputType.new(
         'vm' => VAPI::Bindings::IdType.new('VirtualMachine'),
         'port' => VAPI::Bindings::IdType.new('com.vmware.vcenter.vm.hardware.ParallelPort'),
-        'spec' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::VM::Hardware::Parallel::UpdateSpec')
+        'spec' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::Vm::Hardware::Parallel::UpdateSpec')
       ),
       VAPI::Bindings::VoidType.instance,
       {
@@ -4229,7 +4229,7 @@ module Com::Vmware::Vcenter::Vm::Hardware
     #
     # @param vm [String]
     #     Virtual machine identifier.
-    # @return [Array<Com::Vmware::Vcenter::VM::Hardware::Parallel::Summary>]
+    # @return [Array<Com::Vmware::Vcenter::Vm::Hardware::Parallel::Summary>]
     #     List of commonly used information about virtual parallel ports.
     # @raise [Com::Vmware::Vapi::Std::Errors::Error]
     #     if the system reports an error while responding to the request.
@@ -4254,7 +4254,7 @@ module Com::Vmware::Vcenter::Vm::Hardware
     #     Virtual machine identifier.
     # @param port [String]
     #     Virtual parallel port identifier.
-    # @return [Com::Vmware::Vcenter::VM::Hardware::Parallel::Info]
+    # @return [Com::Vmware::Vcenter::Vm::Hardware::Parallel::Info]
     #     Information about the specified virtual parallel port.
     # @raise [Com::Vmware::Vapi::Std::Errors::Error]
     #     if the system reports an error while responding to the request.
@@ -4278,7 +4278,7 @@ module Com::Vmware::Vcenter::Vm::Hardware
     #
     # @param vm [String]
     #     Virtual machine identifier.
-    # @param spec [Com::Vmware::Vcenter::VM::Hardware::Parallel::CreateSpec]
+    # @param spec [Com::Vmware::Vcenter::Vm::Hardware::Parallel::CreateSpec]
     #     Specification for the new virtual parallel port.
     # @return [String]
     #     Virtual parallel port identifier.
@@ -4314,7 +4314,7 @@ module Com::Vmware::Vcenter::Vm::Hardware
     #     Virtual machine identifier.
     # @param port [String]
     #     Virtual parallel port identifier.
-    # @param spec [Com::Vmware::Vcenter::VM::Hardware::Parallel::UpdateSpec]
+    # @param spec [Com::Vmware::Vcenter::Vm::Hardware::Parallel::UpdateSpec]
     #     Specification for updating the virtual parallel port.
     # @return [Void]
     # @raise [Com::Vmware::Vapi::Std::Errors::Error]
@@ -4371,7 +4371,7 @@ module Com::Vmware::Vcenter::Vm::Hardware
 
     # Connects a virtual parallel port of a powered-on virtual machine to its backing. Connecting the virtual device makes the backing accessible from the perspective of the guest operating system.  
     # 
-    #  For a powered-off virtual machine, the   :func:`Com::Vmware::Vcenter::VM::Hardware::Parallel.update`    method  may be used to configure the virtual parallel port to start in the connected state when the virtual machine is powered on.
+    #  For a powered-off virtual machine, the   :func:`Com::Vmware::Vcenter::Vm::Hardware::Parallel.update`    method  may be used to configure the virtual parallel port to start in the connected state when the virtual machine is powered on.
     #
     # @param vm [String]
     #     Virtual machine identifier.
@@ -4404,7 +4404,7 @@ module Com::Vmware::Vcenter::Vm::Hardware
 
     # Disconnects a virtual parallel port of a powered-on virtual machine from its backing. The virtual device is still present and its backing configuration is unchanged, but from the perspective of the guest operating system, the parallel port is not connected to its backing.  
     # 
-    #  For a powered-off virtual machine, the   :func:`Com::Vmware::Vcenter::VM::Hardware::Parallel.update`    method  may be used to configure the virtual parallel port to start in the disconnected state when the virtual machine is powered on.
+    #  For a powered-off virtual machine, the   :func:`Com::Vmware::Vcenter::Vm::Hardware::Parallel.update`    method  may be used to configure the virtual parallel port to start in the disconnected state when the virtual machine is powered on.
     #
     # @param vm [String]
     #     Virtual machine identifier.
@@ -4435,14 +4435,14 @@ module Com::Vmware::Vcenter::Vm::Hardware
                        'port' => port)
     end
 
-    # The  ``Com::Vmware::Vcenter::VM::Hardware::Parallel::BackingInfo``   class  contains information about the physical resource backing a virtual parallel port.
+    # The  ``Com::Vmware::Vcenter::Vm::Hardware::Parallel::BackingInfo``   class  contains information about the physical resource backing a virtual parallel port.
     # @!attribute [rw] type
-    #     @return [Com::Vmware::Vcenter::VM::Hardware::Parallel::BackingType]
+    #     @return [Com::Vmware::Vcenter::Vm::Hardware::Parallel::BackingType]
     #     Backing type for the virtual parallel port.
     # @!attribute [rw] file
     #     @return [String]
     #     Path of the file backing the virtual parallel port.
-    #     This  field  is optional and it is only relevant when the value of  ``type``  is   :attr:`Com::Vmware::Vcenter::VM::Hardware::Parallel::BackingType.FILE`  .
+    #     This  field  is optional and it is only relevant when the value of  ``type``  is   :attr:`Com::Vmware::Vcenter::Vm::Hardware::Parallel::BackingType.FILE`  .
     # @!attribute [rw] host_device
     #     @return [String, nil]
     #     Name of the device backing the virtual parallel port.  
@@ -4450,7 +4450,7 @@ module Com::Vmware::Vcenter::Vm::Hardware
     # @!attribute [rw] auto_detect
     #     @return [Boolean]
     #     Flag indicating whether the virtual parallel port is configured to automatically detect a suitable host device.
-    #     This  field  is optional and it is only relevant when the value of  ``type``  is   :attr:`Com::Vmware::Vcenter::VM::Hardware::Parallel::BackingType.HOST_DEVICE`  .
+    #     This  field  is optional and it is only relevant when the value of  ``type``  is   :attr:`Com::Vmware::Vcenter::Vm::Hardware::Parallel::BackingType.HOST_DEVICE`  .
     class BackingInfo < VAPI::Bindings::VapiStruct
       class << self
         # Holds (gets or creates) the binding type metadata for this structure type.
@@ -4460,7 +4460,7 @@ module Com::Vmware::Vcenter::Vm::Hardware
           @binding_type ||= VAPI::Bindings::StructType.new(
             'com.vmware.vcenter.vm.hardware.parallel.backing_info',
             {
-              'type' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::VM::Hardware::Parallel::BackingType'),
+              'type' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::Vm::Hardware::Parallel::BackingType'),
               'file' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::StringType.instance),
               'host_device' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::StringType.instance),
               'auto_detect' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::BooleanType.instance)
@@ -4485,14 +4485,14 @@ module Com::Vmware::Vcenter::Vm::Hardware
       end
     end
 
-    # The  ``Com::Vmware::Vcenter::VM::Hardware::Parallel::BackingSpec``   class  provides a specification of the physical resource backing a virtual parallel port.
+    # The  ``Com::Vmware::Vcenter::Vm::Hardware::Parallel::BackingSpec``   class  provides a specification of the physical resource backing a virtual parallel port.
     # @!attribute [rw] type
-    #     @return [Com::Vmware::Vcenter::VM::Hardware::Parallel::BackingType]
+    #     @return [Com::Vmware::Vcenter::Vm::Hardware::Parallel::BackingType]
     #     Backing type for the virtual parallel port.
     # @!attribute [rw] file
     #     @return [String]
     #     Path of the file that should be used as the virtual parallel port backing.
-    #     This  field  is optional and it is only relevant when the value of  ``type``  is   :attr:`Com::Vmware::Vcenter::VM::Hardware::Parallel::BackingType.FILE`  .
+    #     This  field  is optional and it is only relevant when the value of  ``type``  is   :attr:`Com::Vmware::Vcenter::Vm::Hardware::Parallel::BackingType.FILE`  .
     # @!attribute [rw] host_device
     #     @return [String, nil]
     #     Name of the device that should be used as the virtual parallel port backing.
@@ -4506,7 +4506,7 @@ module Com::Vmware::Vcenter::Vm::Hardware
           @binding_type ||= VAPI::Bindings::StructType.new(
             'com.vmware.vcenter.vm.hardware.parallel.backing_spec',
             {
-              'type' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::VM::Hardware::Parallel::BackingType'),
+              'type' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::Vm::Hardware::Parallel::BackingType'),
               'file' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::StringType.instance),
               'host_device' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::StringType.instance)
             },
@@ -4529,12 +4529,12 @@ module Com::Vmware::Vcenter::Vm::Hardware
       end
     end
 
-    # The  ``Com::Vmware::Vcenter::VM::Hardware::Parallel::Info``   class  contains information about a virtual parallel port.
+    # The  ``Com::Vmware::Vcenter::Vm::Hardware::Parallel::Info``   class  contains information about a virtual parallel port.
     # @!attribute [rw] label
     #     @return [String]
     #     Device label.
     # @!attribute [rw] backing
-    #     @return [Com::Vmware::Vcenter::VM::Hardware::Parallel::BackingInfo]
+    #     @return [Com::Vmware::Vcenter::Vm::Hardware::Parallel::BackingInfo]
     #     Physical resource backing for the virtual parallel port.
     class Info < VAPI::Bindings::VapiStruct
       class << self
@@ -4546,8 +4546,8 @@ module Com::Vmware::Vcenter::Vm::Hardware
             'com.vmware.vcenter.vm.hardware.parallel.info',
             {
               'label' => VAPI::Bindings::StringType.instance,
-              'backing' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::VM::Hardware::Parallel::BackingInfo'),
-              'state' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::VM::Hardware::ConnectionState'),
+              'backing' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::Vm::Hardware::Parallel::BackingInfo'),
+              'state' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::Vm::Hardware::ConnectionState'),
               'start_connected' => VAPI::Bindings::BooleanType.instance,
               'allow_guest_control' => VAPI::Bindings::BooleanType.instance
             },
@@ -4572,9 +4572,9 @@ module Com::Vmware::Vcenter::Vm::Hardware
       end
     end
 
-    # The  ``Com::Vmware::Vcenter::VM::Hardware::Parallel::CreateSpec``   class  provides a specification for the configuration of a newly-created virtual parallel port.
+    # The  ``Com::Vmware::Vcenter::Vm::Hardware::Parallel::CreateSpec``   class  provides a specification for the configuration of a newly-created virtual parallel port.
     # @!attribute [rw] backing
-    #     @return [Com::Vmware::Vcenter::VM::Hardware::Parallel::BackingSpec, nil]
+    #     @return [Com::Vmware::Vcenter::Vm::Hardware::Parallel::BackingSpec, nil]
     #     Physical resource backing for the virtual parallel port.
     #     If  nil , defaults to automatic detection of a suitable host device.
     class CreateSpec < VAPI::Bindings::VapiStruct
@@ -4586,7 +4586,7 @@ module Com::Vmware::Vcenter::Vm::Hardware
           @binding_type ||= VAPI::Bindings::StructType.new(
             'com.vmware.vcenter.vm.hardware.parallel.create_spec',
             {
-              'backing' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::VM::Hardware::Parallel::BackingSpec')),
+              'backing' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::Vm::Hardware::Parallel::BackingSpec')),
               'start_connected' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::BooleanType.instance),
               'allow_guest_control' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::BooleanType.instance)
             },
@@ -4609,9 +4609,9 @@ module Com::Vmware::Vcenter::Vm::Hardware
       end
     end
 
-    # The  ``Com::Vmware::Vcenter::VM::Hardware::Parallel::UpdateSpec``   class  describes the updates to be made to the configuration of a virtual parallel port.
+    # The  ``Com::Vmware::Vcenter::Vm::Hardware::Parallel::UpdateSpec``   class  describes the updates to be made to the configuration of a virtual parallel port.
     # @!attribute [rw] backing
-    #     @return [Com::Vmware::Vcenter::VM::Hardware::Parallel::BackingSpec, nil]
+    #     @return [Com::Vmware::Vcenter::Vm::Hardware::Parallel::BackingSpec, nil]
     #     Physical resource backing for the virtual parallel port.  
     #     
     #      This  field  may only be modified if the virtual machine is not powered on or the virtual parallel port is not connected.
@@ -4625,7 +4625,7 @@ module Com::Vmware::Vcenter::Vm::Hardware
           @binding_type ||= VAPI::Bindings::StructType.new(
             'com.vmware.vcenter.vm.hardware.parallel.update_spec',
             {
-              'backing' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::VM::Hardware::Parallel::BackingSpec')),
+              'backing' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::Vm::Hardware::Parallel::BackingSpec')),
               'start_connected' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::BooleanType.instance),
               'allow_guest_control' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::BooleanType.instance)
             },
@@ -4648,7 +4648,7 @@ module Com::Vmware::Vcenter::Vm::Hardware
       end
     end
 
-    # The  ``Com::Vmware::Vcenter::VM::Hardware::Parallel::Summary``   class  contains commonly used information about a virtual parallel port.
+    # The  ``Com::Vmware::Vcenter::Vm::Hardware::Parallel::Summary``   class  contains commonly used information about a virtual parallel port.
     # @!attribute [rw] port
     #     @return [String]
     #     Identifier of the virtual parallel port.
@@ -4680,12 +4680,12 @@ module Com::Vmware::Vcenter::Vm::Hardware
       end
     end
 
-    # The  ``Com::Vmware::Vcenter::VM::Hardware::Parallel::BackingType``   enumerated type  defines the valid backing types for a virtual parallel port.
+    # The  ``Com::Vmware::Vcenter::Vm::Hardware::Parallel::BackingType``   enumerated type  defines the valid backing types for a virtual parallel port.
     # @!attribute [rw] file
-    #     @return [Com::Vmware::Vcenter::VM::Hardware::Parallel::BackingType]
+    #     @return [Com::Vmware::Vcenter::Vm::Hardware::Parallel::BackingType]
     #     Virtual parallel port is backed by a file.
     # @!attribute [rw] host_device
-    #     @return [Com::Vmware::Vcenter::VM::Hardware::Parallel::BackingType]
+    #     @return [Com::Vmware::Vcenter::Vm::Hardware::Parallel::BackingType]
     #     Virtual parallel port is backed by a device on the host where the virtual machine is running.
     class BackingType < VAPI::Bindings::VapiEnum
       class << self
@@ -4721,17 +4721,17 @@ module Com::Vmware::Vcenter::Vm::Hardware
       private_class_method :new
 
       # @!attribute [rw] file
-      #     @return [Com::Vmware::Vcenter::VM::Hardware::Parallel::BackingType]
+      #     @return [Com::Vmware::Vcenter::Vm::Hardware::Parallel::BackingType]
       #     Virtual parallel port is backed by a file.
       FILE = BackingType.send(:new, 'FILE')
 
       # @!attribute [rw] host_device
-      #     @return [Com::Vmware::Vcenter::VM::Hardware::Parallel::BackingType]
+      #     @return [Com::Vmware::Vcenter::Vm::Hardware::Parallel::BackingType]
       #     Virtual parallel port is backed by a device on the host where the virtual machine is running.
       HOST_DEVICE = BackingType.send(:new, 'HOST_DEVICE')
     end
   end
-  # The  ``Com::Vmware::Vcenter::VM::Hardware::Serial``   class  provides  methods  for configuring the virtual serial ports of a virtual machine.
+  # The  ``Com::Vmware::Vcenter::Vm::Hardware::Serial``   class  provides  methods  for configuring the virtual serial ports of a virtual machine.
   class Serial < VAPI::Bindings::VapiService
     # static metamodel definitions
     SERVICE_ID = VAPI::Core::ServiceIdentifier.new('com.vmware.vcenter.vm.hardware.serial')
@@ -4741,7 +4741,7 @@ module Com::Vmware::Vcenter::Vm::Hardware
       VAPI::Bindings::OperationInputType.new(
         'vm' => VAPI::Bindings::IdType.new('VirtualMachine')
       ),
-      VAPI::Bindings::ListType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::VM::Hardware::Serial::Summary')),
+      VAPI::Bindings::ListType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::Vm::Hardware::Serial::Summary')),
       {
         'com.vmware.vapi.std.errors.error' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Error'),
         'com.vmware.vapi.std.errors.not_found' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::NotFound'),
@@ -4760,7 +4760,7 @@ module Com::Vmware::Vcenter::Vm::Hardware
         'vm' => VAPI::Bindings::IdType.new('VirtualMachine'),
         'port' => VAPI::Bindings::IdType.new('com.vmware.vcenter.vm.hardware.SerialPort')
       ),
-      VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::VM::Hardware::Serial::Info'),
+      VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::Vm::Hardware::Serial::Info'),
       {
         'com.vmware.vapi.std.errors.error' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Error'),
         'com.vmware.vapi.std.errors.not_found' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::NotFound'),
@@ -4777,7 +4777,7 @@ module Com::Vmware::Vcenter::Vm::Hardware
       VAPI::Core::OperationIdentifier.new('create', SERVICE_ID),
       VAPI::Bindings::OperationInputType.new(
         'vm' => VAPI::Bindings::IdType.new('VirtualMachine'),
-        'spec' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::VM::Hardware::Serial::CreateSpec')
+        'spec' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::Vm::Hardware::Serial::CreateSpec')
       ),
       VAPI::Bindings::IdType.new('com.vmware.vcenter.vm.hardware.SerialPort'),
       {
@@ -4800,7 +4800,7 @@ module Com::Vmware::Vcenter::Vm::Hardware
       VAPI::Bindings::OperationInputType.new(
         'vm' => VAPI::Bindings::IdType.new('VirtualMachine'),
         'port' => VAPI::Bindings::IdType.new('com.vmware.vcenter.vm.hardware.SerialPort'),
-        'spec' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::VM::Hardware::Serial::UpdateSpec')
+        'spec' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::Vm::Hardware::Serial::UpdateSpec')
       ),
       VAPI::Bindings::VoidType.instance,
       {
@@ -4905,7 +4905,7 @@ module Com::Vmware::Vcenter::Vm::Hardware
     #
     # @param vm [String]
     #     Virtual machine identifier.
-    # @return [Array<Com::Vmware::Vcenter::VM::Hardware::Serial::Summary>]
+    # @return [Array<Com::Vmware::Vcenter::Vm::Hardware::Serial::Summary>]
     #     List of commonly used information about virtual serial ports.
     # @raise [Com::Vmware::Vapi::Std::Errors::Error]
     #     if the system reports an error while responding to the request.
@@ -4930,7 +4930,7 @@ module Com::Vmware::Vcenter::Vm::Hardware
     #     Virtual machine identifier.
     # @param port [String]
     #     Virtual serial port identifier.
-    # @return [Com::Vmware::Vcenter::VM::Hardware::Serial::Info]
+    # @return [Com::Vmware::Vcenter::Vm::Hardware::Serial::Info]
     #     Information about the specified virtual serial port.
     # @raise [Com::Vmware::Vapi::Std::Errors::Error]
     #     if the system reports an error while responding to the request.
@@ -4954,7 +4954,7 @@ module Com::Vmware::Vcenter::Vm::Hardware
     #
     # @param vm [String]
     #     Virtual machine identifier.
-    # @param spec [Com::Vmware::Vcenter::VM::Hardware::Serial::CreateSpec]
+    # @param spec [Com::Vmware::Vcenter::Vm::Hardware::Serial::CreateSpec]
     #     Specification for the new virtual serial port.
     # @return [String]
     #     Virtual serial port identifier.
@@ -4990,7 +4990,7 @@ module Com::Vmware::Vcenter::Vm::Hardware
     #     Virtual machine identifier.
     # @param port [String]
     #     Virtual serial port identifier.
-    # @param spec [Com::Vmware::Vcenter::VM::Hardware::Serial::UpdateSpec]
+    # @param spec [Com::Vmware::Vcenter::Vm::Hardware::Serial::UpdateSpec]
     #     Specification for updating the virtual serial port.
     # @return [Void]
     # @raise [Com::Vmware::Vapi::Std::Errors::Error]
@@ -5047,7 +5047,7 @@ module Com::Vmware::Vcenter::Vm::Hardware
 
     # Connects a virtual serial port of a powered-on virtual machine to its backing. Connecting the virtual device makes the backing accessible from the perspective of the guest operating system.  
     # 
-    #  For a powered-off virtual machine, the   :func:`Com::Vmware::Vcenter::VM::Hardware::Serial.update`    method  may be used to configure the virtual serial port to start in the connected state when the virtual machine is powered on.
+    #  For a powered-off virtual machine, the   :func:`Com::Vmware::Vcenter::Vm::Hardware::Serial.update`    method  may be used to configure the virtual serial port to start in the connected state when the virtual machine is powered on.
     #
     # @param vm [String]
     #     Virtual machine identifier.
@@ -5080,7 +5080,7 @@ module Com::Vmware::Vcenter::Vm::Hardware
 
     # Disconnects a virtual serial port of a powered-on virtual machine from its backing. The virtual device is still present and its backing configuration is unchanged, but from the perspective of the guest operating system, the serial port is not connected to its backing.  
     # 
-    #  For a powered-off virtual machine, the   :func:`Com::Vmware::Vcenter::VM::Hardware::Serial.update`    method  may be used to configure the virtual serial port to start in the disconnected state when the virtual machine is powered on.
+    #  For a powered-off virtual machine, the   :func:`Com::Vmware::Vcenter::Vm::Hardware::Serial.update`    method  may be used to configure the virtual serial port to start in the disconnected state when the virtual machine is powered on.
     #
     # @param vm [String]
     #     Virtual machine identifier.
@@ -5111,14 +5111,14 @@ module Com::Vmware::Vcenter::Vm::Hardware
                        'port' => port)
     end
 
-    # The  ``Com::Vmware::Vcenter::VM::Hardware::Serial::BackingInfo``   class  contains information about the physical resource backing a virtual serial port.
+    # The  ``Com::Vmware::Vcenter::Vm::Hardware::Serial::BackingInfo``   class  contains information about the physical resource backing a virtual serial port.
     # @!attribute [rw] type
-    #     @return [Com::Vmware::Vcenter::VM::Hardware::Serial::BackingType]
+    #     @return [Com::Vmware::Vcenter::Vm::Hardware::Serial::BackingType]
     #     Backing type for the virtual serial port.
     # @!attribute [rw] file
     #     @return [String]
     #     Path of the file backing the virtual serial port.
-    #     This  field  is optional and it is only relevant when the value of  ``type``  is   :attr:`Com::Vmware::Vcenter::VM::Hardware::Serial::BackingType.FILE`  .
+    #     This  field  is optional and it is only relevant when the value of  ``type``  is   :attr:`Com::Vmware::Vcenter::Vm::Hardware::Serial::BackingType.FILE`  .
     # @!attribute [rw] host_device
     #     @return [String, nil]
     #     Name of the device backing the virtual serial port.  
@@ -5126,23 +5126,23 @@ module Com::Vmware::Vcenter::Vm::Hardware
     # @!attribute [rw] auto_detect
     #     @return [Boolean]
     #     Flag indicating whether the virtual serial port is configured to automatically detect a suitable host device.
-    #     This  field  is optional and it is only relevant when the value of  ``type``  is   :attr:`Com::Vmware::Vcenter::VM::Hardware::Serial::BackingType.HOST_DEVICE`  .
+    #     This  field  is optional and it is only relevant when the value of  ``type``  is   :attr:`Com::Vmware::Vcenter::Vm::Hardware::Serial::BackingType.HOST_DEVICE`  .
     # @!attribute [rw] pipe
     #     @return [String]
     #     Name of the pipe backing the virtual serial port.
-    #     This  field  is optional and it is only relevant when the value of  ``type``  is one of   :attr:`Com::Vmware::Vcenter::VM::Hardware::Serial::BackingType.PIPE_SERVER`   or   :attr:`Com::Vmware::Vcenter::VM::Hardware::Serial::BackingType.PIPE_CLIENT`  .
+    #     This  field  is optional and it is only relevant when the value of  ``type``  is one of   :attr:`Com::Vmware::Vcenter::Vm::Hardware::Serial::BackingType.PIPE_SERVER`   or   :attr:`Com::Vmware::Vcenter::Vm::Hardware::Serial::BackingType.PIPE_CLIENT`  .
     # @!attribute [rw] no_rx_loss
     #     @return [Boolean]
     #     Flag that enables optimized data transfer over the pipe. When the value is true, the host buffers data to prevent data overrun. This allows the virtual machine to read all of the data transferred over the pipe with no data loss.
-    #     This  field  is optional and it is only relevant when the value of  ``type``  is one of   :attr:`Com::Vmware::Vcenter::VM::Hardware::Serial::BackingType.PIPE_SERVER`   or   :attr:`Com::Vmware::Vcenter::VM::Hardware::Serial::BackingType.PIPE_CLIENT`  .
+    #     This  field  is optional and it is only relevant when the value of  ``type``  is one of   :attr:`Com::Vmware::Vcenter::Vm::Hardware::Serial::BackingType.PIPE_SERVER`   or   :attr:`Com::Vmware::Vcenter::Vm::Hardware::Serial::BackingType.PIPE_CLIENT`  .
     # @!attribute [rw] network_location
     #     @return [URI]
     #     URI specifying the location of the network service backing the virtual serial port.  
     #     
-    #       * If   :attr:`Com::Vmware::Vcenter::VM::Hardware::Serial::BackingInfo.type`   is   :attr:`Com::Vmware::Vcenter::VM::Hardware::Serial::BackingType.NETWORK_SERVER`  , this  field  is the location used by clients to connect to this server. The hostname part of the URI should either be empty or should specify the address of the host on which the virtual machine is running.
-    #        * If   :attr:`Com::Vmware::Vcenter::VM::Hardware::Serial::BackingInfo.type`   is   :attr:`Com::Vmware::Vcenter::VM::Hardware::Serial::BackingType.NETWORK_CLIENT`  , this  field  is the location used by the virtual machine to connect to the remote server.
+    #       * If   :attr:`Com::Vmware::Vcenter::Vm::Hardware::Serial::BackingInfo.type`   is   :attr:`Com::Vmware::Vcenter::Vm::Hardware::Serial::BackingType.NETWORK_SERVER`  , this  field  is the location used by clients to connect to this server. The hostname part of the URI should either be empty or should specify the address of the host on which the virtual machine is running.
+    #        * If   :attr:`Com::Vmware::Vcenter::Vm::Hardware::Serial::BackingInfo.type`   is   :attr:`Com::Vmware::Vcenter::Vm::Hardware::Serial::BackingType.NETWORK_CLIENT`  , this  field  is the location used by the virtual machine to connect to the remote server.
     #       
-    #     This  field  is optional and it is only relevant when the value of  ``type``  is one of   :attr:`Com::Vmware::Vcenter::VM::Hardware::Serial::BackingType.NETWORK_SERVER`   or   :attr:`Com::Vmware::Vcenter::VM::Hardware::Serial::BackingType.NETWORK_CLIENT`  .
+    #     This  field  is optional and it is only relevant when the value of  ``type``  is one of   :attr:`Com::Vmware::Vcenter::Vm::Hardware::Serial::BackingType.NETWORK_SERVER`   or   :attr:`Com::Vmware::Vcenter::Vm::Hardware::Serial::BackingType.NETWORK_CLIENT`  .
     # @!attribute [rw] proxy
     #     @return [URI, nil]
     #     Proxy service that provides network access to the network backing. If set, the virtual machine initiates a connection with the proxy service and forwards the traffic to the proxy.
@@ -5156,7 +5156,7 @@ module Com::Vmware::Vcenter::Vm::Hardware
           @binding_type ||= VAPI::Bindings::StructType.new(
             'com.vmware.vcenter.vm.hardware.serial.backing_info',
             {
-              'type' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::VM::Hardware::Serial::BackingType'),
+              'type' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::Vm::Hardware::Serial::BackingType'),
               'file' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::StringType.instance),
               'host_device' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::StringType.instance),
               'auto_detect' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::BooleanType.instance),
@@ -5189,14 +5189,14 @@ module Com::Vmware::Vcenter::Vm::Hardware
       end
     end
 
-    # The  ``Com::Vmware::Vcenter::VM::Hardware::Serial::BackingSpec``   class  provides a specification of the physical resource backing a virtual serial port.
+    # The  ``Com::Vmware::Vcenter::Vm::Hardware::Serial::BackingSpec``   class  provides a specification of the physical resource backing a virtual serial port.
     # @!attribute [rw] type
-    #     @return [Com::Vmware::Vcenter::VM::Hardware::Serial::BackingType]
+    #     @return [Com::Vmware::Vcenter::Vm::Hardware::Serial::BackingType]
     #     Backing type for the virtual serial port.
     # @!attribute [rw] file
     #     @return [String]
     #     Path of the file backing the virtual serial port.
-    #     This  field  is optional and it is only relevant when the value of  ``type``  is   :attr:`Com::Vmware::Vcenter::VM::Hardware::Serial::BackingType.FILE`  .
+    #     This  field  is optional and it is only relevant when the value of  ``type``  is   :attr:`Com::Vmware::Vcenter::Vm::Hardware::Serial::BackingType.FILE`  .
     # @!attribute [rw] host_device
     #     @return [String, nil]
     #     Name of the device backing the virtual serial port.  
@@ -5204,7 +5204,7 @@ module Com::Vmware::Vcenter::Vm::Hardware
     # @!attribute [rw] pipe
     #     @return [String]
     #     Name of the pipe backing the virtual serial port.
-    #     This  field  is optional and it is only relevant when the value of  ``type``  is one of   :attr:`Com::Vmware::Vcenter::VM::Hardware::Serial::BackingType.PIPE_SERVER`   or   :attr:`Com::Vmware::Vcenter::VM::Hardware::Serial::BackingType.PIPE_CLIENT`  .
+    #     This  field  is optional and it is only relevant when the value of  ``type``  is one of   :attr:`Com::Vmware::Vcenter::Vm::Hardware::Serial::BackingType.PIPE_SERVER`   or   :attr:`Com::Vmware::Vcenter::Vm::Hardware::Serial::BackingType.PIPE_CLIENT`  .
     # @!attribute [rw] no_rx_loss
     #     @return [Boolean, nil]
     #     Flag that enables optimized data transfer over the pipe. When the value is true, the host buffers data to prevent data overrun. This allows the virtual machine to read all of the data transferred over the pipe with no data loss.
@@ -5213,10 +5213,10 @@ module Com::Vmware::Vcenter::Vm::Hardware
     #     @return [URI]
     #     URI specifying the location of the network service backing the virtual serial port.  
     #     
-    #       * If   :attr:`Com::Vmware::Vcenter::VM::Hardware::Serial::BackingSpec.type`   is   :attr:`Com::Vmware::Vcenter::VM::Hardware::Serial::BackingType.NETWORK_SERVER`  , this  field  is the location used by clients to connect to this server. The hostname part of the URI should either be empty or should specify the address of the host on which the virtual machine is running.
-    #        * If   :attr:`Com::Vmware::Vcenter::VM::Hardware::Serial::BackingSpec.type`   is   :attr:`Com::Vmware::Vcenter::VM::Hardware::Serial::BackingType.NETWORK_CLIENT`  , this  field  is the location used by the virtual machine to connect to the remote server.
+    #       * If   :attr:`Com::Vmware::Vcenter::Vm::Hardware::Serial::BackingSpec.type`   is   :attr:`Com::Vmware::Vcenter::Vm::Hardware::Serial::BackingType.NETWORK_SERVER`  , this  field  is the location used by clients to connect to this server. The hostname part of the URI should either be empty or should specify the address of the host on which the virtual machine is running.
+    #        * If   :attr:`Com::Vmware::Vcenter::Vm::Hardware::Serial::BackingSpec.type`   is   :attr:`Com::Vmware::Vcenter::Vm::Hardware::Serial::BackingType.NETWORK_CLIENT`  , this  field  is the location used by the virtual machine to connect to the remote server.
     #       
-    #     This  field  is optional and it is only relevant when the value of  ``type``  is one of   :attr:`Com::Vmware::Vcenter::VM::Hardware::Serial::BackingType.NETWORK_SERVER`   or   :attr:`Com::Vmware::Vcenter::VM::Hardware::Serial::BackingType.NETWORK_CLIENT`  .
+    #     This  field  is optional and it is only relevant when the value of  ``type``  is one of   :attr:`Com::Vmware::Vcenter::Vm::Hardware::Serial::BackingType.NETWORK_SERVER`   or   :attr:`Com::Vmware::Vcenter::Vm::Hardware::Serial::BackingType.NETWORK_CLIENT`  .
     # @!attribute [rw] proxy
     #     @return [URI, nil]
     #     Proxy service that provides network access to the network backing. If set, the virtual machine initiates a connection with the proxy service and forwards the traffic to the proxy.
@@ -5230,7 +5230,7 @@ module Com::Vmware::Vcenter::Vm::Hardware
           @binding_type ||= VAPI::Bindings::StructType.new(
             'com.vmware.vcenter.vm.hardware.serial.backing_spec',
             {
-              'type' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::VM::Hardware::Serial::BackingType'),
+              'type' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::Vm::Hardware::Serial::BackingType'),
               'file' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::StringType.instance),
               'host_device' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::StringType.instance),
               'pipe' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::StringType.instance),
@@ -5261,7 +5261,7 @@ module Com::Vmware::Vcenter::Vm::Hardware
       end
     end
 
-    # The  ``Com::Vmware::Vcenter::VM::Hardware::Serial::Info``   class  contains information about a virtual serial port.
+    # The  ``Com::Vmware::Vcenter::Vm::Hardware::Serial::Info``   class  contains information about a virtual serial port.
     # @!attribute [rw] label
     #     @return [String]
     #     Device label.
@@ -5269,7 +5269,7 @@ module Com::Vmware::Vcenter::Vm::Hardware
     #     @return [Boolean]
     #     CPU yield behavior. If set to true, the virtual machine will periodically relinquish the processor if its sole task is polling the virtual serial port. The amount of time it takes to regain the processor will depend on the degree of other virtual machine activity on the host.
     # @!attribute [rw] backing
-    #     @return [Com::Vmware::Vcenter::VM::Hardware::Serial::BackingInfo]
+    #     @return [Com::Vmware::Vcenter::Vm::Hardware::Serial::BackingInfo]
     #     Physical resource backing for the virtual serial port.
     class Info < VAPI::Bindings::VapiStruct
       class << self
@@ -5282,8 +5282,8 @@ module Com::Vmware::Vcenter::Vm::Hardware
             {
               'label' => VAPI::Bindings::StringType.instance,
               'yield_on_poll' => VAPI::Bindings::BooleanType.instance,
-              'backing' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::VM::Hardware::Serial::BackingInfo'),
-              'state' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::VM::Hardware::ConnectionState'),
+              'backing' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::Vm::Hardware::Serial::BackingInfo'),
+              'state' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::Vm::Hardware::ConnectionState'),
               'start_connected' => VAPI::Bindings::BooleanType.instance,
               'allow_guest_control' => VAPI::Bindings::BooleanType.instance
             },
@@ -5309,13 +5309,13 @@ module Com::Vmware::Vcenter::Vm::Hardware
       end
     end
 
-    # The  ``Com::Vmware::Vcenter::VM::Hardware::Serial::CreateSpec``   class  provides a specification for the configuration of a newly-created virtual serial port.
+    # The  ``Com::Vmware::Vcenter::Vm::Hardware::Serial::CreateSpec``   class  provides a specification for the configuration of a newly-created virtual serial port.
     # @!attribute [rw] yield_on_poll
     #     @return [Boolean, nil]
     #     CPU yield behavior. If set to true, the virtual machine will periodically relinquish the processor if its sole task is polling the virtual serial port. The amount of time it takes to regain the processor will depend on the degree of other virtual machine activity on the host.
     #     If  nil , defaults to false.
     # @!attribute [rw] backing
-    #     @return [Com::Vmware::Vcenter::VM::Hardware::Serial::BackingSpec, nil]
+    #     @return [Com::Vmware::Vcenter::Vm::Hardware::Serial::BackingSpec, nil]
     #     Physical resource backing for the virtual serial port.
     #     If  nil , defaults to automatic detection of a suitable host device.
     class CreateSpec < VAPI::Bindings::VapiStruct
@@ -5328,7 +5328,7 @@ module Com::Vmware::Vcenter::Vm::Hardware
             'com.vmware.vcenter.vm.hardware.serial.create_spec',
             {
               'yield_on_poll' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::BooleanType.instance),
-              'backing' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::VM::Hardware::Serial::BackingSpec')),
+              'backing' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::Vm::Hardware::Serial::BackingSpec')),
               'start_connected' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::BooleanType.instance),
               'allow_guest_control' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::BooleanType.instance)
             },
@@ -5352,7 +5352,7 @@ module Com::Vmware::Vcenter::Vm::Hardware
       end
     end
 
-    # The  ``Com::Vmware::Vcenter::VM::Hardware::Serial::UpdateSpec``   class  describes the updates to be made to the configuration of a virtual serial port.
+    # The  ``Com::Vmware::Vcenter::Vm::Hardware::Serial::UpdateSpec``   class  describes the updates to be made to the configuration of a virtual serial port.
     # @!attribute [rw] yield_on_poll
     #     @return [Boolean, nil]
     #     CPU yield behavior. If set to true, the virtual machine will periodically relinquish the processor if its sole task is polling the virtual serial port. The amount of time it takes to regain the processor will depend on the degree of other virtual machine activity on the host.  
@@ -5360,7 +5360,7 @@ module Com::Vmware::Vcenter::Vm::Hardware
     #      This  field  may be modified at any time, and changes applied to a connected virtual serial port take effect immediately.
     #     If  nil , the value is unchanged.
     # @!attribute [rw] backing
-    #     @return [Com::Vmware::Vcenter::VM::Hardware::Serial::BackingSpec, nil]
+    #     @return [Com::Vmware::Vcenter::Vm::Hardware::Serial::BackingSpec, nil]
     #     Physical resource backing for the virtual serial port.  
     #     
     #      This  field  may only be modified if the virtual machine is not powered on or the virtual serial port is not connected.
@@ -5375,7 +5375,7 @@ module Com::Vmware::Vcenter::Vm::Hardware
             'com.vmware.vcenter.vm.hardware.serial.update_spec',
             {
               'yield_on_poll' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::BooleanType.instance),
-              'backing' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::VM::Hardware::Serial::BackingSpec')),
+              'backing' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::Vm::Hardware::Serial::BackingSpec')),
               'start_connected' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::BooleanType.instance),
               'allow_guest_control' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::BooleanType.instance)
             },
@@ -5399,7 +5399,7 @@ module Com::Vmware::Vcenter::Vm::Hardware
       end
     end
 
-    # The  ``Com::Vmware::Vcenter::VM::Hardware::Serial::Summary``   class  contains commonly used information about a virtual serial port.
+    # The  ``Com::Vmware::Vcenter::Vm::Hardware::Serial::Summary``   class  contains commonly used information about a virtual serial port.
     # @!attribute [rw] port
     #     @return [String]
     #     Identifier of the virtual serial port.
@@ -5431,24 +5431,24 @@ module Com::Vmware::Vcenter::Vm::Hardware
       end
     end
 
-    # The  ``Com::Vmware::Vcenter::VM::Hardware::Serial::BackingType``   enumerated type  defines the valid backing types for a virtual serial port.
+    # The  ``Com::Vmware::Vcenter::Vm::Hardware::Serial::BackingType``   enumerated type  defines the valid backing types for a virtual serial port.
     # @!attribute [rw] file
-    #     @return [Com::Vmware::Vcenter::VM::Hardware::Serial::BackingType]
+    #     @return [Com::Vmware::Vcenter::Vm::Hardware::Serial::BackingType]
     #     Virtual serial port is backed by a file.
     # @!attribute [rw] host_device
-    #     @return [Com::Vmware::Vcenter::VM::Hardware::Serial::BackingType]
+    #     @return [Com::Vmware::Vcenter::Vm::Hardware::Serial::BackingType]
     #     Virtual serial port is backed by a device on the host where the virtual machine is running.
     # @!attribute [rw] pipe_server
-    #     @return [Com::Vmware::Vcenter::VM::Hardware::Serial::BackingType]
+    #     @return [Com::Vmware::Vcenter::Vm::Hardware::Serial::BackingType]
     #     Virtual serial port is backed by a named pipe server. The virtual machine will accept a connection from a host application or another virtual machine on the same host. This is useful for capturing debugging information sent through the virtual serial port.
     # @!attribute [rw] pipe_client
-    #     @return [Com::Vmware::Vcenter::VM::Hardware::Serial::BackingType]
+    #     @return [Com::Vmware::Vcenter::Vm::Hardware::Serial::BackingType]
     #     Virtual serial port is backed by a named pipe client. The virtual machine will connect to the named pipe provided by a host application or another virtual machine on the same host. This is useful for capturing debugging information sent through the virtual serial port.
     # @!attribute [rw] network_server
-    #     @return [Com::Vmware::Vcenter::VM::Hardware::Serial::BackingType]
+    #     @return [Com::Vmware::Vcenter::Vm::Hardware::Serial::BackingType]
     #     Virtual serial port is backed by a network server. This backing may be used to create a network-accessible serial port on the virtual machine, accepting a connection from a remote system.
     # @!attribute [rw] network_client
-    #     @return [Com::Vmware::Vcenter::VM::Hardware::Serial::BackingType]
+    #     @return [Com::Vmware::Vcenter::Vm::Hardware::Serial::BackingType]
     #     Virtual serial port is backed by a network client. This backing may be used to create a network-accessible serial port on the virtual machine, initiating a connection to a remote system.
     class BackingType < VAPI::Bindings::VapiEnum
       class << self
@@ -5484,37 +5484,37 @@ module Com::Vmware::Vcenter::Vm::Hardware
       private_class_method :new
 
       # @!attribute [rw] file
-      #     @return [Com::Vmware::Vcenter::VM::Hardware::Serial::BackingType]
+      #     @return [Com::Vmware::Vcenter::Vm::Hardware::Serial::BackingType]
       #     Virtual serial port is backed by a file.
       FILE = BackingType.send(:new, 'FILE')
 
       # @!attribute [rw] host_device
-      #     @return [Com::Vmware::Vcenter::VM::Hardware::Serial::BackingType]
+      #     @return [Com::Vmware::Vcenter::Vm::Hardware::Serial::BackingType]
       #     Virtual serial port is backed by a device on the host where the virtual machine is running.
       HOST_DEVICE = BackingType.send(:new, 'HOST_DEVICE')
 
       # @!attribute [rw] pipe_server
-      #     @return [Com::Vmware::Vcenter::VM::Hardware::Serial::BackingType]
+      #     @return [Com::Vmware::Vcenter::Vm::Hardware::Serial::BackingType]
       #     Virtual serial port is backed by a named pipe server. The virtual machine will accept a connection from a host application or another virtual machine on the same host. This is useful for capturing debugging information sent through the virtual serial port.
       PIPE_SERVER = BackingType.send(:new, 'PIPE_SERVER')
 
       # @!attribute [rw] pipe_client
-      #     @return [Com::Vmware::Vcenter::VM::Hardware::Serial::BackingType]
+      #     @return [Com::Vmware::Vcenter::Vm::Hardware::Serial::BackingType]
       #     Virtual serial port is backed by a named pipe client. The virtual machine will connect to the named pipe provided by a host application or another virtual machine on the same host. This is useful for capturing debugging information sent through the virtual serial port.
       PIPE_CLIENT = BackingType.send(:new, 'PIPE_CLIENT')
 
       # @!attribute [rw] network_server
-      #     @return [Com::Vmware::Vcenter::VM::Hardware::Serial::BackingType]
+      #     @return [Com::Vmware::Vcenter::Vm::Hardware::Serial::BackingType]
       #     Virtual serial port is backed by a network server. This backing may be used to create a network-accessible serial port on the virtual machine, accepting a connection from a remote system.
       NETWORK_SERVER = BackingType.send(:new, 'NETWORK_SERVER')
 
       # @!attribute [rw] network_client
-      #     @return [Com::Vmware::Vcenter::VM::Hardware::Serial::BackingType]
+      #     @return [Com::Vmware::Vcenter::Vm::Hardware::Serial::BackingType]
       #     Virtual serial port is backed by a network client. This backing may be used to create a network-accessible serial port on the virtual machine, initiating a connection to a remote system.
       NETWORK_CLIENT = BackingType.send(:new, 'NETWORK_CLIENT')
     end
   end
-  # The  ``Com::Vmware::Vcenter::VM::Hardware::IdeAddressInfo``   class  contains information about the address of a virtual device that is attached to a virtual IDE adapter of a virtual machine.
+  # The  ``Com::Vmware::Vcenter::Vm::Hardware::IdeAddressInfo``   class  contains information about the address of a virtual device that is attached to a virtual IDE adapter of a virtual machine.
   # @!attribute [rw] primary
   #     @return [Boolean]
   #     Flag specifying whether the device is attached to the primary or secondary IDE adapter of the virtual machine.
@@ -5550,7 +5550,7 @@ module Com::Vmware::Vcenter::Vm::Hardware
       super(self.class.binding_type, ruby_values, struct_value)
     end
   end
-  # The  ``Com::Vmware::Vcenter::VM::Hardware::ScsiAddressInfo``   class  contains information about the address of a virtual device that is attached to a virtual SCSI adapter of a virtual machine.
+  # The  ``Com::Vmware::Vcenter::Vm::Hardware::ScsiAddressInfo``   class  contains information about the address of a virtual device that is attached to a virtual SCSI adapter of a virtual machine.
   # @!attribute [rw] bus
   #     @return [Fixnum]
   #     Bus number of the adapter to which the device is attached.
@@ -5586,7 +5586,7 @@ module Com::Vmware::Vcenter::Vm::Hardware
       super(self.class.binding_type, ruby_values, struct_value)
     end
   end
-  # The  ``Com::Vmware::Vcenter::VM::Hardware::SataAddressInfo``   class  contains information about the address of a virtual device that is attached to a virtual SATA adapter of a virtual machine.
+  # The  ``Com::Vmware::Vcenter::Vm::Hardware::SataAddressInfo``   class  contains information about the address of a virtual device that is attached to a virtual SATA adapter of a virtual machine.
   # @!attribute [rw] bus
   #     @return [Fixnum]
   #     Bus number of the adapter to which the device is attached.
@@ -5622,7 +5622,7 @@ module Com::Vmware::Vcenter::Vm::Hardware
       super(self.class.binding_type, ruby_values, struct_value)
     end
   end
-  # The  ``Com::Vmware::Vcenter::VM::Hardware::IdeAddressSpec``   class  contains information for specifying the address of a virtual device that is attached to a virtual IDE adapter of a virtual machine.
+  # The  ``Com::Vmware::Vcenter::Vm::Hardware::IdeAddressSpec``   class  contains information for specifying the address of a virtual device that is attached to a virtual IDE adapter of a virtual machine.
   # @!attribute [rw] primary
   #     @return [Boolean, nil]
   #     Flag specifying whether the device should be attached to the primary or secondary IDE adapter of the virtual machine.
@@ -5660,7 +5660,7 @@ module Com::Vmware::Vcenter::Vm::Hardware
       super(self.class.binding_type, ruby_values, struct_value)
     end
   end
-  # The  ``Com::Vmware::Vcenter::VM::Hardware::ScsiAddressSpec``   class  contains information for specifying the address of a virtual device that is attached to a virtual SCSI adapter of a virtual machine.
+  # The  ``Com::Vmware::Vcenter::Vm::Hardware::ScsiAddressSpec``   class  contains information for specifying the address of a virtual device that is attached to a virtual SCSI adapter of a virtual machine.
   # @!attribute [rw] bus
   #     @return [Fixnum]
   #     Bus number of the adapter to which the device should be attached.
@@ -5697,7 +5697,7 @@ module Com::Vmware::Vcenter::Vm::Hardware
       super(self.class.binding_type, ruby_values, struct_value)
     end
   end
-  # The  ``Com::Vmware::Vcenter::VM::Hardware::SataAddressSpec``   class  contains information for specifying the address of a virtual device that is attached to a virtual SATA adapter of a virtual machine.
+  # The  ``Com::Vmware::Vcenter::Vm::Hardware::SataAddressSpec``   class  contains information for specifying the address of a virtual device that is attached to a virtual SATA adapter of a virtual machine.
   # @!attribute [rw] bus
   #     @return [Fixnum]
   #     Bus number of the adapter to which the device should be attached.
@@ -5734,9 +5734,9 @@ module Com::Vmware::Vcenter::Vm::Hardware
       super(self.class.binding_type, ruby_values, struct_value)
     end
   end
-  # The  ``Com::Vmware::Vcenter::VM::Hardware::ConnectionInfo``   class  provides information about the state and configuration of a removable virtual device.
+  # The  ``Com::Vmware::Vcenter::Vm::Hardware::ConnectionInfo``   class  provides information about the state and configuration of a removable virtual device.
   # @!attribute [rw] state
-  #     @return [Com::Vmware::Vcenter::VM::Hardware::ConnectionState]
+  #     @return [Com::Vmware::Vcenter::Vm::Hardware::ConnectionState]
   #     Connection status of the virtual device.
   # @!attribute [rw] start_connected
   #     @return [Boolean]
@@ -5753,7 +5753,7 @@ module Com::Vmware::Vcenter::Vm::Hardware
         @binding_type ||= VAPI::Bindings::StructType.new(
           'com.vmware.vcenter.vm.hardware.connection_info',
           {
-            'state' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::VM::Hardware::ConnectionState'),
+            'state' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::Vm::Hardware::ConnectionState'),
             'start_connected' => VAPI::Bindings::BooleanType.instance,
             'allow_guest_control' => VAPI::Bindings::BooleanType.instance
           },
@@ -5775,7 +5775,7 @@ module Com::Vmware::Vcenter::Vm::Hardware
       super(self.class.binding_type, ruby_values, struct_value)
     end
   end
-  # The  ``Com::Vmware::Vcenter::VM::Hardware::ConnectionCreateSpec``   class  provides a specification for the configuration of a newly-created removable device.
+  # The  ``Com::Vmware::Vcenter::Vm::Hardware::ConnectionCreateSpec``   class  provides a specification for the configuration of a newly-created removable device.
   # @!attribute [rw] start_connected
   #     @return [Boolean, nil]
   #     Flag indicating whether the virtual device should be connected whenever the virtual machine is powered on.
@@ -5813,7 +5813,7 @@ module Com::Vmware::Vcenter::Vm::Hardware
       super(self.class.binding_type, ruby_values, struct_value)
     end
   end
-  # The  ``Com::Vmware::Vcenter::VM::Hardware::ConnectionUpdateSpec``   class  describes the updates to be made to the configuration of a removable virtual device.
+  # The  ``Com::Vmware::Vcenter::Vm::Hardware::ConnectionUpdateSpec``   class  describes the updates to be made to the configuration of a removable virtual device.
   # @!attribute [rw] start_connected
   #     @return [Boolean, nil]
   #     Flag indicating whether the virtual device should be connected whenever the virtual machine is powered on.
@@ -5851,21 +5851,21 @@ module Com::Vmware::Vcenter::Vm::Hardware
       super(self.class.binding_type, ruby_values, struct_value)
     end
   end
-  # The  ``Com::Vmware::Vcenter::VM::Hardware::ConnectionState``   enumerated type  defines the valid states for a removable device that is configured to be connected.
+  # The  ``Com::Vmware::Vcenter::Vm::Hardware::ConnectionState``   enumerated type  defines the valid states for a removable device that is configured to be connected.
   # @!attribute [rw] connected
-  #     @return [Com::Vmware::Vcenter::VM::Hardware::ConnectionState]
+  #     @return [Com::Vmware::Vcenter::Vm::Hardware::ConnectionState]
   #     The device is connected and working correctly.
   # @!attribute [rw] recoverable_error
-  #     @return [Com::Vmware::Vcenter::VM::Hardware::ConnectionState]
+  #     @return [Com::Vmware::Vcenter::Vm::Hardware::ConnectionState]
   #     Device connection failed due to a recoverable error; for example, the virtual device backing is currently in use by another virtual machine.
   # @!attribute [rw] unrecoverable_error
-  #     @return [Com::Vmware::Vcenter::VM::Hardware::ConnectionState]
+  #     @return [Com::Vmware::Vcenter::Vm::Hardware::ConnectionState]
   #     Device connection failed due to an unrecoverable error; for example, the virtual device backing does not exist.
   # @!attribute [rw] not_connected
-  #     @return [Com::Vmware::Vcenter::VM::Hardware::ConnectionState]
+  #     @return [Com::Vmware::Vcenter::Vm::Hardware::ConnectionState]
   #     The device is not connected.
   # @!attribute [rw] unknown
-  #     @return [Com::Vmware::Vcenter::VM::Hardware::ConnectionState]
+  #     @return [Com::Vmware::Vcenter::Vm::Hardware::ConnectionState]
   #     The device status is unknown.
   class ConnectionState < VAPI::Bindings::VapiEnum
     class << self
@@ -5901,27 +5901,27 @@ module Com::Vmware::Vcenter::Vm::Hardware
     private_class_method :new
 
     # @!attribute [rw] connected
-    #     @return [Com::Vmware::Vcenter::VM::Hardware::ConnectionState]
+    #     @return [Com::Vmware::Vcenter::Vm::Hardware::ConnectionState]
     #     The device is connected and working correctly.
     CONNECTED = ConnectionState.send(:new, 'CONNECTED')
 
     # @!attribute [rw] recoverable_error
-    #     @return [Com::Vmware::Vcenter::VM::Hardware::ConnectionState]
+    #     @return [Com::Vmware::Vcenter::Vm::Hardware::ConnectionState]
     #     Device connection failed due to a recoverable error; for example, the virtual device backing is currently in use by another virtual machine.
     RECOVERABLE_ERROR = ConnectionState.send(:new, 'RECOVERABLE_ERROR')
 
     # @!attribute [rw] unrecoverable_error
-    #     @return [Com::Vmware::Vcenter::VM::Hardware::ConnectionState]
+    #     @return [Com::Vmware::Vcenter::Vm::Hardware::ConnectionState]
     #     Device connection failed due to an unrecoverable error; for example, the virtual device backing does not exist.
     UNRECOVERABLE_ERROR = ConnectionState.send(:new, 'UNRECOVERABLE_ERROR')
 
     # @!attribute [rw] not_connected
-    #     @return [Com::Vmware::Vcenter::VM::Hardware::ConnectionState]
+    #     @return [Com::Vmware::Vcenter::Vm::Hardware::ConnectionState]
     #     The device is not connected.
     NOT_CONNECTED = ConnectionState.send(:new, 'NOT_CONNECTED')
 
     # @!attribute [rw] unknown
-    #     @return [Com::Vmware::Vcenter::VM::Hardware::ConnectionState]
+    #     @return [Com::Vmware::Vcenter::Vm::Hardware::ConnectionState]
     #     The device status is unknown.
     UNKNOWN = ConnectionState.send(:new, 'UNKNOWN')
   end

--- a/client/sdk/com/vmware/vcenter/vm/hardware/adapter.rb
+++ b/client/sdk/com/vmware/vcenter/vm/hardware/adapter.rb
@@ -25,7 +25,7 @@ end
 # 
 #  Note that  classs  for adapters with no configurable properties or runtime state, such as IDE and PCI adapters, are omitted.
 module Com::Vmware::Vcenter::Vm::Hardware::Adapter
-  # The  ``Com::Vmware::Vcenter::VM::Hardware::Adapter::Sata``   class  provides  methods  for configuring the virtual SATA adapters of a virtual machine.
+  # The  ``Com::Vmware::Vcenter::Vm::Hardware::Adapter::Sata``   class  provides  methods  for configuring the virtual SATA adapters of a virtual machine.
   class Sata < VAPI::Bindings::VapiService
     # static metamodel definitions
     SERVICE_ID = VAPI::Core::ServiceIdentifier.new('com.vmware.vcenter.vm.hardware.adapter.sata')
@@ -35,7 +35,7 @@ module Com::Vmware::Vcenter::Vm::Hardware::Adapter
       VAPI::Bindings::OperationInputType.new(
         'vm' => VAPI::Bindings::IdType.new('VirtualMachine')
       ),
-      VAPI::Bindings::ListType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::VM::Hardware::Adapter::Sata::Summary')),
+      VAPI::Bindings::ListType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::Vm::Hardware::Adapter::Sata::Summary')),
       {
         'com.vmware.vapi.std.errors.error' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Error'),
         'com.vmware.vapi.std.errors.not_found' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::NotFound'),
@@ -54,7 +54,7 @@ module Com::Vmware::Vcenter::Vm::Hardware::Adapter
         'vm' => VAPI::Bindings::IdType.new('VirtualMachine'),
         'adapter' => VAPI::Bindings::IdType.new('com.vmware.vcenter.vm.hardware.SataAdapter')
       ),
-      VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::VM::Hardware::Adapter::Sata::Info'),
+      VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::Vm::Hardware::Adapter::Sata::Info'),
       {
         'com.vmware.vapi.std.errors.error' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Error'),
         'com.vmware.vapi.std.errors.not_found' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::NotFound'),
@@ -71,7 +71,7 @@ module Com::Vmware::Vcenter::Vm::Hardware::Adapter
       VAPI::Core::OperationIdentifier.new('create', SERVICE_ID),
       VAPI::Bindings::OperationInputType.new(
         'vm' => VAPI::Bindings::IdType.new('VirtualMachine'),
-        'spec' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::VM::Hardware::Adapter::Sata::CreateSpec')
+        'spec' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::Vm::Hardware::Adapter::Sata::CreateSpec')
       ),
       VAPI::Bindings::IdType.new('com.vmware.vcenter.vm.hardware.SataAdapter'),
       {
@@ -133,7 +133,7 @@ module Com::Vmware::Vcenter::Vm::Hardware::Adapter
     #
     # @param vm [String]
     #     Virtual machine identifier.
-    # @return [Array<Com::Vmware::Vcenter::VM::Hardware::Adapter::Sata::Summary>]
+    # @return [Array<Com::Vmware::Vcenter::Vm::Hardware::Adapter::Sata::Summary>]
     #     List of commonly used information about virtual SATA adapters.
     # @raise [Com::Vmware::Vapi::Std::Errors::Error]
     #     if the system reports an error while responding to the request.
@@ -158,7 +158,7 @@ module Com::Vmware::Vcenter::Vm::Hardware::Adapter
     #     Virtual machine identifier.
     # @param adapter [String]
     #     Virtual SATA adapter identifier.
-    # @return [Com::Vmware::Vcenter::VM::Hardware::Adapter::Sata::Info]
+    # @return [Com::Vmware::Vcenter::Vm::Hardware::Adapter::Sata::Info]
     #     Information about the specified virtual SATA adapter.
     # @raise [Com::Vmware::Vapi::Std::Errors::Error]
     #     if the system reports an error while responding to the request.
@@ -182,7 +182,7 @@ module Com::Vmware::Vcenter::Vm::Hardware::Adapter
     #
     # @param vm [String]
     #     Virtual machine identifier.
-    # @param spec [Com::Vmware::Vcenter::VM::Hardware::Adapter::Sata::CreateSpec]
+    # @param spec [Com::Vmware::Vcenter::Vm::Hardware::Adapter::Sata::CreateSpec]
     #     Specification for the new virtual SATA adapter.
     # @return [String]
     #     Virtual SATA adapter identifier.
@@ -247,12 +247,12 @@ module Com::Vmware::Vcenter::Vm::Hardware::Adapter
                        'adapter' => adapter)
     end
 
-    # The  ``Com::Vmware::Vcenter::VM::Hardware::Adapter::Sata::Info``   class  contains information about a virtual SATA adapter.
+    # The  ``Com::Vmware::Vcenter::Vm::Hardware::Adapter::Sata::Info``   class  contains information about a virtual SATA adapter.
     # @!attribute [rw] label
     #     @return [String]
     #     Device label.
     # @!attribute [rw] type
-    #     @return [Com::Vmware::Vcenter::VM::Hardware::Adapter::Sata::Type]
+    #     @return [Com::Vmware::Vcenter::Vm::Hardware::Adapter::Sata::Type]
     #     Adapter type.
     # @!attribute [rw] bus
     #     @return [Fixnum]
@@ -271,7 +271,7 @@ module Com::Vmware::Vcenter::Vm::Hardware::Adapter
             'com.vmware.vcenter.vm.hardware.adapter.sata.info',
             {
               'label' => VAPI::Bindings::StringType.instance,
-              'type' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::VM::Hardware::Adapter::Sata::Type'),
+              'type' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::Vm::Hardware::Adapter::Sata::Type'),
               'bus' => VAPI::Bindings::IntegerType.instance,
               'pci_slot_number' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::IntegerType.instance)
             },
@@ -295,9 +295,9 @@ module Com::Vmware::Vcenter::Vm::Hardware::Adapter
       end
     end
 
-    # The  ``Com::Vmware::Vcenter::VM::Hardware::Adapter::Sata::CreateSpec``   class  provides a specification for the configuration of a newly-created virtual SATA adapter.
+    # The  ``Com::Vmware::Vcenter::Vm::Hardware::Adapter::Sata::CreateSpec``   class  provides a specification for the configuration of a newly-created virtual SATA adapter.
     # @!attribute [rw] type
-    #     @return [Com::Vmware::Vcenter::VM::Hardware::Adapter::Sata::Type, nil]
+    #     @return [Com::Vmware::Vcenter::Vm::Hardware::Adapter::Sata::Type, nil]
     #     Adapter type.
     #     If  nil , a guest-specific default value will be used.
     # @!attribute [rw] bus
@@ -317,7 +317,7 @@ module Com::Vmware::Vcenter::Vm::Hardware::Adapter
           @binding_type ||= VAPI::Bindings::StructType.new(
             'com.vmware.vcenter.vm.hardware.adapter.sata.create_spec',
             {
-              'type' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::VM::Hardware::Adapter::Sata::Type')),
+              'type' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::Vm::Hardware::Adapter::Sata::Type')),
               'bus' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::IntegerType.instance),
               'pci_slot_number' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::IntegerType.instance)
             },
@@ -340,7 +340,7 @@ module Com::Vmware::Vcenter::Vm::Hardware::Adapter
       end
     end
 
-    # The  ``Com::Vmware::Vcenter::VM::Hardware::Adapter::Sata::Summary``   class  contains commonly used information about a Virtual SATA adapter.
+    # The  ``Com::Vmware::Vcenter::Vm::Hardware::Adapter::Sata::Summary``   class  contains commonly used information about a Virtual SATA adapter.
     # @!attribute [rw] adapter
     #     @return [String]
     #     Identifier of the virtual SATA adapter.
@@ -372,9 +372,9 @@ module Com::Vmware::Vcenter::Vm::Hardware::Adapter
       end
     end
 
-    # The  ``Com::Vmware::Vcenter::VM::Hardware::Adapter::Sata::Type``   enumerated type  defines the valid emulation types for a virtual SATA adapter.
+    # The  ``Com::Vmware::Vcenter::Vm::Hardware::Adapter::Sata::Type``   enumerated type  defines the valid emulation types for a virtual SATA adapter.
     # @!attribute [rw] ahci
-    #     @return [Com::Vmware::Vcenter::VM::Hardware::Adapter::Sata::Type]
+    #     @return [Com::Vmware::Vcenter::Vm::Hardware::Adapter::Sata::Type]
     #     AHCI host bus adapter.
     class Type < VAPI::Bindings::VapiEnum
       class << self
@@ -410,12 +410,12 @@ module Com::Vmware::Vcenter::Vm::Hardware::Adapter
       private_class_method :new
 
       # @!attribute [rw] ahci
-      #     @return [Com::Vmware::Vcenter::VM::Hardware::Adapter::Sata::Type]
+      #     @return [Com::Vmware::Vcenter::Vm::Hardware::Adapter::Sata::Type]
       #     AHCI host bus adapter.
       AHCI = Type.send(:new, 'AHCI')
     end
   end
-  # The  ``Com::Vmware::Vcenter::VM::Hardware::Adapter::Scsi``   class  provides  methods  for configuring the virtual SCSI adapters of a virtual machine.
+  # The  ``Com::Vmware::Vcenter::Vm::Hardware::Adapter::Scsi``   class  provides  methods  for configuring the virtual SCSI adapters of a virtual machine.
   class Scsi < VAPI::Bindings::VapiService
     # static metamodel definitions
     SERVICE_ID = VAPI::Core::ServiceIdentifier.new('com.vmware.vcenter.vm.hardware.adapter.scsi')
@@ -425,7 +425,7 @@ module Com::Vmware::Vcenter::Vm::Hardware::Adapter
       VAPI::Bindings::OperationInputType.new(
         'vm' => VAPI::Bindings::IdType.new('VirtualMachine')
       ),
-      VAPI::Bindings::ListType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::VM::Hardware::Adapter::Scsi::Summary')),
+      VAPI::Bindings::ListType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::Vm::Hardware::Adapter::Scsi::Summary')),
       {
         'com.vmware.vapi.std.errors.error' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Error'),
         'com.vmware.vapi.std.errors.not_found' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::NotFound'),
@@ -444,7 +444,7 @@ module Com::Vmware::Vcenter::Vm::Hardware::Adapter
         'vm' => VAPI::Bindings::IdType.new('VirtualMachine'),
         'adapter' => VAPI::Bindings::IdType.new('com.vmware.vcenter.vm.hardware.ScsiAdapter')
       ),
-      VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::VM::Hardware::Adapter::Scsi::Info'),
+      VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::Vm::Hardware::Adapter::Scsi::Info'),
       {
         'com.vmware.vapi.std.errors.error' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Error'),
         'com.vmware.vapi.std.errors.not_found' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::NotFound'),
@@ -461,7 +461,7 @@ module Com::Vmware::Vcenter::Vm::Hardware::Adapter
       VAPI::Core::OperationIdentifier.new('create', SERVICE_ID),
       VAPI::Bindings::OperationInputType.new(
         'vm' => VAPI::Bindings::IdType.new('VirtualMachine'),
-        'spec' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::VM::Hardware::Adapter::Scsi::CreateSpec')
+        'spec' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::Vm::Hardware::Adapter::Scsi::CreateSpec')
       ),
       VAPI::Bindings::IdType.new('com.vmware.vcenter.vm.hardware.ScsiAdapter'),
       {
@@ -487,7 +487,7 @@ module Com::Vmware::Vcenter::Vm::Hardware::Adapter
       VAPI::Bindings::OperationInputType.new(
         'vm' => VAPI::Bindings::IdType.new('VirtualMachine'),
         'adapter' => VAPI::Bindings::IdType.new('com.vmware.vcenter.vm.hardware.ScsiAdapter'),
-        'spec' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::VM::Hardware::Adapter::Scsi::UpdateSpec')
+        'spec' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::Vm::Hardware::Adapter::Scsi::UpdateSpec')
       ),
       VAPI::Bindings::VoidType.instance,
       {
@@ -546,7 +546,7 @@ module Com::Vmware::Vcenter::Vm::Hardware::Adapter
     #
     # @param vm [String]
     #     Virtual machine identifier.
-    # @return [Array<Com::Vmware::Vcenter::VM::Hardware::Adapter::Scsi::Summary>]
+    # @return [Array<Com::Vmware::Vcenter::Vm::Hardware::Adapter::Scsi::Summary>]
     #     List of commonly used information about virtual SCSI adapters.
     # @raise [Com::Vmware::Vapi::Std::Errors::Error]
     #     if the system reports an error while responding to the request.
@@ -571,7 +571,7 @@ module Com::Vmware::Vcenter::Vm::Hardware::Adapter
     #     Virtual machine identifier.
     # @param adapter [String]
     #     Virtual SCSI adapter identifier.
-    # @return [Com::Vmware::Vcenter::VM::Hardware::Adapter::Scsi::Info]
+    # @return [Com::Vmware::Vcenter::Vm::Hardware::Adapter::Scsi::Info]
     #     Information about the specified virtual SCSI adapter.
     # @raise [Com::Vmware::Vapi::Std::Errors::Error]
     #     if the system reports an error while responding to the request.
@@ -595,7 +595,7 @@ module Com::Vmware::Vcenter::Vm::Hardware::Adapter
     #
     # @param vm [String]
     #     Virtual machine identifier.
-    # @param spec [Com::Vmware::Vcenter::VM::Hardware::Adapter::Scsi::CreateSpec]
+    # @param spec [Com::Vmware::Vcenter::Vm::Hardware::Adapter::Scsi::CreateSpec]
     #     Specification for the new virtual SCSI adapter.
     # @return [String]
     #     Virtual SCSI adapter identifier.
@@ -637,7 +637,7 @@ module Com::Vmware::Vcenter::Vm::Hardware::Adapter
     #     Virtual machine identifier.
     # @param adapter [String]
     #     Virtual SCSI adapter identifier.
-    # @param spec [Com::Vmware::Vcenter::VM::Hardware::Adapter::Scsi::UpdateSpec]
+    # @param spec [Com::Vmware::Vcenter::Vm::Hardware::Adapter::Scsi::UpdateSpec]
     #     Specification for updating the virtual SCSI adapter.
     # @return [Void]
     # @raise [Com::Vmware::Vapi::Std::Errors::Error]
@@ -692,22 +692,22 @@ module Com::Vmware::Vcenter::Vm::Hardware::Adapter
                        'adapter' => adapter)
     end
 
-    # The  ``Com::Vmware::Vcenter::VM::Hardware::Adapter::Scsi::Info``   class  contains information about a virtual SCSI adapter.
+    # The  ``Com::Vmware::Vcenter::Vm::Hardware::Adapter::Scsi::Info``   class  contains information about a virtual SCSI adapter.
     # @!attribute [rw] label
     #     @return [String]
     #     Device label.
     # @!attribute [rw] type
-    #     @return [Com::Vmware::Vcenter::VM::Hardware::Adapter::Scsi::Type]
+    #     @return [Com::Vmware::Vcenter::Vm::Hardware::Adapter::Scsi::Type]
     #     Adapter type.
     # @!attribute [rw] scsi
-    #     @return [Com::Vmware::Vcenter::VM::Hardware::ScsiAddressInfo]
+    #     @return [Com::Vmware::Vcenter::Vm::Hardware::ScsiAddressInfo]
     #     Address of the SCSI adapter on the SCSI bus.
     # @!attribute [rw] pci_slot_number
     #     @return [Fixnum, nil]
     #     Address of the SCSI adapter on the PCI bus. If the PCI address is invalid, the server will change it when the VM is started or as the device is hot added.
     #     May be  nil  if the virtual machine has never been powered on since the adapter was created.
     # @!attribute [rw] sharing
-    #     @return [Com::Vmware::Vcenter::VM::Hardware::Adapter::Scsi::Sharing]
+    #     @return [Com::Vmware::Vcenter::Vm::Hardware::Adapter::Scsi::Sharing]
     #     Bus sharing mode.
     class Info < VAPI::Bindings::VapiStruct
       class << self
@@ -719,10 +719,10 @@ module Com::Vmware::Vcenter::Vm::Hardware::Adapter
             'com.vmware.vcenter.vm.hardware.adapter.scsi.info',
             {
               'label' => VAPI::Bindings::StringType.instance,
-              'type' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::VM::Hardware::Adapter::Scsi::Type'),
-              'scsi' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::VM::Hardware::ScsiAddressInfo'),
+              'type' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::Vm::Hardware::Adapter::Scsi::Type'),
+              'scsi' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::Vm::Hardware::ScsiAddressInfo'),
               'pci_slot_number' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::IntegerType.instance),
-              'sharing' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::VM::Hardware::Adapter::Scsi::Sharing')
+              'sharing' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::Vm::Hardware::Adapter::Scsi::Sharing')
             },
             Info,
             false,
@@ -745,9 +745,9 @@ module Com::Vmware::Vcenter::Vm::Hardware::Adapter
       end
     end
 
-    # The  ``Com::Vmware::Vcenter::VM::Hardware::Adapter::Scsi::CreateSpec``   class  provides a specification for the configuration of a newly-created virtual SCSI adapter.
+    # The  ``Com::Vmware::Vcenter::Vm::Hardware::Adapter::Scsi::CreateSpec``   class  provides a specification for the configuration of a newly-created virtual SCSI adapter.
     # @!attribute [rw] type
-    #     @return [Com::Vmware::Vcenter::VM::Hardware::Adapter::Scsi::Type, nil]
+    #     @return [Com::Vmware::Vcenter::Vm::Hardware::Adapter::Scsi::Type, nil]
     #     Adapter type.
     #     If  nil , a guest-specific default value will be used.
     # @!attribute [rw] bus
@@ -759,9 +759,9 @@ module Com::Vmware::Vcenter::Vm::Hardware::Adapter
     #     Address of the SCSI adapter on the PCI bus. If the PCI address is invalid, the server will change it when the VM is started or as the device is hot added.
     #     If  nil , the server will choose an available address when the virtual machine is powered on.
     # @!attribute [rw] sharing
-    #     @return [Com::Vmware::Vcenter::VM::Hardware::Adapter::Scsi::Sharing, nil]
+    #     @return [Com::Vmware::Vcenter::Vm::Hardware::Adapter::Scsi::Sharing, nil]
     #     Bus sharing mode.
-    #     If  nil , the adapter will default to   :attr:`Com::Vmware::Vcenter::VM::Hardware::Adapter::Scsi::Sharing.NONE`  .
+    #     If  nil , the adapter will default to   :attr:`Com::Vmware::Vcenter::Vm::Hardware::Adapter::Scsi::Sharing.NONE`  .
     class CreateSpec < VAPI::Bindings::VapiStruct
       class << self
         # Holds (gets or creates) the binding type metadata for this structure type.
@@ -771,10 +771,10 @@ module Com::Vmware::Vcenter::Vm::Hardware::Adapter
           @binding_type ||= VAPI::Bindings::StructType.new(
             'com.vmware.vcenter.vm.hardware.adapter.scsi.create_spec',
             {
-              'type' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::VM::Hardware::Adapter::Scsi::Type')),
+              'type' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::Vm::Hardware::Adapter::Scsi::Type')),
               'bus' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::IntegerType.instance),
               'pci_slot_number' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::IntegerType.instance),
-              'sharing' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::VM::Hardware::Adapter::Scsi::Sharing'))
+              'sharing' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::Vm::Hardware::Adapter::Scsi::Sharing'))
             },
             CreateSpec,
             false,
@@ -796,9 +796,9 @@ module Com::Vmware::Vcenter::Vm::Hardware::Adapter
       end
     end
 
-    # The  ``Com::Vmware::Vcenter::VM::Hardware::Adapter::Scsi::UpdateSpec``   class  describes the updates to be made to the configuration of a virtual SCSI adapter.
+    # The  ``Com::Vmware::Vcenter::Vm::Hardware::Adapter::Scsi::UpdateSpec``   class  describes the updates to be made to the configuration of a virtual SCSI adapter.
     # @!attribute [rw] sharing
-    #     @return [Com::Vmware::Vcenter::VM::Hardware::Adapter::Scsi::Sharing, nil]
+    #     @return [Com::Vmware::Vcenter::Vm::Hardware::Adapter::Scsi::Sharing, nil]
     #     Bus sharing mode.  
     #     
     #      This  field  may only be modified if the virtual machine is not powered on.
@@ -812,7 +812,7 @@ module Com::Vmware::Vcenter::Vm::Hardware::Adapter
           @binding_type ||= VAPI::Bindings::StructType.new(
             'com.vmware.vcenter.vm.hardware.adapter.scsi.update_spec',
             {
-              'sharing' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::VM::Hardware::Adapter::Scsi::Sharing'))
+              'sharing' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::Vm::Hardware::Adapter::Scsi::Sharing'))
             },
             UpdateSpec,
             false,
@@ -831,7 +831,7 @@ module Com::Vmware::Vcenter::Vm::Hardware::Adapter
       end
     end
 
-    # The  ``Com::Vmware::Vcenter::VM::Hardware::Adapter::Scsi::Summary``   class  contains commonly used information about a Virtual SCSI adapter.
+    # The  ``Com::Vmware::Vcenter::Vm::Hardware::Adapter::Scsi::Summary``   class  contains commonly used information about a Virtual SCSI adapter.
     # @!attribute [rw] adapter
     #     @return [String]
     #     Identifier of the virtual SCSI adapter.
@@ -863,18 +863,18 @@ module Com::Vmware::Vcenter::Vm::Hardware::Adapter
       end
     end
 
-    # The  ``Com::Vmware::Vcenter::VM::Hardware::Adapter::Scsi::Type``   enumerated type  defines the valid emulation types for a virtual SCSI adapter.
+    # The  ``Com::Vmware::Vcenter::Vm::Hardware::Adapter::Scsi::Type``   enumerated type  defines the valid emulation types for a virtual SCSI adapter.
     # @!attribute [rw] buslogic
-    #     @return [Com::Vmware::Vcenter::VM::Hardware::Adapter::Scsi::Type]
+    #     @return [Com::Vmware::Vcenter::Vm::Hardware::Adapter::Scsi::Type]
     #     BusLogic host bus adapter.
     # @!attribute [rw] lsilogic
-    #     @return [Com::Vmware::Vcenter::VM::Hardware::Adapter::Scsi::Type]
+    #     @return [Com::Vmware::Vcenter::Vm::Hardware::Adapter::Scsi::Type]
     #     LSI Logic host bus adapter.
     # @!attribute [rw] lsilogicsas
-    #     @return [Com::Vmware::Vcenter::VM::Hardware::Adapter::Scsi::Type]
+    #     @return [Com::Vmware::Vcenter::Vm::Hardware::Adapter::Scsi::Type]
     #     LSI Logic SAS 1068 host bus adapter.
     # @!attribute [rw] pvscsi
-    #     @return [Com::Vmware::Vcenter::VM::Hardware::Adapter::Scsi::Type]
+    #     @return [Com::Vmware::Vcenter::Vm::Hardware::Adapter::Scsi::Type]
     #     Paravirtualized host bus adapter.
     class Type < VAPI::Bindings::VapiEnum
       class << self
@@ -910,34 +910,34 @@ module Com::Vmware::Vcenter::Vm::Hardware::Adapter
       private_class_method :new
 
       # @!attribute [rw] buslogic
-      #     @return [Com::Vmware::Vcenter::VM::Hardware::Adapter::Scsi::Type]
+      #     @return [Com::Vmware::Vcenter::Vm::Hardware::Adapter::Scsi::Type]
       #     BusLogic host bus adapter.
       BUSLOGIC = Type.send(:new, 'BUSLOGIC')
 
       # @!attribute [rw] lsilogic
-      #     @return [Com::Vmware::Vcenter::VM::Hardware::Adapter::Scsi::Type]
+      #     @return [Com::Vmware::Vcenter::Vm::Hardware::Adapter::Scsi::Type]
       #     LSI Logic host bus adapter.
       LSILOGIC = Type.send(:new, 'LSILOGIC')
 
       # @!attribute [rw] lsilogicsas
-      #     @return [Com::Vmware::Vcenter::VM::Hardware::Adapter::Scsi::Type]
+      #     @return [Com::Vmware::Vcenter::Vm::Hardware::Adapter::Scsi::Type]
       #     LSI Logic SAS 1068 host bus adapter.
       LSILOGICSAS = Type.send(:new, 'LSILOGICSAS')
 
       # @!attribute [rw] pvscsi
-      #     @return [Com::Vmware::Vcenter::VM::Hardware::Adapter::Scsi::Type]
+      #     @return [Com::Vmware::Vcenter::Vm::Hardware::Adapter::Scsi::Type]
       #     Paravirtualized host bus adapter.
       PVSCSI = Type.send(:new, 'PVSCSI')
     end
-    # The  ``Com::Vmware::Vcenter::VM::Hardware::Adapter::Scsi::Sharing``   enumerated type  defines the valid bus sharing modes for a virtual SCSI adapter.
+    # The  ``Com::Vmware::Vcenter::Vm::Hardware::Adapter::Scsi::Sharing``   enumerated type  defines the valid bus sharing modes for a virtual SCSI adapter.
     # @!attribute [rw] none
-    #     @return [Com::Vmware::Vcenter::VM::Hardware::Adapter::Scsi::Sharing]
+    #     @return [Com::Vmware::Vcenter::Vm::Hardware::Adapter::Scsi::Sharing]
     #     The virtual SCSI bus is not shared.
     # @!attribute [rw] virtual
-    #     @return [Com::Vmware::Vcenter::VM::Hardware::Adapter::Scsi::Sharing]
+    #     @return [Com::Vmware::Vcenter::Vm::Hardware::Adapter::Scsi::Sharing]
     #     The virtual SCSI bus is shared between two or more virtual machines. In this case, no physical machine is involved.
     # @!attribute [rw] physical
-    #     @return [Com::Vmware::Vcenter::VM::Hardware::Adapter::Scsi::Sharing]
+    #     @return [Com::Vmware::Vcenter::Vm::Hardware::Adapter::Scsi::Sharing]
     #     The virtual SCSI bus is shared between two or more virtual machines residing on different physical hosts.
     class Sharing < VAPI::Bindings::VapiEnum
       class << self
@@ -973,17 +973,17 @@ module Com::Vmware::Vcenter::Vm::Hardware::Adapter
       private_class_method :new
 
       # @!attribute [rw] none
-      #     @return [Com::Vmware::Vcenter::VM::Hardware::Adapter::Scsi::Sharing]
+      #     @return [Com::Vmware::Vcenter::Vm::Hardware::Adapter::Scsi::Sharing]
       #     The virtual SCSI bus is not shared.
       NONE = Sharing.send(:new, 'NONE')
 
       # @!attribute [rw] virtual
-      #     @return [Com::Vmware::Vcenter::VM::Hardware::Adapter::Scsi::Sharing]
+      #     @return [Com::Vmware::Vcenter::Vm::Hardware::Adapter::Scsi::Sharing]
       #     The virtual SCSI bus is shared between two or more virtual machines. In this case, no physical machine is involved.
       VIRTUAL = Sharing.send(:new, 'VIRTUAL')
 
       # @!attribute [rw] physical
-      #     @return [Com::Vmware::Vcenter::VM::Hardware::Adapter::Scsi::Sharing]
+      #     @return [Com::Vmware::Vcenter::Vm::Hardware::Adapter::Scsi::Sharing]
       #     The virtual SCSI bus is shared between two or more virtual machines residing on different physical hosts.
       PHYSICAL = Sharing.send(:new, 'PHYSICAL')
     end

--- a/client/sdk/com/vmware/vcenter/vm/hardware/boot.rb
+++ b/client/sdk/com/vmware/vcenter/vm/hardware/boot.rb
@@ -23,14 +23,14 @@ end
 
 # The  ``com.vmware.vcenter.vm.hardware.boot``   package  provides  classs  for managing the virtual devices used to boot a virtual machine.
 module Com::Vmware::Vcenter::Vm::Hardware::Boot
-  # The  ``Com::Vmware::Vcenter::VM::Hardware::Boot::Device``   class  provides  methods  for configuring the device order used when booting a virtual machine.  
+  # The  ``Com::Vmware::Vcenter::Vm::Hardware::Boot::Device``   class  provides  methods  for configuring the device order used when booting a virtual machine.  
   # 
   #  The boot order may be specified using a mixture of device classes and device instances, chosen from among the following:  
   # 
-  #   *  :attr:`Com::Vmware::Vcenter::VM::Hardware::Boot::Device::Type.CDROM`  : Boot from a virtual CD-ROM drive; the device instance(s) will be chosen by the BIOS subsystem.
-  #    *  :attr:`Com::Vmware::Vcenter::VM::Hardware::Boot::Device::Type.FLOPPY`  : Boot from a virtual floppy drive; the device instance(s) will be chosen by the BIOS subsystem.
-  #    *  :attr:`Com::Vmware::Vcenter::VM::Hardware::Boot::Device::Type.DISK`  : Boot from a virtual disk device; the device instance is specified explicitly in   :attr:`Com::Vmware::Vcenter::VM::Hardware::Boot::Device::Entry.disks`   list, and multiple instances may be specified in the list.
-  #    *  :attr:`Com::Vmware::Vcenter::VM::Hardware::Boot::Device::Type.ETHERNET`  : Boot from a virtual Ethernet adapter; the device instance is specified explicitly as   :attr:`Com::Vmware::Vcenter::VM::Hardware::Boot::Device::Entry.nic`  , and multiple adapters may be specified in the boot order list.
+  #   *  :attr:`Com::Vmware::Vcenter::Vm::Hardware::Boot::Device::Type.CDROM`  : Boot from a virtual CD-ROM drive; the device instance(s) will be chosen by the BIOS subsystem.
+  #    *  :attr:`Com::Vmware::Vcenter::Vm::Hardware::Boot::Device::Type.FLOPPY`  : Boot from a virtual floppy drive; the device instance(s) will be chosen by the BIOS subsystem.
+  #    *  :attr:`Com::Vmware::Vcenter::Vm::Hardware::Boot::Device::Type.DISK`  : Boot from a virtual disk device; the device instance is specified explicitly in   :attr:`Com::Vmware::Vcenter::Vm::Hardware::Boot::Device::Entry.disks`   list, and multiple instances may be specified in the list.
+  #    *  :attr:`Com::Vmware::Vcenter::Vm::Hardware::Boot::Device::Type.ETHERNET`  : Boot from a virtual Ethernet adapter; the device instance is specified explicitly as   :attr:`Com::Vmware::Vcenter::Vm::Hardware::Boot::Device::Entry.nic`  , and multiple adapters may be specified in the boot order list.
   #   
   class Device < VAPI::Bindings::VapiService
     # static metamodel definitions
@@ -41,7 +41,7 @@ module Com::Vmware::Vcenter::Vm::Hardware::Boot
       VAPI::Bindings::OperationInputType.new(
         'vm' => VAPI::Bindings::IdType.new('VirtualMachine')
       ),
-      VAPI::Bindings::ListType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::VM::Hardware::Boot::Device::Entry')),
+      VAPI::Bindings::ListType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::Vm::Hardware::Boot::Device::Entry')),
       {
         'com.vmware.vapi.std.errors.error' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::Error'),
         'com.vmware.vapi.std.errors.not_found' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vapi::Std::Errors::NotFound'),
@@ -58,7 +58,7 @@ module Com::Vmware::Vcenter::Vm::Hardware::Boot
       VAPI::Core::OperationIdentifier.new('set', SERVICE_ID),
       VAPI::Bindings::OperationInputType.new(
         'vm' => VAPI::Bindings::IdType.new('VirtualMachine'),
-        'devices' => VAPI::Bindings::ListType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::VM::Hardware::Boot::Device::Entry'))
+        'devices' => VAPI::Bindings::ListType.new(VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::Vm::Hardware::Boot::Device::Entry'))
       ),
       VAPI::Bindings::VoidType.instance,
       {
@@ -92,7 +92,7 @@ module Com::Vmware::Vcenter::Vm::Hardware::Boot
     #
     # @param vm [String]
     #     Virtual machine identifier.
-    # @return [Array<Com::Vmware::Vcenter::VM::Hardware::Boot::Device::Entry>]
+    # @return [Array<Com::Vmware::Vcenter::Vm::Hardware::Boot::Device::Entry>]
     #     Ordered list of configured boot devices.
     # @raise [Com::Vmware::Vapi::Std::Errors::Error]
     #     if the system reports an error while responding to the request.
@@ -111,11 +111,11 @@ module Com::Vmware::Vcenter::Vm::Hardware::Boot
                        'vm' => vm)
     end
 
-    # Sets the virtual devices that will be used to boot the virtual machine. The virtual machine will check the devices in order, attempting to boot from each, until the virtual machine boots successfully. If the  list  is empty, the virtual machine will use a default boot sequence. There should be no more than one instance of   :class:`Com::Vmware::Vcenter::VM::Hardware::Boot::Device::Entry`   for a given device type except   :attr:`Com::Vmware::Vcenter::VM::Hardware::Boot::Device::Type.ETHERNET`   in the  list .
+    # Sets the virtual devices that will be used to boot the virtual machine. The virtual machine will check the devices in order, attempting to boot from each, until the virtual machine boots successfully. If the  list  is empty, the virtual machine will use a default boot sequence. There should be no more than one instance of   :class:`Com::Vmware::Vcenter::Vm::Hardware::Boot::Device::Entry`   for a given device type except   :attr:`Com::Vmware::Vcenter::Vm::Hardware::Boot::Device::Type.ETHERNET`   in the  list .
     #
     # @param vm [String]
     #     Virtual machine identifier.
-    # @param devices [Array<Com::Vmware::Vcenter::VM::Hardware::Boot::Device::Entry>]
+    # @param devices [Array<Com::Vmware::Vcenter::Vm::Hardware::Boot::Device::Entry>]
     #     Ordered list of boot devices.
     # @return [Void]
     # @raise [Com::Vmware::Vapi::Std::Errors::Error]
@@ -123,7 +123,7 @@ module Com::Vmware::Vcenter::Vm::Hardware::Boot
     # @raise [Com::Vmware::Vapi::Std::Errors::NotFound]
     #     if the virtual machine is not found, or if any of the specified virtual devices is not found.
     # @raise [Com::Vmware::Vapi::Std::Errors::InvalidArgument]
-    #     if a any of the  ``CDROM``, ``DISK``, ``ETHERNET``, ``FLOPPY``  values appears in more than one  ``Com::Vmware::Vcenter::VM::Hardware::Boot::Device::Entry``  with the exception of   :attr:`Com::Vmware::Vcenter::VM::Hardware::Boot::Device::Type.ETHERNET`  , which may appear multiple times if the virtual machine has been configured with multiple Ethernet adapters.
+    #     if a any of the  ``CDROM``, ``DISK``, ``ETHERNET``, ``FLOPPY``  values appears in more than one  ``Com::Vmware::Vcenter::Vm::Hardware::Boot::Device::Entry``  with the exception of   :attr:`Com::Vmware::Vcenter::Vm::Hardware::Boot::Device::Type.ETHERNET`  , which may appear multiple times if the virtual machine has been configured with multiple Ethernet adapters.
     # @raise [Com::Vmware::Vapi::Std::Errors::ResourceBusy]
     #     if the virtual machine is busy performing another operation.
     # @raise [Com::Vmware::Vapi::Std::Errors::ResourceInaccessible]
@@ -140,9 +140,9 @@ module Com::Vmware::Vcenter::Vm::Hardware::Boot
                        'devices' => devices)
     end
 
-    # The  class   ``Com::Vmware::Vcenter::VM::Hardware::Boot::Device::EntryCreateSpec``  specifies a list of bootable virtual device classes. When a VM is being created and a  list  of  ``Com::Vmware::Vcenter::VM::Hardware::Boot::Device::EntryCreateSpec``  is specified, the boot order of the specific device instances are not specified in this  class . The boot order of the specific device instance will be the order in which the Ethernet and Disk devices appear in the  ``nics``  and  ``disks``  respectively.
+    # The  class   ``Com::Vmware::Vcenter::Vm::Hardware::Boot::Device::EntryCreateSpec``  specifies a list of bootable virtual device classes. When a VM is being created and a  list  of  ``Com::Vmware::Vcenter::Vm::Hardware::Boot::Device::EntryCreateSpec``  is specified, the boot order of the specific device instances are not specified in this  class . The boot order of the specific device instance will be the order in which the Ethernet and Disk devices appear in the  ``nics``  and  ``disks``  respectively.
     # @!attribute [rw] type
-    #     @return [Com::Vmware::Vcenter::VM::Hardware::Boot::Device::Type]
+    #     @return [Com::Vmware::Vcenter::Vm::Hardware::Boot::Device::Type]
     #     Virtual Boot device type.
     class EntryCreateSpec < VAPI::Bindings::VapiStruct
       class << self
@@ -153,7 +153,7 @@ module Com::Vmware::Vcenter::Vm::Hardware::Boot
           @binding_type ||= VAPI::Bindings::StructType.new(
             'com.vmware.vcenter.vm.hardware.boot.device.entry_create_spec',
             {
-              'type' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::VM::Hardware::Boot::Device::Type')
+              'type' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::Vm::Hardware::Boot::Device::Type')
             },
             EntryCreateSpec,
             false,
@@ -172,18 +172,18 @@ module Com::Vmware::Vcenter::Vm::Hardware::Boot
       end
     end
 
-    # The  ``Com::Vmware::Vcenter::VM::Hardware::Boot::Device::Entry``   class  specifies a bootable virtual device class or specific bootable virtual device(s).
+    # The  ``Com::Vmware::Vcenter::Vm::Hardware::Boot::Device::Entry``   class  specifies a bootable virtual device class or specific bootable virtual device(s).
     # @!attribute [rw] type
-    #     @return [Com::Vmware::Vcenter::VM::Hardware::Boot::Device::Type]
+    #     @return [Com::Vmware::Vcenter::Vm::Hardware::Boot::Device::Type]
     #     Virtual device type.
     # @!attribute [rw] nic
     #     @return [String]
     #     Virtual Ethernet device. Ethernet device to use as boot device for this entry.
-    #     This  field  is optional and it is only relevant when the value of  ``type``  is   :attr:`Com::Vmware::Vcenter::VM::Hardware::Boot::Device::Type.ETHERNET`  .
+    #     This  field  is optional and it is only relevant when the value of  ``type``  is   :attr:`Com::Vmware::Vcenter::Vm::Hardware::Boot::Device::Type.ETHERNET`  .
     # @!attribute [rw] disks
     #     @return [Array<String>]
     #     Virtual disk device. List of virtual disks in boot order.
-    #     This  field  is optional and it is only relevant when the value of  ``type``  is   :attr:`Com::Vmware::Vcenter::VM::Hardware::Boot::Device::Type.DISK`  .
+    #     This  field  is optional and it is only relevant when the value of  ``type``  is   :attr:`Com::Vmware::Vcenter::Vm::Hardware::Boot::Device::Type.DISK`  .
     class Entry < VAPI::Bindings::VapiStruct
       class << self
         # Holds (gets or creates) the binding type metadata for this structure type.
@@ -193,7 +193,7 @@ module Com::Vmware::Vcenter::Vm::Hardware::Boot
           @binding_type ||= VAPI::Bindings::StructType.new(
             'com.vmware.vcenter.vm.hardware.boot.device.entry',
             {
-              'type' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::VM::Hardware::Boot::Device::Type'),
+              'type' => VAPI::Bindings::ReferenceType.new('Com::Vmware::Vcenter::Vm::Hardware::Boot::Device::Type'),
               'nic' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::IdType.new),
               'disks' => VAPI::Bindings::OptionalType.new(VAPI::Bindings::ListType.new(VAPI::Bindings::IdType.new))
             },
@@ -216,18 +216,18 @@ module Com::Vmware::Vcenter::Vm::Hardware::Boot
       end
     end
 
-    # The  ``Com::Vmware::Vcenter::VM::Hardware::Boot::Device::Type``   enumerated type  defines the valid device types that may be used as bootable devices.
+    # The  ``Com::Vmware::Vcenter::Vm::Hardware::Boot::Device::Type``   enumerated type  defines the valid device types that may be used as bootable devices.
     # @!attribute [rw] cdrom
-    #     @return [Com::Vmware::Vcenter::VM::Hardware::Boot::Device::Type]
+    #     @return [Com::Vmware::Vcenter::Vm::Hardware::Boot::Device::Type]
     #     Virtual CD-ROM device.
     # @!attribute [rw] disk
-    #     @return [Com::Vmware::Vcenter::VM::Hardware::Boot::Device::Type]
+    #     @return [Com::Vmware::Vcenter::Vm::Hardware::Boot::Device::Type]
     #     Virtual disk device.
     # @!attribute [rw] ethernet
-    #     @return [Com::Vmware::Vcenter::VM::Hardware::Boot::Device::Type]
+    #     @return [Com::Vmware::Vcenter::Vm::Hardware::Boot::Device::Type]
     #     Virtual Ethernet adapter.
     # @!attribute [rw] floppy
-    #     @return [Com::Vmware::Vcenter::VM::Hardware::Boot::Device::Type]
+    #     @return [Com::Vmware::Vcenter::Vm::Hardware::Boot::Device::Type]
     #     Virtual floppy drive.
     class Type < VAPI::Bindings::VapiEnum
       class << self
@@ -263,22 +263,22 @@ module Com::Vmware::Vcenter::Vm::Hardware::Boot
       private_class_method :new
 
       # @!attribute [rw] cdrom
-      #     @return [Com::Vmware::Vcenter::VM::Hardware::Boot::Device::Type]
+      #     @return [Com::Vmware::Vcenter::Vm::Hardware::Boot::Device::Type]
       #     Virtual CD-ROM device.
       CDROM = Type.send(:new, 'CDROM')
 
       # @!attribute [rw] disk
-      #     @return [Com::Vmware::Vcenter::VM::Hardware::Boot::Device::Type]
+      #     @return [Com::Vmware::Vcenter::Vm::Hardware::Boot::Device::Type]
       #     Virtual disk device.
       DISK = Type.send(:new, 'DISK')
 
       # @!attribute [rw] ethernet
-      #     @return [Com::Vmware::Vcenter::VM::Hardware::Boot::Device::Type]
+      #     @return [Com::Vmware::Vcenter::Vm::Hardware::Boot::Device::Type]
       #     Virtual Ethernet adapter.
       ETHERNET = Type.send(:new, 'ETHERNET')
 
       # @!attribute [rw] floppy
-      #     @return [Com::Vmware::Vcenter::VM::Hardware::Boot::Device::Type]
+      #     @return [Com::Vmware::Vcenter::Vm::Hardware::Boot::Device::Type]
       #     Virtual floppy drive.
       FLOPPY = Type.send(:new, 'FLOPPY')
     end


### PR DESCRIPTION
There is a class 'VM' and a module 'Vm'. The language binding generation
is always generating 'VM' even in cases where it should be 'Vm'. Fixed
casing in appropriate places.