### PR TITLE
Correct User-Agent

### DIFF
--- a/appliance/lib/vsphere-automation-appliance/api_client.rb
+++ b/appliance/lib/vsphere-automation-appliance/api_client.rb
@@ -29,7 +29,7 @@ module VSphereAutomation
     # @option config [Configuration] Configuration for initializing the object, default to Configuration.default
     def initialize(config = Configuration.default)
       @config = config
-      @user_agent = "OpenAPI-Generator/#{Appliance::VERSION}/ruby"
+      @user_agent = "SDK/0.1.0 Ruby/#{RUBY_VERSION} (#{Gem::Platform.local.os}; #{Gem::Platform.local.version}; #{Gem::Platform.local.cpu})"
       @default_headers = {
         'Content-Type' => 'application/json',
         'User-Agent' => @user_agent

--- a/cis/lib/vsphere-automation-cis/api_client.rb
+++ b/cis/lib/vsphere-automation-cis/api_client.rb
@@ -29,7 +29,7 @@ module VSphereAutomation
     # @option config [Configuration] Configuration for initializing the object, default to Configuration.default
     def initialize(config = Configuration.default)
       @config = config
-      @user_agent = "OpenAPI-Generator/#{CIS::VERSION}/ruby"
+      @user_agent = "SDK/0.1.0 Ruby/#{RUBY_VERSION} (#{Gem::Platform.local.os}; #{Gem::Platform.local.version}; #{Gem::Platform.local.cpu})"
       @default_headers = {
         'Content-Type' => 'application/json',
         'User-Agent' => @user_agent

--- a/content/lib/vsphere-automation-content/api_client.rb
+++ b/content/lib/vsphere-automation-content/api_client.rb
@@ -29,7 +29,7 @@ module VSphereAutomation
     # @option config [Configuration] Configuration for initializing the object, default to Configuration.default
     def initialize(config = Configuration.default)
       @config = config
-      @user_agent = "OpenAPI-Generator/#{Content::VERSION}/ruby"
+      @user_agent = "SDK/0.1.0 Ruby/#{RUBY_VERSION} (#{Gem::Platform.local.os}; #{Gem::Platform.local.version}; #{Gem::Platform.local.cpu})"
       @default_headers = {
         'Content-Type' => 'application/json',
         'User-Agent' => @user_agent

--- a/sdk/lib/vsphere-automation-sdk/api_client.rb
+++ b/sdk/lib/vsphere-automation-sdk/api_client.rb
@@ -29,7 +29,7 @@ module VSphereAutomation
     # @option config [Configuration] Configuration for initializing the object, default to Configuration.default
     def initialize(config = Configuration.default)
       @config = config
-      @user_agent = "OpenAPI-Generator/#{VERSION}/ruby"
+      @user_agent = "SDK/0.1.0 Ruby/#{RUBY_VERSION} (#{Gem::Platform.local.os}; #{Gem::Platform.local.version}; #{Gem::Platform.local.cpu})"
       @default_headers = {
         'Content-Type' => 'application/json',
         'User-Agent' => @user_agent

--- a/vapi/lib/vsphere-automation-vapi/api_client.rb
+++ b/vapi/lib/vsphere-automation-vapi/api_client.rb
@@ -29,7 +29,7 @@ module VSphereAutomation
     # @option config [Configuration] Configuration for initializing the object, default to Configuration.default
     def initialize(config = Configuration.default)
       @config = config
-      @user_agent = "OpenAPI-Generator/#{VAPI::VERSION}/ruby"
+      @user_agent = "SDK/0.1.0 Ruby/#{RUBY_VERSION} (#{Gem::Platform.local.os}; #{Gem::Platform.local.version}; #{Gem::Platform.local.cpu})"
       @default_headers = {
         'Content-Type' => 'application/json',
         'User-Agent' => @user_agent

--- a/vcenter/lib/vsphere-automation-vcenter/api_client.rb
+++ b/vcenter/lib/vsphere-automation-vcenter/api_client.rb
@@ -29,7 +29,7 @@ module VSphereAutomation
     # @option config [Configuration] Configuration for initializing the object, default to Configuration.default
     def initialize(config = Configuration.default)
       @config = config
-      @user_agent = "OpenAPI-Generator/#{VCenter::VERSION}/ruby"
+      @user_agent = "SDK/0.1.0 Ruby/#{RUBY_VERSION} (#{Gem::Platform.local.os}; #{Gem::Platform.local.version}; #{Gem::Platform.local.cpu})"
       @default_headers = {
         'Content-Type' => 'application/json',
         'User-Agent' => @user_agent


### PR DESCRIPTION
**What this PR does / why we need it**:

Correct the User-Agent to match the other vSphere Automation SDKs. This
does not include the vAPI section like the others do as this SDK does
not utilize the vAPI core.

**Which issue(s) this PR fixes**:

Fixes #36

**Special notes for your reviewer**:

Tested to ensure output is correct. Below is the output from Pry.

```
[2] pry(#<VSphereAutomation::ApiClient>):1> @user_agent
=> "SDK/0.1.0 Ruby/2.6.0 (darwin; 18; x86_64)"
```