### PR TITLE
Only ship the contents of the lib dir in the gem

### DIFF
--- a/appliance/vsphere-automation-appliance.gemspec
+++ b/appliance/vsphere-automation-appliance.gemspec
@@ -33,8 +33,6 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'vcr', '~> 5.0'
   s.add_development_dependency 'webmock', '~> 3.6'
 
-  s.files         = `find *`.split("\n").uniq.sort.select { |f| !f.empty? }
-  s.test_files    = `find spec/*`.split("\n")
-  s.executables   = []
-  s.require_paths = ["lib"]
+  s.files = Dir.glob('lib/**/*')
+  s.require_paths = ['lib']
 end

--- a/cis/vsphere-automation-cis.gemspec
+++ b/cis/vsphere-automation-cis.gemspec
@@ -32,8 +32,6 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'vcr', '~> 5.0'
   s.add_development_dependency 'webmock', '~> 3.6'
 
-  s.files         = `find *`.split("\n").uniq.sort.select { |f| !f.empty? }
-  s.test_files    = `find spec/*`.split("\n")
-  s.executables   = []
-  s.require_paths = ["lib"]
+  s.files = Dir.glob('lib/**/*')
+  s.require_paths = ['lib']
 end

--- a/content/vsphere-automation-content.gemspec
+++ b/content/vsphere-automation-content.gemspec
@@ -33,8 +33,6 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'vcr', '~> 5.0'
   s.add_development_dependency 'webmock', '~> 3.6'
 
-  s.files         = `find *`.split("\n").uniq.sort.select { |f| !f.empty? }
-  s.test_files    = `find spec/*`.split("\n")
-  s.executables   = []
-  s.require_paths = ["lib"]
+  s.files = Dir.glob('lib/**/*')
+  s.require_paths = ['lib']
 end

--- a/runtime/vsphere-automation-runtime.gemspec
+++ b/runtime/vsphere-automation-runtime.gemspec
@@ -31,8 +31,6 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'vcr', '~> 5.0'
   s.add_development_dependency 'webmock', '~> 3.6'
 
-  s.files         = `find *`.split("\n").uniq.sort.select { |f| !f.empty? }
-  s.test_files    = `find spec/*`.split("\n")
-  s.executables   = []
-  s.require_paths = ["lib"]
+  s.files = Dir.glob('lib/**/*')
+  s.require_paths = ['lib']
 end

--- a/sdk/vsphere-automation-sdk.gemspec
+++ b/sdk/vsphere-automation-sdk.gemspec
@@ -32,7 +32,6 @@ Gem::Specification.new do |s|
 
   s.add_development_dependency 'rake', '~> 12.3'
 
-  s.files         = `find *`.split("\n").uniq.sort.select { |f| !f.empty? }
-  s.executables   = []
-  s.require_paths = ["lib"]
+  s.files = Dir.glob('lib/**/*')
+  s.require_paths = ['lib']
 end

--- a/vapi/vsphere-automation-vapi.gemspec
+++ b/vapi/vsphere-automation-vapi.gemspec
@@ -33,8 +33,6 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'vcr', '~> 5.0'
   s.add_development_dependency 'webmock', '~> 3.6'
 
-  s.files         = `find *`.split("\n").uniq.sort.select { |f| !f.empty? }
-  s.test_files    = `find spec/*`.split("\n")
-  s.executables   = []
-  s.require_paths = ["lib"]
+  s.files = Dir.glob('lib/**/*')
+  s.require_paths = ['lib']
 end

--- a/vcenter/vsphere-automation-vcenter.gemspec
+++ b/vcenter/vsphere-automation-vcenter.gemspec
@@ -33,8 +33,6 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'vcr', '~> 5.0'
   s.add_development_dependency 'webmock', '~> 3.6'
 
-  s.files         = `find *`.split("\n").uniq.sort.select { |f| !f.empty? }
-  s.test_files    = `find spec/*`.split("\n")
-  s.executables   = []
-  s.require_paths = ["lib"]
+  s.files = Dir.glob('lib/**/*')
+  s.require_paths = ['lib']
 end


### PR DESCRIPTION
This is what we use in a lot of our projects and it works really well to reduce total file count, which is particularly impacting on Windows systems were malmare scanners have to scan each of these files.

Here's the before / after compared to the 0.4.5. install I had on disk already that included the gem files in the pkg dir:

38.5 megs on disk -> 11.5
4331 files -> 1423

This resolves #63 

Signed-off-by: Tim Smith <tsmith@chef.io>