### PR TITLE
Fix casing of `mib` vs `MiB`

### DIFF
--- a/client/sdk/com/vmware/vcenter/vm/hardware.rb
+++ b/client/sdk/com/vmware/vcenter/vm/hardware.rb
@@ -3955,7 +3955,7 @@ module Com::Vmware::Vcenter::Vm::Hardware
     end
 
     # The  ``Com::Vmware::Vcenter::Vm::Hardware::Memory::Info``   class  contains memory-related information about a virtual machine.
-    # @!attribute [rw] size_mib
+    # @!attribute [rw] size_MiB
     #     @return [Fixnum]
     #     Memory size in mebibytes.
     # @!attribute [rw] hot_add_enabled
@@ -3963,11 +3963,11 @@ module Com::Vmware::Vcenter::Vm::Hardware
     #     Flag indicating whether adding memory while the virtual machine is running is enabled.  
     #     
     #      Some guest operating systems may consume more resources or perform less efficiently when they run on hardware that supports adding memory while the machine is running.
-    # @!attribute [rw] hot_add_increment_size_mib
+    # @!attribute [rw] hot_add_increment_size_MiB
     #     @return [Fixnum, nil]
     #     The granularity, in mebibytes, at which memory can be added to a running virtual machine.  
     #     
-    #      When adding memory to a running virtual machine, the amount of memory added must be at least   :attr:`Com::Vmware::Vcenter::Vm::Hardware::Memory::Info.hot_add_increment_size_mib`   and the total memory size of the virtual machine must be a multiple of {\@link>hotAddIncrementSize}.
+    #      When adding memory to a running virtual machine, the amount of memory added must be at least   :attr:`Com::Vmware::Vcenter::Vm::Hardware::Memory::Info.hot_add_increment_size_MiB`   and the total memory size of the virtual machine must be a multiple of {\@link>hotAddIncrementSize}.
     #     Only set when   :attr:`Com::Vmware::Vcenter::Vm::Hardware::Memory::Info.hot_add_enabled`   is true and the virtual machine is running.
     # @!attribute [rw] hot_add_limit_mib
     #     @return [Fixnum, nil]
@@ -3994,9 +3994,9 @@ module Com::Vmware::Vcenter::Vm::Hardware
         end
       end
 
-      attr_accessor :size_mib,
+      attr_accessor :size_MiB,
                     :hot_add_enabled,
-                    :hot_add_increment_size_mib,
+                    :hot_add_increment_size_MiB,
                     :hot_add_limit_mib
 
       # Constructs a new instance.
@@ -4008,13 +4008,13 @@ module Com::Vmware::Vcenter::Vm::Hardware
     end
 
     # The  ``Com::Vmware::Vcenter::Vm::Hardware::Memory::UpdateSpec``   class  describes the updates to be made to the memory-related settings of a virtual machine.
-    # @!attribute [rw] size_mib
+    # @!attribute [rw] size_MiB
     #     @return [Fixnum, nil]
     #     New memory size in mebibytes.  
     #     
     #      The supported range of memory sizes is constrained by the configured guest operating system and virtual hardware version of the virtual machine.  
     #     
-    #      If the virtual machine is running, this value may only be changed if   :attr:`Com::Vmware::Vcenter::Vm::Hardware::Memory::Info.hot_add_enabled`   is true, and the new memory size must satisfy the constraints specified by   :attr:`Com::Vmware::Vcenter::Vm::Hardware::Memory::Info.hot_add_increment_size_mib`   and   :attr:`Com::Vmware::Vcenter::Vm::Hardware::Memory::Info.hot_add_limit_mib`  .
+    #      If the virtual machine is running, this value may only be changed if   :attr:`Com::Vmware::Vcenter::Vm::Hardware::Memory::Info.hot_add_enabled`   is true, and the new memory size must satisfy the constraints specified by   :attr:`Com::Vmware::Vcenter::Vm::Hardware::Memory::Info.hot_add_increment_size_MiB`   and   :attr:`Com::Vmware::Vcenter::Vm::Hardware::Memory::Info.hot_add_limit_mib`  .
     #     If  nil , the value is unchanged.
     # @!attribute [rw] hot_add_enabled
     #     @return [Boolean, nil]
@@ -4043,7 +4043,7 @@ module Com::Vmware::Vcenter::Vm::Hardware
         end
       end
 
-      attr_accessor :size_mib,
+      attr_accessor :size_MiB,
                     :hot_add_enabled
 
       # Constructs a new instance.

--- a/client/sdk/com/vmware/vcenter/vm/hardware.rb
+++ b/client/sdk/com/vmware/vcenter/vm/hardware.rb
@@ -3969,7 +3969,7 @@ module Com::Vmware::Vcenter::Vm::Hardware
     #     
     #      When adding memory to a running virtual machine, the amount of memory added must be at least   :attr:`Com::Vmware::Vcenter::Vm::Hardware::Memory::Info.hot_add_increment_size_MiB`   and the total memory size of the virtual machine must be a multiple of {\@link>hotAddIncrementSize}.
     #     Only set when   :attr:`Com::Vmware::Vcenter::Vm::Hardware::Memory::Info.hot_add_enabled`   is true and the virtual machine is running.
-    # @!attribute [rw] hot_add_limit_mib
+    # @!attribute [rw] hot_add_limit_MiB
     #     @return [Fixnum, nil]
     #     The maximum amount of memory, in mebibytes, that can be added to a running virtual machine.
     #     Only set when   :attr:`Com::Vmware::Vcenter::Vm::Hardware::Memory::Info.hot_add_enabled`   is true and the virtual machine is running.
@@ -3997,7 +3997,7 @@ module Com::Vmware::Vcenter::Vm::Hardware
       attr_accessor :size_MiB,
                     :hot_add_enabled,
                     :hot_add_increment_size_MiB,
-                    :hot_add_limit_mib
+                    :hot_add_limit_MiB
 
       # Constructs a new instance.
       # @param ruby_values [Hash] a map of initial property values (optional)
@@ -4014,7 +4014,7 @@ module Com::Vmware::Vcenter::Vm::Hardware
     #     
     #      The supported range of memory sizes is constrained by the configured guest operating system and virtual hardware version of the virtual machine.  
     #     
-    #      If the virtual machine is running, this value may only be changed if   :attr:`Com::Vmware::Vcenter::Vm::Hardware::Memory::Info.hot_add_enabled`   is true, and the new memory size must satisfy the constraints specified by   :attr:`Com::Vmware::Vcenter::Vm::Hardware::Memory::Info.hot_add_increment_size_MiB`   and   :attr:`Com::Vmware::Vcenter::Vm::Hardware::Memory::Info.hot_add_limit_mib`  .
+    #      If the virtual machine is running, this value may only be changed if   :attr:`Com::Vmware::Vcenter::Vm::Hardware::Memory::Info.hot_add_enabled`   is true, and the new memory size must satisfy the constraints specified by   :attr:`Com::Vmware::Vcenter::Vm::Hardware::Memory::Info.hot_add_increment_size_MiB`   and   :attr:`Com::Vmware::Vcenter::Vm::Hardware::Memory::Info.hot_add_limit_MiB`  .
     #     If  nil , the value is unchanged.
     # @!attribute [rw] hot_add_enabled
     #     @return [Boolean, nil]

--- a/docs/apidocs/vsphereautomation-bindings/Com/Vmware/Vcenter/Vm/Hardware/Memory/Info.html
+++ b/docs/apidocs/vsphereautomation-bindings/Com/Vmware/Vcenter/Vm/Hardware/Memory/Info.html
@@ -182,7 +182,7 @@ virtual machine.
       <li class="public ">
   <span class="summary_signature">
     
-      <a href="#hot_add_limit_mib-instance_method" title="#hot_add_limit_mib (instance method)">- (Fixnum<sup>?</sup>) <strong>hot_add_limit_mib</strong> </a>
+      <a href="#hot_add_limit_MiB-instance_method" title="#hot_add_limit_MiB (instance method)">- (Fixnum<sup>?</sup>) <strong>hot_add_limit_MiB</strong> </a>
     
 
     
@@ -512,7 +512,7 @@ is enabled.
   <span class='id identifier rubyid_attr_accessor'>attr_accessor</span> <span class='symbol'>:size_MiB</span><span class='comma'>,</span>
                 <span class='symbol'>:hot_add_enabled</span><span class='comma'>,</span>
                 <span class='symbol'>:hot_add_increment_size_MiB</span><span class='comma'>,</span>
-                <span class='symbol'>:hot_add_limit_mib</span>
+                <span class='symbol'>:hot_add_limit_MiB</span>
 
   <span class='comment'># Constructs a new instance.
 </span>  <span class='comment'># @param ruby_values [Hash] a map of initial property values (optional)
@@ -638,7 +638,7 @@ is true and the virtual machine is running.
   <span class='id identifier rubyid_attr_accessor'>attr_accessor</span> <span class='symbol'>:size_MiB</span><span class='comma'>,</span>
                 <span class='symbol'>:hot_add_enabled</span><span class='comma'>,</span>
                 <span class='symbol'>:hot_add_increment_size_MiB</span><span class='comma'>,</span>
-                <span class='symbol'>:hot_add_limit_mib</span>
+                <span class='symbol'>:hot_add_limit_MiB</span>
 
   <span class='comment'># Constructs a new instance.
 </span>  <span class='comment'># @param ruby_values [Hash] a map of initial property values (optional)
@@ -653,11 +653,11 @@ is true and the virtual machine is running.
 </div>
     
       
-      <span id="hot_add_limit_mib=-instance_method"></span>
+      <span id="hot_add_limit_MiB=-instance_method"></span>
       <div class="method_details ">
-  <h3 class="signature " id="hot_add_limit_mib-instance_method">
+  <h3 class="signature " id="hot_add_limit_MiB-instance_method">
   
-    - (<tt>Fixnum</tt><sup>?</sup>) <strong>hot_add_limit_mib</strong> 
+    - (<tt>Fixnum</tt><sup>?</sup>) <strong>hot_add_limit_MiB</strong> 
   
 
   
@@ -758,7 +758,7 @@ is true and the virtual machine is running.
   <span class='id identifier rubyid_attr_accessor'>attr_accessor</span> <span class='symbol'>:size_MiB</span><span class='comma'>,</span>
                 <span class='symbol'>:hot_add_enabled</span><span class='comma'>,</span>
                 <span class='symbol'>:hot_add_increment_size_MiB</span><span class='comma'>,</span>
-                <span class='symbol'>:hot_add_limit_mib</span>
+                <span class='symbol'>:hot_add_limit_MiB</span>
 
   <span class='comment'># Constructs a new instance.
 </span>  <span class='comment'># @param ruby_values [Hash] a map of initial property values (optional)
@@ -875,7 +875,7 @@ Memory size in mebibytes.
   <span class='id identifier rubyid_attr_accessor'>attr_accessor</span> <span class='symbol'>:size_MiB</span><span class='comma'>,</span>
                 <span class='symbol'>:hot_add_enabled</span><span class='comma'>,</span>
                 <span class='symbol'>:hot_add_increment_size_MiB</span><span class='comma'>,</span>
-                <span class='symbol'>:hot_add_limit_mib</span>
+                <span class='symbol'>:hot_add_limit_MiB</span>
 
   <span class='comment'># Constructs a new instance.
 </span>  <span class='comment'># @param ruby_values [Hash] a map of initial property values (optional)

--- a/docs/apidocs/vsphereautomation-bindings/Com/Vmware/Vcenter/Vm/Hardware/Memory/Info.html
+++ b/docs/apidocs/vsphereautomation-bindings/Com/Vmware/Vcenter/Vm/Hardware/Memory/Info.html
@@ -153,7 +153,7 @@ is enabled.
       <li class="public ">
   <span class="summary_signature">
     
-      <a href="#hot_add_increment_size_mib-instance_method" title="#hot_add_increment_size_mib (instance method)">- (Fixnum<sup>?</sup>) <strong>hot_add_increment_size_mib</strong> </a>
+      <a href="#hot_add_increment_size_MiB-instance_method" title="#hot_add_increment_size_MiB (instance method)">- (Fixnum<sup>?</sup>) <strong>hot_add_increment_size_MiB</strong> </a>
     
 
     
@@ -211,7 +211,7 @@ virtual machine.
       <li class="public ">
   <span class="summary_signature">
     
-      <a href="#size_mib-instance_method" title="#size_mib (instance method)">- (Fixnum) <strong>size_mib</strong> </a>
+      <a href="#size_MiB-instance_method" title="#size_MiB (instance method)">- (Fixnum) <strong>size_MiB</strong> </a>
     
 
     
@@ -509,9 +509,9 @@ is enabled.
     <span class='kw'>end</span>
   <span class='kw'>end</span>
 
-  <span class='id identifier rubyid_attr_accessor'>attr_accessor</span> <span class='symbol'>:size_mib</span><span class='comma'>,</span>
+  <span class='id identifier rubyid_attr_accessor'>attr_accessor</span> <span class='symbol'>:size_MiB</span><span class='comma'>,</span>
                 <span class='symbol'>:hot_add_enabled</span><span class='comma'>,</span>
-                <span class='symbol'>:hot_add_increment_size_mib</span><span class='comma'>,</span>
+                <span class='symbol'>:hot_add_increment_size_MiB</span><span class='comma'>,</span>
                 <span class='symbol'>:hot_add_limit_mib</span>
 
   <span class='comment'># Constructs a new instance.
@@ -527,11 +527,11 @@ is enabled.
 </div>
     
       
-      <span id="hot_add_increment_size_mib=-instance_method"></span>
+      <span id="hot_add_increment_size_MiB=-instance_method"></span>
       <div class="method_details ">
-  <h3 class="signature " id="hot_add_increment_size_mib-instance_method">
+  <h3 class="signature " id="hot_add_increment_size_MiB-instance_method">
   
-    - (<tt>Fixnum</tt><sup>?</sup>) <strong>hot_add_increment_size_mib</strong> 
+    - (<tt>Fixnum</tt><sup>?</sup>) <strong>hot_add_increment_size_MiB</strong> 
   
 
   
@@ -544,7 +544,7 @@ The granularity, in mebibytes, at which memory can be added to a running
 virtual machine.  
 </p>
 <pre class="code ruby"><code class="ruby">
- When adding memory to a running virtual machine, the amount of memory added must be at least   :attr:`Com::Vmware::Vcenter::Vm::Hardware::Memory::Info.hot_add_increment_size_mib`   and the total memory size of the virtual machine must be a multiple of {\@link&gt;hotAddIncrementSize}.
+ When adding memory to a running virtual machine, the amount of memory added must be at least   :attr:`Com::Vmware::Vcenter::Vm::Hardware::Memory::Info.hot_add_increment_size_MiB`   and the total memory size of the virtual machine must be a multiple of {\@link&gt;hotAddIncrementSize}.
 </code></pre>
 <p>
 Only set when  
@@ -635,9 +635,9 @@ is true and the virtual machine is running.
     <span class='kw'>end</span>
   <span class='kw'>end</span>
 
-  <span class='id identifier rubyid_attr_accessor'>attr_accessor</span> <span class='symbol'>:size_mib</span><span class='comma'>,</span>
+  <span class='id identifier rubyid_attr_accessor'>attr_accessor</span> <span class='symbol'>:size_MiB</span><span class='comma'>,</span>
                 <span class='symbol'>:hot_add_enabled</span><span class='comma'>,</span>
-                <span class='symbol'>:hot_add_increment_size_mib</span><span class='comma'>,</span>
+                <span class='symbol'>:hot_add_increment_size_MiB</span><span class='comma'>,</span>
                 <span class='symbol'>:hot_add_limit_mib</span>
 
   <span class='comment'># Constructs a new instance.
@@ -755,9 +755,9 @@ is true and the virtual machine is running.
     <span class='kw'>end</span>
   <span class='kw'>end</span>
 
-  <span class='id identifier rubyid_attr_accessor'>attr_accessor</span> <span class='symbol'>:size_mib</span><span class='comma'>,</span>
+  <span class='id identifier rubyid_attr_accessor'>attr_accessor</span> <span class='symbol'>:size_MiB</span><span class='comma'>,</span>
                 <span class='symbol'>:hot_add_enabled</span><span class='comma'>,</span>
-                <span class='symbol'>:hot_add_increment_size_mib</span><span class='comma'>,</span>
+                <span class='symbol'>:hot_add_increment_size_MiB</span><span class='comma'>,</span>
                 <span class='symbol'>:hot_add_limit_mib</span>
 
   <span class='comment'># Constructs a new instance.
@@ -773,11 +773,11 @@ is true and the virtual machine is running.
 </div>
     
       
-      <span id="size_mib=-instance_method"></span>
+      <span id="size_MiB=-instance_method"></span>
       <div class="method_details ">
-  <h3 class="signature " id="size_mib-instance_method">
+  <h3 class="signature " id="size_MiB-instance_method">
   
-    - (<tt>Fixnum</tt>) <strong>size_mib</strong> 
+    - (<tt>Fixnum</tt>) <strong>size_MiB</strong> 
   
 
   
@@ -872,9 +872,9 @@ Memory size in mebibytes.
     <span class='kw'>end</span>
   <span class='kw'>end</span>
 
-  <span class='id identifier rubyid_attr_accessor'>attr_accessor</span> <span class='symbol'>:size_mib</span><span class='comma'>,</span>
+  <span class='id identifier rubyid_attr_accessor'>attr_accessor</span> <span class='symbol'>:size_MiB</span><span class='comma'>,</span>
                 <span class='symbol'>:hot_add_enabled</span><span class='comma'>,</span>
-                <span class='symbol'>:hot_add_increment_size_mib</span><span class='comma'>,</span>
+                <span class='symbol'>:hot_add_increment_size_MiB</span><span class='comma'>,</span>
                 <span class='symbol'>:hot_add_limit_mib</span>
 
   <span class='comment'># Constructs a new instance.

--- a/docs/apidocs/vsphereautomation-bindings/Com/Vmware/Vcenter/Vm/Hardware/Memory/UpdateSpec.html
+++ b/docs/apidocs/vsphereautomation-bindings/Com/Vmware/Vcenter/Vm/Hardware/Memory/UpdateSpec.html
@@ -486,7 +486,7 @@ New memory size in mebibytes.
 <pre class="code ruby"><code class="ruby">
  The supported range of memory sizes is constrained by the configured guest operating system and virtual hardware version of the virtual machine.  
 
- If the virtual machine is running, this value may only be changed if   :attr:`Com::Vmware::Vcenter::Vm::Hardware::Memory::Info.hot_add_enabled`   is true, and the new memory size must satisfy the constraints specified by   :attr:`Com::Vmware::Vcenter::Vm::Hardware::Memory::Info.hot_add_increment_size_MiB`   and   :attr:`Com::Vmware::Vcenter::Vm::Hardware::Memory::Info.hot_add_limit_mib`  .
+ If the virtual machine is running, this value may only be changed if   :attr:`Com::Vmware::Vcenter::Vm::Hardware::Memory::Info.hot_add_enabled`   is true, and the new memory size must satisfy the constraints specified by   :attr:`Com::Vmware::Vcenter::Vm::Hardware::Memory::Info.hot_add_increment_size_MiB`   and   :attr:`Com::Vmware::Vcenter::Vm::Hardware::Memory::Info.hot_add_limit_MiB`  .
 </code></pre>
 <p>
 If  nil , the value is unchanged.

--- a/docs/apidocs/vsphereautomation-bindings/Com/Vmware/Vcenter/Vm/Hardware/Memory/UpdateSpec.html
+++ b/docs/apidocs/vsphereautomation-bindings/Com/Vmware/Vcenter/Vm/Hardware/Memory/UpdateSpec.html
@@ -154,7 +154,7 @@ should be enabled.
       <li class="public ">
   <span class="summary_signature">
     
-      <a href="#size_mib-instance_method" title="#size_mib (instance method)">- (Fixnum<sup>?</sup>) <strong>size_mib</strong> </a>
+      <a href="#size_MiB-instance_method" title="#size_MiB (instance method)">- (Fixnum<sup>?</sup>) <strong>size_MiB</strong> </a>
     
 
     
@@ -452,7 +452,7 @@ If  nil , the value is unchanged.
     <span class='kw'>end</span>
   <span class='kw'>end</span>
 
-  <span class='id identifier rubyid_attr_accessor'>attr_accessor</span> <span class='symbol'>:size_mib</span><span class='comma'>,</span>
+  <span class='id identifier rubyid_attr_accessor'>attr_accessor</span> <span class='symbol'>:size_MiB</span><span class='comma'>,</span>
                 <span class='symbol'>:hot_add_enabled</span>
 
   <span class='comment'># Constructs a new instance.
@@ -468,11 +468,11 @@ If  nil , the value is unchanged.
 </div>
     
       
-      <span id="size_mib=-instance_method"></span>
+      <span id="size_MiB=-instance_method"></span>
       <div class="method_details ">
-  <h3 class="signature " id="size_mib-instance_method">
+  <h3 class="signature " id="size_MiB-instance_method">
   
-    - (<tt>Fixnum</tt><sup>?</sup>) <strong>size_mib</strong> 
+    - (<tt>Fixnum</tt><sup>?</sup>) <strong>size_MiB</strong> 
   
 
   
@@ -486,7 +486,7 @@ New memory size in mebibytes.
 <pre class="code ruby"><code class="ruby">
  The supported range of memory sizes is constrained by the configured guest operating system and virtual hardware version of the virtual machine.  
 
- If the virtual machine is running, this value may only be changed if   :attr:`Com::Vmware::Vcenter::Vm::Hardware::Memory::Info.hot_add_enabled`   is true, and the new memory size must satisfy the constraints specified by   :attr:`Com::Vmware::Vcenter::Vm::Hardware::Memory::Info.hot_add_increment_size_mib`   and   :attr:`Com::Vmware::Vcenter::Vm::Hardware::Memory::Info.hot_add_limit_mib`  .
+ If the virtual machine is running, this value may only be changed if   :attr:`Com::Vmware::Vcenter::Vm::Hardware::Memory::Info.hot_add_enabled`   is true, and the new memory size must satisfy the constraints specified by   :attr:`Com::Vmware::Vcenter::Vm::Hardware::Memory::Info.hot_add_increment_size_MiB`   and   :attr:`Com::Vmware::Vcenter::Vm::Hardware::Memory::Info.hot_add_limit_mib`  .
 </code></pre>
 <p>
 If  nil , the value is unchanged.
@@ -569,7 +569,7 @@ If  nil , the value is unchanged.
     <span class='kw'>end</span>
   <span class='kw'>end</span>
 
-  <span class='id identifier rubyid_attr_accessor'>attr_accessor</span> <span class='symbol'>:size_mib</span><span class='comma'>,</span>
+  <span class='id identifier rubyid_attr_accessor'>attr_accessor</span> <span class='symbol'>:size_MiB</span><span class='comma'>,</span>
                 <span class='symbol'>:hot_add_enabled</span>
 
   <span class='comment'># Constructs a new instance.

--- a/docs/apidocs/vsphereautomation-bindings/method_list.html
+++ b/docs/apidocs/vsphereautomation-bindings/method_list.html
@@ -10548,7 +10548,7 @@
   
 
   <li class="r1 ">
-    <span class='object_link'><a href="Com/Vmware/Vcenter/Vm/Hardware/Memory/Info.html#hot_add_increment_size_mib-instance_method" title="Com::Vmware::Vcenter::Vm::Hardware::Memory::Info#hot_add_increment_size_mib (method)">#hot_add_increment_size_mib</a></span>
+    <span class='object_link'><a href="Com/Vmware/Vcenter/Vm/Hardware/Memory/Info.html#hot_add_increment_size_MiB-instance_method" title="Com::Vmware::Vcenter::Vm::Hardware::Memory::Info#hot_add_increment_size_MiB (method)">#hot_add_increment_size_MiB</a></span>
     <small>Com::Vmware::Vcenter::Vm::Hardware::Memory::Info</small>
   </li>
   
@@ -18504,13 +18504,13 @@
   
 
   <li class="r1 ">
-    <span class='object_link'><a href="Com/Vmware/Vcenter/Vm/Hardware/Memory/UpdateSpec.html#size_mib-instance_method" title="Com::Vmware::Vcenter::Vm::Hardware::Memory::UpdateSpec#size_mib (method)">#size_mib</a></span>
+    <span class='object_link'><a href="Com/Vmware/Vcenter/Vm/Hardware/Memory/UpdateSpec.html#size_MiB-instance_method" title="Com::Vmware::Vcenter::Vm::Hardware::Memory::UpdateSpec#size_MiB (method)">#size_MiB</a></span>
     <small>Com::Vmware::Vcenter::Vm::Hardware::Memory::UpdateSpec</small>
   </li>
   
 
   <li class="r2 ">
-    <span class='object_link'><a href="Com/Vmware/Vcenter/Vm/Hardware/Memory/Info.html#size_mib-instance_method" title="Com::Vmware::Vcenter::Vm::Hardware::Memory::Info#size_mib (method)">#size_mib</a></span>
+    <span class='object_link'><a href="Com/Vmware/Vcenter/Vm/Hardware/Memory/Info.html#size_MiB-instance_method" title="Com::Vmware::Vcenter::Vm::Hardware::Memory::Info#size_MiB (method)">#size_MiB</a></span>
     <small>Com::Vmware::Vcenter::Vm::Hardware::Memory::Info</small>
   </li>
   

--- a/docs/apidocs/vsphereautomation-bindings/method_list.html
+++ b/docs/apidocs/vsphereautomation-bindings/method_list.html
@@ -10554,7 +10554,7 @@
   
 
   <li class="r2 ">
-    <span class='object_link'><a href="Com/Vmware/Vcenter/Vm/Hardware/Memory/Info.html#hot_add_limit_mib-instance_method" title="Com::Vmware::Vcenter::Vm::Hardware::Memory::Info#hot_add_limit_mib (method)">#hot_add_limit_mib</a></span>
+    <span class='object_link'><a href="Com/Vmware/Vcenter/Vm/Hardware/Memory/Info.html#hot_add_limit_MiB-instance_method" title="Com::Vmware::Vcenter::Vm::Hardware::Memory::Info#hot_add_limit_MiB (method)">#hot_add_limit_MiB</a></span>
     <small>Com::Vmware::Vcenter::Vm::Hardware::Memory::Info</small>
   </li>
   


### PR DESCRIPTION
In several places, the incorrect casing of `mib` was used instead of
`MiB`. The binding generator generates this incorrectly and this was
caused when generating the 6.6.1 bindings. This was reported in #25.

Fixes #25

Signed-off-by: J.R. Garcia <jrg@vmware.com>